### PR TITLE
cmd/launch: explain why claude desktop cannot be restored off macos and windows

### DIFF
--- a/cmd/launch/claude_desktop.go
+++ b/cmd/launch/claude_desktop.go
@@ -27,6 +27,7 @@ const (
 	claudeDesktopAPIKeyURL       = "https://ollama.com/settings/keys"
 	claudeDesktopModelLabel      = "Ollama Cloud"
 	claudeDesktopUnsupported     = "Claude Desktop is no longer supported. Existing installations can be restored with 'ollama launch claude-desktop --restore'."
+	claudeDesktopUnsupportedOS   = "Ollama only configured Claude Desktop on macOS and Windows, so there is nothing to restore on this system."
 	claudeDesktopSuccessMessage  = "Claude Desktop profile changed to Ollama Cloud."
 	claudeDesktopRestoreMessage  = "To restore the usual Claude profile, run: ollama launch claude-desktop --restore"
 	claudeDesktopRestoredMessage = "Claude Desktop restored to the usual Claude profile."
@@ -171,7 +172,7 @@ func claudeDesktopSupported() error {
 	case "darwin", "windows":
 		return nil
 	default:
-		return fmt.Errorf("Claude Desktop launch is only supported on macOS and Windows")
+		return errors.New(claudeDesktopUnsupportedOS)
 	}
 }
 

--- a/cmd/launch/claude_desktop_test.go
+++ b/cmd/launch/claude_desktop_test.go
@@ -144,6 +144,33 @@ func TestLaunchIntegration_ClaudeDesktopLaunchReturnsUnsupported(t *testing.T) {
 	}
 }
 
+// Claude Desktop launch is disabled on every platform, so an unsupported OS
+// must not be blamed for it.
+func TestLaunchIntegration_ClaudeDesktopLaunchOnUnsupportedOSReportsDeprecation(t *testing.T) {
+	withClaudeDesktopPlatform(t, "linux")
+
+	err := LaunchIntegration(context.Background(), IntegrationLaunchRequest{Name: "claude-desktop"})
+	if err == nil {
+		t.Fatal("expected Claude Desktop launch to fail")
+	}
+	if err.Error() != claudeDesktopUnsupported {
+		t.Fatalf("expected deprecation guidance, got %v", err)
+	}
+}
+
+func TestLaunchIntegration_ClaudeDesktopRestoreOnUnsupportedOS(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	withClaudeDesktopPlatform(t, "linux")
+
+	err := LaunchIntegration(context.Background(), IntegrationLaunchRequest{Name: "claude-desktop", Restore: true})
+	if err == nil {
+		t.Fatal("expected Claude Desktop restore to fail")
+	}
+	if err.Error() != claudeDesktopUnsupportedOS {
+		t.Fatalf("expected nothing to restore guidance, got %v", err)
+	}
+}
+
 func TestLaunchIntegration_ClaudeDesktopRestoreStillWorks(t *testing.T) {
 	tmpDir := t.TempDir()
 	setTestHome(t, tmpDir)


### PR DESCRIPTION
`ollama launch claude-desktop --restore` fails on Linux with:

```
Error: Claude Desktop launch is only supported on macOS and Windows
```

The message blames the operating system, but Claude Desktop launch is not supported on macOS and Windows either. `LaunchIntegration` rejects the integration on every platform at `cmd/launch/launch.go:483`, added in #16028 and released in v0.23.2. `--restore` is the only path left that runs, and it reaches `claudeDesktopSupported()` through `EnsureIntegrationInstalled`, which is where the platform message comes from.

The real reason is different. `ConfigureAutodiscovery` was gated by that same macOS/Windows check, so Ollama never wrote a Claude Desktop profile anywhere else. On Linux there is nothing to restore. This changes the message to say that, and leaves the platform switch alone.

I did not add Linux support. The integration drives Claude Desktop's third-party (3P) deployment mode, writing `deploymentMode: "3p"`, a `Claude-3p` user data directory, and a gateway profile under `configLibrary`. Anthropic documents 3P for macOS (`.dmg`) and Windows (`.msix`) only, with no Linux entry in the 3P system requirements. Adding path and process handling for a code path that is disabled on every platform would be dead code.

## Tests

Two in `cmd/launch/claude_desktop_test.go`, both pinning `claudeDesktopGOOS` to `linux`:

- `--restore` returns the new "nothing to restore" message
- plain launch still returns the deprecation message

The second is a regression guard on ordering. The deprecation gate runs before `Supported()`; if that order is ever swapped, Linux users get a platform error for plain launch too, which is the confusion reported in #17653. The existing `TestLaunchIntegration_ClaudeDesktopLaunchReturnsUnsupported` does not pin the platform, so it would not catch that.

Closes #17653
