### PR TITLE
parsers: recover boundary tokens fumbled into glimmer ATEM invoke names

### DIFF
--- a/model/parsers/glimmer.go
+++ b/model/parsers/glimmer.go
@@ -369,24 +369,52 @@ func glimmerATEMInvokeName(body string) string {
 	if !strings.HasPrefix(inner, glimmerATEMInvokeOpen) {
 		return ""
 	}
-	name, _, ok := strings.Cut(inner[len(glimmerATEMInvokeOpen):], `">`)
+	name, _, ok := glimmerCutInvokeName(inner[len(glimmerATEMInvokeOpen):])
 	if !ok {
 		return ""
 	}
-	return glimmerTrimStrayMessageTag(name)
+	return name
 }
 
-// glimmerTrimStrayMessageTag drops <|message|> boundary tokens the model
-// occasionally fumbles into the invoke name (e.g. `name="read<|message|>">`),
-// echoing the header form `to=read<|message|>`. Function names are
-// identifiers, so the tag is never legitimate there; parameter values are
-// left untouched (control-token text is preserved in values).
-func glimmerTrimStrayMessageTag(name string) string {
-	if !strings.Contains(name, glimmerMessageTag) {
-		return name
+// glimmerCutInvokeName splits an ATEM invoke element's name attribute from
+// the text after its `">` terminator, recovering the <|message|> boundary
+// tokens the model occasionally fumbles into the name region — echoing the
+// header form `to=read<|message|>`. Observed shapes: the tag inside a
+// terminated name (`name="read<|message|>">`) and the tag in place of the
+// terminator itself (`name="read<|message|><atem:parameter ...`). Function
+// names are identifiers, so a boundary token before the terminator is never
+// legitimate; parameter values are unaffected because they only appear
+// after the terminator.
+func glimmerCutInvokeName(s string) (name, rest string, ok bool) {
+	var b strings.Builder
+	rest = s
+	fumbled := false
+	for {
+		termIdx := strings.Index(rest, `">`)
+		tagIdx := strings.Index(rest, glimmerMessageTag)
+		if tagIdx >= 0 && (termIdx < 0 || tagIdx < termIdx) {
+			// Boundary token before the terminator: drop it and keep
+			// scanning. If the parameter list begins immediately after,
+			// the token replaced the terminator and the name is complete.
+			fumbled = true
+			b.WriteString(rest[:tagIdx])
+			rest = rest[tagIdx+len(glimmerMessageTag):]
+			if strings.HasPrefix(rest, glimmerATEMParamOpen) {
+				break
+			}
+			continue
+		}
+		if termIdx < 0 {
+			return "", "", false
+		}
+		b.WriteString(rest[:termIdx])
+		rest = rest[termIdx+2:]
+		break
 	}
-	slog.Warn("glimmer parser recovered stray message boundary token in ATEM invoke name", "name", name)
-	return strings.ReplaceAll(name, glimmerMessageTag, "")
+	if fumbled {
+		slog.Warn("glimmer parser recovered stray message boundary token in ATEM invoke name", "name", b.String())
+	}
+	return b.String(), rest, true
 }
 
 func (p *GlimmerParser) parseToolCall(body string) (api.ToolCall, error) {
@@ -458,12 +486,11 @@ func parseGlimmerATEM(body string, tool api.Tool) (string, api.ToolCallFunctionA
 		return "", api.ToolCallFunctionArguments{}, fmt.Errorf("missing ATEM invoke wrapper")
 	}
 	invoke = invoke[len(glimmerATEMInvokeOpen):]
-	nameEnd := strings.Index(invoke, `">`)
-	if nameEnd < 0 {
+	name, rest, ok := glimmerCutInvokeName(invoke)
+	if !ok || len(rest) < len(glimmerATEMInvokeClose) {
 		return "", api.ToolCallFunctionArguments{}, fmt.Errorf("malformed ATEM invoke name")
 	}
-	name := glimmerTrimStrayMessageTag(invoke[:nameEnd])
-	params := invoke[nameEnd+2 : len(invoke)-len(glimmerATEMInvokeClose)]
+	params := rest[:len(rest)-len(glimmerATEMInvokeClose)]
 	params = strings.TrimPrefix(params, "\n")
 	params = strings.TrimSuffix(params, "\n")
 

--- a/model/parsers/glimmer_test.go
+++ b/model/parsers/glimmer_test.go
@@ -246,6 +246,76 @@ func TestGlimmerParserStrayMessageTagInInvokeName(t *testing.T) {
 	}
 }
 
+// TestGlimmerParserMessageTagReplacesInvokeTerminator covers the fleet-observed
+// stress failure where the model emits a <|message|> boundary token in place
+// of the `">` terminator of the invoke name (`name="read<|message|><atem:parameter ...`).
+// The name must recover as the text before the tag and parameter parsing must
+// resume at the parameter element.
+func TestGlimmerParserMessageTagReplacesInvokeTerminator(t *testing.T) {
+	tool := glimmerTestTool("read", map[string]api.ToolProperty{
+		"path": {Type: api.PropertyType{"string"}},
+	})
+
+	for name, invoke := range map[string]string{
+		"terminator replaced": `read<|message|><atem:parameter name="path">go.mod</atem:parameter>
+`,
+		"tag mid-name": `re<|message|>ad"><atem:parameter name="path">go.mod</atem:parameter>
+`,
+		"repeated tags": `read<|message|><|message|>"><atem:parameter name="path">go.mod</atem:parameter>
+`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			input := ` to=read<|message|><atem:function_calls>
+<atem:invoke name="` + invoke + `</atem:invoke>
+</atem:function_calls><|eot|>`
+
+			p := &GlimmerParser{}
+			p.Init([]api.Tool{tool}, nil, nil)
+			content, thinking, calls, err := p.Add(input, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if content != "" || thinking != "" || len(calls) != 1 {
+				t.Fatalf("got content=%q thinking=%q calls=%v", content, thinking, calls)
+			}
+			if calls[0].Function.Name != "read" {
+				t.Fatalf("call name = %q, want %q", calls[0].Function.Name, "read")
+			}
+			if got, ok := calls[0].Function.Arguments.Get("path"); !ok || got != "go.mod" {
+				t.Fatalf("path = %#v, %v; want %q", got, ok, "go.mod")
+			}
+		})
+	}
+}
+
+// TestGlimmerParserMessageTagInParamValueUntouched pins the non-recovery side:
+// a literal <|message|> inside a parameter value sits after the name
+// terminator and must be preserved verbatim, not treated as a fumble.
+func TestGlimmerParserMessageTagInParamValueUntouched(t *testing.T) {
+	tool := glimmerTestTool("echo", map[string]api.ToolProperty{
+		"text": {Type: api.PropertyType{"string"}},
+	})
+	value := `keep <|message|> literal`
+	input := ` to=echo<|message|>` + glimmerTestATEM(
+		"echo",
+		`<atem:parameter name="text">`+value+`</atem:parameter>
+`,
+	) + `<|eot|>`
+
+	p := &GlimmerParser{}
+	p.Init([]api.Tool{tool}, nil, nil)
+	_, _, calls, err := p.Add(input, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("calls = %v, want 1", calls)
+	}
+	if got, ok := calls[0].Function.Arguments.Get("text"); !ok || got != value {
+		t.Fatalf("text = %#v, %v; want %q", got, ok, value)
+	}
+}
+
 // TestGlimmerParserNamespacedSelfReference covers the observed stress failure
 // where the model addresses an undotted tool through its own derived
 // namespace (`read.read` for a tool declared as `read`) — the chat template


### PR DESCRIPTION
The model occasionally emits a <|message|> boundary token in the invoke name region, echoing the header form `to=read<|message|>`. The existing recovery handled the tag inside a terminated name (`name="read<|message|>">`) but not the fleet-observed shape where the tag replaces the `">` terminator itself (`name="read<|message|><atem:parameter ...`), which failed the call with "malformed ATEM parameter".

Replace the strip-after-cut recovery with a single name scan shared by parseGlimmerATEM and the content fallback: the name ends at the first `">`, boundary tokens before it are dropped, and a parameter element immediately after a dropped token means the token replaced the terminator. Well-formed calls are unaffected — a boundary token is never legitimate before the terminator, and parameter values (where the literal text is preserved) only appear after it. Murkier garbles still fail loudly, the recipient cross-check still applies, and the recovery WARN is retained.