### PR TITLE
agent: scan each skill root once and explain rejected skill names

### DIFF
--- a/agent/skills.go
+++ b/agent/skills.go
@@ -180,7 +180,7 @@ func DiscoverSkills(dir string) (*SkillCatalog, error) {
 			continue
 		}
 		if !skillName.MatchString(name) {
-			catalog.diagnostics = append(catalog.diagnostics, fmt.Errorf("invalid skill directory %q", name))
+			catalog.diagnostics = append(catalog.diagnostics, fmt.Errorf("invalid skill directory %q in %s: skill names may use only lowercase letters, numbers, and single hyphens", name, dir))
 			continue
 		}
 		skill, err := parseSkill(filepath.Join(dir, name, skillFilename), name)
@@ -646,7 +646,20 @@ func defaultSkillRoots(projectDir string) ([]skillRoot, error) {
 			)
 		}
 	}
-	return roots, nil
+
+	// Running the agent from the home directory makes the user and project
+	// roots resolve to the same paths. Keep the first occurrence so the
+	// documented precedence still holds, and scan each path only once.
+	seen := make(map[string]bool, len(roots))
+	deduped := roots[:0]
+	for _, root := range roots {
+		if seen[root.path] {
+			continue
+		}
+		seen[root.path] = true
+		deduped = append(deduped, root)
+	}
+	return deduped, nil
 }
 
 func (c *SkillCatalog) Dir() string {

--- a/agent/skills_test.go
+++ b/agent/skills_test.go
@@ -85,6 +85,17 @@ func TestDiscoverSkillsSkipsMalformedEntries(t *testing.T) {
 	if got, want := len(catalog.Diagnostics()), 7; got != want {
 		t.Fatalf("diagnostics = %d, want %d: %#v", got, want, catalog.Diagnostics())
 	}
+	// The diagnostic has to name the rule; "invalid" alone leaves the user
+	// guessing which of the name, contents, or permissions was rejected.
+	var underscore string
+	for _, d := range catalog.Diagnostics() {
+		if strings.Contains(d.Error(), `"under_score"`) {
+			underscore = d.Error()
+		}
+	}
+	if !strings.Contains(underscore, "lowercase letters, numbers, and single hyphens") || !strings.Contains(underscore, dir) {
+		t.Fatalf("under_score diagnostic = %q, want the naming rule and the directory scanned", underscore)
+	}
 	if _, err := catalog.Load("broken"); err == nil || !strings.Contains(err.Error(), "not found") {
 		t.Fatalf("load broken error = %v", err)
 	}
@@ -269,6 +280,32 @@ func TestLoadDefaultSkillsPrecedenceAndCollisions(t *testing.T) {
 		if strings.Contains(d.Error(), "shadows") {
 			t.Fatalf("unexpected shadow diagnostic: %v", d)
 		}
+	}
+}
+
+func TestLoadDefaultSkillsScansEachRootOnce(t *testing.T) {
+	// Running the agent from the home directory makes the user and project
+	// roots resolve to the same paths, which scanned each of them twice and
+	// reported every diagnostic from them twice.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows: os.UserHomeDir uses %USERPROFILE%
+	t.Setenv(SkillsDirEnv, filepath.Join(home, ".ollama", "skills"))
+
+	writeCatalogSkill(t, filepath.Join(home, ".agents", "skills"), "under_score", "invalid directory")
+
+	catalog, err := LoadDefaultSkills(home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var invalid []error
+	for _, d := range catalog.Diagnostics() {
+		if strings.Contains(d.Error(), "under_score") {
+			invalid = append(invalid, d)
+		}
+	}
+	if got, want := len(invalid), 1; got != want {
+		t.Fatalf("diagnostics for under_score = %d, want %d: %v", got, want, invalid)
 	}
 }
 


### PR DESCRIPTION
Refs #17652.

That report has a user whose `local_search` skill is silently dropped while two neighbours in the same directory load. Two things in `agent/skills.go` made this hard to diagnose. The name itself is correctly rejected — this PR does not change that rule — but neither defect should stand.

## Each root is scanned twice when the agent starts in the home directory

`defaultSkillRoots` appends the user roots and then the project roots:

```
~/.agents/skills          (user, cross-client)
<SkillsDir>               (user, Ollama-owned)
<project>/.agents/skills  (project, cross-client)
<project>/.ollama/skills  (project, Ollama-owned)
```

When the agent's working directory is the home directory, roots 1 and 3 are the same path, and so are 2 and 4 under the default `SkillsDir`. Every skill under them is parsed twice and every diagnostic is recorded twice. This is why the report shows the warning duplicated:

```
warning: ignored invalid agent skill: invalid skill directory "local_search"
warning: ignored invalid agent skill: invalid skill directory "local_search"
```

The roots are now deduplicated, keeping the first occurrence so the documented precedence is unchanged — a later root that duplicates an earlier one would have overridden it with identical contents anyway, while dropping the earlier entry instead would let `.agents/skills` outrank the Ollama-owned directory at the same scope.

## The rejection says only that something was invalid

The diagnostic was `invalid skill directory "local_search"`. It named neither the rule nor the root, so it does not distinguish a bad name from bad contents or bad permissions, and it gives nothing to act on. The report reflects that cost — the reporter checked frontmatter, YAML fences, file permissions and timestamps across all three skills before asking whether the constraint was undocumented.

It now reads:

```
invalid skill directory "local_search" in /home/u/.ollama/skills: skill names may use only lowercase letters, numbers, and single hyphens
```

which names the one property that was rejected and the root it came from.

## On the underscore

`skillName` is `^[a-z0-9]+(?:-[a-z0-9]+)*$`. Rejecting underscores is deliberate: the bundled `skill-creator` instructions state "Use lowercase letters, numbers, and single hyphens only", and `under_score` is already covered as an invalid directory in `TestDiscoverSkillsSkipsMalformedEntries`. So the rule is left alone and only made discoverable. If underscores should be accepted, that is a separate change to the naming spec and worth its own issue.

## Tests

`TestLoadDefaultSkillsScansEachRootOnce` covers the duplicate, and fails on `main` with `diagnostics for under_score = 2, want 1`. `TestDiscoverSkillsSkipsMalformedEntries` now asserts the diagnostic carries the rule and the directory. `go test ./agent/... ./cmd/...` passes; `gofumpt` and `go vet` are clean.