### PR TITLE
docs: fix broken links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,5 +19,5 @@
 ### Resources
 
 * [Troubleshooting Guide](https://docs.ollama.com/troubleshooting)
-* [FAQ](https://docs.ollama.com/faq#faq)
+* [FAQ](https://docs.ollama.com/faq)
 * [Development guide](./development.md)

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,7 +16,6 @@
 - [Generate Embeddings](#generate-embeddings)
 - [List Running Models](#list-running-models)
 - [Version](#version)
-- [Experimental: Image Generation](#image-generation-experimental)
 
 ## Conventions
 
@@ -1180,7 +1179,7 @@ Create a model from:
 - a safetensors directory; or
 - a GGUF file.
 
-If you are creating a model from a safetensors directory or from a GGUF file, you must [create a blob](#create-a-blob) for each of the files and then use the file name and SHA256 digest associated with each blob in the `files` field.
+If you are creating a model from a safetensors directory or from a GGUF file, you must [create a blob](#push-a-blob) for each of the files and then use the file name and SHA256 digest associated with each blob in the `files` field.
 
 ### Parameters
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1179,7 +1179,7 @@ Create a model from:
 - a safetensors directory; or
 - a GGUF file.
 
-If you are creating a model from a safetensors directory or from a GGUF file, you must [create a blob](#push-a-blob) for each of the files and then use the file name and SHA256 digest associated with each blob in the `files` field.
+If you are creating a model from a safetensors directory or from a GGUF file, you must [push a blob](#push-a-blob) for each of the files and then use the file name and SHA256 digest associated with each blob in the `files` field.
 
 ### Parameters
 

--- a/docs/api/introduction.mdx
+++ b/docs/api/introduction.mdx
@@ -16,7 +16,7 @@ After installation, Ollama's API is served by default at:
 http://localhost:11434/api
 ```
 
-For running cloud models on **ollama.com**, the same API is available with the following base URL:
+For running cloud models on [ollama.com](https://ollama.com), the same API is available with the following base URL:
 
 ```
 https://ollama.com/api
@@ -40,7 +40,7 @@ Ollama has official libraries for Python and JavaScript:
 - [Python](https://github.com/ollama/ollama-python)
 - [JavaScript](https://github.com/ollama/ollama-js)
 
-Several community-maintained libraries are available for Ollama. For a full list, see the [Ollama GitHub repository](https://github.com/ollama/ollama?tab=readme-ov-file#libraries-1).
+Several community-maintained libraries are available for Ollama. For a full list, see the [Ollama GitHub repository](https://github.com/ollama/ollama?tab=readme-ov-file#libraries--sdks).
 
 ## Versioning
 

--- a/docs/cloud.mdx
+++ b/docs/cloud.mdx
@@ -229,7 +229,7 @@ curl https://ollama.com/api/chat \
 
 ## Local only
 
-Ollama can run in local-only mode by [disabling Ollama's cloud](./faq#how-do-i-disable-ollama-cloud) features.
+Ollama can run in local-only mode by [disabling Ollama's cloud](./faq#how-do-i-disable-ollama-cloud-features) features.
 
 ## Retirements
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -61,6 +61,10 @@
   },
   "redirects": [
     {
+      "source": "/development.md",
+      "destination": "/development"
+    },
+    {
       "source": "/api/openai-compatibility.mdx",
       "destination": "/api/openai-compatibility"
     },

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -61,6 +61,22 @@
   },
   "redirects": [
     {
+      "source": "/api/openai-compatibility.mdx",
+      "destination": "/api/openai-compatibility"
+    },
+    {
+      "source": "/gpu.mdx",
+      "destination": "/gpu"
+    },
+    {
+      "source": "/integrations/vscode.mdx",
+      "destination": "/integrations/vscode"
+    },
+    {
+      "source": "/troubleshooting.mdx",
+      "destination": "/troubleshooting"
+    },
+    {
       "source": "/openai",
       "destination": "/api/openai-compatibility"
     },

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,4 +11,4 @@ Ollama JavaScript examples at [ollama-js/examples](https://github.com/ollama/oll
 
 
 ## OpenAI compatibility examples
-Ollama OpenAI compatibility examples at [ollama/examples/openai](./api/openai-compatibility)
+Ollama OpenAI compatibility examples at [ollama/examples/openai](./api/openai-compatibility.mdx)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,4 +11,4 @@ Ollama JavaScript examples at [ollama-js/examples](https://github.com/ollama/oll
 
 
 ## OpenAI compatibility examples
-Ollama OpenAI compatibility examples at [ollama/examples/openai](../docs/openai.md)
+Ollama OpenAI compatibility examples at [ollama/examples/openai](./api/openai-compatibility)

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -14,11 +14,11 @@ curl -fsSL https://ollama.com/install.sh | sh
 
 ## How can I view the logs?
 
-Review the [Troubleshooting](./troubleshooting.mdx) docs for more about using logs.
+Review the [Troubleshooting](./troubleshooting) docs for more about using logs.
 
 ## Is my GPU compatible with Ollama?
 
-Please refer to the [GPU docs](./gpu.mdx).
+Please refer to the [GPU docs](./gpu).
 
 ## How can I specify the context window size?
 
@@ -160,7 +160,7 @@ docker run -d -e HTTPS_PROXY=https://my.proxy.example.com -p 11434:11434 ollama-
 
 Ollama runs locally. We don't see your prompts or data when you run locally. When using cloud-hosted models, we process your prompts and responses to provide the service but do not store or log that content and never train on it. We collect basic account info and limited usage metadata to provide the service that does not include prompt or response content. We don't sell your data. You can delete your account anytime.
 
-## How do I disable Ollama's cloud features?
+## How do I disable Ollama Cloud features?
 
 Ollama can run in local only mode by disabling Ollama's cloud features. By turning off Ollama's cloud features, you will lose the ability to use Ollama's cloud models and web search. 
 
@@ -248,7 +248,7 @@ Refer to the section [above](#how-do-i-configure-ollama-server) for how to set e
 
 ## How can I use Ollama in Visual Studio Code?
 
-There is already a large collection of plugins available for VS Code as well as other editors that leverage Ollama. See the list of [extensions & plugins](https://github.com/ollama/ollama#extensions--plugins) at the bottom of the main repository readme.
+Install the [Ollama extension](https://marketplace.visualstudio.com/items?itemName=Ollama.ollama) to use Ollama models in VS Code Chat. See the [VS Code integration guide](./integrations/vscode) for setup and troubleshooting.
 
 ## How do I use Ollama with GPU acceleration in Docker?
 

--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -14,11 +14,11 @@ curl -fsSL https://ollama.com/install.sh | sh
 
 ## How can I view the logs?
 
-Review the [Troubleshooting](./troubleshooting) docs for more about using logs.
+Review the [Troubleshooting](./troubleshooting.mdx) docs for more about using logs.
 
 ## Is my GPU compatible with Ollama?
 
-Please refer to the [GPU docs](./gpu).
+Please refer to the [GPU docs](./gpu.mdx).
 
 ## How can I specify the context window size?
 
@@ -248,7 +248,7 @@ Refer to the section [above](#how-do-i-configure-ollama-server) for how to set e
 
 ## How can I use Ollama in Visual Studio Code?
 
-Install the [Ollama extension](https://marketplace.visualstudio.com/items?itemName=Ollama.ollama) to use Ollama models in VS Code Chat. See the [VS Code integration guide](./integrations/vscode) for setup and troubleshooting.
+Install the [Ollama extension](https://marketplace.visualstudio.com/items?itemName=Ollama.ollama) to use Ollama models in VS Code Chat. See the [VS Code integration guide](./integrations/vscode.mdx) for setup and troubleshooting.
 
 ## How do I use Ollama with GPU acceleration in Docker?
 

--- a/docs/gpu.mdx
+++ b/docs/gpu.mdx
@@ -35,7 +35,7 @@ Check your compute compatibility to see if your card is supported:
 | 5.0                | GeForce GTX         | `GTX 750 Ti` `GTX 750` `NVS 810`                                                                                               |
 |                    | Quadro              | `K2200` `K1200` `K620` `M1200` `M520` `M5000M` `M4000M` `M3000M` `M2000M` `M1000M` `K620M` `M600M` `M500M`                     |
 
-For building locally to support older GPUs, see [developer](./development#linux-cuda-nvidia)
+For building locally to support older GPUs, see [development](./development).
 
 ### GPU Selection
 

--- a/docs/gpu.mdx
+++ b/docs/gpu.mdx
@@ -35,7 +35,7 @@ Check your compute compatibility to see if your card is supported:
 | 5.0                | GeForce GTX         | `GTX 750 Ti` `GTX 750` `NVS 810`                                                                                               |
 |                    | Quadro              | `K2200` `K1200` `K620` `M1200` `M520` `M5000M` `M4000M` `M3000M` `M2000M` `M1000M` `K620M` `M600M` `M500M`                     |
 
-For building locally to support older GPUs, see [development](./development).
+For building locally to support older GPUs, see [development](./development.md).
 
 ### GPU Selection
 

--- a/docs/import.mdx
+++ b/docs/import.mdx
@@ -4,10 +4,10 @@ title: Importing a Model
 
 ## Table of Contents
 
-- [Importing a Safetensors adapter](#Importing-a-fine-tuned-adapter-from-Safetensors-weights)
-- [Importing a Safetensors model](#Importing-a-model-from-Safetensors-weights)
-- [Importing a GGUF file](#Importing-a-GGUF-based-model-or-adapter)
-- [Sharing models on ollama.com](#Sharing-your-model-on-ollamacom)
+- [Importing a Safetensors adapter](#importing-a-fine-tuned-adapter-from-safetensors-weights)
+- [Importing a Safetensors model](#importing-a-model-from-safetensors-weights)
+- [Importing a GGUF file](#importing-a-gguf-based-model-or-adapter)
+- [Sharing models on ollama.com](#sharing-your-model-on-ollama-com)
 
 ## Importing a fine tuned adapter from Safetensors weights
 

--- a/docs/integrations/goose.mdx
+++ b/docs/integrations/goose.mdx
@@ -4,7 +4,7 @@ title: Goose
 
 ## Goose Desktop
 
-Install [Goose](https://block.github.io/goose/docs/getting-started/installation/) Desktop.
+Install [Goose](https://goose-docs.ai/docs/getting-started/installation/) Desktop.
 
 ### Usage with Ollama
 1. In Goose, open **Settings** → **Configure Provider**.  
@@ -27,7 +27,7 @@ Install [Goose](https://block.github.io/goose/docs/getting-started/installation/
 
 ## Goose CLI
 
-Install [Goose](https://block.github.io/goose/docs/getting-started/installation/) CLI
+Install [Goose](https://goose-docs.ai/docs/getting-started/installation/) CLI
 
 ### Usage with Ollama
 1. Run `goose configure`

--- a/docs/linux.mdx
+++ b/docs/linux.mdx
@@ -116,7 +116,7 @@ sudo systemctl status ollama
   While AMD has contributed the `amdgpu` driver upstream to the official linux
   kernel source, the version is older and may not support all ROCm features. We
   recommend you install the latest driver from
-  https://www.amd.com/en/support/linux-drivers for best support of your Radeon
+  https://www.amd.com/en/support/download/linux-drivers.html for best support of your Radeon
   GPU.
 </Note>
 

--- a/docs/modelfile.mdx
+++ b/docs/modelfile.mdx
@@ -107,12 +107,8 @@ FROM <model name>:<tag>
 FROM llama3.2
 ```
 
-<Card title="Base Models" href="https://github.com/ollama/ollama#model-library">
-  A list of available base models
-</Card>
-
-<Card title="Base Models" href="https://ollama.com/library">
-  Additional models can be found at
+<Card title="Model library" href="https://ollama.com/library">
+  Browse available models
 </Card>
 
 #### Build from a Safetensors model

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -137,7 +137,7 @@ After upgrading, reboot and restart Ollama.
 
 If you experience gibberish responses when models load across multiple AMD GPUs on Linux, see the following guide.
 
-- https://rocm.docs.amd.com/projects/radeon/en/latest/docs/install/native_linux/mgpu.html#mgpu-known-issues-and-limitations
+- https://rocm.docs.amd.com/projects/radeon-ryzen/en/latest/docs/install/installrad/native_linux/mgpu.html#mgpu-known-issues-and-limitations
 
 ## Windows Terminal Errors
 


### PR DESCRIPTION
## Summary

- fix internal documentation routes and section anchors that returned 404s or targeted missing sections
- update moved Goose, AMD, ROCm, and GitHub destinations
- point the FAQ to Ollama's official VS Code extension and integration guide
- link ollama.com from the API introduction and consolidate the obsolete model-library card

## Why

Several links retained source extensions or stale routes and anchors after the docs site, repository README, and external documentation moved. This caused 404s or sent readers to missing sections.

## Validation

- `npx mintlify broken-links --check-anchors --check-snippets`
- `npx mintlify validate`
- independent internal route and anchor audit: 149 occurrences, 0 problems
- external URL audit: 113 distinct targets confirmed; AMD timed out once in the concurrent pass and returned 200 on a bounded retry
- external fragment audit: 10 fragments found