### PR TITLE
readme: add AI Career OS to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ console.log(response.message.content);
 - [Painting Droid](https://github.com/mateuszmigas/painting-droid) - Painting app with AI integrations
 - [Serene Pub](https://github.com/doolijb/serene-pub) - AI roleplaying app
 - [Mayan EDMS](https://gitlab.com/mayan-edms/mayan-edms) - Document management with Ollama workflows
+- [AI Career OS](https://github.com/semirturgay/ai-career-os) - Explainable job matching and resume tailoring, fully local
 - [TagSpaces](https://www.tagspaces.org) - File management with [AI tagging](https://docs.tagspaces.org/ai/)
 
 ### Observability & Monitoring


### PR DESCRIPTION
Adds [AI Career OS](https://github.com/semirturgay/ai-career-os) under Productivity & Apps.

It's an open-source, MIT-licensed career assistant — resume extraction, evidence-backed job matching, resume tailoring, and cover letters. Ollama is a first-class provider alongside LM Studio and the cloud APIs, and the whole pipeline runs against a local model, so nothing leaves the user's machine.

Single-line addition, matching the existing format.