### PR TITLE
model/parsers: wrap tool-call parse errors with client-facing context

### DIFF
--- a/model/parsers/glm46.go
+++ b/model/parsers/glm46.go
@@ -114,7 +114,7 @@ func (p *GLM46Parser) Add(s string, done bool) (content string, thinking string,
 			toolCall, err := parseGLM46ToolCall(event, p.tools)
 			if err != nil {
 				slog.Warn("glm-4.6 tool call parsing failed", "error", err)
-				return "", "", nil, err
+				return "", "", nil, fmt.Errorf("failed to parse model-generated tool call: %w", err)
 			}
 			toolCall.Function.Index = p.callIndex
 			p.callIndex++

--- a/model/parsers/qwen3.go
+++ b/model/parsers/qwen3.go
@@ -115,7 +115,7 @@ func (p *Qwen3Parser) Add(s string, done bool) (content string, thinking string,
 			toolCall, err := parseQwen3ToolCall(event, p.tools)
 			if err != nil {
 				slog.Warn("qwen3 tool call parsing failed", "error", err)
-				return "", "", nil, err
+				return "", "", nil, fmt.Errorf("failed to parse model-generated tool call: %w", err)
 			}
 			toolCall.Function.Index = p.callIndex
 			p.callIndex++

--- a/model/parsers/qwen35.go
+++ b/model/parsers/qwen35.go
@@ -2,6 +2,7 @@ package parsers
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"unicode"
@@ -103,7 +104,7 @@ func (p *Qwen35Parser) Add(s string, done bool) (content string, thinking string
 			parsedContent, _, parsedCalls, err := p.toolParser.Add(event.content, done)
 			if err != nil {
 				slog.Warn("qwen3.5 tool call parsing failed", "error", err)
-				return "", "", nil, err
+				return "", "", nil, fmt.Errorf("failed to parse model-generated tool call: %w", err)
 			}
 			contentSb.WriteString(parsedContent)
 			calls = append(calls, parsedCalls...)

--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -69,7 +69,7 @@ func (p *Qwen3CoderParser) Add(s string, done bool) (content string, thinking st
 			toolCall, err := parseToolCall(event, p.tools)
 			if err != nil {
 				slog.Warn("qwen tool call parsing failed", "error", err)
-				return "", "", nil, err
+				return "", "", nil, fmt.Errorf("failed to parse model-generated tool call: %w", err)
 			}
 			toolCall.Function.Index = p.callIndex
 			p.callIndex++

--- a/model/parsers/qwen3vl.go
+++ b/model/parsers/qwen3vl.go
@@ -3,6 +3,7 @@ package parsers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"strings"
 	"unicode"
@@ -88,7 +89,7 @@ func (p *Qwen3VLParser) Add(s string, done bool) (content string, thinking strin
 			toolCall, err := parseJSONToolCall(event, p.tools)
 			if err != nil {
 				slog.Warn("qwen tool call parsing failed", "error", err)
-				return "", "", nil, err
+				return "", "", nil, fmt.Errorf("failed to parse model-generated tool call: %w", err)
 			}
 			calls = append(calls, toolCall)
 		case qwenEventThinkingContent:

--- a/model/parsers/qwen3vl_nonthinking_test.go
+++ b/model/parsers/qwen3vl_nonthinking_test.go
@@ -2,6 +2,7 @@ package parsers
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -883,5 +884,31 @@ func TestQwen3VLNonThinkingToolCallWhitespaceHandling(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+
+// Regression for https://github.com/ollama/ollama/issues/17647: when a
+// tool-call payload fails to parse, the error returned from Add() (which the
+// server surfaces verbatim to HTTP clients via routes.go) must identify the
+// failure as a tool-call parsing error rather than leak the raw underlying
+// JSON error with no context. The same wrap is applied identically in
+// qwen3.go, qwen35.go, qwen3coder.go, and glm46.go.
+func TestQwen3VLParserWrapsToolCallParseErrors(t *testing.T) {
+	parser := &Qwen3VLParser{hasThinkingSupport: false}
+	parser.Init([]api.Tool{
+		{Type: "function", Function: api.ToolFunction{Name: "foo"}},
+	}, nil, nil)
+
+	// Malformed JSON inside a well-formed <tool_call> block: the outer parser
+	// extracts the raw payload, parseJSONToolCall's json.Unmarshal fails, and
+	// the error bubbles up through Add().
+	_, _, _, err := parser.Add(`<tool_call>{"name":"foo","arguments":{broken</tool_call>`, true)
+	if err == nil {
+		t.Fatal("expected an error for malformed tool-call JSON, got nil")
+	}
+	want := "failed to parse model-generated tool call"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected error to contain %q, got %q", want, err.Error())
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #17647 — tool-call parser errors currently reach the HTTP client as bare JSON/XML `Unmarshal` messages with no indication of the failure stage.

The reporter identified the exact pattern in `model/parsers/qwen3vl.go`; the same shape exists in four other parsers. This PR wraps the error at every site where the parser bubbles it up to the caller (which `server/routes.go:686-688` surfaces verbatim to clients via `err.Error()`), so the client-facing message becomes:

```
failed to parse model-generated tool call: invalid character ']' after object key:value pair
```

instead of the current:

```
invalid character ']' after object key:value pair
```

## Change

In each of the 5 files below, the same one-liner replaces `return "", "", nil, err` with `return "", "", nil, fmt.Errorf("failed to parse model-generated tool call: %w", err)`:

- `model/parsers/qwen3vl.go:91` — reporter's exact case (uses `parseJSONToolCall`, which returns raw `json.Unmarshal` errors unwrapped)
- `model/parsers/qwen3.go:118` — via `parseQwen3ToolCall`
- `model/parsers/qwen35.go:106` — via delegated inner tool parser
- `model/parsers/qwen3coder.go:72` — via `parseToolCall`
- `model/parsers/glm46.go:117` — via `parseGLM46ToolCall`

`fmt` was already imported in three of the five files; added to `qwen3vl.go` and `qwen35.go`.

The `slog.Warn(...)` at each site is unchanged, so server logs still carry the per-parser identifier (`"qwen tool call parsing failed"`, `"qwen3.5 tool call parsing failed"`, etc.) for debugging. `%w` preserves the wrap chain for any callers using `errors.Is` / `errors.As`.

### Sites deliberately not touched

Five other parsers have `slog.Warn(...parsing failed...)` calls that only log and continue (`continue` or a plain `return events, false` without an error) — the malformed call is dropped silently and processing proceeds. Those aren't part of this fix because they don't reach the client at all:

- `model/parsers/gemma4.go:321,334`
- `model/parsers/deepseek3.go:251`
- `model/parsers/cogito.go:260`
- `model/parsers/lfm2.go:352`
- `model/parsers/cohere.go:276`

(Whether those should also error-instead-of-drop is arguably worth its own discussion — the reporter's linked issues #12064 / #14570 / #14492 / #11800 hint at the broader pattern — but that's a behavior change, not just an error-message change, and out of scope here.)

## Test plan

- [x] `go test ./model/parsers/...` — all pass, including the new `TestQwen3VLParserWrapsToolCallParseErrors` regression test that feeds malformed JSON into a well-formed `<tool_call>` block and asserts the returned error contains `failed to parse model-generated tool call`.
- [x] Confirmed the new test **fails** without the fix (returns the raw `invalid character 'b' looking for beginning of object key string`), matching the reporter's symptom exactly.
- [x] Other four parsers use the same one-line wrap; verified by code review that a similar test would pass for each. Happy to add per-parser tests if reviewers prefer explicit coverage over inspection.
