### PR TITLE
cmd, readline: add opt-in vim-style key bindings for interactive CLI

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2351,6 +2351,7 @@ func NewCLI() *cobra.Command {
 	runCmd.Flags().String("keepalive", "", "Duration to keep a model loaded (e.g. 5m)")
 	runCmd.Flags().Bool("verbose", false, "Show timings for response")
 	runCmd.Flags().Bool("insecure", false, "Use an insecure registry")
+	runCmd.Flags().Bool("vim", false, "Use vim-style key bindings in the interactive prompt")
 	runCmd.Flags().Bool("nowordwrap", false, "Don't wrap words to the next line automatically")
 	runCmd.Flags().String("format", "", "Response format (e.g. json)")
 	runCmd.Flags().String("think", "", "Enable thinking mode: true/false or high/medium/low for supported models")

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -32,6 +32,8 @@ const (
 )
 
 func generateInteractive(cmd *cobra.Command, opts runOptions) error {
+	vimMode, _ := cmd.Flags().GetBool("vim")
+
 	usage := func() {
 		fmt.Fprintln(os.Stderr, "Available Commands:")
 		fmt.Fprintln(os.Stderr, "  /set            Set session variables")
@@ -85,6 +87,18 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 		fmt.Fprintln(os.Stderr, "  Ctrl + c            Stop the model from responding")
 		fmt.Fprintln(os.Stderr, "  Ctrl + d            Exit ollama (/bye)")
 		fmt.Fprintln(os.Stderr, "")
+		if vimMode {
+			fmt.Fprintln(os.Stderr, "Vim mode (started with --vim):")
+			fmt.Fprintln(os.Stderr, "  Esc                 Enter normal mode")
+			fmt.Fprintln(os.Stderr, "  h l                 Move cursor left / right")
+			fmt.Fprintln(os.Stderr, "  0 $                 Move to start / end of line")
+			fmt.Fprintln(os.Stderr, "  w b                 Move forward / backward one word")
+			fmt.Fprintln(os.Stderr, "  x                   Delete the character under the cursor")
+			fmt.Fprintln(os.Stderr, "  dd                  Delete the entire line")
+			fmt.Fprintln(os.Stderr, "  dw                  Delete the word after the cursor")
+			fmt.Fprintln(os.Stderr, "  i a I A o           Return to insert mode")
+			fmt.Fprintln(os.Stderr, "")
+		}
 	}
 
 	usageShow := func() {
@@ -125,6 +139,12 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 		return err
 	}
 
+	scanner.VimMode = vimMode
+
+	if vimMode {
+		fmt.Fprintln(os.Stderr, "Vim mode enabled. Press Esc for normal mode, then ? for a list of commands.")
+	}
+
 	if envconfig.NoHistory() {
 		scanner.HistoryDisable()
 	}
@@ -162,6 +182,12 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 				continue
 			}
 			scanner.Prefill = content
+			continue
+		case errors.Is(err, readline.ErrVimHelp):
+			usageShortcuts()
+			if line != "" {
+				scanner.Prefill = line
+			}
 			continue
 		case err != nil:
 			return err

--- a/readline/buffer.go
+++ b/readline/buffer.go
@@ -450,6 +450,24 @@ func (b *Buffer) DeleteWord() {
 	}
 }
 
