### PR TITLE
feat: opt-in progressive Qwen tool-call argument streaming

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -158,6 +158,14 @@ type ChatRequest struct {
 	// for supported models.
 	Think *ThinkValue `json:"think,omitempty"`
 
+	// StreamToolCalls, when true, asks supported parsers (currently Qwen3 /
+	// Qwen3.5 XML tool calls) to emit partial tool_calls while arguments are
+	// still being generated. Partial chunks populate
+	// ToolCallFunction.ArgumentsDelta and leave Arguments empty; the final
+	// assembled call is still emitted once the tool block closes. Opt-in so
+	// existing clients keep receiving only complete tool_calls.
+	StreamToolCalls *bool `json:"stream_tool_calls,omitempty"`
+
 	// Truncate is a boolean that, when set to true, truncates the chat history messages
 	// if the rendered prompt exceeds the context length limit.
 	Truncate *bool `json:"truncate,omitempty"`
@@ -227,6 +235,11 @@ type ToolCallFunction struct {
 	Index     int                       `json:"index"`
 	Name      string                    `json:"name"`
 	Arguments ToolCallFunctionArguments `json:"arguments"`
+	// ArgumentsDelta is opt-in progressive tool-argument text while the model
+	// is still generating a tool call (see ChatRequest.StreamToolCalls). It is
+	// the cumulative raw tool-call body so far (e.g. Qwen XML). Empty on the
+	// final assembled tool call.
+	ArgumentsDelta string `json:"arguments_delta,omitempty"`
 }
 
 // ToolCallFunctionArguments holds tool call arguments in insertion order.

--- a/model/parsers/parsers.go
+++ b/model/parsers/parsers.go
@@ -23,6 +23,12 @@ type Parser interface {
 	HasThinkingSupport() bool
 }
 
+// StreamToolCallsSetter is implemented by parsers that can emit progressive
+// tool-call argument deltas (ChatRequest.StreamToolCalls).
+type StreamToolCallsSetter interface {
+	SetStreamToolCalls(enabled bool)
+}
+
 type ParserConstructor func() Parser
 
 type ParserRegistry struct {

--- a/model/parsers/qwen35.go
+++ b/model/parsers/qwen35.go
@@ -75,6 +75,10 @@ func (p *Qwen35Parser) Init(tools []api.Tool, lastMessage *api.Message, thinkVal
 	return tools
 }
 
+func (p *Qwen35Parser) SetStreamToolCalls(enabled bool) {
+	p.toolParser.SetStreamToolCalls(enabled)
+}
+
 type qwen35Event interface {
 	isQwen35Event()
 }

--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -21,6 +21,10 @@ type qwenParserState int
 const (
 	toolOpenTag  = "<tool_call>"
 	toolCloseTag = "</tool_call>"
+
+	// Minimum growth in buffered tool-call body before emitting another
+	// arguments_delta chunk when StreamToolCalls is enabled.
+	streamToolCallDeltaMinBytes = 128
 )
 
 const (
@@ -33,6 +37,13 @@ type Qwen3CoderParser struct {
 	acc       strings.Builder
 	tools     []api.Tool
 	callIndex int
+
+	// Progressive tool-call streaming (opt-in via SetStreamToolCalls).
+	streamToolCalls bool
+	streamName      string
+	streamIndex     int
+	streamStarted   bool
+	lastStreamedLen int
 }
 
 func (p *Qwen3CoderParser) HasToolSupport() bool {
@@ -41,6 +52,10 @@ func (p *Qwen3CoderParser) HasToolSupport() bool {
 
 func (p *Qwen3CoderParser) HasThinkingSupport() bool {
 	return false
+}
+
+func (p *Qwen3CoderParser) SetStreamToolCalls(enabled bool) {
+	p.streamToolCalls = enabled
 }
 
 func (p *Qwen3CoderParser) PreservedTokens() []string {
@@ -53,7 +68,15 @@ func (p *Qwen3CoderParser) PreservedTokens() []string {
 func (p *Qwen3CoderParser) Init(tools []api.Tool, lastMessage *api.Message, thinkValue *api.ThinkValue) []api.Tool {
 	p.tools = tools
 	p.callIndex = 0
+	p.resetStreamState()
 	return tools // Qwen doesn't modify tools
+}
+
+func (p *Qwen3CoderParser) resetStreamState() {
+	p.streamName = ""
+	p.streamIndex = 0
+	p.streamStarted = false
+	p.lastStreamedLen = 0
 }
 
 func (p *Qwen3CoderParser) Add(s string, done bool) (content string, thinking string, calls []api.ToolCall, err error) {
@@ -73,7 +96,17 @@ func (p *Qwen3CoderParser) Add(s string, done bool) (content string, thinking st
 			}
 			toolCall.Function.Index = p.callIndex
 			p.callIndex++
+			p.resetStreamState()
 			toolCalls = append(toolCalls, toolCall)
+		case qwenEventToolCallDelta:
+			toolCalls = append(toolCalls, api.ToolCall{
+				Function: api.ToolCallFunction{
+					Index:          event.index,
+					Name:           event.name,
+					Arguments:      api.NewToolCallFunctionArguments(),
+					ArgumentsDelta: event.delta,
+				},
+			})
 		case qwenEventContent:
 			// TODO(drifkin): if the same turn contains multiple interleaved content
 			// events, we naively append them together here. See the note below about
@@ -123,8 +156,58 @@ type qwenEventContent struct {
 	content string
 }
 
-func (qwenEventContent) isQwenEvent()     {}
-func (qwenEventRawToolCall) isQwenEvent() {}
+// qwenEventToolCallDelta is emitted while collecting tool content when
+// StreamToolCalls is enabled. delta is the cumulative raw body so far.
+type qwenEventToolCallDelta struct {
+	name  string
+	index int
+	delta string
+}
+
+func (qwenEventContent) isQwenEvent()       {}
+func (qwenEventRawToolCall) isQwenEvent()   {}
+func (qwenEventToolCallDelta) isQwenEvent() {}
+
+var (
+	qwenFunctionNameRe       = regexp.MustCompile(`(?s)<function=([^>"\s]+)`)
+	qwenFunctionNameQuotedRe = regexp.MustCompile(`(?s)<function="([^"]+)"`)
+)
+
+func peekQwenFunctionName(raw string) string {
+	if m := qwenFunctionNameQuotedRe.FindStringSubmatch(raw); len(m) == 2 {
+		return m[1]
+	}
+	if m := qwenFunctionNameRe.FindStringSubmatch(raw); len(m) == 2 {
+		return m[1]
+	}
+	return ""
+}
+
+func (p *Qwen3CoderParser) maybeStreamToolDelta() []qwenEvent {
+	if !p.streamToolCalls {
+		return nil
+	}
+	acc := p.acc.String()
+	name := peekQwenFunctionName(acc)
+	if name == "" {
+		return nil
+	}
+	if !p.streamStarted {
+		p.streamName = name
+		p.streamIndex = p.callIndex
+		p.streamStarted = true
+	}
+	grew := len(acc) - p.lastStreamedLen
+	if p.lastStreamedLen > 0 && grew < streamToolCallDeltaMinBytes {
+		return nil
+	}
+	p.lastStreamedLen = len(acc)
+	return []qwenEvent{qwenEventToolCallDelta{
+		name:  p.streamName,
+		index: p.streamIndex,
+		delta: acc,
+	}}
+}
 
 // eat consumes the parser's buffer, and returns a list of any unambiguous
 // events from the current parser state. If the parser transitions to another
@@ -193,10 +276,11 @@ func eat(p *Qwen3CoderParser) ([]qwenEvent, bool) {
 			p.state = qwenParserState_LookingForToolStart
 			return events, true
 		} else {
-			// note that we don't need to check the overlap here because we only plan
-			// on parsing the tool call once we see the full closing tag. We don't
-			// stream back the unparsed tool content, so there's no need to be eager
-			// here
+			// Default: hold until </tool_call>. With StreamToolCalls, emit
+			// progressive argument deltas once the function name is known.
+			if deltas := p.maybeStreamToolDelta(); len(deltas) > 0 {
+				return deltas, false
+			}
 			return events, false
 		}
 	default:

--- a/model/parsers/qwen3coder_test.go
+++ b/model/parsers/qwen3coder_test.go
@@ -1,7 +1,9 @@
 package parsers
 
 import (
+	"fmt"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/ollama/ollama/api"
@@ -1238,5 +1240,74 @@ func TestOverlapFunction(t *testing.T) {
 				t.Errorf("overlap(%q, %q) = %d, want %d", tc.s, tc.delim, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestQwen3CoderParserStreamToolCallDeltas(t *testing.T) {
+	parser := Qwen3CoderParser{}
+	parser.Init(nil, nil, nil)
+	parser.SetStreamToolCalls(true)
+
+	_, _, calls, err := parser.Add("<tool_call><function=editor><parameter=new_string>\n", false)
+	if err != nil {
+		t.Fatalf("step 1: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("step 1: expected 1 delta, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "editor" {
+		t.Fatalf("step 1: name=%q", calls[0].Function.Name)
+	}
+	if calls[0].Function.ArgumentsDelta == "" {
+		t.Fatal("step 1: expected arguments_delta")
+	}
+	if calls[0].Function.Index != 0 {
+		t.Fatalf("step 1: index=%d", calls[0].Function.Index)
+	}
+
+	body := strings.Repeat("x", streamToolCallDeltaMinBytes)
+	_, _, calls, err = parser.Add(body, false)
+	if err != nil {
+		t.Fatalf("step 2: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("step 2: expected 1 delta after growth, got %d", len(calls))
+	}
+	if !strings.Contains(calls[0].Function.ArgumentsDelta, body) {
+		t.Fatal("step 2: delta should include new body")
+	}
+
+	_, _, calls, err = parser.Add("\n</parameter></function></tool_call>", true)
+	if err != nil {
+		t.Fatalf("step 3: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("step 3: expected final call, got %d", len(calls))
+	}
+	if calls[0].Function.ArgumentsDelta != "" {
+		t.Fatalf("step 3: final should not have arguments_delta, got %q", calls[0].Function.ArgumentsDelta)
+	}
+	if calls[0].Function.Name != "editor" {
+		t.Fatalf("step 3: name=%q", calls[0].Function.Name)
+	}
+	got, ok := calls[0].Function.Arguments.Get("new_string")
+	if !ok {
+		t.Fatal("step 3: missing new_string argument")
+	}
+	if !strings.Contains(fmt.Sprint(got), "xxx") {
+		t.Fatalf("step 3: unexpected new_string=%v", got)
+	}
+}
+
+func TestQwen3CoderParserStreamToolCallsOffNoDeltas(t *testing.T) {
+	parser := Qwen3CoderParser{}
+	parser.Init(nil, nil, nil)
+
+	_, _, calls, err := parser.Add("<tool_call><function=editor><parameter=new_string>\n"+strings.Repeat("y", 300), false)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Fatalf("expected no partial calls with streaming off, got %d", len(calls))
 	}
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -2375,7 +2375,13 @@ func writeChatResponse(c *gin.Context, req api.ChatRequest, ch chan any) {
 				sbContent.WriteString(t.Message.Content)
 				resp = t
 				if len(req.Tools) > 0 {
-					toolCalls = append(toolCalls, t.Message.ToolCalls...)
+					for _, tc := range t.Message.ToolCalls {
+						// Skip progressive deltas — only keep final assembled calls.
+						if tc.Function.ArgumentsDelta != "" {
+							continue
+						}
+						toolCalls = append(toolCalls, tc)
+					}
 				}
 				if len(t.Logprobs) > 0 {
 					allLogprobs = append(allLogprobs, t.Logprobs...)
@@ -2666,6 +2672,11 @@ func (s *Server) ChatHandler(c *gin.Context) {
 			}
 			// Initialize parser and get processed tools
 			processedTools = builtinParser.Init(req.Tools, lastMessage, req.Think)
+			if req.StreamToolCalls != nil && *req.StreamToolCalls {
+				if setter, ok := builtinParser.(parsers.StreamToolCallsSetter); ok {
+					setter.SetStreamToolCalls(true)
+				}
+			}
 		}
 	}
 
@@ -2724,6 +2735,8 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		defer close(ch)
 
 		structuredOutputsState := structuredOutputsState_None
+		// Stable tool call IDs across progressive arguments_delta chunks.
+		streamedToolCallIDs := map[int]string{}
 
 		for {
 			var tb strings.Builder
@@ -2791,7 +2804,14 @@ func (s *Server) ChatHandler(c *gin.Context) {
 					res.Message.Content = content
 					res.Message.Thinking = thinking
 					for i := range toolCalls {
-						toolCalls[i].ID = toolCallId()
+						idx := toolCalls[i].Function.Index
+						if id, ok := streamedToolCallIDs[idx]; ok {
+							toolCalls[i].ID = id
+						} else {
+							id := toolCallId()
+							streamedToolCallIDs[idx] = id
+							toolCalls[i].ID = id
+						}
 					}
 					res.Message.ToolCalls = toolCalls
 


### PR DESCRIPTION
## Summary
- Adds opt-in `stream_tool_calls` on `/api/chat` so supported parsers can emit progressive tool-argument text while a tool call is still being generated.
- Qwen3 / Qwen3.5 XML tool parsers emit cumulative `arguments_delta` (throttled) during collection, then a final complete `tool_calls` entry on `</tool_call>`.
- Streaming responses keep a stable tool-call `id` per index; non-stream aggregation ignores delta-only chunks.

This addresses the current behavior where complete `tool_calls` only appear after the full tool block finishes (see https://github.com/ollama/ollama/issues/13581), which blocks live UI previews for large tool arguments (e.g. long `editor` payloads).

## Test plan
- [ ] `go test ./model/parsers/` (includes new stream-delta tests)
- [ ] Chat with a Qwen3/Qwen3.5 model and `stream_tool_calls: true`; confirm NDJSON chunks include `arguments_delta` before `</tool_call>`
- [ ] Same request without the flag; confirm behavior unchanged (only final tool calls)
- [ ] Non-stream (`stream: false`) response still returns only complete tool calls
- [ ] Client using stable `id` across delta chunks can render a live argument preview


Made with [Cursor](https://cursor.com)