### PR TITLE
mlx: add Gemma4 image input support

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -455,12 +455,6 @@ func (m *Model) filterUnsupportedCapabilities(capabilities []model.Capability, m
 			return c == model.CapabilityAudio
 		})
 	}
-	if isGemma4Renderer(m.Config.Renderer) && m.Config.ModelFormat == "safetensors" {
-		capabilities = slices.DeleteFunc(capabilities, func(c model.Capability) bool {
-			return c == model.CapabilityVision
-		})
-	}
-
 	return capabilities
 }
 

--- a/server/images_test.go
+++ b/server/images_test.go
@@ -516,7 +516,7 @@ func TestModelCapabilities(t *testing.T) {
 			expectedCaps: []model.Capability{model.CapabilityCompletion, model.CapabilityVision},
 		},
 		{
-			name: "gemma4 small safetensors suppresses vision and audio",
+			name: "gemma4 small safetensors exposes vision and suppresses audio",
 			model: Model{
 				Config: model.ConfigV2{
 					ModelFormat:  "safetensors",
@@ -525,9 +525,10 @@ func TestModelCapabilities(t *testing.T) {
 				},
 				Template: chatTemplate,
 			},
+			expectedCaps: []model.Capability{model.CapabilityVision},
 		},
 		{
-			name: "gemma4 large safetensors suppresses vision and audio",
+			name: "gemma4 large safetensors exposes vision and suppresses audio",
 			model: Model{
 				Config: model.ConfigV2{
 					ModelFormat:  "safetensors",
@@ -536,9 +537,10 @@ func TestModelCapabilities(t *testing.T) {
 				},
 				Template: chatTemplate,
 			},
+			expectedCaps: []model.Capability{model.CapabilityVision},
 		},
 		{
-			name: "default gemma4 safetensors suppresses vision and audio",
+			name: "default gemma4 safetensors exposes vision and suppresses audio",
 			model: Model{
 				Config: model.ConfigV2{
 					ModelFormat:  "safetensors",
@@ -547,6 +549,7 @@ func TestModelCapabilities(t *testing.T) {
 				},
 				Template: chatTemplate,
 			},
+			expectedCaps: []model.Capability{model.CapabilityVision},
 		},
 	}
 

--- a/server/model_list_cache.go
+++ b/server/model_list_cache.go
@@ -393,7 +393,7 @@ func buildModelListSummary(name model.Name, mf *manifest.Manifest) (modelListSum
 
 	if cfg.ModelFormat == "safetensors" && isGemma4Renderer(cfg.Renderer) {
 		summary.Capabilities = slices.DeleteFunc(summary.Capabilities, func(c model.Capability) bool {
-			return c == model.CapabilityVision || c == model.CapabilityAudio
+			return c == model.CapabilityAudio
 		})
 	}
 

--- a/server/model_list_cache_test.go
+++ b/server/model_list_cache_test.go
@@ -339,3 +339,37 @@ func writeModelListGGUFUint64(t *testing.T, b *bytes.Buffer, v uint64) {
 		t.Fatal(err)
 	}
 }
+
+func TestModelListCacheGemma4SafetensorsCapabilities(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setTestHome(t, t.TempDir())
+
+	name := model.ParseName("gemma4-list")
+	configLayer, err := createConfigLayer(model.ConfigV2{
+		ModelFormat:  "safetensors",
+		ModelFamily:  "gemma4",
+		Renderer:     gemma4RendererSmall,
+		Capabilities: []string{"completion", "vision", "audio"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := manifest.WriteManifest(name, *configLayer, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	cache := newModelListCache()
+	if err := cache.hydrate(context.Background()); err != nil {
+		t.Fatalf("hydrate failed: %v", err)
+	}
+	summary, ok := cache.Get(name)
+	if !ok {
+		t.Fatal("list summary missing")
+	}
+	if !slices.Contains(summary.Capabilities, model.CapabilityVision) {
+		t.Errorf("capabilities = %v, want vision", summary.Capabilities)
+	}
+	if slices.Contains(summary.Capabilities, model.CapabilityAudio) {
+		t.Errorf("capabilities = %v, want no audio", summary.Capabilities)
+	}
+}

--- a/x/models/gemma4/gemma4.go
+++ b/x/models/gemma4/gemma4.go
@@ -29,7 +29,32 @@ func init() {
 }
 
 // Compile-time interface checks.
-var _ base.Model = (*Model)(nil)
+var (
+	_ base.Model      = (*Model)(nil)
+	_ base.MediaModel = (*Model)(nil)
+)
+
+// bidirectionalAttention accepts both config spellings seen in Gemma 4
+// checkpoints: the named "vision" mode and a legacy boolean.
+type bidirectionalAttention string
+
+func (a *bidirectionalAttention) UnmarshalJSON(data []byte) error {
+	var mode string
+	if err := json.Unmarshal(data, &mode); err == nil {
+		*a = bidirectionalAttention(mode)
+		return nil
+	}
+
+	var enabled bool
+	if err := json.Unmarshal(data, &enabled); err != nil {
+		return fmt.Errorf("use_bidirectional_attention: want a string or bool, got %s", data)
+	}
+	*a = ""
+	if enabled {
+		*a = "true"
+	}
+	return nil
+}
 
 // RopeParams holds per-layer-type RoPE settings.
 type RopeParams struct {
@@ -67,6 +92,7 @@ type TextConfig struct {
 	ExpertIntermediateSize int32                  `json:"moe_intermediate_size"`
 	RopeParameters         map[string]*RopeParams `json:"rope_parameters"`
 	ImageTokenIDValue      int32                  `json:"image_token_id"`
+	UseBidirectionalAttn   bidirectionalAttention `json:"use_bidirectional_attention"`
 
 	// Quantization parameters.
 	QuantGroupSize int                               `json:"-"`
@@ -380,6 +406,10 @@ type Model struct {
 	Norm        *nn.RMSNorm
 	LMHead      nn.LinearLayer
 
+	VisionEncoder   *VisionEncoder
+	MultimodalEmbed *MultimodalEmbedder
+	VisionConfig    *VisionConfig
+
 	// PLE model-level components (nil if no PLE).
 	EmbedTokensPerLayer nn.EmbeddingLayer
 	PerLayerModelProj   nn.LinearLayer
@@ -394,6 +424,11 @@ type Model struct {
 
 	SuppressLogitBias *mlx.Array
 	weightPrefix      string
+
+	imageStartTokenID int32
+	imageTokenID      int32
+	imageEndTokenID   int32
+	imageTokenLimit   int
 }
 
 func parseTextConfig(configData []byte) (TextConfig, error) {
@@ -646,11 +681,35 @@ func newModel(root *model.Root) (base.Model, error) {
 		return nil, fmt.Errorf("parse tokenizer: %w", err)
 	}
 
+	visionConfig, err := parseVisionConfig(configData)
+	if err != nil {
+		return nil, err
+	}
+
 	m := &Model{
 		Layers:            make([]*DecoderLayer, cfg.NumHiddenLayers),
 		TextConfig:        &cfg,
 		tok:               tok,
 		SuppressLogitBias: makeSuppressLogitBias(suppressTokens, cfg.VocabSize),
+		VisionConfig:      visionConfig,
+	}
+	if visionConfig != nil {
+		m.VisionEncoder = &VisionEncoder{Cfg: visionConfig}
+		m.imageTokenLimit = int(visionConfig.ImageSeqLength)
+		if processorData, err := root.Manifest.ReadConfig("processor_config.json"); err == nil {
+			m.imageTokenLimit = parseImageTokenLimit(processorData, m.imageTokenLimit)
+		}
+
+		var ok bool
+		if m.imageStartTokenID, ok = tok.GetSpecialToken("<|image>"); !ok {
+			return nil, fmt.Errorf("tokenizer is missing <|image>")
+		}
+		if m.imageTokenID, ok = tok.GetSpecialToken("<|image|>"); !ok {
+			return nil, fmt.Errorf("tokenizer is missing <|image|>")
+		}
+		if m.imageEndTokenID, ok = tok.GetSpecialToken("<image|>"); !ok {
+			return nil, fmt.Errorf("tokenizer is missing <image|>")
+		}
 	}
 
 	for i := range m.Layers {
@@ -980,21 +1039,51 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 	if m.NormScaled == nil {
 		return fmt.Errorf("missing precomputed final norm weight")
 	}
+	if m.VisionEncoder != nil {
+		if err := m.loadVisionWeights(tensors, linears); err != nil {
+			return err
+		}
+		precomputeVisionScaledWeights(m.VisionEncoder)
+	}
 
 	return nil
 }
 
 func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden *mlx.Array) {
+	h := m.embed(b.InputIDs)
+	pleTokens := b.InputIDs
+	attentionMask := nn.CausalMask()
+	if len(b.Media) > 0 {
+		h = m.scatterMedia(h, b)
+		if m.HiddenSizePerLayer > 0 {
+			pleTokens = maskMediaTokens(b.InputIDs, b)
+		}
+		if m.UseBidirectionalAttn == "vision" {
+			attentionMask = mediaAttentionMask(b)
+		}
+	}
+	return m.forwardEmbeddings(h, b, caches, pleTokens, attentionMask)
+}
+
+func (m *Model) embed(inputIDs *mlx.Array) *mlx.Array {
+	return mlx.MulScalar(m.EmbedTokens.Forward(inputIDs), m.EmbedScale)
+}
+
+func (m *Model) forwardEmbeddings(
+	h *mlx.Array,
+	b *batch.Batch,
+	caches []cache.Cache,
+	pleTokens *mlx.Array,
+	attentionMask nn.AttentionMask,
+) (hidden, auxHidden *mlx.Array) {
 	dims := b.InputIDs.Dims()
 	B, L := int32(dims[0]), int32(dims[1])
 	positions := mlx.FromValues(b.SeqOffsets, len(b.SeqOffsets))
-	h := m.EmbedTokens.Forward(b.InputIDs)
-	h = mlx.MulScalar(h, m.EmbedScale)
 
 	// Compute PLE inputs if configured.
 	var perLayerInputs *mlx.Array
-	if m.HiddenSizePerLayer > 0 && m.EmbedTokensPerLayer != nil {
-		perLayerInputs = m.computePLEInputs(b.InputIDs, h)
+	if m.HiddenSizePerLayer > 0 && m.EmbedTokensPerLayer != nil && pleTokens != nil {
+		perLayerInputs = m.computePLEInputs(pleTokens, h)
 	}
 
 	// KV sharing: each donor layer stores its KVHistory here so later
@@ -1024,8 +1113,13 @@ func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden
 			}
 		}
 
+		layerMask := nn.CausalMask()
+		if layer.IsSliding {
+			layerMask = attentionMask
+		}
+
 		var donorKV *sharedHistory
-		h, donorKV = layer.Forward(h, b, c, positions, B, L, m.TextConfig, pleInput, donor)
+		h, donorKV = layer.Forward(h, b, c, positions, B, L, m.TextConfig, pleInput, donor, layerMask)
 
 		// If this layer is a donor, store its cached KV for later shared layers.
 		if layer.IsDonor && donorKV != nil {
@@ -1091,7 +1185,7 @@ func (m *Model) Tokenizer() *tokenizer.Tokenizer {
 
 // TokenEmbeddings returns the target model's scaled token embeddings for MTP.
 func (m *Model) TokenEmbeddings(inputIDs *mlx.Array) *mlx.Array {
-	return mlx.MulScalar(m.EmbedTokens.Forward(inputIDs), m.EmbedScale)
+	return m.embed(inputIDs)
 }
 
 // NewCaches creates cache objects for layers that own KV state.
@@ -1155,9 +1249,9 @@ func sliceLayerDim(combined *mlx.Array, layerIdx, B, L, pleDim int32) *mlx.Array
 	return mlx.Squeeze(sliced, 2)
 }
 
-func (l *DecoderLayer) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positions *mlx.Array, B, L int32, cfg *TextConfig, pleInput *mlx.Array, donor *sharedHistory) (*mlx.Array, *sharedHistory) {
+func (l *DecoderLayer) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positions *mlx.Array, B, L int32, cfg *TextConfig, pleInput *mlx.Array, donor *sharedHistory, attentionMask nn.AttentionMask) (*mlx.Array, *sharedHistory) {
 	normed := mlx.RMSNormFn(x, l.InputNormScaled, cfg.RMSNormEps)
-	attnOut, kv := l.Attention.Forward(normed, b, c, positions, B, L, l.IsSliding, cfg, donor)
+	attnOut, kv := l.Attention.Forward(normed, b, c, positions, B, L, l.IsSliding, cfg, donor, attentionMask)
 	attnOut = mlx.RMSNormFn(attnOut, l.PostAttnNormScaled, cfg.RMSNormEps)
 	h := mlx.Add(x, attnOut)
 
@@ -1205,7 +1299,7 @@ func (l *DecoderLayer) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, posi
 	return h, kv
 }
 
-func (a *Attention) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positions *mlx.Array, B, L int32, isSliding bool, cfg *TextConfig, donor *sharedHistory) (*mlx.Array, *sharedHistory) {
+func (a *Attention) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positions *mlx.Array, B, L int32, isSliding bool, cfg *TextConfig, donor *sharedHistory, attentionMask nn.AttentionMask) (*mlx.Array, *sharedHistory) {
 	// Determine head dim and scale based on layer type.
 	headDim := cfg.HeadDim
 	scale := cfg.SlidingScale
@@ -1281,7 +1375,7 @@ func (a *Attention) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positio
 		// kernel only handles L < 4 (generation). For prefill, we fall back
 		// to explicit matmul+softmax+matmul on CUDA.
 		var k, v *mlx.Array
-		mask := nn.CausalMask().Intersect(nn.QPaddingMask(b, q.DType()))
+		mask := attentionMask.Intersect(nn.QPaddingMask(b, q.DType()))
 		if kv.history != nil {
 			k, v = kv.history.K(), kv.history.V()
 			mask = kv.history.Mask(mask)
@@ -1311,7 +1405,7 @@ func (a *Attention) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, positio
 		out = mlx.Reshape(out, B, cfg.NumAttentionHeads, L, headDim)
 	} else {
 		var opt nn.SDPAOption
-		mask := nn.CausalMask()
+		mask := attentionMask
 		if kv.history != nil {
 			opt = nn.WithKVHistory(kv.history)
 		} else {

--- a/x/models/gemma4/gemma4_test.go
+++ b/x/models/gemma4/gemma4_test.go
@@ -24,6 +24,33 @@ func TestParseSuppressTokens(t *testing.T) {
 	}
 }
 
+func TestParseTextConfigBidirectionalAttention(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		raw  string
+		want bidirectionalAttention
+	}{
+		{name: "absent", raw: `{}`, want: ""},
+		{name: "vision mode", raw: `{"use_bidirectional_attention":"vision"}`, want: "vision"},
+		{name: "bool true", raw: `{"use_bidirectional_attention":true}`, want: "true"},
+		{name: "bool false", raw: `{"use_bidirectional_attention":false}`, want: ""},
+		{name: "nested", raw: `{"text_config":{"use_bidirectional_attention":"vision"}}`, want: "vision"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg, err := parseTextConfig([]byte(tt.raw))
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cfg.UseBidirectionalAttn != tt.want {
+				t.Fatalf("mode = %q, want %q", cfg.UseBidirectionalAttn, tt.want)
+			}
+		})
+	}
+	if _, err := parseTextConfig([]byte(`{"use_bidirectional_attention":3}`)); err == nil {
+		t.Fatal("numeric use_bidirectional_attention did not fail")
+	}
+}
+
 func TestParseTextConfigE2B(t *testing.T) {
 	skipIfNoMLX(t)
 	data := []byte(`{

--- a/x/models/gemma4/gemma4_vision.go
+++ b/x/models/gemma4/gemma4_vision.go
@@ -1,0 +1,790 @@
+// Vision encoder for Gemma 4 multimodal models.
+package gemma4
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model"
+	"github.com/ollama/ollama/x/models/nn"
+)
+
+// VisionConfig holds configuration for the vision encoder.
+type VisionConfig struct {
+	ModelType             string          `json:"model_type"`
+	HiddenSize            int32           `json:"hidden_size"`             // 768
+	IntermediateSize      int32           `json:"intermediate_size"`       // 3072
+	NumHiddenLayers       int32           `json:"num_hidden_layers"`       // 16
+	NumAttentionHeads     int32           `json:"num_attention_heads"`     // 12
+	NumKeyValueHeads      int32           `json:"num_key_value_heads"`     // 12
+	HeadDim               int32           `json:"head_dim"`                // 64
+	PatchSize             int32           `json:"patch_size"`              // 16
+	PositionEmbeddingSize int32           `json:"position_embedding_size"` // 10240
+	ImageSeqLength        int32           `json:"image_seq_length"`        // 280
+	DefaultOutputLength   int32           `json:"default_output_length"`
+	PoolingKernelSize     int32           `json:"pooling_kernel_size"` // 3
+	RMSNormEps            float32         `json:"rms_norm_eps"`        // 1e-6
+	Standardize           bool            `json:"standardize"`
+	RopeParameters        json.RawMessage `json:"rope_parameters"`
+	LayerTypes            []string        `json:"layer_types"`
+
+	// Unified vision uses a transformer-less patch embedder with different
+	// names for the equivalent dimensions.
+	MMEmbeddingDim          int32 `json:"mm_embed_dim"`
+	MMPositionEmbeddingSize int32 `json:"mm_posemb_size"`
+	ModelPatchSize          int32 `json:"model_patch_size"`
+	NumSoftTokens           int32 `json:"num_soft_tokens"`
+
+	// Computed fields.
+	RopeTheta float32 `json:"-"` // from rope_parameters
+	Scale     float32 `json:"-"` // 1/sqrt(head_dim)
+}
+
+// ClipBounds holds input/output clamp bounds for a clippable linear layer.
+type ClipBounds struct {
+	InputMin  *mlx.Array
+	InputMax  *mlx.Array
+	OutputMin *mlx.Array
+	OutputMax *mlx.Array
+}
+
+// ClippableLinear wraps a linear layer with optional input/output clamping.
+type ClippableLinear struct {
+	Linear nn.LinearLayer
+	Clip   *ClipBounds
+}
+
+func (cl *ClippableLinear) Forward(x *mlx.Array) *mlx.Array {
+	if cl.Clip != nil && cl.Clip.InputMin != nil && cl.Clip.InputMax != nil {
+		x = mlx.Clip(x, cl.Clip.InputMin, cl.Clip.InputMax)
+	}
+	x = cl.Linear.Forward(x)
+	if cl.Clip != nil && cl.Clip.OutputMin != nil && cl.Clip.OutputMax != nil {
+		x = mlx.Clip(x, cl.Clip.OutputMin, cl.Clip.OutputMax)
+	}
+	return x
+}
+
+// VisionAttention implements multi-head attention for the vision encoder.
+type VisionAttention struct {
+	QProj *ClippableLinear
+	KProj *ClippableLinear
+	VProj *ClippableLinear
+	OProj *ClippableLinear
+
+	QNorm *nn.RMSNorm
+	KNorm *nn.RMSNorm
+
+	// Norm weight for Q/K RMSNorm.
+	QNormScaled *mlx.Array
+	KNormScaled *mlx.Array
+}
+
+// VisionMLP is the feed-forward network for vision layers.
+type VisionMLP struct {
+	GateProj *ClippableLinear
+	UpProj   *ClippableLinear
+	DownProj *ClippableLinear
+}
+
+// VisionDecoderLayer is a single vision transformer block.
+type VisionDecoderLayer struct {
+	InputNorm    *nn.RMSNorm
+	Attention    *VisionAttention
+	PostAttnNorm *nn.RMSNorm
+	PreFFNorm    *nn.RMSNorm
+	MLP          *VisionMLP
+	PostFFNorm   *nn.RMSNorm
+
+	// Layer scalar (vision layers have this too).
+	LayerScalar *mlx.Array
+
+	// Norm weight for RMSNorm.
+	InputNormScaled    *mlx.Array
+	PostAttnNormScaled *mlx.Array
+	PreFFNormScaled    *mlx.Array
+	PostFFNormScaled   *mlx.Array
+}
+
+// VisionPatchEmbedder converts images to patch embeddings with 2D position info.
+type VisionPatchEmbedder struct {
+	InputProj              nn.LinearLayer // Linear(3*patch_size^2, hidden_size)
+	PositionEmbeddingTable *mlx.Array     // [2, position_embedding_size, hidden_size]
+}
+
+// UnifiedVisionPatchEmbedder implements Gemma4's transformer-less vision path.
+type UnifiedVisionPatchEmbedder struct {
+	PatchNorm1        *nn.LayerNorm
+	PatchDense        nn.LinearLayer
+	PatchNorm2        *nn.LayerNorm
+	PositionEmbedding *mlx.Array
+	PositionNorm      *nn.LayerNorm
+}
+
+// VisionEncoder orchestrates the full vision encoding pipeline.
+type VisionEncoder struct {
+	PatchEmbedder        *VisionPatchEmbedder
+	UnifiedPatchEmbedder *UnifiedVisionPatchEmbedder
+	Layers               []*VisionDecoderLayer
+	Cfg                  *VisionConfig
+	StdBias              *mlx.Array
+	StdScale             *mlx.Array
+}
+
+// MultimodalEmbedder projects vision tokens into language model space.
+type MultimodalEmbedder struct {
+	EmbeddingProjection nn.LinearLayer // Linear(multimodal_hidden, text_hidden)
+	Eps                 float32        // RMSNorm epsilon
+}
+
+// Forward normalizes and projects multimodal embeddings.
+func (me *MultimodalEmbedder) Forward(x *mlx.Array) *mlx.Array {
+	x = mlx.RMSNormFn(x, nil, me.Eps)
+	return me.EmbeddingProjection.Forward(x)
+}
+
+// makeClippableLinear creates a ClippableLinear from a linear layer and optional clip bounds.
+// ClippableLinear wraps nn.Linear as self.linear, so the weight path is
+// prefix.linear.weight (e.g., self_attn.q_proj.linear.weight).
+func makeClippableLinear(linears model.LinearFactory, tensors map[string]*mlx.Array, prefix string) *ClippableLinear {
+	linear := linears.Make(prefix + ".linear")
+	if linear == nil {
+		return nil
+	}
+	cl := &ClippableLinear{Linear: linear}
+
+	// Load clip bounds if present.
+	inputMin := tensors[prefix+".input_min"]
+	inputMax := tensors[prefix+".input_max"]
+	outputMin := tensors[prefix+".output_min"]
+	outputMax := tensors[prefix+".output_max"]
+
+	if inputMin != nil || outputMin != nil {
+		cl.Clip = &ClipBounds{
+			InputMin:  inputMin,
+			InputMax:  inputMax,
+			OutputMin: outputMin,
+			OutputMax: outputMax,
+		}
+	}
+	return cl
+}
+
+func parseVisionConfig(configData []byte) (*VisionConfig, error) {
+	var wrapper struct {
+		VisionConfig *VisionConfig `json:"vision_config"`
+	}
+	if err := json.Unmarshal(configData, &wrapper); err != nil {
+		return nil, fmt.Errorf("parse vision config: %w", err)
+	}
+	if wrapper.VisionConfig == nil {
+		return nil, nil // No vision config means a text-only model.
+	}
+
+	cfg := wrapper.VisionConfig
+	switch cfg.ModelType {
+	case "", "gemma4_vision":
+	case "gemma4_unified_vision":
+		if cfg.ModelPatchSize == 0 {
+			cfg.ModelPatchSize = cfg.PatchSize * cfg.PoolingKernelSize
+		}
+		cfg.PatchSize = cfg.ModelPatchSize
+		cfg.PoolingKernelSize = 1
+		cfg.HiddenSize = cfg.MMEmbeddingDim
+		cfg.PositionEmbeddingSize = cfg.MMPositionEmbeddingSize
+		cfg.ImageSeqLength = cfg.NumSoftTokens
+	default:
+		// The manifest advertises vision whenever a vision_config is present
+		// (x/create/client/create.go), so degrading to text-only here would
+		// leave the capability claiming a tower we cannot run.
+		return nil, fmt.Errorf("unsupported vision tower %q", cfg.ModelType)
+	}
+
+	// Defaults.
+	if cfg.HeadDim == 0 {
+		cfg.HeadDim = 64
+	}
+	if cfg.NumKeyValueHeads == 0 {
+		cfg.NumKeyValueHeads = cfg.NumAttentionHeads
+	}
+	if cfg.PatchSize == 0 {
+		cfg.PatchSize = 16
+	}
+	if cfg.PoolingKernelSize == 0 {
+		cfg.PoolingKernelSize = 3
+	}
+	if cfg.ImageSeqLength == 0 {
+		cfg.ImageSeqLength = cfg.DefaultOutputLength
+		if cfg.ImageSeqLength == 0 {
+			cfg.ImageSeqLength = 280
+		}
+	}
+	if cfg.PositionEmbeddingSize == 0 {
+		cfg.PositionEmbeddingSize = 10240
+	}
+	if cfg.RMSNormEps == 0 {
+		cfg.RMSNormEps = 1e-6
+	}
+
+	cfg.Scale = 1.0 // Gemma 4 vision uses scale=1.0 (Q/K norms handle magnitude)
+
+	// Extract RoPE theta from rope_parameters: {"rope_theta": 100.0, "rope_type": "default"}
+	cfg.RopeTheta = 100.0
+	if len(cfg.RopeParameters) > 0 {
+		var rp struct {
+			RopeTheta float32 `json:"rope_theta"`
+		}
+		if json.Unmarshal(cfg.RopeParameters, &rp) == nil && rp.RopeTheta > 0 {
+			cfg.RopeTheta = rp.RopeTheta
+		}
+	}
+
+	return cfg, nil
+}
+
+// loadVisionWeights loads vision encoder and multimodal embedder weights.
+func (m *Model) loadVisionWeights(tensors map[string]*mlx.Array, linears model.LinearFactory) error {
+	if m.VisionConfig.ModelType == "gemma4_unified_vision" {
+		return m.loadUnifiedVisionWeights(tensors, linears)
+	}
+
+	prefix := "model."
+
+	// Resolve prefix: try "model.vision_tower." first, then "vision_tower.".
+	visionPrefix := prefix + "vision_tower."
+	if tensors[visionPrefix+"patch_embedder.input_proj.weight"] == nil {
+		visionPrefix = "vision_tower."
+		if tensors[visionPrefix+"patch_embedder.input_proj.weight"] == nil {
+			return fmt.Errorf("missing vision tower weights")
+		}
+	}
+
+	// Patch embedder.
+	m.VisionEncoder.PatchEmbedder = &VisionPatchEmbedder{}
+	m.VisionEncoder.PatchEmbedder.InputProj = linears.Make(visionPrefix + "patch_embedder.input_proj")
+	if m.VisionEncoder.PatchEmbedder.InputProj == nil {
+		return fmt.Errorf("missing vision patch embedder input_proj")
+	}
+	m.VisionEncoder.PatchEmbedder.PositionEmbeddingTable = tensors[visionPrefix+"patch_embedder.position_embedding_table"]
+	if m.VisionEncoder.PatchEmbedder.PositionEmbeddingTable == nil {
+		return fmt.Errorf("missing vision patch embedder position_embedding_table")
+	}
+
+	// Vision transformer layers.
+	vcfg := m.VisionConfig
+	m.VisionEncoder.Layers = make([]*VisionDecoderLayer, vcfg.NumHiddenLayers)
+	for i := range vcfg.NumHiddenLayers {
+		layerPrefix := fmt.Sprintf("%sencoder.layers.%d", visionPrefix, i)
+
+		layer := &VisionDecoderLayer{
+			Attention: &VisionAttention{},
+			MLP:       &VisionMLP{},
+		}
+
+		// Norms.
+		if w := tensors[layerPrefix+".input_layernorm.weight"]; w != nil {
+			layer.InputNorm = nn.NewRMSNorm(w, vcfg.RMSNormEps)
+		}
+		if w := tensors[layerPrefix+".post_attention_layernorm.weight"]; w != nil {
+			layer.PostAttnNorm = nn.NewRMSNorm(w, vcfg.RMSNormEps)
+		}
+		if w := tensors[layerPrefix+".pre_feedforward_layernorm.weight"]; w != nil {
+			layer.PreFFNorm = nn.NewRMSNorm(w, vcfg.RMSNormEps)
+		}
+		if w := tensors[layerPrefix+".post_feedforward_layernorm.weight"]; w != nil {
+			layer.PostFFNorm = nn.NewRMSNorm(w, vcfg.RMSNormEps)
+		}
+
+		// Attention projections (with clip bounds).
+		layer.Attention.QProj = makeClippableLinear(linears, tensors, layerPrefix+".self_attn.q_proj")
+		layer.Attention.KProj = makeClippableLinear(linears, tensors, layerPrefix+".self_attn.k_proj")
+		layer.Attention.VProj = makeClippableLinear(linears, tensors, layerPrefix+".self_attn.v_proj")
+		layer.Attention.OProj = makeClippableLinear(linears, tensors, layerPrefix+".self_attn.o_proj")
+
+		if w := tensors[layerPrefix+".self_attn.q_norm.weight"]; w != nil {
+			layer.Attention.QNorm = nn.NewRMSNorm(w, vcfg.RMSNormEps)
+		}
+		if w := tensors[layerPrefix+".self_attn.k_norm.weight"]; w != nil {
+			layer.Attention.KNorm = nn.NewRMSNorm(w, vcfg.RMSNormEps)
+		}
+
+		// MLP (with clip bounds).
+		layer.MLP.GateProj = makeClippableLinear(linears, tensors, layerPrefix+".mlp.gate_proj")
+		layer.MLP.UpProj = makeClippableLinear(linears, tensors, layerPrefix+".mlp.up_proj")
+		layer.MLP.DownProj = makeClippableLinear(linears, tensors, layerPrefix+".mlp.down_proj")
+
+		// Layer scalar.
+		if w := tensors[layerPrefix+".layer_scalar"]; w != nil {
+			layer.LayerScalar = w
+		}
+
+		// Validation.
+		if layer.InputNorm == nil || layer.PostAttnNorm == nil ||
+			layer.PreFFNorm == nil || layer.PostFFNorm == nil {
+			return fmt.Errorf("vision layer %d: missing norm weights", i)
+		}
+		if layer.Attention.QProj == nil || layer.Attention.KProj == nil ||
+			layer.Attention.VProj == nil || layer.Attention.OProj == nil {
+			return fmt.Errorf("vision layer %d: missing attention projections", i)
+		}
+		if layer.Attention.QNorm == nil || layer.Attention.KNorm == nil {
+			return fmt.Errorf("vision layer %d: missing attention q/k norms", i)
+		}
+		if layer.MLP.GateProj == nil || layer.MLP.UpProj == nil || layer.MLP.DownProj == nil {
+			return fmt.Errorf("vision layer %d: missing mlp projections", i)
+		}
+		if layer.Attention.QProj.Linear == nil || layer.Attention.KProj.Linear == nil ||
+			layer.Attention.VProj.Linear == nil || layer.Attention.OProj.Linear == nil {
+			return fmt.Errorf("vision layer %d: missing attention linear weights", i)
+		}
+		if layer.MLP.GateProj.Linear == nil || layer.MLP.UpProj.Linear == nil || layer.MLP.DownProj.Linear == nil {
+			return fmt.Errorf("vision layer %d: missing mlp linear weights", i)
+		}
+
+		m.VisionEncoder.Layers[i] = layer
+	}
+	if vcfg.Standardize {
+		m.VisionEncoder.StdBias = tensors[visionPrefix+"std_bias"]
+		m.VisionEncoder.StdScale = tensors[visionPrefix+"std_scale"]
+		if m.VisionEncoder.StdBias == nil || m.VisionEncoder.StdScale == nil {
+			return fmt.Errorf("missing vision standardization weights")
+		}
+	}
+
+	return m.loadVisionProjection(tensors, linears)
+}
+
+func (m *Model) loadUnifiedVisionWeights(tensors map[string]*mlx.Array, linears model.LinearFactory) error {
+	const prefix = "model.vision_embedder."
+
+	patchDense := linears.Make(prefix + "patch_dense")
+	patchNorm1Weight := tensors[prefix+"patch_ln1.weight"]
+	patchNorm1Bias := tensors[prefix+"patch_ln1.bias"]
+	patchNorm2Weight := tensors[prefix+"patch_ln2.weight"]
+	patchNorm2Bias := tensors[prefix+"patch_ln2.bias"]
+	positionEmbedding := tensors[prefix+"pos_embedding"]
+	positionNormWeight := tensors[prefix+"pos_norm.weight"]
+	positionNormBias := tensors[prefix+"pos_norm.bias"]
+	if patchDense == nil || patchNorm1Weight == nil || patchNorm1Bias == nil ||
+		patchNorm2Weight == nil || patchNorm2Bias == nil || positionEmbedding == nil ||
+		positionNormWeight == nil || positionNormBias == nil {
+		return fmt.Errorf("missing unified vision embedder weights")
+	}
+	if dims := positionEmbedding.Dims(); len(dims) != 3 ||
+		dims[0] != int(m.VisionConfig.PositionEmbeddingSize) ||
+		dims[1] != 2 ||
+		dims[2] != int(m.VisionConfig.HiddenSize) {
+		return fmt.Errorf("unexpected unified vision position embedding shape %v", dims)
+	}
+	// Unified checkpoints store this as [position, axis, hidden], while the
+	// regular vision tower and the shared lookup path use [axis, position, hidden].
+	positionEmbedding = mlx.Transpose(positionEmbedding, 1, 0, 2)
+
+	m.VisionEncoder.UnifiedPatchEmbedder = &UnifiedVisionPatchEmbedder{
+		PatchNorm1: &nn.LayerNorm{
+			Weight: patchNorm1Weight,
+			Bias:   patchNorm1Bias,
+		},
+		PatchDense: patchDense,
+		PatchNorm2: &nn.LayerNorm{
+			Weight: patchNorm2Weight,
+			Bias:   patchNorm2Bias,
+		},
+		PositionEmbedding: positionEmbedding,
+		PositionNorm: &nn.LayerNorm{
+			Weight: positionNormWeight,
+			Bias:   positionNormBias,
+		},
+	}
+
+	return m.loadVisionProjection(tensors, linears)
+}
+
+func (m *Model) loadVisionProjection(tensors map[string]*mlx.Array, linears model.LinearFactory) error {
+	embedPrefix := "model.embed_vision."
+	if tensors[embedPrefix+"embedding_projection.weight"] == nil {
+		embedPrefix = "embed_vision."
+	}
+	m.MultimodalEmbed = &MultimodalEmbedder{
+		EmbeddingProjection: linears.Make(embedPrefix + "embedding_projection"),
+		Eps:                 m.VisionConfig.RMSNormEps,
+	}
+	if m.MultimodalEmbed.EmbeddingProjection == nil {
+		return fmt.Errorf("missing multimodal embedder embedding_projection")
+	}
+
+	return nil
+}
+
+// precomputeVisionScaledWeights assigns raw norm weights to the *Scaled fields.
+// Gemma 4 uses scale_shift=0.0 for all norms (no +1.0 adjustment).
+func precomputeVisionScaledWeights(ve *VisionEncoder) {
+	for _, layer := range ve.Layers {
+		if layer.InputNorm != nil {
+			layer.InputNormScaled = layer.InputNorm.Weight
+		}
+		if layer.PostAttnNorm != nil {
+			layer.PostAttnNormScaled = layer.PostAttnNorm.Weight
+		}
+		if layer.PreFFNorm != nil {
+			layer.PreFFNormScaled = layer.PreFFNorm.Weight
+		}
+		if layer.PostFFNorm != nil {
+			layer.PostFFNormScaled = layer.PostFFNorm.Weight
+		}
+		if layer.Attention.QNorm != nil {
+			layer.Attention.QNormScaled = layer.Attention.QNorm.Weight
+		}
+		if layer.Attention.KNorm != nil {
+			layer.Attention.KNormScaled = layer.Attention.KNorm.Weight
+		}
+	}
+}
+
+// patchify converts pixel values to patch embeddings.
+// Input: pixelValues [B, 3, H, W] (channels-first, float32, rescaled to [0,1])
+// Output: patches [B, numPatches, 3*patchSize^2]
+func patchify(pixelValues *mlx.Array, patchSize int32) *mlx.Array {
+	dims := pixelValues.Dims()
+	B := int32(dims[0])
+	H, W := int32(dims[2]), int32(dims[3])
+	patchH := H / patchSize
+	patchW := W / patchSize
+	C := int32(3) // channels
+
+	// Reshape: [B, C, pH, pS, pW, pS]
+	x := mlx.Reshape(pixelValues, B, C, patchH, patchSize, patchW, patchSize)
+	// Permute to: [B, pH, pW, pS, pS, C]
+	x = mlx.Transpose(x, 0, 2, 4, 3, 5, 1)
+	// Flatten to: [B, pH*pW, pS*pS*C]
+	return mlx.Reshape(x, B, patchH*patchW, patchSize*patchSize*C)
+}
+
+// compute2DRoPE precomputes cos/sin arrays for 2D rotary position embeddings.
+// positions is a flat slice of [x0, y0, x1, y1, ...] patch coordinates.
+// Returns cos, sin arrays of shape [1, 1, numPatches, headDim] for broadcasting.
+func compute2DRoPE(positions []int32, headDim int32, theta float32) (*mlx.Array, *mlx.Array) {
+	numPatches := int32(len(positions) / 2)
+	ndim := int32(2)
+	dimPerSpatial := headDim / ndim // 32 for head_dim=64
+	halfDim := dimPerSpatial / 2    // 16
+
+	// Compute inverse frequencies for each spatial dimension.
+	invFreq := make([]float64, halfDim)
+	for i := range halfDim {
+		invFreq[i] = 1.0 / math.Pow(float64(theta), 2.0*float64(i)/float64(dimPerSpatial))
+	}
+
+	cosVals := make([]float32, numPatches*headDim)
+	sinVals := make([]float32, numPatches*headDim)
+
+	for p := range numPatches {
+		px := float64(positions[p*2])
+		py := float64(positions[p*2+1])
+		offset := p * headDim
+
+		// X-dimension: dims [0, dimPerSpatial)
+		// emb_x = [freqs_x, freqs_x] (duplicated for rotate_half convention)
+		for i := range halfDim {
+			freq := px * invFreq[i]
+			c, s := float32(math.Cos(freq)), float32(math.Sin(freq))
+			cosVals[offset+i] = c
+			sinVals[offset+i] = s
+			cosVals[offset+halfDim+i] = c
+			sinVals[offset+halfDim+i] = s
+		}
+
+		// Y-dimension: dims [dimPerSpatial, headDim)
+		for i := range halfDim {
+			freq := py * invFreq[i]
+			c, s := float32(math.Cos(freq)), float32(math.Sin(freq))
+			cosVals[offset+dimPerSpatial+i] = c
+			sinVals[offset+dimPerSpatial+i] = s
+			cosVals[offset+dimPerSpatial+halfDim+i] = c
+			sinVals[offset+dimPerSpatial+halfDim+i] = s
+		}
+	}
+
+	// Shape: [1, 1, numPatches, headDim] for broadcasting with [B, numHeads, seq, headDim]
+	cos := mlx.FromValues(cosVals, 1, 1, int(numPatches), int(headDim))
+	sin := mlx.FromValues(sinVals, 1, 1, int(numPatches), int(headDim))
+	return cos, sin
+}
+
+// applyRoPE2D applies 2D rotary position embeddings using precomputed cos/sin.
+// x: [B, numHeads, seq, headDim], cos/sin: [1, 1, seq, headDim]
+// The rotation is applied per spatial dimension (headDim/2 each), matching
+// Python's apply_multidimensional_rope which splits into ndim=2 parts.
+func applyRoPE2D(x, cos, sin *mlx.Array) *mlx.Array {
+	dims := x.Dims()
+	B, H, S := int32(dims[0]), int32(dims[1]), int32(dims[2])
+	headDim := int32(dims[3])
+	dimPerSpatial := headDim / 2 // 32 for headDim=64
+	halfDim := dimPerSpatial / 2 // 16
+
+	// Process each spatial dimension independently.
+	var parts []*mlx.Array
+	for d := range int32(2) {
+		off := d * dimPerSpatial
+
+		// Extract this spatial dimension's slice: x[..., off:off+dimPerSpatial]
+		xPart := mlx.SliceStartStop(x,
+			[]int32{0, 0, 0, off},
+			[]int32{B, H, S, off + dimPerSpatial},
+		)
+		cosPart := mlx.SliceStartStop(cos,
+			[]int32{0, 0, 0, off},
+			[]int32{1, 1, S, off + dimPerSpatial},
+		)
+		sinPart := mlx.SliceStartStop(sin,
+			[]int32{0, 0, 0, off},
+			[]int32{1, 1, S, off + dimPerSpatial},
+		)
+
+		// rotate_half within this part: [-x2, x1]
+		x1 := mlx.SliceStartStop(xPart,
+			[]int32{0, 0, 0, 0},
+			[]int32{B, H, S, halfDim},
+		)
+		x2 := mlx.SliceStartStop(xPart,
+			[]int32{0, 0, 0, halfDim},
+			[]int32{B, H, S, dimPerSpatial},
+		)
+		rotated := mlx.Concatenate([]*mlx.Array{mlx.Neg(x2), x1}, 3)
+
+		// xPart * cos + rotated * sin
+		parts = append(parts, mlx.Add(mlx.Mul(xPart, cosPart), mlx.Mul(rotated, sinPart)))
+	}
+
+	return mlx.Concatenate(parts, 3)
+}
+
+// buildPatchPositions creates patch coordinates in row-major image order.
+func buildPatchPositions(patchH, patchW int32) []int32 {
+	positions := make([]int32, patchH*patchW*2)
+	idx := int32(0)
+	for y := range patchH {
+		for x := range patchW {
+			positions[idx*2] = x
+			positions[idx*2+1] = y
+			idx++
+		}
+	}
+
+	return positions
+}
+
+// compute2DPositionEmbeddings computes position embeddings from the embedding table.
+// positions: [numPatches*2] flat (x0,y0,...)
+// table: [2, posEmbSize, hiddenSize]
+// Returns: [1, numPatches, hiddenSize]
+func compute2DPositionEmbeddings(positions []int32, table *mlx.Array, posEmbSize, hiddenSize int32) *mlx.Array {
+	numPatches := int32(len(positions) / 2)
+
+	// Build index arrays for each spatial dimension.
+	xIndices := make([]int32, numPatches)
+	yIndices := make([]int32, numPatches)
+	for p := range numPatches {
+		xIndices[p] = positions[p*2]
+		yIndices[p] = positions[p*2+1]
+	}
+
+	// table: [2, posEmbSize, hiddenSize]
+	// Extract x-dim table (table[0]) and y-dim table (table[1]).
+	xTable := mlx.SliceStartStop(table,
+		[]int32{0, 0, 0},
+		[]int32{1, posEmbSize, hiddenSize},
+	)
+	xTable = mlx.Squeeze(xTable, 0) // [posEmbSize, hiddenSize]
+
+	yTable := mlx.SliceStartStop(table,
+		[]int32{1, 0, 0},
+		[]int32{2, posEmbSize, hiddenSize},
+	)
+	yTable = mlx.Squeeze(yTable, 0) // [posEmbSize, hiddenSize]
+
+	// Gather: look up positions from each table.
+	xIdx := mlx.NewArrayInt32(xIndices, []int32{numPatches})
+	yIdx := mlx.NewArrayInt32(yIndices, []int32{numPatches})
+
+	xEmb := mlx.Take(xTable, xIdx, 0) // [numPatches, hiddenSize]
+	yEmb := mlx.Take(yTable, yIdx, 0) // [numPatches, hiddenSize]
+
+	// Sum x and y embeddings.
+	posEmb := mlx.Add(xEmb, yEmb) // [numPatches, hiddenSize]
+
+	// Add batch dim: [1, numPatches, hiddenSize]
+	return mlx.ExpandDims(posEmb, 0)
+}
+
+// VisionTokenCount computes how many soft tokens a given image size will produce,
+// without running the vision encoder. This allows the pipeline to determine the
+// token count before deciding whether vision encoding is needed.
+func (m *Model) VisionTokenCount(height, width int) int {
+	vcfg := m.VisionConfig
+	if vcfg == nil {
+		return 0
+	}
+	patchH := int32(height) / vcfg.PatchSize
+	patchW := int32(width) / vcfg.PatchSize
+	k := vcfg.PoolingKernelSize
+	return int((patchH / k) * (patchW / k))
+}
+
+// ForwardVision encodes pixel values into soft tokens in text embedding space.
+// pixelValues: [B, 3, H, W] float32 tensor (channels-first, values in [0, 1]).
+// Returns: soft tokens [1, numRealTokens, textHiddenSize].
+func (m *Model) ForwardVision(pixelValues *mlx.Array) *mlx.Array {
+	ve := m.VisionEncoder
+	vcfg := ve.Cfg
+	if ve.UnifiedPatchEmbedder != nil {
+		return m.forwardUnifiedVision(pixelValues)
+	}
+
+	dims := pixelValues.Dims()
+	B := int32(dims[0])
+	H, W := int32(dims[2]), int32(dims[3])
+	patchH := H / vcfg.PatchSize
+	patchW := W / vcfg.PatchSize
+
+	positions := buildPatchPositions(patchH, patchW)
+
+	// Patchify and project.
+	patches := patchify(pixelValues, vcfg.PatchSize)
+	patches = mlx.AddScalar(mlx.MulScalar(patches, 2.0), -1.0)
+	h := ve.PatchEmbedder.InputProj.Forward(patches)
+
+	// Add 2D position embeddings.
+	posEmb := compute2DPositionEmbeddings(positions,
+		ve.PatchEmbedder.PositionEmbeddingTable, vcfg.PositionEmbeddingSize, vcfg.HiddenSize)
+	h = mlx.Add(h, posEmb)
+
+	cos, sin := compute2DRoPE(positions, vcfg.HeadDim, vcfg.RopeTheta)
+
+	// Run through vision transformer layers.
+	for _, layer := range ve.Layers {
+		h = visionLayerForward(layer, h, cos, sin, B, vcfg)
+	}
+
+	h = visionPool(h, patchH, patchW, vcfg.PoolingKernelSize)
+
+	// Scale by sqrt(hidden_size).
+	h = mlx.MulScalar(h, float32(math.Sqrt(float64(vcfg.HiddenSize))))
+
+	if vcfg.Standardize {
+		h = mlx.Mul(mlx.Sub(h, ve.StdBias), ve.StdScale)
+	}
+
+	// Project to text embedding space via multimodal embedder.
+	h = m.MultimodalEmbed.Forward(h)
+
+	return h
+}
+
+func (m *Model) forwardUnifiedVision(pixelValues *mlx.Array) *mlx.Array {
+	ve := m.VisionEncoder
+	cfg := ve.Cfg
+	embedder := ve.UnifiedPatchEmbedder
+
+	dims := pixelValues.Dims()
+	patchH := int32(dims[2]) / cfg.PatchSize
+	patchW := int32(dims[3]) / cfg.PatchSize
+	positions := buildPatchPositions(patchH, patchW)
+
+	h := embedder.PatchNorm1.Forward(patchify(pixelValues, cfg.PatchSize))
+	h = embedder.PatchDense.Forward(h)
+	h = embedder.PatchNorm2.Forward(h)
+	h = mlx.Add(h, compute2DPositionEmbeddings(
+		positions,
+		embedder.PositionEmbedding,
+		cfg.PositionEmbeddingSize,
+		cfg.HiddenSize,
+	))
+	h = embedder.PositionNorm.Forward(h)
+	return m.MultimodalEmbed.Forward(h)
+}
+
+func visionLayerForward(layer *VisionDecoderLayer, x, cos, sin *mlx.Array, B int32, cfg *VisionConfig) *mlx.Array {
+	S := int32(x.Dim(1))
+
+	// Pre-attention norm.
+	normed := mlx.RMSNormFn(x, layer.InputNormScaled, cfg.RMSNormEps)
+
+	// Self-attention.
+	attnOut := visionAttentionForward(layer.Attention, normed, cos, sin, B, S, cfg)
+	attnOut = mlx.RMSNormFn(attnOut, layer.PostAttnNormScaled, cfg.RMSNormEps)
+	h := mlx.Add(x, attnOut)
+
+	// MLP.
+	normed = mlx.RMSNormFn(h, layer.PreFFNormScaled, cfg.RMSNormEps)
+	mlpOut := visionMLPForward(layer.MLP, normed)
+	mlpOut = mlx.RMSNormFn(mlpOut, layer.PostFFNormScaled, cfg.RMSNormEps)
+	h = mlx.Add(h, mlpOut)
+
+	// Layer scalar.
+	if layer.LayerScalar != nil {
+		h = mlx.Mul(h, layer.LayerScalar)
+	}
+
+	return h
+}
+
+func visionAttentionForward(a *VisionAttention, x, cos, sin *mlx.Array, B, S int32, cfg *VisionConfig) *mlx.Array {
+	headDim := cfg.HeadDim
+	numHeads := cfg.NumAttentionHeads
+	numKVHeads := cfg.NumKeyValueHeads
+
+	q := a.QProj.Forward(x)
+	q = mlx.Reshape(q, B, S, numHeads, headDim)
+
+	k := a.KProj.Forward(x)
+	k = mlx.Reshape(k, B, S, numKVHeads, headDim)
+
+	v := a.VProj.Forward(x)
+	v = mlx.Reshape(v, B, S, numKVHeads, headDim)
+
+	// Apply Q/K norms.
+	q = mlx.RMSNormFn(q, a.QNormScaled, cfg.RMSNormEps)
+	k = mlx.RMSNormFn(k, a.KNormScaled, cfg.RMSNormEps)
+
+	// Apply V norm (no learnable weight).
+	v = mlx.RMSNormFn(v, nil, cfg.RMSNormEps)
+
+	// Apply 2D RoPE (after norms, before transpose).
+	q = mlx.Transpose(q, 0, 2, 1, 3)
+	k = mlx.Transpose(k, 0, 2, 1, 3)
+
+	q = applyRoPE2D(q, cos, sin)
+	k = applyRoPE2D(k, cos, sin)
+
+	v = mlx.Transpose(v, 0, 2, 1, 3)
+
+	// Bidirectional attention over the image's real patches.
+	out := mlx.FastScaledDotProductAttention(q, k, v, cfg.Scale, "", nil)
+
+	// Reshape and project output.
+	out = mlx.Transpose(out, 0, 2, 1, 3)
+	out = mlx.Reshape(out, B, S, numHeads*headDim)
+	return a.OProj.Forward(out)
+}
+
+func visionMLPForward(mlp *VisionMLP, x *mlx.Array) *mlx.Array {
+	gate := mlx.GELUApprox(mlp.GateProj.Forward(x))
+	up := mlp.UpProj.Forward(x)
+	return mlp.DownProj.Forward(mlx.Mul(gate, up))
+}
+
+// visionPool performs non-overlapping 2D spatial average pooling.
+func visionPool(h *mlx.Array, patchH, patchW, kernel int32) *mlx.Array {
+	B := int32(h.Dim(0))
+	hidden := int32(h.Dim(2))
+	pooledH := patchH / kernel
+	pooledW := patchW / kernel
+
+	h = mlx.Reshape(h, B, pooledH, kernel, pooledW, kernel, hidden)
+	h = mlx.Mean(h, 4, false)
+	h = mlx.Mean(h, 2, false)
+	return mlx.Reshape(h, B, pooledH*pooledW, hidden)
+}

--- a/x/models/gemma4/gemma4_vision_test.go
+++ b/x/models/gemma4/gemma4_vision_test.go
@@ -1,0 +1,164 @@
+package gemma4
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseVisionConfig(t *testing.T) {
+	t.Run("small vision tower", func(t *testing.T) {
+		cfg, err := parseVisionConfig([]byte(`{
+			"vision_config": {
+				"model_type": "gemma4_vision",
+				"hidden_size": 768,
+				"num_hidden_layers": 16,
+				"num_attention_heads": 12,
+				"patch_size": 16,
+				"pooling_kernel_size": 3,
+				"default_output_length": 280
+			}
+		}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg == nil {
+			t.Fatal("expected supported vision config")
+		}
+		if cfg.ImageSeqLength != 280 {
+			t.Fatalf("image sequence length = %d, want 280", cfg.ImageSeqLength)
+		}
+	})
+
+	t.Run("unified vision tower", func(t *testing.T) {
+		cfg, err := parseVisionConfig([]byte(`{
+			"vision_config": {
+				"model_type": "gemma4_unified_vision",
+				"mm_embed_dim": 3840,
+				"mm_posemb_size": 1120,
+				"model_patch_size": 48,
+				"patch_size": 16,
+				"pooling_kernel_size": 3,
+				"num_soft_tokens": 280
+			}
+		}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg == nil {
+			t.Fatal("expected supported unified vision config")
+		}
+		if cfg.HiddenSize != 3840 || cfg.PositionEmbeddingSize != 1120 {
+			t.Fatalf("embedding dimensions = (%d, %d), want (3840, 1120)", cfg.HiddenSize, cfg.PositionEmbeddingSize)
+		}
+		if cfg.PatchSize != 48 || cfg.PoolingKernelSize != 1 {
+			t.Fatalf("patch configuration = (%d, %d), want (48, 1)", cfg.PatchSize, cfg.PoolingKernelSize)
+		}
+		if cfg.ImageSeqLength != 280 {
+			t.Fatalf("image sequence length = %d, want 280", cfg.ImageSeqLength)
+		}
+	})
+
+	t.Run("no vision config is text only", func(t *testing.T) {
+		cfg, err := parseVisionConfig([]byte(`{"hidden_size": 768}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg != nil {
+			t.Fatalf("vision config = %+v, want nil for a text-only model", cfg)
+		}
+	})
+
+	t.Run("unsupported vision tower is an error", func(t *testing.T) {
+		// The manifest advertises vision for any config carrying a
+		// vision_config, so a silent text-only fallback here would leave
+		// /api/show claiming a tower the runner cannot execute.
+		cfg, err := parseVisionConfig([]byte(`{"vision_config": {"model_type": "gemma4_future_vision"}}`))
+		if err == nil {
+			t.Fatalf("vision config = %+v, want an error naming the tower", cfg)
+		}
+		if !strings.Contains(err.Error(), "gemma4_future_vision") {
+			t.Fatalf("error = %v, want it to name the unsupported tower", err)
+		}
+	})
+
+	t.Run("large vision tower", func(t *testing.T) {
+		cfg, err := parseVisionConfig([]byte(`{
+			"vision_config": {
+				"model_type": "gemma4_vision",
+				"hidden_size": 1152,
+				"num_hidden_layers": 27,
+				"num_attention_heads": 16,
+				"head_dim": 72,
+				"standardize": true
+			}
+		}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cfg == nil {
+			t.Fatal("expected supported vision config")
+		}
+		if !cfg.Standardize {
+			t.Fatal("expected vision output standardization")
+		}
+	})
+}
+
+func TestVisionTokenCount(t *testing.T) {
+	m := &Model{VisionConfig: &VisionConfig{
+		PatchSize:         16,
+		PoolingKernelSize: 3,
+		ImageSeqLength:    280,
+	}}
+
+	if got := m.VisionTokenCount(48, 48); got != 1 {
+		t.Fatalf("48x48 token count = %d, want 1", got)
+	}
+	if got := m.VisionTokenCount(48, 96); got != 2 {
+		t.Fatalf("96x48 token count = %d, want 2", got)
+	}
+
+	m.VisionConfig = &VisionConfig{
+		ModelType:         "gemma4_unified_vision",
+		PatchSize:         48,
+		PoolingKernelSize: 1,
+		ImageSeqLength:    280,
+	}
+	if got := m.VisionTokenCount(48, 96); got != 2 {
+		t.Fatalf("unified 96x48 token count = %d, want 2", got)
+	}
+}
+
+func TestGemma4ImageSize(t *testing.T) {
+	const alignment = 48
+
+	for _, tt := range []struct {
+		name                  string
+		height, width         int
+		minTokens, maxTokens  int
+		wantHeight, wantWidth int
+	}{
+		{name: "small square", height: 100, width: 100, minTokens: 280, maxTokens: 1120, wantHeight: 768, wantWidth: 768},
+		{name: "small landscape", height: 300, width: 600, minTokens: 280, maxTokens: 1120, wantHeight: 528, wantWidth: 1104},
+		{name: "preserve high resolution", height: 1080, width: 1920, minTokens: 280, maxTokens: 1120, wantHeight: 1104, wantWidth: 1920},
+		{name: "downscale high resolution", height: 1080, width: 1920, minTokens: 280, maxTokens: 280, wantHeight: 576, wantWidth: 1056},
+		{name: "very wide", height: 1, width: 10000, minTokens: 280, maxTokens: 1120, wantHeight: 48, wantWidth: 13440},
+		{name: "very tall", height: 10000, width: 1, minTokens: 280, maxTokens: 1120, wantHeight: 13440, wantWidth: 48},
+		{name: "extreme wide", height: 1, width: 1000000000, minTokens: 280, maxTokens: 1120, wantHeight: 48, wantWidth: 53760},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			minPixels := tt.minTokens * alignment * alignment
+			maxPixels := tt.maxTokens * alignment * alignment
+			gotH, gotW := gemma4ImageSize(tt.height, tt.width, alignment, minPixels, maxPixels)
+			if gotH != tt.wantHeight || gotW != tt.wantWidth {
+				t.Fatalf("size = %dx%d, want %dx%d", gotH, gotW, tt.wantHeight, tt.wantWidth)
+			}
+			if gotH%alignment != 0 || gotW%alignment != 0 {
+				t.Fatalf("size %dx%d is not aligned to %d", gotH, gotW, alignment)
+			}
+			if gotH*gotW > maxPixels {
+				t.Fatalf("size %dx%d exceeds pixel budget %d", gotH, gotW, maxPixels)
+			}
+		})
+	}
+}

--- a/x/models/gemma4/gemma4_vision_weights_test.go
+++ b/x/models/gemma4/gemma4_vision_weights_test.go
@@ -1,0 +1,138 @@
+package gemma4
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model"
+)
+
+func testVisionTensor(shape ...int) *mlx.Array {
+	n := 1
+	for _, d := range shape {
+		n *= d
+	}
+	values := make([]float32, n)
+	for i := range values {
+		values[i] = float32(i%7+1) / 16
+	}
+	return mlx.FromValues(values, shape...)
+}
+
+func testVisionProjection(tensors map[string]*mlx.Array, textHidden, visionHidden int) {
+	tensors["model.embed_vision.embedding_projection.weight"] = testVisionTensor(textHidden, visionHidden)
+}
+
+func TestGemma4VisionWeightSchemes(t *testing.T) {
+	skipIfNoMLX(t)
+
+	t.Run("12b vision_embedder", func(t *testing.T) {
+		cfg := &VisionConfig{
+			ModelType:             "gemma4_unified_vision",
+			HiddenSize:            4,
+			PositionEmbeddingSize: 4,
+			PatchSize:             2,
+			PoolingKernelSize:     1,
+			ImageSeqLength:        1,
+			RMSNormEps:            1e-6,
+		}
+		m := &Model{
+			TextConfig:   &TextConfig{HiddenSize: 6},
+			VisionConfig: cfg,
+			VisionEncoder: &VisionEncoder{
+				Cfg: cfg,
+			},
+		}
+		const prefix = "model.vision_embedder."
+		tensors := map[string]*mlx.Array{
+			prefix + "patch_ln1.weight":   testVisionTensor(12),
+			prefix + "patch_ln1.bias":     testVisionTensor(12),
+			prefix + "patch_dense.weight": testVisionTensor(4, 12),
+			prefix + "patch_ln2.weight":   testVisionTensor(4),
+			prefix + "patch_ln2.bias":     testVisionTensor(4),
+			prefix + "pos_embedding":      testVisionTensor(4, 2, 4),
+			prefix + "pos_norm.weight":    testVisionTensor(4),
+			prefix + "pos_norm.bias":      testVisionTensor(4),
+		}
+		testVisionProjection(tensors, 6, 4)
+		linears := model.NewLinearFactory(tensors, 0, 0, "", nil)
+		if err := m.loadVisionWeights(tensors, linears); err != nil {
+			t.Fatal(err)
+		}
+		if m.VisionEncoder.UnifiedPatchEmbedder == nil || m.VisionEncoder.PatchEmbedder != nil {
+			t.Fatal("unified vision embedder was not selected")
+		}
+		assertVisionForwardShape(t, m, 6)
+	})
+
+	t.Run("26b 31b vision_tower", func(t *testing.T) {
+		cfg := &VisionConfig{
+			ModelType:             "gemma4_vision",
+			HiddenSize:            4,
+			IntermediateSize:      8,
+			NumHiddenLayers:       1,
+			NumAttentionHeads:     1,
+			NumKeyValueHeads:      1,
+			HeadDim:               4,
+			PatchSize:             2,
+			PositionEmbeddingSize: 4,
+			PoolingKernelSize:     1,
+			ImageSeqLength:        1,
+			RMSNormEps:            1e-6,
+			RopeTheta:             100,
+			Scale:                 1,
+		}
+		m := &Model{
+			TextConfig:   &TextConfig{HiddenSize: 6},
+			VisionConfig: cfg,
+			VisionEncoder: &VisionEncoder{
+				Cfg: cfg,
+			},
+		}
+		const tower = "model.vision_tower."
+		tensors := map[string]*mlx.Array{
+			tower + "patch_embedder.input_proj.weight":        testVisionTensor(4, 12),
+			tower + "patch_embedder.position_embedding_table": testVisionTensor(2, 4, 4),
+		}
+		layer := tower + "encoder.layers.0"
+		for _, name := range []string{
+			"input_layernorm.weight",
+			"post_attention_layernorm.weight",
+			"pre_feedforward_layernorm.weight",
+			"post_feedforward_layernorm.weight",
+			"self_attn.q_norm.weight",
+			"self_attn.k_norm.weight",
+		} {
+			tensors[layer+"."+name] = testVisionTensor(4)
+		}
+		for _, name := range []string{"q_proj", "k_proj", "v_proj", "o_proj"} {
+			tensors[fmt.Sprintf("%s.self_attn.%s.linear.weight", layer, name)] = testVisionTensor(4, 4)
+		}
+		for _, name := range []string{"gate_proj", "up_proj"} {
+			tensors[fmt.Sprintf("%s.mlp.%s.linear.weight", layer, name)] = testVisionTensor(8, 4)
+		}
+		tensors[layer+".mlp.down_proj.linear.weight"] = testVisionTensor(4, 8)
+		testVisionProjection(tensors, 6, 4)
+
+		linears := model.NewLinearFactory(tensors, 0, 0, "", nil)
+		if err := m.loadVisionWeights(tensors, linears); err != nil {
+			t.Fatal(err)
+		}
+		precomputeVisionScaledWeights(m.VisionEncoder)
+		if m.VisionEncoder.PatchEmbedder == nil || len(m.VisionEncoder.Layers) != 1 {
+			t.Fatal("transformer vision tower was not selected")
+		}
+		assertVisionForwardShape(t, m, 6)
+	})
+}
+
+func assertVisionForwardShape(t *testing.T, m *Model, hidden int) {
+	t.Helper()
+	pixels := testVisionTensor(1, 3, 2, 2)
+	out := m.ForwardVision(pixels)
+	mlx.Eval(out)
+	if got := out.Dims(); len(got) != 3 || got[0] != 1 || got[1] != 1 || got[2] != hidden {
+		t.Fatalf("vision output shape = %v, want [1 1 %d]", got, hidden)
+	}
+}

--- a/x/models/gemma4/media.go
+++ b/x/models/gemma4/media.go
@@ -1,0 +1,240 @@
+package gemma4
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"image"
+	"math"
+
+	"golang.org/x/image/draw"
+
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+	"github.com/ollama/ollama/x/models/nn"
+)
+
+const (
+	gemma4MinImageTokens     = 40
+	gemma4DefaultImageTokens = 280
+)
+
+type preparedImage struct {
+	height    int
+	width     int
+	numTokens int
+}
+
+func parseImageTokenLimit(data []byte, fallback int) int {
+	if fallback <= 0 {
+		fallback = gemma4DefaultImageTokens
+	}
+	var cfg struct {
+		ImageProcessor struct {
+			MaxSoftTokens int `json:"max_soft_tokens"`
+			ImageSeqLen   int `json:"image_seq_length"`
+		} `json:"image_processor"`
+		ImageSeqLen int `json:"image_seq_length"`
+	}
+	if json.Unmarshal(data, &cfg) != nil {
+		return fallback
+	}
+	for _, n := range []int{cfg.ImageProcessor.MaxSoftTokens, cfg.ImageProcessor.ImageSeqLen, cfg.ImageSeqLen} {
+		if n > 0 {
+			return n
+		}
+	}
+	return fallback
+}
+
+// PrepareMedia implements base.MediaModel: decode and resize each image on the
+// CPU, then splice image_start + soft-token placeholders + image_end.
+func (m *Model) PrepareMedia(segments []base.Segment) (*base.PreparedRequest, error) {
+	prepared := &base.PreparedRequest{}
+	for s, seg := range segments {
+		if seg.Data == nil {
+			prepared.Tokens = append(prepared.Tokens, seg.Tokens...)
+			continue
+		}
+		if m.VisionEncoder == nil || m.MultimodalEmbed == nil {
+			return nil, fmt.Errorf("this model does not support %s input", seg.Kind)
+		}
+		if seg.Kind != "image" {
+			return nil, fmt.Errorf("gemma4 does not support %s input", seg.Kind)
+		}
+
+		pixels, geom, err := m.preprocessImage(seg.Data, m.imageTokenLimit)
+		if err != nil {
+			return nil, fmt.Errorf("preprocess image: %w", err)
+		}
+
+		start := len(prepared.Tokens)
+		prepared.Tokens = append(prepared.Tokens, m.imageStartTokenID)
+		for range geom.numTokens {
+			prepared.Tokens = append(prepared.Tokens, m.imageTokenID)
+		}
+		prepared.Tokens = append(prepared.Tokens, m.imageEndTokenID)
+
+		prepared.Items = append(prepared.Items, base.PreparedItem{
+			Range:     [2]int{start, len(prepared.Tokens)},
+			Source:    s,
+			MediaData: pixels,
+			Dims:      []int{1, 3, geom.height, geom.width},
+			Opaque:    geom,
+		})
+	}
+	return prepared, nil
+}
+
+// EncodeMedia runs the selected Gemma 4 vision path and returns lazy
+// [numTokens, hidden] features. Evaluation is pulled by the text forward.
+func (m *Model) EncodeMedia(_ *base.PreparedItem, data *mlx.Array) *mlx.Array {
+	return mlx.Squeeze(m.ForwardVision(data), 0)
+}
+
+func gemma4SoftRun(item batch.MediaItem) (start, end int) {
+	geom := item.Opaque.(preparedImage)
+	return item.Pos + 1, item.Pos + 1 + geom.numTokens
+}
+
+func (m *Model) scatterMedia(h *mlx.Array, b *batch.Batch) *mlx.Array {
+	for _, item := range b.Media {
+		if item.Features == nil {
+			continue
+		}
+		start, end := gemma4SoftRun(item)
+		off := int(b.SeqOffsets[item.Seq])
+		qLo := max(start, off)
+		qHi := min(end, off+int(b.SeqQueryLens[item.Seq]))
+		if qHi <= qLo {
+			continue
+		}
+
+		features := item.Features.Slice(mlx.Slice(qLo-start, qHi-start), mlx.Slice())
+		features = mlx.Reshape(features.AsType(h.DType()), 1, int32(qHi-qLo), m.HiddenSize)
+		h = h.SliceUpdate(features,
+			mlx.Slice(item.Seq, item.Seq+1),
+			mlx.Slice(qLo-off, qHi-off),
+			mlx.Slice(),
+		)
+	}
+	return h
+}
+
+// PLE has a separate token table. Vision rows use zero there while their
+// hidden-state contribution comes from the projected image features.
+func maskMediaTokens(tokens *mlx.Array, b *batch.Batch) *mlx.Array {
+	masked := tokens
+	for _, item := range b.Media {
+		start, end := gemma4SoftRun(item)
+		off := int(b.SeqOffsets[item.Seq])
+		qLo := max(start, off)
+		qHi := min(end, off+int(b.SeqQueryLens[item.Seq]))
+		if qHi <= qLo {
+			continue
+		}
+		zeros := mlx.Zeros(mlx.DTypeInt32, 1, qHi-qLo)
+		masked = masked.SliceUpdate(zeros,
+			mlx.Slice(item.Seq, item.Seq+1),
+			mlx.Slice(qLo-off, qHi-off),
+		)
+	}
+	return masked
+}
+
+func mediaAttentionMask(b *batch.Batch) nn.AttentionMask {
+	mask := nn.CausalMask()
+	for _, item := range b.Media {
+		start, end := gemma4SoftRun(item)
+		mask = mask.Relax(item.Seq, start, end, start, end)
+	}
+	return mask
+}
+
+func (m *Model) preprocessImage(data []byte, maxTokens int) ([]float32, preparedImage, error) {
+	if m.VisionConfig == nil {
+		return nil, preparedImage{}, fmt.Errorf("model has no vision config")
+	}
+	src, _, err := image.Decode(bytes.NewReader(data))
+	if err != nil {
+		return nil, preparedImage{}, fmt.Errorf("decode: %w", err)
+	}
+
+	bounds := src.Bounds()
+	if bounds.Dx() <= 0 || bounds.Dy() <= 0 {
+		return nil, preparedImage{}, fmt.Errorf("invalid image dimensions %dx%d", bounds.Dx(), bounds.Dy())
+	}
+
+	cfg := m.VisionConfig
+	if maxTokens <= 0 {
+		maxTokens = max(gemma4DefaultImageTokens, int(cfg.ImageSeqLength))
+	}
+	patchSize := int(cfg.PatchSize)
+	alignment := int(cfg.PoolingKernelSize) * patchSize
+	pixelsPerToken := alignment * alignment
+	minTokens := min(maxTokens, max(gemma4MinImageTokens, int(cfg.ImageSeqLength)))
+	targetH, targetW := gemma4ImageSize(
+		bounds.Dy(),
+		bounds.Dx(),
+		alignment,
+		minTokens*pixelsPerToken,
+		maxTokens*pixelsPerToken,
+	)
+
+	resized := image.NewRGBA(image.Rect(0, 0, targetW, targetH))
+	draw.CatmullRom.Scale(resized, resized.Bounds(), src, bounds, draw.Src, nil)
+
+	pixels := make([]float32, 3*targetH*targetW)
+	plane := targetH * targetW
+	for y := range targetH {
+		for x := range targetW {
+			srcAt := y*resized.Stride + x*4
+			dstAt := y*targetW + x
+			pixels[dstAt] = float32(resized.Pix[srcAt]) / 255
+			pixels[plane+dstAt] = float32(resized.Pix[srcAt+1]) / 255
+			pixels[2*plane+dstAt] = float32(resized.Pix[srcAt+2]) / 255
+		}
+	}
+
+	return pixels, preparedImage{
+		height:    targetH,
+		width:     targetW,
+		numTokens: m.VisionTokenCount(targetH, targetW),
+	}, nil
+}
+
+func gemma4ImageSize(height, width, alignment, minPixels, maxPixels int) (int, int) {
+	roundTo := func(value float64) int {
+		return int(math.Round(value/float64(alignment))) * alignment
+	}
+
+	targetH := max(alignment, roundTo(float64(height)))
+	targetW := max(alignment, roundTo(float64(width)))
+	switch {
+	case float64(targetH)*float64(targetW) > float64(maxPixels):
+		targetH, targetW = gemma4FitImageSize(height, width, alignment, maxPixels)
+	case float64(targetH)*float64(targetW) < float64(minPixels):
+		targetH, targetW = gemma4FitImageSize(height, width, alignment, minPixels)
+	}
+	return targetH, targetW
+}
+
+func gemma4FitImageSize(height, width, alignment, pixelBudget int) (int, int) {
+	scale := math.Sqrt(float64(pixelBudget) / (float64(height) * float64(width)))
+	targetH := int(math.Floor(scale*float64(height)/float64(alignment))) * alignment
+	targetW := int(math.Floor(scale*float64(width)/float64(alignment))) * alignment
+
+	maxSide := pixelBudget / (alignment * alignment) * alignment
+	switch {
+	case targetH == 0 && targetW == 0:
+		return alignment, alignment
+	case targetH == 0:
+		targetH = alignment
+		targetW = min(int(math.Floor(float64(width)/float64(height)))*alignment, maxSide)
+	case targetW == 0:
+		targetW = alignment
+		targetH = min(int(math.Floor(float64(height)/float64(width)))*alignment, maxSide)
+	}
+	return targetH, targetW
+}

--- a/x/models/gemma4/media_test.go
+++ b/x/models/gemma4/media_test.go
@@ -1,0 +1,138 @@
+package gemma4
+
+import (
+	"bytes"
+	"image"
+	"image/color"
+	"image/png"
+	"slices"
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+)
+
+func testPNG(t *testing.T) []byte {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, 2, 1))
+	img.Set(0, 0, color.RGBA{R: 255, A: 255})
+	img.Set(1, 0, color.RGBA{G: 255, A: 255})
+	var b bytes.Buffer
+	if err := png.Encode(&b, img); err != nil {
+		t.Fatal(err)
+	}
+	return b.Bytes()
+}
+
+func TestParseImageTokenLimit(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		data     string
+		fallback int
+		want     int
+	}{
+		{name: "nested max", data: `{"image_processor":{"max_soft_tokens":560}}`, fallback: 280, want: 560},
+		{name: "nested sequence", data: `{"image_processor":{"image_seq_length":140}}`, fallback: 280, want: 140},
+		{name: "top level", data: `{"image_seq_length":70}`, fallback: 280, want: 70},
+		{name: "invalid", data: `{`, fallback: 280, want: 280},
+		{name: "default fallback", data: `{}`, fallback: 0, want: gemma4DefaultImageTokens},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseImageTokenLimit([]byte(tt.data), tt.fallback); got != tt.want {
+				t.Fatalf("limit = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrepareMediaGemma4VisionSchemes(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		cfg  VisionConfig
+	}{
+		{
+			name: "12b vision_embedder",
+			cfg: VisionConfig{
+				ModelType:         "gemma4_unified_vision",
+				PatchSize:         48,
+				PoolingKernelSize: 1,
+				ImageSeqLength:    1,
+			},
+		},
+		{
+			name: "26b 31b vision_tower",
+			cfg: VisionConfig{
+				ModelType:         "gemma4_vision",
+				PatchSize:         16,
+				PoolingKernelSize: 3,
+				ImageSeqLength:    1,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &Model{
+				VisionConfig:      &tt.cfg,
+				VisionEncoder:     &VisionEncoder{Cfg: &tt.cfg},
+				MultimodalEmbed:   &MultimodalEmbedder{},
+				imageStartTokenID: 10,
+				imageTokenID:      11,
+				imageEndTokenID:   12,
+				imageTokenLimit:   1,
+			}
+			prepared, err := m.PrepareMedia([]base.Segment{
+				{Tokens: []int32{1, 2}},
+				{Kind: "image", Data: testPNG(t)},
+				{Tokens: []int32{3}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if want := []int32{1, 2, 10, 11, 12, 3}; !slices.Equal(prepared.Tokens, want) {
+				t.Fatalf("tokens = %v, want %v", prepared.Tokens, want)
+			}
+			if len(prepared.Items) != 1 {
+				t.Fatalf("items = %d, want 1", len(prepared.Items))
+			}
+			item := prepared.Items[0]
+			if item.Range != [2]int{2, 5} || item.Source != 1 {
+				t.Fatalf("item range/source = %v/%d", item.Range, item.Source)
+			}
+			if want := []int{1, 3, 48, 48}; !slices.Equal(item.Dims, want) {
+				t.Fatalf("dims = %v, want %v", item.Dims, want)
+			}
+			if geom := item.Opaque.(preparedImage); geom.numTokens != 1 {
+				t.Fatalf("tokens = %d, want 1", geom.numTokens)
+			}
+			if item.Causal {
+				t.Fatal("Gemma4 image expansion must stay atomic")
+			}
+		})
+	}
+}
+
+func TestPrepareMediaRejectsUnsupportedInput(t *testing.T) {
+	cfg := &VisionConfig{PatchSize: 48, PoolingKernelSize: 1, ImageSeqLength: 1}
+	m := &Model{
+		VisionConfig:    cfg,
+		VisionEncoder:   &VisionEncoder{Cfg: cfg},
+		MultimodalEmbed: &MultimodalEmbedder{},
+	}
+	if _, err := m.PrepareMedia([]base.Segment{{Kind: "audio", Data: []byte{1}}}); err == nil {
+		t.Fatal("audio input did not fail")
+	}
+	text := &Model{}
+	if _, err := text.PrepareMedia([]base.Segment{{Kind: "image", Data: testPNG(t)}}); err == nil {
+		t.Fatal("text-only model accepted an image")
+	}
+}
+
+func TestMediaAttentionMaskUsesSoftTokenRange(t *testing.T) {
+	b := &batch.Batch{Media: []batch.MediaItem{{
+		Seq:    0,
+		Pos:    3,
+		Opaque: preparedImage{numTokens: 2},
+	}}}
+	if mediaAttentionMask(b).IsCausal() {
+		t.Fatal("image soft-token span did not relax the causal mask")
+	}
+}


### PR DESCRIPTION
## Summary

- add Gemma4 image preprocessing and vision embeddings through the generic `base.MediaModel` interface
- support both unified `vision_embedder.*` checkpoints and transformer-based `vision_tower.*` checkpoints
- integrate image embeddings with Gemma4 PLE and bidirectional image attention behavior
- expose the vision capability for Gemma4 safetensors models while keeping audio unsupported
- rely on the existing media-aware prefix cache without Gemma4-specific runner or cache code

This ports the model-side Gemma4 vision work from #17487 onto the generic media framework introduced in #17600. The temporary runner and cache implementation from #17487 is intentionally not included.

## Testing

- `go vet ./x/models/gemma4 ./x/mlxrunner/... ./server`
- `go test -count=1 ./x/models/gemma4 ./x/mlxrunner/... ./server`
- live inference with a Gemma4 12B unified `vision_embedder.*` checkpoint
- live inference with a Gemma4 26B/A4B transformer `vision_tower.*` checkpoint
- verified a full prefix-cache hit for the same image and prompt
- verified that a different image with identical text diverges before the image expansion