+func (b *Buffer) DeleteWordForward() {
+	if b.Buf.Size() > 0 && b.Pos < b.Buf.Size() {
+		var foundNonspace bool
+		for b.Pos < b.Buf.Size() {
+			v, _ := b.Buf.Get(b.Pos)
+			if v == ' ' {
+				if foundNonspace {
+					break
+				}
+				b.Delete()
+			} else {
+				foundNonspace = true
+				b.Delete()
+			}
+		}
+	}
+}
+
 func (b *Buffer) ClearScreen() {
 	fmt.Print(ClearScreen + CursorReset + b.Prompt.prompt())
 	if b.IsEmpty() {

--- a/readline/errors.go
+++ b/readline/errors.go
@@ -7,6 +7,7 @@ import (
 var (
 	ErrInterrupt  = errors.New("Interrupt")
 	ErrEditPrompt = errors.New("EditPrompt")
+	ErrVimHelp    = errors.New("VimHelp")
 )
 
 type InterruptError struct {

--- a/readline/readline.go
+++ b/readline/readline.go
@@ -42,7 +42,10 @@ type Instance struct {
 	History     *History
 	Pasting     bool
 	Prefill     string
+	VimMode     bool
 	pastedLines []string
+	vimNormal   bool
+	vimPendingD bool
 }
 
 func New(prompt Prompt) (*Instance, error) {
@@ -110,6 +113,9 @@ func (i *Instance) Readline() (string, error) {
 			}
 		}
 	}
+
+	i.vimNormal = false
+	i.vimPendingD = false
 
 	var esc bool
 	var escex bool
@@ -215,6 +221,81 @@ func (i *Instance) Readline() (string, error) {
 			continue
 		}
 
+		if i.VimMode && r == CharEsc && i.Terminal.reader.Buffered() == 0 {
+			i.vimNormal = true
+			i.vimPendingD = false
+			continue
+		}
+
+		if i.VimMode && i.vimNormal {
+			if i.vimPendingD {
+				i.vimPendingD = false
+				switch r {
+				case 'd':
+					buf.MoveToStart()
+					buf.DeleteRemaining()
+				case 'w':
+					buf.DeleteWordForward()
+				}
+				continue
+			}
+
+			handled := true
+			switch r {
+			case 'h':
+				buf.MoveLeft()
+			case 'l':
+				buf.MoveRight()
+			case '0':
+				buf.MoveToStart()
+			case '$':
+				buf.MoveToEnd()
+			case 'w':
+				buf.MoveRightWord()
+			case 'b':
+				buf.MoveLeftWord()
+			case 'x':
+				buf.Delete()
+			case 'd':
+				i.vimPendingD = true
+			case '?':
+				return i.clearInput(buf), ErrVimHelp
+			case 'i':
+				i.vimNormal = false
+			case 'a':
+				buf.MoveRight()
+				i.vimNormal = false
+			case 'I':
+				buf.MoveToStart()
+				i.vimNormal = false
+			case 'A':
+				buf.MoveToEnd()
+				i.vimNormal = false
+			case 'o':
+				buf.MoveToEnd()
+				i.pastedLines = append(i.pastedLines, buf.String())
+				buf.Buf.Clear()
+				buf.Pos = 0
+				buf.DisplayPos = 0
+				buf.LineHasSpace.Clear()
+				fmt.Println()
+				fmt.Print(i.Prompt.AltPrompt)
+				i.Prompt.UseAlt = true
+				i.vimNormal = false
+			default:
+				handled = false
+			}
+
+			if handled {
+				continue
+			}
+
+			// swallow any other printable character; normal mode doesn't insert text
+			if r >= CharSpace {
+				continue
+			}
+		}
+
 		switch r {
 		case CharNull:
 			continue
@@ -274,28 +355,7 @@ func (i *Instance) Readline() (string, error) {
 		case CharCtrlW:
 			buf.DeleteWord()
 		case CharBell:
-			output := buf.String()
-			numPastedLines := len(i.pastedLines)
-			if numPastedLines > 0 {
-				output = strings.Join(i.pastedLines, "\n") + "\n" + output
-				i.pastedLines = nil
-			}
-
-			// Move cursor to the last display line of the current buffer
-			currLine := buf.DisplayPos / buf.LineWidth
-			lastLine := buf.DisplaySize() / buf.LineWidth
-			if lastLine > currLine {
-				fmt.Print(CursorDownN(lastLine - currLine))
-			}
-
-			// Clear all lines from bottom to top: buffer wrapped lines + pasted lines
-			for range lastLine + numPastedLines {
-				fmt.Print(CursorBOL + ClearToEOL + CursorUp)
-			}
-			fmt.Print(CursorBOL + ClearToEOL)
-
-			i.Prompt.UseAlt = false
-			return output, ErrEditPrompt
+			return i.clearInput(buf), ErrEditPrompt
 		case CharCtrlZ:
 			fd := os.Stdin.Fd()
 			return handleCharCtrlZ(fd, i.Terminal.termios)
@@ -338,6 +398,33 @@ func (i *Instance) Readline() (string, error) {
 			}
 		}
 	}
+}
+
+// clearInput clears the currently displayed input (including any pasted
+// multiline lines) from the terminal and returns the full buffered text.
+func (i *Instance) clearInput(buf *Buffer) string {
+	output := buf.String()
+	numPastedLines := len(i.pastedLines)
+	if numPastedLines > 0 {
+		output = strings.Join(i.pastedLines, "\n") + "\n" + output
+		i.pastedLines = nil
+	}
+
+	// Move cursor to the last display line of the current buffer
+	currLine := buf.DisplayPos / buf.LineWidth
+	lastLine := buf.DisplaySize() / buf.LineWidth
+	if lastLine > currLine {
+		fmt.Print(CursorDownN(lastLine - currLine))
+	}
+
+	// Clear all lines from bottom to top: buffer wrapped lines + pasted lines
+	for range lastLine + numPastedLines {
+		fmt.Print(CursorBOL + ClearToEOL + CursorUp)
+	}
+	fmt.Print(CursorBOL + ClearToEOL)
+
+	i.Prompt.UseAlt = false
+	return output
 }
 
 func (i *Instance) HistoryEnable() {


### PR DESCRIPTION
## Summary
- Adds an opt-in `--vim` flag to `ollama run` for vim-style modal editing in the interactive prompt. Default behavior is unchanged unless the flag is passed.
- Starts in insert mode (identical to current behavior). `Esc` enters normal mode with motions (`h`/`l`/`0`/`$`/`w`/`b`), edits (`x`/`dd`/`dw`), and mode switches (`i`/`a`/`I`/`A`/`o`).
- `?` in normal mode (or `/? shortcuts` at any time) shows the vim shortcut list and restores any in-progress input.
- `readline/readline.go`: added `VimMode`/`vimNormal`/`vimPendingD` state to `Instance`; a standalone `Esc` (no buffered follow-up byte) is disambiguated from existing Alt-key escape sequences to enter normal mode; extracted a shared `clearInput` helper (previously inline in the Ctrl+G external-editor handler) reused by the new `?` help path.
- `readline/buffer.go`: added `DeleteWordForward` (existing `DeleteWord` only deletes backward).
- `readline/errors.go`: added `ErrVimHelp` sentinel, mirroring `ErrEditPrompt`.
- `cmd/cmd.go` / `cmd/interactive.go`: registered `--vim` flag, wired it into the scanner, added startup banner and vim section in the shortcuts help.

Closes #16898

## Test plan
- [x] `go build -o ollama.exe .` succeeds
- [x] Typing normally (insert mode) is unaffected by the change when `--vim` is not passed
- [x] `Esc` enters normal mode; `h`/`l`/`0`/`$`/`w`/`b` move without inserting text
- [x] `x` deletes under cursor, `dd` clears line, `dw` deletes word forward
- [x] `i`/`a`/`I`/`A`/`o` return to insert mode at the correct position
- [x] `?` shows shortcuts and restores in-progress text
- [x] Automated unit tests for the new readline paths (not yet added — happy to add if maintainers want them)