### PR TITLE
README: add Sealos to cloud deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,7 @@ console.log(response.message.content);
 - [Google Cloud](https://cloud.google.com/run/docs/tutorials/gpu-gemma2-with-ollama)
 - [Fly.io](https://fly.io/docs/python/do-more/add-ollama/)
 - [Koyeb](https://www.koyeb.com/deploy/ollama)
+- [Sealos](https://sealos.io/products/app-store/ollama) - One-click CPU deployment with persistent model storage; add an authenticated network boundary for shared use
 - [Harbor](https://github.com/av/harbor) - Containerized LLM toolkit with Ollama as default backend
 
 #### Package Managers


### PR DESCRIPTION
## Summary

Add Sealos to the existing `Infrastructure & Deployment > Cloud` list in `README.md`.

The entry links a community-maintained one-click CPU deployment that:

- uses the official Ollama image
- persists downloaded models
- calls out the authenticated network boundary needed for shared use

## Why

The Cloud section already lists hosted deployment paths. This one-line entry gives Sealos users the same discoverable route while preserving the README structure and keeping the security requirement next to the link.

This supersedes #17670, which was closed during an internal review before the entry was reduced to the existing one-line list pattern.

## Validation

- `git diff --check`
- Sealos App Store link returns HTTP 200
- Source template: https://github.com/labring-actions/templates/tree/kb-0.9/template/ollama
- Live checks in labring-actions/templates#737 cover model pull, native REST generation, OpenAI-compatible generation, persistence, readiness, and complete cleanup
- Duplicate search found no other Sealos contribution

Prepared with AI assistance and reviewed against the final one-line diff.
