### PR TITLE
docs: require VS Code 1.127 for Ollama extension

### DIFF
--- a/docs/integrations/vscode.mdx
+++ b/docs/integrations/vscode.mdx
@@ -6,9 +6,11 @@ Use Ollama models in VS Code Chat with the [Ollama extension](https://marketplac
 
 ## Requirements
 
-- [Visual Studio Code 1.120 or newer](https://code.visualstudio.com/download)
+- [Visual Studio Code 1.127 or newer](https://code.visualstudio.com/download)
 - Ollama installed and running
 - At least one local or cloud model available in Ollama
+
+Earlier VS Code versions do not reliably cancel requests from language model providers.
 
 Ollama 0.17.6 or newer is recommended for cloud model sign-in and richer model metadata. Older versions may still work with local models.
 


### PR DESCRIPTION
## Summary

- update the VS Code integration requirement from 1.120 to 1.127
- explain that earlier VS Code versions do not reliably cancel language model provider requests

## Why

ollama/ollama-vscode#50 raises the extension's minimum supported VS Code version because VS Code 1.127 fixed cancellation propagation for contributed language model providers. Without that fix, a stopped or failed chat can leave the Ollama request running.

This keeps the integration documentation aligned with the extension manifest and gives users a clear upgrade path.

## Validation

- `mintlify validate`
