### PR TITLE
docs: fix broken GPU docs link in FAQ

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -18,7 +18,7 @@ Review the [Troubleshooting](./troubleshooting.mdx) docs for more about using lo
 
 ## Is my GPU compatible with Ollama?
 
-Please refer to the [GPU docs](./gpu.mdx).
+Please refer to the [GPU docs](./gpu).
 
 ## How can I specify the context window size?
 


### PR DESCRIPTION
Fixed broken ./gpu.mdx link in FAQ — changed to ./gpu. Fixes #14243.