### PR TITLE
Windows-on-Arm: set GGML_CPU_ARM_ARCH so the CPU build isn't baseline armv8-a

### DIFF
--- a/llama/server/CMakePresets.json
+++ b/llama/server/CMakePresets.json
@@ -36,6 +36,7 @@
       "toolchainFile": "${sourceDir}/../../cmake/windows-arm64-llvm-mingw.cmake",
       "cacheVariables": {
         "GGML_CPU_ALL_VARIANTS": "OFF",
+        "GGML_CPU_ARM_ARCH": "armv8.2-a+dotprod",
         "OLLAMA_RUNNER_DIR": "",
         "OLLAMA_WINDOWS_RUNTIME_ARCH": "arm64"
       }


### PR DESCRIPTION
### Summary

The Windows-on-Arm CPU runner is built with no `-march`, so it falls back to baseline `armv8-a` and ships **zero** dot-product or matrix instructions. One line in the `cpu_arm64` preset fixes it, with no compatibility risk on any shipped Windows-on-Arm device.

### Evidence

The shipped `lib/ollama/ggml-cpu.dll` from the official `ollama-windows-arm64` release disassembles to baseline NEON — no `sdot`, no `smmla`:

```
$ objdump -d ggml-cpu.dll | grep -cE '\b(sdot|smmla|udot|ummla)\b'
0
```

llama.cpp's own `win-arm64` release, built from the same ggml source on the same OS, has them (`sdot` ×1052, `smmla` ×244). So this is a build-configuration difference, not a platform limitation.

### Root cause

`llama/server/CMakePresets.json` builds the Linux/x86 CPU runner with `GGML_CPU_ALL_VARIANTS=ON` (which compiles all ISA variants and dlopens the best at runtime). That path is unsupported on Windows-on-Arm in ggml (it raises a CMake `FATAL_ERROR`), so `cpu_arm64` correctly sets it `OFF`. But nothing then sets a target arch. In `ggml/src/ggml-cpu/CMakeLists.txt`:

```cmake
if (GGML_CPU_ARM_ARCH)
    list(APPEND ARCH_FLAGS -march=${GGML_CPU_ARM_ARCH})
elseif(GGML_CPU_ALL_VARIANTS)
    ...
endif()
# neither set (+ GGML_NATIVE=OFF): no -march is appended -> compiler default armv8-a
```

ggml's dot-product / i8mm kernels are `#if`-guarded on `__ARM_FEATURE_DOTPROD` / `__ARM_FEATURE_MATMUL_INT8`, so under `armv8-a` they are compiled out entirely.

### Fix

`armv8.2-a+dotprod` is the safe floor: every Windows-on-Arm device supports FEAT_DotProd (Cortex-A76 based Surface SQ1/SQ2, and Snapdragon X / Oryon), so there is no illegal-instruction risk on any shipped hardware.

### Impact

Same model (Qwen2.5-0.5B Q4_0), same Arm hardware (Neoverse N2), changing only `-march`:

| build | prompt processing | vs baseline |
|---|---:|---:|
| `armv8-a` (current) | 94.7 tok/s | 1.0x |
| `armv8.2-a+dotprod` (this PR) | 543.9 tok/s | **5.75x** |

Token generation improves ~2.2x as well (dot-product helps the memory-bound decode path). This is also a plausible root cause for #8246 (5–10 s/token on some Arm CPUs), which is the fingerprint of a scalar fallback.

### Follow-up option (not in this PR)

For a Snapdragon-X-targeted build, `armv8.7-a` additionally enables i8mm (`smmla`) for more prefill throughput, matching what llama.cpp's own WoA release ships — at the cost of dropping pre-Snapdragon-X SQ-series compatibility. I kept this PR to the zero-regression `+dotprod` floor; happy to gate an i8mm build behind a separate preset if preferred.
