### PR TITLE
Add AI Job Search to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ console.log(response.message.content);
 - [Serene Pub](https://github.com/doolijb/serene-pub) - AI roleplaying app
 - [Mayan EDMS](https://gitlab.com/mayan-edms/mayan-edms) - Document management with Ollama workflows
 - [TagSpaces](https://www.tagspaces.org) - File management with [AI tagging](https://docs.tagspaces.org/ai/)
+- [AI Job Search](https://github.com/mrWD/ai-job-search) - Local-first job search that scores postings against your CV
 
 ### Observability & Monitoring
 


### PR DESCRIPTION
Adds [AI Job Search](https://github.com/mrWD/ai-job-search) to Community Integrations → Productivity & Apps.

A local-first desktop app (macOS/Windows/Linux, MIT) that walks company career pages and ATS boards, then scores each posting against the user's CV. Ollama is one of the supported engines: the app detects it, lists installed models and checks the machine has enough memory before offering one — so the whole pipeline can run locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)