### PR TITLE
api: expose projected context length in model details

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -961,6 +961,8 @@ type GenerateResponse struct {
 
 // ModelDetails provides details about a model.
 type ModelDetails struct {
+	RecommendedContextLength int `json:"recommended_context_length,omitempty"`
+
 	ParentModel       string   `json:"parent_model"`
 	Format            string   `json:"format"`
 	Family            string   `json:"family"`

--- a/cmd/launch/model_inventory.go
+++ b/cmd/launch/model_inventory.go
@@ -134,12 +134,17 @@ func resolveLaunchModels(names []string, models []LaunchModel) ([]LaunchModel, b
 }
 
 func launchModelFromListResponse(model api.ListModelResponse) LaunchModel {
+	contextLength := model.Details.RecommendedContextLength
+	if contextLength <= 0 {
+		contextLength = model.Details.ContextLength
+	}
+
 	return LaunchModel{
 		Name:            model.Name,
 		Remote:          model.RemoteModel != "",
 		ToolCapable:     slices.Contains(model.Capabilities, modelpkg.CapabilityTools),
 		Capabilities:    append([]modelpkg.Capability(nil), model.Capabilities...),
-		ContextLength:   model.Details.ContextLength,
+		ContextLength:   contextLength,
 		EmbeddingLength: model.Details.EmbeddingLength,
 		Size:            model.Size,
 		Details:         model.Details,

--- a/cmd/launch/model_inventory_test.go
+++ b/cmd/launch/model_inventory_test.go
@@ -24,7 +24,7 @@ func TestModelInventoryResolveRefreshesLocalMiss(t *testing.T) {
 			fmt.Fprint(w, `{"models":[]}`)
 			return
 		}
-		fmt.Fprint(w, `{"models":[{"name":"new-model","size":123,"details":{"context_length":65536,"embedding_length":1024},"capabilities":["vision","tools"]}]}`)
+		fmt.Fprint(w, `{"models":[{"name":"new-model","size":123,"details":{"context_length":65536,"recommended_context_length":32768,"embedding_length":1024},"capabilities":["vision","tools"]}]}`)
 	}))
 	defer srv.Close()
 
@@ -41,11 +41,39 @@ func TestModelInventoryResolveRefreshesLocalMiss(t *testing.T) {
 	if got[0].Name != "new-model" {
 		t.Fatalf("Name = %q, want new-model", got[0].Name)
 	}
-	if got[0].ContextLength != 65_536 || got[0].EmbeddingLength != 1_024 {
+	if got[0].ContextLength != 32_768 || got[0].EmbeddingLength != 1_024 {
 		t.Fatalf("metadata = context %d embedding %d, want refreshed metadata", got[0].ContextLength, got[0].EmbeddingLength)
 	}
 	if !got[0].HasCapability(modelpkg.CapabilityVision) || !got[0].ToolCapable {
 		t.Fatalf("capabilities = %v toolCapable=%v, want refreshed capabilities", got[0].Capabilities, got[0].ToolCapable)
+	}
+}
+
+func TestLaunchModelFromListResponseContextLength(t *testing.T) {
+	tests := []struct {
+		name    string
+		details api.ModelDetails
+		want    int
+	}{
+		{
+			name:    "recommended",
+			details: api.ModelDetails{ContextLength: 131_072, RecommendedContextLength: 32_768},
+			want:    32_768,
+		},
+		{
+			name:    "architectural fallback",
+			details: api.ModelDetails{ContextLength: 131_072},
+			want:    131_072,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := launchModelFromListResponse(api.ListModelResponse{Name: "test", Details: tt.details})
+			if got.ContextLength != tt.want {
+				t.Fatalf("ContextLength = %d, want %d", got.ContextLength, tt.want)
+			}
+		})
 	}
 }
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1413,7 +1413,9 @@ A single JSON object will be returned.
         "family": "qwen2",
         "families": ["qwen2"],
         "parameter_size": "7.6B",
-        "quantization_level": "Q4_K_M"
+        "quantization_level": "Q4_K_M",
+        "context_length": 131072,
+        "recommended_context_length": 32768
       }
     },
     {
@@ -1428,7 +1430,9 @@ A single JSON object will be returned.
         "family": "llama",
         "families": ["llama"],
         "parameter_size": "3.2B",
-        "quantization_level": "Q4_K_M"
+        "quantization_level": "Q4_K_M",
+        "context_length": 131072,
+        "recommended_context_length": 32768
       }
     }
   ]

--- a/server/context.go
+++ b/server/context.go
@@ -1,0 +1,18 @@
+package server
+
+import (
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/envconfig"
+)
+
+func (s *Server) recommendedContextLength(model api.ListModelResponse) int {
+	// This bucket remains the fallback when no runner-specific preflight estimate is available.
+	recommended := int(envconfig.ContextLength())
+	if recommended == 0 {
+		recommended = s.defaultNumCtx
+	}
+	if model.Details.ContextLength > 0 {
+		recommended = min(recommended, model.Details.ContextLength)
+	}
+	return recommended
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -1646,6 +1646,13 @@ func (s *Server) ListHandler(c *gin.Context) {
 		return
 	}
 
+	for i := range models {
+		if models[i].RemoteHost != "" || models[i].RemoteModel != "" {
+			continue
+		}
+		models[i].Details.RecommendedContextLength = s.recommendedContextLength(models[i])
+	}
+
 	c.JSON(http.StatusOK, api.ListResponse{Models: models})
 }
 

--- a/server/routes_list_test.go
+++ b/server/routes_list_test.go
@@ -36,7 +36,7 @@ func TestList(t *testing.T) {
 		"myhost/mynamespace/lips:code",
 	}
 
-	s := Server{modelCaches: &modelCaches{modelList: newModelListCache()}}
+	s := Server{defaultNumCtx: 32_768, modelCaches: &modelCaches{modelList: newModelListCache()}}
 	s.modelCaches.modelList.Start(context.Background())
 	if err := s.modelCaches.modelList.Wait(context.Background()); err != nil {
 		t.Fatal(err)
@@ -81,6 +81,35 @@ func TestList(t *testing.T) {
 		if !slices.Contains(m.Capabilities, "completion") {
 			t.Fatalf("capabilities for %q = %v, want completion", m.Name, m.Capabilities)
 		}
+		if m.Details.RecommendedContextLength != 32_768 {
+			t.Fatalf("recommended context length for %q = %d, want 32768", m.Name, m.Details.RecommendedContextLength)
+		}
+	}
+}
+
+func TestRecommendedContextLength(t *testing.T) {
+	tests := []struct {
+		name       string
+		env        string
+		bucket     int
+		modelLimit int
+		want       int
+	}{
+		{name: "bucket", bucket: 32_768, modelLimit: 131_072, want: 32_768},
+		{name: "model limit", bucket: 262_144, modelLimit: 131_072, want: 131_072},
+		{name: "unknown model limit", bucket: 4_096, want: 4_096},
+		{name: "environment override", env: "65536", bucket: 4_096, modelLimit: 131_072, want: 65_536},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OLLAMA_CONTEXT_LENGTH", tt.env)
+			s := Server{defaultNumCtx: tt.bucket}
+			model := api.ListModelResponse{Details: api.ModelDetails{ContextLength: tt.modelLimit}}
+			if got := s.recommendedContextLength(model); got != tt.want {
+				t.Fatalf("recommendedContextLength(%d) = %d, want %d", tt.modelLimit, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
While bucket-based today, this could be expanded in the future with better estimation logic from the MLX runner.