### PR TITLE
mlxrunner: add structured output support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -214,6 +214,7 @@ WORKDIR /go/src/github.com/ollama/ollama
 COPY CMakeLists.txt CMakePresets.json .
 COPY cmake cmake
 COPY x/mlxrunner/mlx x/mlxrunner/mlx
+COPY x/mlxrunner/constraint/native x/mlxrunner/constraint/native
 COPY go.mod go.sum .
 COPY MLX_VERSION MLX_C_VERSION .
 RUN curl -fsSL https://golang.org/dl/go$(awk '/^go/ { print $2 }' go.mod).linux-$(case $(uname -m) in x86_64) echo amd64 ;; aarch64) echo arm64 ;; esac).tar.gz | tar xz -C /usr/local

--- a/cmake/local.cmake
+++ b/cmake/local.cmake
@@ -521,6 +521,7 @@ function(ollama_add_mlx_build name)
             ${OLLAMA_NATIVE_CONFIG_ARG}
             ${OLLAMA_NATIVE_BUILD_TARGET_ARG} mlx
             ${OLLAMA_NATIVE_BUILD_TARGET_ARG} mlxc
+            ${OLLAMA_NATIVE_BUILD_TARGET_ARG} ollama_constraints
         INSTALL_COMMAND ${CMAKE_COMMAND} --install <BINARY_DIR>
             ${OLLAMA_NATIVE_CONFIG_ARG}
             --component MLX

--- a/cmake/mlx/CMakeLists.txt
+++ b/cmake/mlx/CMakeLists.txt
@@ -52,6 +52,35 @@ option(OLLAMA_MLX_GENERATE_WRAPPERS "Regenerate MLX Go wrappers" OFF)
 message(STATUS "Setting up MLX (this takes a while...)")
 add_subdirectory(${OLLAMA_SOURCE_DIR}/x/mlxrunner/mlx ${CMAKE_BINARY_DIR}/x/mlxrunner/mlx)
 
+include(FetchContent)
+FetchContent_Declare(xgrammar
+    GIT_REPOSITORY "https://github.com/mlc-ai/xgrammar.git"
+    GIT_TAG v0.2.5
+    GIT_SHALLOW TRUE
+    GIT_SUBMODULES 3rdparty/dlpack
+    # Do not add XGrammar's Python-oriented CMake project.
+    SOURCE_SUBDIR cmake/ollama)
+FetchContent_MakeAvailable(xgrammar)
+
+file(GLOB_RECURSE XGRAMMAR_SOURCES CONFIGURE_DEPENDS "${xgrammar_SOURCE_DIR}/cpp/*.cc")
+list(FILTER XGRAMMAR_SOURCES EXCLUDE REGEX "/cpp/tvm_ffi/.*\\.cc$")
+add_library(xgrammar STATIC ${XGRAMMAR_SOURCES})
+set_target_properties(xgrammar PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(xgrammar PUBLIC "${xgrammar_SOURCE_DIR}/include")
+target_include_directories(xgrammar SYSTEM PUBLIC
+    "${xgrammar_SOURCE_DIR}/3rdparty/picojson"
+    "${xgrammar_SOURCE_DIR}/3rdparty/dlpack/include")
+target_compile_definitions(xgrammar PUBLIC
+    XGRAMMAR_ENABLE_CPPTRACE=0
+    XGRAMMAR_ENABLE_INTERNAL_CHECK=0)
+
+add_library(ollama_constraints SHARED
+    "${OLLAMA_SOURCE_DIR}/x/mlxrunner/constraint/native/constraint.cpp")
+target_include_directories(ollama_constraints PRIVATE
+    "${OLLAMA_SOURCE_DIR}/x/mlxrunner/constraint/native")
+target_compile_definitions(ollama_constraints PRIVATE OLLAMA_CONSTRAINT_BUILD=1)
+target_link_libraries(ollama_constraints PRIVATE xgrammar Threads::Threads)
+
 # Find CUDA toolkit if MLX is built with CUDA support.
 find_package(CUDAToolkit)
 
@@ -88,12 +117,22 @@ endif()
 
 # Keep mlx/mlxc targets separate from runtime dependencies so --strip only
 # applies to the binaries we build, not vendor DLLs/libs.
-install(TARGETS mlx mlxc
+install(TARGETS mlx mlxc ollama_constraints
     RUNTIME_DEPENDENCY_SET mlx_runtime_deps
     RUNTIME DESTINATION ${OLLAMA_INSTALL_DIR} COMPONENT MLX
     LIBRARY DESTINATION ${OLLAMA_INSTALL_DIR} COMPONENT MLX
     FRAMEWORK DESTINATION ${OLLAMA_INSTALL_DIR} COMPONENT MLX
 )
+install(FILES
+    "${xgrammar_SOURCE_DIR}/LICENSE"
+    DESTINATION ${OLLAMA_INSTALL_DIR}
+    RENAME XGRAMMAR_LICENSE
+    COMPONENT MLX)
+install(FILES
+    "${xgrammar_SOURCE_DIR}/NOTICE"
+    DESTINATION ${OLLAMA_INSTALL_DIR}
+    RENAME XGRAMMAR_NOTICE
+    COMPONENT MLX)
 install(RUNTIME_DEPENDENCY_SET mlx_runtime_deps
     DIRECTORIES ${MLX_RUNTIME_DIRS}
     PRE_INCLUDE_REGEXES ${MLX_INCLUDE_REGEXES}

--- a/integration/reg_release_test.go
+++ b/integration/reg_release_test.go
@@ -2,6 +2,8 @@
 
 package integration
 
+import "testing"
+
 var (
 	releaseUnicodeInputModel    = integrationModel{Name: "deepseek-coder-v2:16b-lite-instruct-q2_K", MinVRAMGB: 12}
 	releaseUnicodeOutputModel   = "gemma2:2b"
@@ -63,6 +65,10 @@ var (
 
 const releaseSplitBatchVisionModel = "qwen3.5:2b"
 
+func TestStructuredOutput(t *testing.T) {
+	runIntegrationGroup(t, "structured-output")
+}
+
 func init() {
 	// Fixed release regression cases
 	registerIntegrationCases(
@@ -118,6 +124,7 @@ func init() {
 		integrationTestCase("create-gguf", "", runCreateGGUF),
 		integrationTestCase("quantization", "qwen2.5:0.5b-instruct-fp16", runQuantization),
 	)
+	registerStructuredOutputCases()
 
 	// Model-parametric cases
 	registerModelMinVRAM([]integrationModel{releaseUnicodeInputModel, releaseParallelHistoryModel})

--- a/integration/structured_output_test.go
+++ b/integration/structured_output_test.go
@@ -1,0 +1,194 @@
+//go:build integration
+
+package integration
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"math"
+	"testing"
+
+	"github.com/ollama/ollama/api"
+)
+
+var structuredOutputSchema = json.RawMessage(`{
+  "type": "object",
+  "properties": {
+    "color": {"type": "string", "enum": ["blue", "violet"]},
+    "count": {"type": "integer", "minimum": 1, "maximum": 3}
+  },
+  "required": ["color", "count"],
+  "additionalProperties": false
+}`)
+
+func validateStructuredObject(t *testing.T, content string) {
+	t.Helper()
+	if !json.Valid([]byte(content)) {
+		t.Fatalf("response is not valid JSON: %q", content)
+	}
+	var object map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(content), &object); err != nil {
+		t.Fatal(err)
+	}
+	if len(object) != 2 || object["color"] == nil || object["count"] == nil {
+		t.Fatalf("response has the wrong fields: %s", content)
+	}
+	var color string
+	if err := json.Unmarshal(object["color"], &color); err != nil || (color != "blue" && color != "violet") {
+		t.Fatalf("color = %q, %v", color, err)
+	}
+	var count int
+	if err := json.Unmarshal(object["count"], &count); err != nil || count < 1 || count > 3 {
+		t.Fatalf("count = %d, %v", count, err)
+	}
+}
+
+func validateConstrainedLogprobs(t *testing.T, logprobs []api.Logprob) {
+	t.Helper()
+	if len(logprobs) == 0 {
+		t.Fatal("constrained response did not include logprobs")
+	}
+	for i, entry := range logprobs {
+		if math.IsInf(entry.Logprob, 0) || math.IsNaN(entry.Logprob) {
+			t.Fatalf("logprob[%d] is not finite: %v", i, entry.Logprob)
+		}
+		for j, alternative := range entry.TopLogprobs {
+			if math.IsInf(alternative.Logprob, 0) || math.IsNaN(alternative.Logprob) {
+				t.Fatalf("logprob[%d].top_logprobs[%d] is not finite: %v", i, j, alternative.Logprob)
+			}
+		}
+	}
+}
+
+const structuredOutputMLXModel = "qwen3.5:2b-nvfp4"
+
+func registerStructuredOutputCases() {
+	registerModelMinVRAM([]integrationModel{{Name: structuredOutputMLXModel, MinVRAMGB: 4}})
+	registerModelIntegrationCases("structured-output", testModels([]string{smol, structuredOutputMLXModel}), runStructuredOutput)
+}
+
+func runStructuredOutput(t *testing.T, model string) {
+	skipRegisteredMinVRAM(t, model)
+	ctx, cancel := context.WithTimeout(context.Background(), apiTestTimeout)
+	defer cancel()
+	client, _, cleanup := InitServerConnection(ctx, t)
+	defer cleanup()
+	pullOrSkip(ctx, t, client, model)
+	noThink := api.ThinkValue{Value: false}
+	preloadGenerateModel(ctx, t, client, api.GenerateRequest{
+		Model:  model,
+		Prompt: "Respond with one word.",
+		Think:  &noThink,
+		Options: map[string]any{
+			"temperature": 0,
+			"num_predict": 1,
+		},
+	})
+
+	t.Run("generate builtin JSON streaming", func(t *testing.T) {
+		stream := true
+		req := api.GenerateRequest{
+			Model:  model,
+			Prompt: "Return the smallest possible JSON value. Output JSON only.",
+			Stream: &stream,
+			Format: json.RawMessage(`"json"`),
+			Think:  &noThink,
+			Options: map[string]any{
+				"temperature": 0,
+				"seed":        17,
+				"num_predict": 96,
+			},
+		}
+		var content bytes.Buffer
+		if err := client.Generate(ctx, &req, func(response api.GenerateResponse) error {
+			content.WriteString(response.Response)
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		if !json.Valid(content.Bytes()) {
+			t.Fatalf("response is not valid JSON: %q", content.String())
+		}
+	})
+
+	t.Run("generate schema greedy with logprobs", func(t *testing.T) {
+		stream := false
+		req := api.GenerateRequest{
+			Model:       model,
+			Prompt:      "Return an object with a color and a small count. Output JSON only.",
+			Stream:      &stream,
+			Format:      structuredOutputSchema,
+			Think:       &noThink,
+			Logprobs:    true,
+			TopLogprobs: 20,
+			Options: map[string]any{
+				"temperature": 0,
+				"seed":        23,
+				"num_predict": 96,
+			},
+		}
+		var content bytes.Buffer
+		var logprobs []api.Logprob
+		if err := client.Generate(ctx, &req, func(response api.GenerateResponse) error {
+			content.WriteString(response.Response)
+			logprobs = append(logprobs, response.Logprobs...)
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		validateStructuredObject(t, content.String())
+		validateConstrainedLogprobs(t, logprobs)
+	})
+
+	t.Run("generate schema sampled streaming", func(t *testing.T) {
+		stream := true
+		req := api.GenerateRequest{
+			Model:  model,
+			Prompt: "Return a color and count as a JSON object. Output JSON only.",
+			Stream: &stream,
+			Format: structuredOutputSchema,
+			Think:  &noThink,
+			Options: map[string]any{
+				"temperature": 0.7,
+				"seed":        29,
+				"num_predict": 96,
+			},
+		}
+		var content bytes.Buffer
+		if err := client.Generate(ctx, &req, func(response api.GenerateResponse) error {
+			content.WriteString(response.Response)
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		validateStructuredObject(t, content.String())
+	})
+
+	t.Run("chat schema greedy", func(t *testing.T) {
+		stream := false
+		req := api.ChatRequest{
+			Model: model,
+			Messages: []api.Message{{
+				Role:    "user",
+				Content: "Return an object with a color and a small count. Output JSON only.",
+			}},
+			Stream: &stream,
+			Format: structuredOutputSchema,
+			Think:  &noThink,
+			Options: map[string]any{
+				"temperature": 0,
+				"seed":        31,
+				"num_predict": 96,
+			},
+		}
+		var content bytes.Buffer
+		if err := client.Chat(ctx, &req, func(response api.ChatResponse) error {
+			content.WriteString(response.Message.Content)
+			return nil
+		}); err != nil {
+			t.Fatal(err)
+		}
+		validateStructuredObject(t, content.String())
+	})
+}

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -113,6 +113,7 @@ func (c *Client) WaitUntilRunning(ctx context.Context) error {
 type CompletionRequest struct {
 	Prompt      string
 	Media       []llm.MediaData
+	Format      json.RawMessage
 	Options     api.Options
 	Logprobs    bool
 	TopLogprobs int
@@ -154,9 +155,14 @@ func (c *Client) Close() error {
 
 // Completion implements llm.LlamaServer.
 func (c *Client) Completion(ctx context.Context, req llm.CompletionRequest, fn func(llm.CompletionResponse)) error {
+	if req.Grammar != "" {
+		return errors.New("raw grammar is not supported by the MLX runner")
+	}
+
 	creq := CompletionRequest{
 		Prompt:      req.Prompt,
 		Media:       req.Media,
+		Format:      req.Format,
 		Logprobs:    req.Logprobs,
 		TopLogprobs: req.TopLogprobs,
 	}

--- a/x/mlxrunner/client_test.go
+++ b/x/mlxrunner/client_test.go
@@ -1,0 +1,66 @@
+package mlxrunner
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/llm"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return f(r)
+}
+
+func TestCompletionPropagatesFormat(t *testing.T) {
+	wantFormat := json.RawMessage(`{"type":"object","required":["answer"]}`)
+
+	var got CompletionRequest
+	client := &Client{port: 1, client: &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		if err := json.NewDecoder(r.Body).Decode(&got); err != nil {
+			return nil, err
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader(`{"Done":true}` + "\n")),
+			Request:    r,
+		}, nil
+	})}}
+
+	err := client.Completion(t.Context(), llm.CompletionRequest{
+		Format: wantFormat,
+	}, func(response llm.CompletionResponse) {
+		if !response.Done {
+			t.Error("completion response is not done")
+		}
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(got.Format) != string(wantFormat) {
+		t.Errorf("format = %s, want %s", got.Format, wantFormat)
+	}
+}
+
+func TestCompletionRejectsRawGrammar(t *testing.T) {
+	called := false
+	client := &Client{client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+		called = true
+		return nil, errors.New("unexpected request")
+	})}}
+
+	err := client.Completion(t.Context(), llm.CompletionRequest{Grammar: `root ::= "ok"`}, func(llm.CompletionResponse) {})
+	if err == nil || !strings.Contains(err.Error(), "raw grammar is not supported") {
+		t.Fatalf("Completion error = %v, want unsupported raw grammar", err)
+	}
+	if called {
+		t.Fatal("Completion sent a raw grammar request to the MLX runner")
+	}
+}

--- a/x/mlxrunner/constrained_decoder.go
+++ b/x/mlxrunner/constrained_decoder.go
@@ -1,0 +1,134 @@
+package mlxrunner
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	sampler "github.com/ollama/ollama/x/mlxrunner/sample"
+)
+
+type constrainedDecoder struct {
+	r             *Runner
+	spec          *speculationSession
+	caches        []cache.Cache
+	layout        []any
+	matcher       requestConstraint
+	position      int
+	tokenMask     []bool
+	pendingSample sampler.Result
+	eosForwarded  bool
+}
+
+func (r *Runner) constrainedDecoder(spec *speculationSession, caches []cache.Cache, seed *mlx.Array, position int, layout []any, matcher requestConstraint) (*constrainedDecoder, error) {
+	d := &constrainedDecoder{
+		r: r, spec: spec, caches: caches, layout: layout,
+		matcher: matcher, position: position, tokenMask: make([]bool, matcher.VocabSize()),
+	}
+	logits, err := d.startForward(seed.ExpandDims(-1))
+	if err != nil {
+		return nil, err
+	}
+	d.pendingSample, err = d.sampleLogits(logits)
+	if err != nil {
+		return nil, err
+	}
+	return d, nil
+}
+
+func (d *constrainedDecoder) startForward(token *mlx.Array) (*mlx.Array, error) {
+	hidden, auxHidden := d.r.Model.Forward(&batch.Batch{
+		InputIDs:     token,
+		SeqOffsets:   []int32{int32(d.position)},
+		SeqQueryLens: []int32{int32(token.Dim(1))},
+		Layout:       d.layout,
+	}, d.caches)
+	d.spec.committed(token, auxHidden, d.position, nil)
+	d.position += token.Dim(1)
+
+	logits := d.r.Model.Unembed(hidden)
+	if logits.NumDims() != 3 {
+		return nil, fmt.Errorf("constraint model logits have %d dimensions, want 3", logits.NumDims())
+	}
+	logits = logits.Slice(mlx.Slice(), mlx.Slice(logits.Dim(1)-1), mlx.Slice()).Squeeze(1)
+	if got, want := logits.Dim(logits.NumDims()-1), d.matcher.VocabSize(); got != want {
+		return nil, fmt.Errorf("constraint vocabulary size %d does not match model logits %d", want, got)
+	}
+	mlx.Pin(logits)
+	mlx.Sweep()
+	mlx.AsyncEval(logits)
+	return logits, nil
+}
+
+func (d *constrainedDecoder) sampleLogits(logits *mlx.Array) (sampler.Result, error) {
+	source := logits
+	packed, needsApply, err := d.matcher.Fill()
+	if err != nil {
+		mlx.Unpin(source)
+		return sampler.Result{}, err
+	}
+	if needsApply {
+		unpackTokenMaskInto(d.tokenMask, packed)
+		mask := mlx.FromValues(d.tokenMask, d.matcher.VocabSize())
+		negInf := mlx.FromValue(float32(math.Inf(-1))).AsType(logits.DType())
+		logits = mlx.Where(mask, logits, negInf)
+	}
+	next := d.r.Sampler.Sample([]int{pipelineSlot}, logits)
+	mlx.Pin(next.Arrays()...)
+	mlx.Unpin(source)
+	mlx.Sweep()
+	mlx.AsyncEval(next.Arrays()...)
+	return next, nil
+}
+
+func (d *constrainedDecoder) next(int) ([]sampler.Result, error) {
+	out := d.pendingSample
+
+	// Start the independent forward before reading the sampled token back to the host.
+	logits, err := d.startForward(out.Token.ExpandDims(-1))
+	if err != nil {
+		return nil, err
+	}
+	id := int32(out.Token.Int())
+	if err := d.matcher.Accept(id); err != nil {
+		mlx.Unpin(logits)
+		return nil, err
+	}
+	if d.r.Tokenizer.IsEOS(id) {
+		mlx.Unpin(logits)
+		mlx.Unpin(out.Arrays()...)
+		d.pendingSample = sampler.Result{}
+		d.eosForwarded = true
+		return []sampler.Result{out}, nil
+	}
+	next, err := d.sampleLogits(logits)
+	if err != nil {
+		return nil, err
+	}
+	d.pendingSample = next
+	mlx.Unpin(out.Arrays()...)
+	return []sampler.Result{out}, nil
+}
+
+func (d *constrainedDecoder) drain() ([]sampler.Result, int) {
+	if d.eosForwarded {
+		return nil, d.position
+	}
+	return []sampler.Result{d.pendingSample}, d.position
+}
+
+func (d *constrainedDecoder) close() {
+	if d.eosForwarded {
+		return
+	}
+	d.spec.settle(d.pendingSample.Token)
+	mlx.Unpin(d.pendingSample.Arrays()...)
+}
+
+func unpackTokenMaskInto(mask []bool, packed []int32) {
+	for id := range mask {
+		mask[id] = uint32(packed[id/32])&(uint32(1)<<uint(id%32)) != 0
+	}
+}

--- a/x/mlxrunner/constrained_decoder_test.go
+++ b/x/mlxrunner/constrained_decoder_test.go
@@ -1,0 +1,185 @@
+package mlxrunner
+
+import (
+	"errors"
+	"fmt"
+	"math"
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+	sampler "github.com/ollama/ollama/x/mlxrunner/sample"
+	"github.com/ollama/ollama/x/tokenizer"
+)
+
+type constrainedDecoderTestModel struct {
+	matcher                   *constrainedDecoderTestMatcher
+	forwards                  int
+	secondForwardBeforeAccept bool
+}
+
+func (*constrainedDecoderTestModel) LoadWeights(map[string]*mlx.Array) error { return nil }
+func (*constrainedDecoderTestModel) NewCaches() []cache.Cache                { return nil }
+func (m *constrainedDecoderTestModel) Forward(*batch.Batch, []cache.Cache) (*mlx.Array, *mlx.Array) {
+	m.forwards++
+	if m.forwards == 2 {
+		m.secondForwardBeforeAccept = len(m.matcher.accepted) == 0
+	}
+	// Token 3 wins unmasked; token 2 wins when only 1 and 2 are allowed.
+	return mlx.FromValues([]float32{-4, 1, 5, 20}, 1, 1, 4), nil
+}
+func (*constrainedDecoderTestModel) Unembed(hidden *mlx.Array) *mlx.Array { return hidden }
+func (*constrainedDecoderTestModel) Tokenizer() *tokenizer.Tokenizer      { return nil }
+func (*constrainedDecoderTestModel) MaxContextLength() int                { return 32 }
+
+var _ base.Model = (*constrainedDecoderTestModel)(nil)
+
+type constrainedDecoderTestMatcher struct {
+	accepted  []int32
+	needsMask bool
+	acceptAny bool
+	fills     int
+	failFill  int
+}
+
+func (*constrainedDecoderTestMatcher) VocabSize() int { return 4 }
+
+func (m *constrainedDecoderTestMatcher) Fill() ([]int32, bool, error) {
+	m.fills++
+	if m.fills == m.failFill {
+		return nil, false, errors.New("test fill failure")
+	}
+	if !m.needsMask {
+		return nil, false, nil
+	}
+	if len(m.accepted) > 0 {
+		return []int32{int32(uint32(1) << 1)}, true, nil
+	}
+	return []int32{int32(uint32(1)<<1 | uint32(1)<<2)}, true, nil
+}
+
+func (m *constrainedDecoderTestMatcher) Accept(id int32) error {
+	if !m.acceptAny && id != 1 && id != 2 {
+		return fmt.Errorf("token %d is not allowed", id)
+	}
+	m.accepted = append(m.accepted, id)
+	return nil
+}
+
+func (*constrainedDecoderTestMatcher) Close() {}
+
+func TestConstrainedDecoderMasksBeforeSampling(t *testing.T) {
+	skipIfNoMLX(t)
+	matcher := &constrainedDecoderTestMatcher{needsMask: true}
+	model := &constrainedDecoderTestModel{matcher: matcher}
+	r := &Runner{
+		Model:     model,
+		Tokenizer: newTestTokenizer(t, nil),
+		Sampler:   sampler.New(32),
+	}
+	r.Sampler.Add(pipelineSlot, sampler.Options{
+		Temperature: 0,
+		Logprobs:    true,
+		TopLogprobs: 4,
+	}, []int32{0})
+	defer r.Sampler.Remove(pipelineSlot)
+
+	decoder, err := r.constrainedDecoder(nil, nil, mlx.FromValues([]int32{0}, 1), 0, nil, matcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer decoder.close()
+	results, err := decoder.next(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || int32(results[0].Token.Int()) != 2 {
+		t.Fatalf("sampled token = %v, want allowed token 2", results)
+	}
+	if len(matcher.accepted) != 1 || matcher.accepted[0] != 2 {
+		t.Fatalf("accepted tokens = %v, want [2]", matcher.accepted)
+	}
+	if model.forwards != 2 || !model.secondForwardBeforeAccept {
+		t.Fatalf("forwards = %d, second before accept = %v; want pipelined forward before grammar acceptance", model.forwards, model.secondForwardBeforeAccept)
+	}
+	drained, position := decoder.drain()
+	if len(drained) != 1 || int32(drained[0].Token.Int()) != 1 || position != 2 {
+		t.Fatalf("drain = %v at %d, want next grammar-valid token 1 at position 2", drained, position)
+	}
+	if len(matcher.accepted) != 1 {
+		t.Fatalf("drain accepted tokens = %v, want only the emitted token", matcher.accepted)
+	}
+
+	logprobs := buildLogprob(results[0], true, 4, func(ids []int32) string {
+		return fmt.Sprintf("%d", ids[0])
+	})
+	if len(logprobs) != 1 || len(logprobs[0].TopLogprobs) != 4 {
+		t.Fatalf("unconstrained top logprobs = %+v, want all four tokens", logprobs)
+	}
+	removeMaskedTopLogprobs(logprobs)
+	if len(logprobs) != 1 || len(logprobs[0].TopLogprobs) != 2 {
+		t.Fatalf("top logprobs = %+v, want the two allowed tokens only", logprobs)
+	}
+	for _, alternative := range logprobs[0].TopLogprobs {
+		if math.IsInf(alternative.Logprob, 0) || math.IsNaN(alternative.Logprob) {
+			t.Fatalf("non-finite constrained logprob: %+v", alternative)
+		}
+	}
+}
+
+func TestConstrainedDecoderSkipsAllTrueMask(t *testing.T) {
+	skipIfNoMLX(t)
+	matcher := &constrainedDecoderTestMatcher{acceptAny: true}
+	model := &constrainedDecoderTestModel{matcher: matcher}
+	r := &Runner{Model: model, Tokenizer: newTestTokenizer(t, []int32{3}), Sampler: sampler.New(32)}
+	r.Sampler.Add(pipelineSlot, sampler.Options{Temperature: 0}, []int32{0})
+	defer r.Sampler.Remove(pipelineSlot)
+
+	decoder, err := r.constrainedDecoder(nil, nil, mlx.FromValues([]int32{0}, 1), 0, nil, matcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer decoder.close()
+	results, err := decoder.next(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || int32(results[0].Token.Int()) != 3 {
+		t.Fatalf("sample = %v, want EOS token 3", results)
+	}
+	drained, position := decoder.drain()
+	if len(drained) != 0 || position != 2 {
+		t.Fatalf("drain = %v at %d, want no lookahead after EOS at position 2", drained, position)
+	}
+	if len(matcher.accepted) != 1 || matcher.accepted[0] != 3 {
+		t.Fatalf("accepted tokens = %v, want [3]", matcher.accepted)
+	}
+	if matcher.fills != 1 {
+		t.Fatalf("mask fills = %d, want no fill after accepting EOS", matcher.fills)
+	}
+}
+
+func TestConstrainedDecoderPreservesSampleAfterFillError(t *testing.T) {
+	skipIfNoMLX(t)
+	matcher := &constrainedDecoderTestMatcher{needsMask: true, failFill: 2}
+	model := &constrainedDecoderTestModel{matcher: matcher}
+	r := &Runner{Model: model, Tokenizer: newTestTokenizer(t, nil), Sampler: sampler.New(32)}
+	r.Sampler.Add(pipelineSlot, sampler.Options{Temperature: 0}, []int32{0})
+	defer r.Sampler.Remove(pipelineSlot)
+
+	decoder, err := r.constrainedDecoder(nil, nil, mlx.FromValues([]int32{0}, 1), 0, nil, matcher)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer decoder.close()
+	if _, err := decoder.next(1); err == nil || err.Error() != "test fill failure" {
+		t.Fatalf("next error = %v, want test fill failure", err)
+	}
+
+	drained, position := decoder.drain()
+	if len(drained) != 1 || int32(drained[0].Token.Int()) != 2 || position != 2 {
+		t.Fatalf("drain = %v at %d, want preserved token 2 at position 2", drained, position)
+	}
+}

--- a/x/mlxrunner/constraint/constraint.go
+++ b/x/mlxrunner/constraint/constraint.go
@@ -1,0 +1,232 @@
+package constraint
+
+// #cgo linux LDFLAGS: -ldl
+// #include "dynamic.h"
+// #include <stdlib.h>
+import "C"
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"unsafe"
+)
+
+type Kind int
+
+const (
+	JSON Kind = iota
+	JSONSchema
+)
+
+// The native library is loaded once and never unloaded.
+var library struct {
+	sync.Mutex
+	handle C.ollama_constraint_dynamic_handle
+	path   string
+}
+
+func Load(dir string) error {
+	library.Lock()
+	defer library.Unlock()
+	if library.path != "" {
+		return nil
+	}
+
+	var name string
+	switch runtime.GOOS {
+	case "darwin":
+		name = "libollama_constraints.dylib"
+	case "linux":
+		name = "libollama_constraints.so"
+	case "windows":
+		name = "ollama_constraints.dll"
+	default:
+		return fmt.Errorf("constraint library is not supported on %s", runtime.GOOS)
+	}
+	path, err := filepath.Abs(filepath.Join(dir, name))
+	if err != nil {
+		return fmt.Errorf("resolve constraint library path: %w", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		return fmt.Errorf("constraint library not found at %s: %w", path, err)
+	}
+	cPath := C.CString(path)
+	result := C.ollama_constraint_dynamic_load(&library.handle, cPath)
+	C.free(unsafe.Pointer(cPath))
+	if result != 0 {
+		return fmt.Errorf("load constraint library %s: %s", path, C.GoString(C.ollama_constraint_dynamic_error()))
+	}
+	library.path = path
+	return nil
+}
+
+func LoadedLibraryPath() string {
+	library.Lock()
+	defer library.Unlock()
+	return library.path
+}
+
+type Model struct {
+	ctxMu     sync.Mutex
+	ctx       *C.ollama_constraint_model
+	vocabSize int
+}
+
+func NewModel(pieces []string, vocabSize int, stopIDs []int32) (*Model, error) {
+	library.Lock()
+	loaded := library.path != ""
+	library.Unlock()
+	if !loaded {
+		return nil, errors.New("constraint library is not loaded")
+	}
+	if vocabSize <= 0 || len(pieces) > vocabSize {
+		return nil, fmt.Errorf("invalid vocabulary size %d for %d token pieces", vocabSize, len(pieces))
+	}
+	if len(stopIDs) == 0 {
+		return nil, errors.New("tokenizer has no stop tokens")
+	}
+
+	var data []byte
+	offsets := make([]C.uint64_t, len(pieces))
+	for i, piece := range pieces {
+		data = append(data, piece...)
+		offsets[i] = C.uint64_t(len(data))
+	}
+	cStops := make([]C.int32_t, len(stopIDs))
+	for i, id := range stopIDs {
+		cStops[i] = C.int32_t(id)
+	}
+
+	var dataPtr *C.char
+	if len(data) > 0 {
+		dataPtr = (*C.char)(unsafe.Pointer(&data[0]))
+	}
+	var offsetPtr *C.uint64_t
+	if len(offsets) > 0 {
+		offsetPtr = &offsets[0]
+	}
+	var ctx *C.ollama_constraint_model
+	var cError *C.char
+	if C.ollama_constraint_dynamic_model_new(
+		dataPtr, C.size_t(len(data)), offsetPtr, C.size_t(len(offsets)), C.int32_t(vocabSize),
+		&cStops[0], C.size_t(len(cStops)), &ctx, &cError,
+	) != 0 {
+		return nil, nativeError("create constraint model", cError)
+	}
+	return &Model{ctx: ctx, vocabSize: vocabSize}, nil
+}
+
+func (m *Model) Close() {
+	if m == nil {
+		return
+	}
+	m.ctxMu.Lock()
+	defer m.ctxMu.Unlock()
+	if m.ctx != nil {
+		C.ollama_constraint_dynamic_model_free(m.ctx)
+		m.ctx = nil
+	}
+}
+
+func (m *Model) Compile(kind Kind, source string) (*Matcher, error) {
+	if m == nil {
+		return nil, errors.New("constraint model is unavailable")
+	}
+	m.ctxMu.Lock()
+	defer m.ctxMu.Unlock()
+	if m.ctx == nil {
+		return nil, errors.New("constraint model is closed")
+	}
+
+	var sourcePtr *C.char
+	if len(source) > 0 {
+		sourcePtr = (*C.char)(unsafe.Pointer(unsafe.StringData(source)))
+	}
+	var ctx *C.ollama_constraint_matcher
+	var cError *C.char
+	if C.ollama_constraint_dynamic_matcher_new(
+		m.ctx, C.ollama_constraint_kind(kind), sourcePtr, C.size_t(len(source)), &ctx, &cError,
+	) != 0 {
+		return nil, nativeError("compile constraint", cError)
+	}
+	return &Matcher{ctx: ctx, vocabSize: m.vocabSize}, nil
+}
+
+type Matcher struct {
+	ctxMu     sync.Mutex
+	ctx       *C.ollama_constraint_matcher
+	vocabSize int
+}
+
+func (m *Matcher) VocabSize() int {
+	if m == nil {
+		return 0
+	}
+	return m.vocabSize
+}
+
+func (m *Matcher) Fill() ([]int32, bool, error) {
+	if m == nil {
+		return nil, false, errors.New("constraint matcher is closed")
+	}
+	m.ctxMu.Lock()
+	defer m.ctxMu.Unlock()
+	if m.ctx == nil {
+		return nil, false, errors.New("constraint matcher is closed")
+	}
+	mask := make([]int32, (m.vocabSize+31)/32)
+	var needsApply C.int
+	var cError *C.char
+	if C.ollama_constraint_dynamic_matcher_fill(m.ctx, (*C.int32_t)(unsafe.Pointer(&mask[0])), C.size_t(len(mask)), &needsApply, &cError) != 0 {
+		return nil, false, nativeError("build token mask", cError)
+	}
+	return mask, needsApply != 0, nil
+}
+
+func (m *Matcher) Accept(tokenID int32) error {
+	if m == nil {
+		return errors.New("constraint matcher is closed")
+	}
+	m.ctxMu.Lock()
+	defer m.ctxMu.Unlock()
+	if m.ctx == nil {
+		return errors.New("constraint matcher is closed")
+	}
+	var accepted C.int
+	var cError *C.char
+	if C.ollama_constraint_dynamic_matcher_accept(m.ctx, C.int32_t(tokenID), &accepted, &cError) != 0 {
+		return nativeError("accept token", cError)
+	}
+	if accepted == 0 {
+		return fmt.Errorf("constraint rejected sampled token %d", tokenID)
+	}
+	return nil
+}
+
+func (m *Matcher) Close() {
+	if m == nil {
+		return
+	}
+	m.ctxMu.Lock()
+	defer m.ctxMu.Unlock()
+	if m.ctx != nil {
+		C.ollama_constraint_dynamic_matcher_free(m.ctx)
+		m.ctx = nil
+	}
+}
+
+func nativeError(op string, cMessage *C.char) error {
+	message := "unknown error"
+	if cMessage != nil {
+		defer C.free(unsafe.Pointer(cMessage))
+		message = C.GoString(cMessage)
+	}
+	if message == "" {
+		message = "unknown error"
+	}
+	return fmt.Errorf("%s: %s", op, message)
+}

--- a/x/mlxrunner/constraint/constraint_test.go
+++ b/x/mlxrunner/constraint/constraint_test.go
@@ -1,0 +1,228 @@
+package constraint_test
+
+import (
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/constraint"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+const (
+	testEOS       int32 = 32                // Stop token in the second packed-mask word.
+	testVocabSize       = 40                // Spans two packed-mask words, with the second only partly used.
+	testPaddedID  int32 = testVocabSize - 1 // Empty padding at the vocabulary boundary must stay disallowed.
+)
+
+func testVocabulary() []string {
+	pieces := []string{
+		"{", "}", `"`, ":", ",", "a", "n", "s", "w", "e", "r", "o", "k", " ",
+		"1", "2", "[", "]", "true", "false", "ok", "answer", "\x00", "\xff",
+	}
+	for len(pieces) < testVocabSize {
+		pieces = append(pieces, "")
+	}
+	pieces[testEOS] = "<eos>"
+	return pieces
+}
+
+func testConstraintModel(t testing.TB) *constraint.Model {
+	t.Helper()
+	path, err := mlx.LoadedLibraryPath()
+	if err != nil {
+		t.Skipf("native MLX payload is not built: %v", err)
+	}
+	if err := constraint.Load(filepath.Dir(path)); err != nil {
+		t.Skipf("native constraint payload is not built: %v", err)
+	}
+	if constraint.LoadedLibraryPath() == "" {
+		t.Fatal("constraint library loaded without recording its path")
+	}
+
+	pieces := testVocabulary()
+	model, err := constraint.NewModel(pieces, testVocabSize, []int32{testEOS})
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(model.Close)
+	return model
+}
+
+func FuzzJSONSchemaMatcher(f *testing.F) {
+	model := testConstraintModel(f)
+	for _, seed := range []struct {
+		schema string
+		tokens []byte
+	}{
+		{schema: `{}`, tokens: []byte{0, 1, byte(testEOS)}},                    // Accept {}, then EOS.
+		{schema: `{"type":"string"}`, tokens: []byte{2, 20, 2, byte(testEOS)}}, // Accept "ok", then EOS.
+		{schema: `{"$defs":{"node":{"type":"array","items":{"$ref":"#/$defs/node"}}},"$ref":"#/$defs/node"}`},
+		{schema: `{"enum":["a","b","c"]}`},
+		{schema: `{"type":`},
+		{schema: string([]byte{'{', '"', 'x', '"', ':', '"', 0xff, '"', '}'})},
+	} {
+		f.Add(seed.schema, seed.tokens)
+	}
+
+	f.Fuzz(func(t *testing.T, schema string, tokens []byte) {
+		if len(schema) > 1<<20 || len(tokens) > 256 {
+			return
+		}
+		matcher, err := model.Compile(constraint.JSONSchema, schema)
+		if err != nil {
+			return
+		}
+		defer matcher.Close()
+
+		for _, token := range tokens {
+			id := int32(token) % testVocabSize
+			if _, _, err := matcher.Fill(); err != nil {
+				return
+			}
+			if err := matcher.Accept(id); err != nil {
+				return
+			}
+		}
+	})
+}
+
+func allowed(mask []int32, id int32) bool {
+	return uint32(mask[id/32])&(uint32(1)<<uint(id%32)) != 0
+}
+
+func acceptPieces(t *testing.T, matcher *constraint.Matcher, pieces ...string) {
+	t.Helper()
+	vocab := testVocabulary()
+	for _, piece := range pieces {
+		id := int32(slices.Index(vocab, piece))
+		if id < 0 {
+			t.Fatalf("test vocabulary does not contain %q", piece)
+		}
+		mask, _, err := matcher.Fill()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !allowed(mask, id) {
+			t.Fatalf("token %d is not allowed by mask %032b", id, uint32(mask[id/32]))
+		}
+		if err := matcher.Accept(id); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestJSONSchemaMatcher(t *testing.T) {
+	model := testConstraintModel(t)
+	schema := `{"type":"object","properties":{"answer":{"type":"string","enum":["ok"]}},"required":["answer"],"additionalProperties":false}`
+	matcher, err := model.Compile(constraint.JSONSchema, schema)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer matcher.Close()
+	if got := matcher.VocabSize(); got != testVocabSize {
+		t.Fatalf("matcher vocabulary size = %d, want %d", got, testVocabSize)
+	}
+
+	mask, _, err := matcher.Fill()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if allowed(mask, testEOS) {
+		t.Fatal("EOS is allowed before the schema is complete")
+	}
+	if allowed(mask, testPaddedID) {
+		t.Fatal("a padded vocabulary ID is allowed")
+	}
+
+	acceptPieces(t, matcher, "{", `"`, "answer", `"`, ":", `"`, "ok", `"`, "}")
+	mask, _, err = matcher.Fill()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !allowed(mask, testEOS) {
+		t.Fatal("EOS is not allowed after the schema is complete")
+	}
+	acceptPieces(t, matcher, "<eos>")
+}
+
+func TestBuiltinJSON(t *testing.T) {
+	model := testConstraintModel(t)
+	matcher, err := model.Compile(constraint.JSON, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer matcher.Close()
+	acceptPieces(t, matcher, "{", "}", "<eos>")
+}
+
+func TestInvalidConstraintReturnsError(t *testing.T) {
+	model := testConstraintModel(t)
+	for _, tt := range []struct {
+		name   string
+		source string
+	}{
+		{name: "empty", source: ""},
+		{name: "malformed", source: `{"type":`},
+		{name: "too large", source: strings.Repeat(" ", (1<<20)+1)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			matcher, err := model.Compile(constraint.JSONSchema, tt.source)
+			if matcher != nil {
+				matcher.Close()
+			}
+			if err == nil {
+				t.Fatal("Compile unexpectedly succeeded")
+			}
+			if !strings.Contains(err.Error(), "compile constraint") {
+				t.Fatalf("Compile error = %v", err)
+			}
+		})
+	}
+}
+
+func TestModelValidationAndClosedState(t *testing.T) {
+	loaded := testConstraintModel(t)
+	for _, tt := range []struct {
+		name      string
+		pieces    []string
+		vocabSize int
+		stops     []int32
+	}{
+		{name: "zero vocabulary", vocabSize: 0, stops: []int32{0}},
+		{name: "too many pieces", pieces: []string{"a", "b"}, vocabSize: 1, stops: []int32{0}},
+		{name: "vocabulary exceeds native limit", pieces: []string{"a"}, vocabSize: (1 << 20) + 1, stops: []int32{0}},
+		{name: "no stop tokens", pieces: []string{"a"}, vocabSize: 1},
+		{name: "too many stop tokens", pieces: []string{"a"}, vocabSize: 1, stops: []int32{0, 0}},
+		{name: "stop outside vocabulary", pieces: []string{"a"}, vocabSize: 1, stops: []int32{1}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			model, err := constraint.NewModel(tt.pieces, tt.vocabSize, tt.stops)
+			if model != nil {
+				model.Close()
+			}
+			if err == nil {
+				t.Fatal("NewModel unexpectedly succeeded")
+			}
+		})
+	}
+
+	matcher, err := loaded.Compile(constraint.JSON, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	matcher.Close()
+	matcher.Close()
+	if _, _, err := matcher.Fill(); err == nil {
+		t.Fatal("Fill on closed matcher unexpectedly succeeded")
+	}
+	if err := matcher.Accept(0); err == nil {
+		t.Fatal("Accept on closed matcher unexpectedly succeeded")
+	}
+	loaded.Close()
+	loaded.Close()
+	if matcher, err := loaded.Compile(constraint.JSON, ""); err == nil || matcher != nil {
+		t.Fatalf("Compile on closed model = %v, %v; want error", matcher, err)
+	}
+}

--- a/x/mlxrunner/constraint/dynamic.c
+++ b/x/mlxrunner/constraint/dynamic.c
@@ -1,0 +1,139 @@
+#include "dynamic.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+
+#ifndef LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR
+#define LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR 0x00000100
+#endif
+#ifndef LOAD_LIBRARY_SEARCH_DEFAULT_DIRS
+#define LOAD_LIBRARY_SEARCH_DEFAULT_DIRS 0x00001000
+#endif
+
+static void* open_library(const char* path) {
+    int length = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, NULL, 0);
+    if (length == 0) {
+        return NULL;
+    }
+    wchar_t* wide_path = malloc((size_t)length * sizeof(wchar_t));
+    if (wide_path == NULL) {
+        return NULL;
+    }
+    if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, path, -1, wide_path, length) == 0) {
+        free(wide_path);
+        return NULL;
+    }
+    HMODULE module = LoadLibraryExW(
+        wide_path,
+        NULL,
+        LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS);
+    free(wide_path);
+    return (void*)module;
+}
+
+#define OPEN(path) open_library(path)
+#define CLOSE(handle) FreeLibrary((HMODULE)(handle))
+#define SYMBOL(handle, name) ((void*)GetProcAddress((HMODULE)(handle), name))
+#else
+#include <dlfcn.h>
+#define OPEN(path) dlopen(path, RTLD_NOW | RTLD_LOCAL)
+#define CLOSE(handle) dlclose(handle)
+#define SYMBOL(handle, name) dlsym(handle, name)
+#endif
+
+static const char* (*last_error_fn)(void);
+static int (*model_new_fn)(const char*, size_t, const uint64_t*, size_t, int32_t, const int32_t*, size_t, ollama_constraint_model**);
+static void (*model_free_fn)(ollama_constraint_model*);
+static int (*matcher_new_fn)(ollama_constraint_model*, ollama_constraint_kind, const char*, size_t, ollama_constraint_matcher**);
+static void (*matcher_free_fn)(ollama_constraint_matcher*);
+static int (*matcher_fill_fn)(ollama_constraint_matcher*, int32_t*, size_t, int*);
+static int (*matcher_accept_fn)(ollama_constraint_matcher*, int32_t, int*);
+static const char* load_error;
+
+static void clear_symbols(void) {
+    last_error_fn = NULL;
+    model_new_fn = NULL;
+    model_free_fn = NULL;
+    matcher_new_fn = NULL;
+    matcher_free_fn = NULL;
+    matcher_fill_fn = NULL;
+    matcher_accept_fn = NULL;
+}
+
+#define LOAD(handle, field, name) do { \
+    *(void**)(&field) = SYMBOL((handle)->ctx, name); \
+    if ((field) == NULL) { load_error = "constraint library is missing symbol " name; goto fail; } \
+} while (0)
+
+int ollama_constraint_dynamic_load(ollama_constraint_dynamic_handle* handle, const char* path) {
+    clear_symbols();
+    if (handle == NULL || path == NULL) {
+        load_error = "invalid constraint library path";
+        return 1;
+    }
+    handle->ctx = OPEN(path);
+    if (handle->ctx == NULL) {
+        load_error = "unable to open constraint library";
+        return 1;
+    }
+    LOAD(handle, last_error_fn, "ollama_constraint_last_error");
+    LOAD(handle, model_new_fn, "ollama_constraint_model_new");
+    LOAD(handle, model_free_fn, "ollama_constraint_model_free");
+    LOAD(handle, matcher_new_fn, "ollama_constraint_matcher_new");
+    LOAD(handle, matcher_free_fn, "ollama_constraint_matcher_free");
+    LOAD(handle, matcher_fill_fn, "ollama_constraint_matcher_fill");
+    LOAD(handle, matcher_accept_fn, "ollama_constraint_matcher_accept");
+    load_error = NULL;
+    return 0;
+
+fail:
+    CLOSE(handle->ctx);
+    handle->ctx = NULL;
+    clear_symbols();
+    return 1;
+}
+
+const char* ollama_constraint_dynamic_error(void) {
+    if (last_error_fn != NULL) {
+        const char* message = last_error_fn();
+        if (message != NULL && message[0] != '\0') {
+            return message;
+        }
+    }
+	return load_error == NULL ? "constraint library error" : load_error;
+}
+
+static int capture_error(int result, char** error) {
+	if (error != NULL) {
+		*error = NULL;
+	}
+	if (result == 0 || error == NULL) {
+		return result;
+	}
+	const char* message = ollama_constraint_dynamic_error();
+	size_t size = strlen(message) + 1;
+	*error = malloc(size);
+	if (*error != NULL) {
+		memcpy(*error, message, size);
+	}
+	return result;
+}
+
+int ollama_constraint_dynamic_model_new(const char* d, size_t ds, const uint64_t* o, size_t n, int32_t v, const int32_t* s, size_t ns, ollama_constraint_model** m, char** error) {
+	return capture_error(model_new_fn(d, ds, o, n, v, s, ns, m), error);
+}
+void ollama_constraint_dynamic_model_free(ollama_constraint_model* m) { model_free_fn(m); }
+int ollama_constraint_dynamic_matcher_new(ollama_constraint_model* m, ollama_constraint_kind k, const char* s, size_t n, ollama_constraint_matcher** out, char** error) {
+	return capture_error(matcher_new_fn(m, k, s, n, out), error);
+}
+void ollama_constraint_dynamic_matcher_free(ollama_constraint_matcher* m) { matcher_free_fn(m); }
+int ollama_constraint_dynamic_matcher_fill(ollama_constraint_matcher* m, int32_t* b, size_t n, int* a, char** error) {
+	return capture_error(matcher_fill_fn(m, b, n, a), error);
+}
+int ollama_constraint_dynamic_matcher_accept(ollama_constraint_matcher* m, int32_t t, int* a, char** error) {
+	return capture_error(matcher_accept_fn(m, t, a), error);
+}

--- a/x/mlxrunner/constraint/dynamic.h
+++ b/x/mlxrunner/constraint/dynamic.h
@@ -1,0 +1,24 @@
+#ifndef OLLAMA_CONSTRAINT_DYNAMIC_H
+#define OLLAMA_CONSTRAINT_DYNAMIC_H
+
+#include "native/constraint.h"
+
+typedef struct ollama_constraint_dynamic_handle {
+    void* ctx;
+} ollama_constraint_dynamic_handle;
+
+int ollama_constraint_dynamic_load(ollama_constraint_dynamic_handle* handle, const char* path);
+const char* ollama_constraint_dynamic_error(void);
+
+int ollama_constraint_dynamic_model_new(
+	const char*, size_t, const uint64_t*, size_t, int32_t,
+	const int32_t*, size_t, ollama_constraint_model**, char**);
+void ollama_constraint_dynamic_model_free(ollama_constraint_model*);
+int ollama_constraint_dynamic_matcher_new(
+	ollama_constraint_model*, ollama_constraint_kind, const char*, size_t,
+	ollama_constraint_matcher**, char**);
+void ollama_constraint_dynamic_matcher_free(ollama_constraint_matcher*);
+int ollama_constraint_dynamic_matcher_fill(ollama_constraint_matcher*, int32_t*, size_t, int*, char**);
+int ollama_constraint_dynamic_matcher_accept(ollama_constraint_matcher*, int32_t, int*, char**);
+
+#endif

--- a/x/mlxrunner/constraint/native/constraint.cpp
+++ b/x/mlxrunner/constraint/native/constraint.cpp
@@ -1,0 +1,214 @@
+#include "constraint.h"
+
+#include <dlpack/dlpack.h>
+#include <xgrammar/xgrammar.h>
+
+#include <algorithm>
+#include <exception>
+#include <memory>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+thread_local std::string last_error;
+
+constexpr int32_t kMaxVocabSize = 1 << 20;
+constexpr size_t kMaxSourceSize = 1 << 20;
+
+template <typename F>
+int protect(F&& fn) {
+    try {
+        last_error.clear();
+        fn();
+        return 0;
+    } catch (const std::exception& e) {
+        last_error = e.what();
+    } catch (...) {
+        last_error = "unknown constraint library error";
+    }
+    return 1;
+}
+
+}  // namespace
+
+struct ollama_constraint_model {
+    int32_t vocab_size;
+    xgrammar::TokenizerInfo tokenizer;
+    xgrammar::GrammarCompiler compiler;
+
+    ollama_constraint_model(std::vector<std::string> vocab, int32_t size, std::vector<int32_t> stops)
+        : vocab_size(size),
+          tokenizer(vocab, xgrammar::VocabType::RAW, size, std::move(stops)),
+          compiler(tokenizer, /*max_threads=*/8, /*cache_enabled=*/false) {}
+};
+
+struct ollama_constraint_matcher {
+    int32_t vocab_size;
+    xgrammar::GrammarMatcher matcher;
+
+    ollama_constraint_matcher(int32_t size, xgrammar::CompiledGrammar grammar)
+        : vocab_size(size), matcher(grammar) {}
+};
+
+extern "C" {
+
+const char* ollama_constraint_last_error(void) {
+    return last_error.c_str();
+}
+
+int ollama_constraint_model_new(
+    const char* token_data,
+    size_t token_data_size,
+    const uint64_t* token_offsets,
+    size_t token_count,
+    int32_t vocab_size,
+    const int32_t* stop_token_ids,
+    size_t stop_token_count,
+    ollama_constraint_model** model) {
+    return protect([&] {
+        if (model == nullptr) {
+            throw std::invalid_argument("model output is null");
+        }
+        *model = nullptr;
+        if (vocab_size <= 0 || vocab_size > kMaxVocabSize ||
+            token_count > static_cast<size_t>(vocab_size)) {
+            throw std::invalid_argument("invalid vocabulary size");
+        }
+        if (token_count > 0 && token_offsets == nullptr) {
+            throw std::invalid_argument("token offsets are null");
+        }
+        if (token_data_size > 0 && token_data == nullptr) {
+            throw std::invalid_argument("token data is null");
+        }
+        if (stop_token_count == 0 || stop_token_ids == nullptr) {
+            throw std::invalid_argument("at least one stop token is required");
+        }
+        if (stop_token_count > static_cast<size_t>(vocab_size)) {
+            throw std::invalid_argument("too many stop tokens");
+        }
+
+        std::vector<std::string> vocab;
+        vocab.reserve(token_count);
+        const char* base = token_data == nullptr ? "" : token_data;
+        uint64_t begin = 0;
+        for (size_t i = 0; i < token_count; ++i) {
+            uint64_t end = token_offsets[i];
+            if (end < begin || end > token_data_size) {
+                throw std::invalid_argument("invalid token offsets");
+            }
+            vocab.emplace_back(base + begin, static_cast<size_t>(end - begin));
+            begin = end;
+        }
+        if (begin != token_data_size) {
+            throw std::invalid_argument("token offsets do not consume token data");
+        }
+
+        std::vector<int32_t> stops(stop_token_ids, stop_token_ids + stop_token_count);
+        for (int32_t id : stops) {
+            if (id < 0 || id >= vocab_size) {
+                throw std::invalid_argument("stop token is outside vocabulary");
+            }
+        }
+        *model = new ollama_constraint_model(std::move(vocab), vocab_size, std::move(stops));
+    });
+}
+
+void ollama_constraint_model_free(ollama_constraint_model* model) {
+    delete model;
+}
+
+int ollama_constraint_matcher_new(
+    ollama_constraint_model* model,
+    ollama_constraint_kind kind,
+    const char* source,
+    size_t source_size,
+    ollama_constraint_matcher** matcher) {
+    return protect([&] {
+        if (model == nullptr || matcher == nullptr) {
+            throw std::invalid_argument("model or matcher output is null");
+        }
+        *matcher = nullptr;
+        if (source_size > 0 && source == nullptr) {
+            throw std::invalid_argument("constraint source is null");
+        }
+        if (source_size > kMaxSourceSize) {
+            throw std::invalid_argument("constraint source is too large");
+        }
+        const char* source_data = source == nullptr ? "" : source;
+
+        xgrammar::CompiledGrammar compiled = [&]() -> xgrammar::CompiledGrammar {
+            switch (kind) {
+            case OLLAMA_CONSTRAINT_JSON:
+                return model->compiler.CompileBuiltinJSONGrammar();
+            case OLLAMA_CONSTRAINT_JSON_SCHEMA:
+                return model->compiler.CompileJSONSchema(std::string(source_data, source_size));
+            default:
+                throw std::invalid_argument("unknown constraint kind");
+            }
+        }();
+        *matcher = new ollama_constraint_matcher(model->vocab_size, std::move(compiled));
+    });
+}
+
+void ollama_constraint_matcher_free(ollama_constraint_matcher* matcher) {
+    delete matcher;
+}
+
+int ollama_constraint_matcher_fill(
+    ollama_constraint_matcher* matcher,
+    int32_t* bitmask,
+    size_t bitmask_words,
+    int* needs_apply) {
+    return protect([&] {
+        if (matcher == nullptr || bitmask == nullptr || needs_apply == nullptr) {
+            throw std::invalid_argument("matcher, bitmask, or result is null");
+        }
+        size_t expected = static_cast<size_t>(xgrammar::GetBitmaskSize(matcher->vocab_size));
+        if (bitmask_words != expected) {
+            throw std::invalid_argument("incorrect bitmask size");
+        }
+
+        int64_t shape[] = {static_cast<int64_t>(bitmask_words)};
+        DLTensor tensor{};
+        tensor.data = bitmask;
+        tensor.device = DLDevice{kDLCPU, 0};
+        tensor.ndim = 1;
+        tensor.dtype = xgrammar::GetBitmaskDLType();
+        tensor.shape = shape;
+        tensor.strides = nullptr;
+        tensor.byte_offset = 0;
+        *needs_apply = matcher->matcher.FillNextTokenBitmask(&tensor) ? 1 : 0;
+
+        bool any = false;
+        for (int32_t id = 0; id < matcher->vocab_size; ++id) {
+            if ((static_cast<uint32_t>(bitmask[id / 32]) & (uint32_t{1} << (id % 32))) != 0) {
+                any = true;
+                break;
+            }
+        }
+        if (!any) {
+            throw std::runtime_error("constraint rejects every vocabulary token");
+        }
+    });
+}
+
+int ollama_constraint_matcher_accept(
+    ollama_constraint_matcher* matcher,
+    int32_t token_id,
+    int* accepted) {
+    return protect([&] {
+        if (matcher == nullptr || accepted == nullptr) {
+            throw std::invalid_argument("matcher or result is null");
+        }
+        if (token_id < 0 || token_id >= matcher->vocab_size) {
+            throw std::invalid_argument("token is outside vocabulary");
+        }
+        *accepted = matcher->matcher.AcceptToken(token_id) ? 1 : 0;
+    });
+}
+
+}  // extern "C"

--- a/x/mlxrunner/constraint/native/constraint.h
+++ b/x/mlxrunner/constraint/native/constraint.h
@@ -1,0 +1,64 @@
+#ifndef OLLAMA_CONSTRAINT_H
+#define OLLAMA_CONSTRAINT_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(_WIN32)
+#if defined(OLLAMA_CONSTRAINT_BUILD)
+#define OLLAMA_CONSTRAINT_API __declspec(dllexport)
+#else
+#define OLLAMA_CONSTRAINT_API __declspec(dllimport)
+#endif
+#else
+#define OLLAMA_CONSTRAINT_API __attribute__((visibility("default")))
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct ollama_constraint_model ollama_constraint_model;
+typedef struct ollama_constraint_matcher ollama_constraint_matcher;
+
+typedef enum ollama_constraint_kind {
+    OLLAMA_CONSTRAINT_JSON = 0,
+    OLLAMA_CONSTRAINT_JSON_SCHEMA = 1,
+} ollama_constraint_kind;
+
+OLLAMA_CONSTRAINT_API const char* ollama_constraint_last_error(void);
+
+OLLAMA_CONSTRAINT_API int ollama_constraint_model_new(
+    const char* token_data,
+    size_t token_data_size,
+    const uint64_t* token_offsets,
+    size_t token_count,
+    int32_t vocab_size,
+    const int32_t* stop_token_ids,
+    size_t stop_token_count,
+    ollama_constraint_model** model);
+OLLAMA_CONSTRAINT_API void ollama_constraint_model_free(ollama_constraint_model* model);
+
+OLLAMA_CONSTRAINT_API int ollama_constraint_matcher_new(
+    ollama_constraint_model* model,
+    ollama_constraint_kind kind,
+    const char* source,
+    size_t source_size,
+    ollama_constraint_matcher** matcher);
+OLLAMA_CONSTRAINT_API void ollama_constraint_matcher_free(ollama_constraint_matcher* matcher);
+
+OLLAMA_CONSTRAINT_API int ollama_constraint_matcher_fill(
+    ollama_constraint_matcher* matcher,
+    int32_t* bitmask,
+    size_t bitmask_words,
+    int* needs_apply);
+OLLAMA_CONSTRAINT_API int ollama_constraint_matcher_accept(
+    ollama_constraint_matcher* matcher,
+    int32_t token_id,
+    int* accepted);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/x/mlxrunner/constraint_logprobs.go
+++ b/x/mlxrunner/constraint_logprobs.go
@@ -1,0 +1,16 @@
+package mlxrunner
+
+import (
+	"math"
+	"slices"
+
+	"github.com/ollama/ollama/llm"
+)
+
+func removeMaskedTopLogprobs(logprobs []llm.Logprob) {
+	for i := range logprobs {
+		logprobs[i].TopLogprobs = slices.DeleteFunc(logprobs[i].TopLogprobs, func(token llm.TokenLogprob) bool {
+			return math.IsInf(token.Logprob, -1)
+		})
+	}
+}

--- a/x/mlxrunner/constraint_mask_test.go
+++ b/x/mlxrunner/constraint_mask_test.go
@@ -1,0 +1,34 @@
+package mlxrunner
+
+import (
+	"slices"
+	"testing"
+)
+
+func TestUnpackTokenMask(t *testing.T) {
+	const (
+		bitsPerMaskWord       = 32
+		firstTokenID          = 0                   // Least-significant bit of the first mask word.
+		interiorTokenID       = 7                   // Arbitrary non-boundary bit in the first mask word.
+		lastIDInFirstMaskWord = bitsPerMaskWord - 1 // Sign bit of the int32-backed first mask word.
+		lastVocabID           = 40                  // Final valid ID in a partially used second mask word.
+		vocabSize             = lastVocabID + 1
+	)
+	allowedIDs := []int{firstTokenID, interiorTokenID, lastIDInFirstMaskWord, lastVocabID}
+	word0 := uint32(1)<<firstTokenID |
+		uint32(1)<<interiorTokenID |
+		uint32(1)<<lastIDInFirstMaskWord
+	packed := []int32{
+		int32(word0),
+		int32(uint32(1) << (lastVocabID - bitsPerMaskWord)),
+	}
+	got := make([]bool, vocabSize)
+	unpackTokenMaskInto(got, packed)
+	want := make([]bool, vocabSize)
+	for _, id := range allowedIDs {
+		want[id] = true
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("unpackTokenMask = %v, want %v", got, want)
+	}
+}

--- a/x/mlxrunner/constraints.go
+++ b/x/mlxrunner/constraints.go
@@ -1,0 +1,226 @@
+package mlxrunner
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"path/filepath"
+	"slices"
+	"unicode/utf8"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/x/mlxrunner/constraint"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model"
+)
+
+type requestConstraint interface {
+	VocabSize() int
+	Fill() ([]int32, bool, error)
+	Accept(int32) error
+	Close()
+}
+
+type constraintSpec struct {
+	kind   constraint.Kind
+	source string
+}
+
+const (
+	maxConstraintSchemaBytes  = 1 << 20
+	maxConstraintSchemaDepth  = 128
+	maxConstraintSchemaTokens = 1 << 12
+)
+
+func parseConstraint(format json.RawMessage) (*constraintSpec, error) {
+	if len(format) > 0 {
+		if len(format) > maxConstraintSchemaBytes {
+			return nil, fmt.Errorf("invalid format: input is %d bytes; limit is %d", len(format), maxConstraintSchemaBytes)
+		}
+		switch string(format) {
+		case `null`, `""`:
+			return nil, nil
+		case `"json"`:
+			return &constraintSpec{kind: constraint.JSON}, nil
+		default:
+			if format[0] != '{' {
+				return nil, errors.New("invalid format: expected \"json\" or a valid JSON Schema object")
+			}
+			if err := validateConstraintSchema(format); err != nil {
+				return nil, fmt.Errorf("invalid JSON Schema: %w", err)
+			}
+			return &constraintSpec{kind: constraint.JSONSchema, source: string(format)}, nil
+		}
+	}
+	return nil, nil
+}
+
+func validateConstraintSchema(schema []byte) error {
+	if len(schema) > maxConstraintSchemaBytes {
+		return fmt.Errorf("schema is %d bytes; limit is %d", len(schema), maxConstraintSchemaBytes)
+	}
+	if !utf8.Valid(schema) {
+		return errors.New("schema is not valid UTF-8")
+	}
+
+	decoder := json.NewDecoder(bytes.NewReader(schema))
+	decoder.UseNumber()
+	first, err := decoder.Token()
+	if err != nil {
+		return fmt.Errorf("invalid JSON: %w", err)
+	}
+	if first != json.Delim('{') {
+		return errors.New("schema must be a JSON object")
+	}
+
+	tokens, depth := 1, 1
+	for depth > 0 {
+		token, err := decoder.Token()
+		if err != nil {
+			if err == io.EOF {
+				return errors.New("unexpected end of JSON")
+			}
+			return fmt.Errorf("invalid JSON: %w", err)
+		}
+		tokens++
+		if tokens > maxConstraintSchemaTokens {
+			return fmt.Errorf("schema contains more than %d JSON tokens", maxConstraintSchemaTokens)
+		}
+
+		if delim, ok := token.(json.Delim); ok {
+			switch delim {
+			case '{', '[':
+				depth++
+				if depth > maxConstraintSchemaDepth {
+					return fmt.Errorf("schema nesting exceeds %d levels", maxConstraintSchemaDepth)
+				}
+			case '}', ']':
+				depth--
+			}
+		}
+	}
+
+	if _, err := decoder.Token(); err != io.EOF {
+		if err != nil {
+			return fmt.Errorf("invalid JSON after schema object: %w", err)
+		}
+		return errors.New("schema contains more than one JSON value")
+	}
+	return nil
+}
+
+func (r *Runner) prepareConstraint(request *Request) error {
+	spec, err := parseConstraint(request.Format)
+	if err != nil || spec == nil {
+		return err
+	}
+	if r.constraints == nil {
+		message := "structured output is unavailable"
+		if r.constraintErr != nil {
+			message += ": " + r.constraintErr.Error()
+		}
+		return api.StatusError{StatusCode: http.StatusNotImplemented, ErrorMessage: message}
+	}
+	request.Constraint, err = r.constraints.Compile(spec.kind, spec.source)
+	if err != nil {
+		return fmt.Errorf("invalid structured output constraint: %w", err)
+	}
+	return nil
+}
+
+func (r *Runner) loadConstraints(root *model.Root) {
+	library, err := mlx.LoadedLibraryPath()
+	if err != nil {
+		r.constraintErr = err
+		return
+	}
+	if err := constraint.Load(filepath.Dir(library)); err != nil {
+		r.constraintErr = err
+		slog.Warn("Structured output is unavailable", "error", err)
+		return
+	}
+
+	configuredVocabSize, err := modelVocabSize(root)
+	if err != nil {
+		r.constraintErr = err
+		slog.Warn("Structured output is unavailable", "error", err)
+		return
+	}
+	vocabSize, err := constraintVocabSize(configuredVocabSize, r.Tokenizer.VocabSize())
+	if err != nil {
+		r.constraintErr = err
+		slog.Warn("Structured output is unavailable", "error", err)
+		return
+	}
+	pieces := make([]string, vocabSize)
+	for id := range vocabSize {
+		pieces[id] = r.Tokenizer.Decode([]int32{int32(id)})
+	}
+	stops := slices.DeleteFunc(slices.Clone(r.Tokenizer.EOSTokens()), func(id int32) bool {
+		return id < 0 || int(id) >= vocabSize
+	})
+	r.constraints, err = constraint.NewModel(pieces, vocabSize, stops)
+	if err != nil {
+		r.constraintErr = err
+		slog.Warn("Structured output is unavailable", "error", err)
+		return
+	}
+	r.constraintErr = nil
+	slog.Info("Structured output initialized", "vocab_size", vocabSize, "library", constraint.LoadedLibraryPath())
+}
+
+func modelVocabSize(root *model.Root) (int, error) {
+	data, err := root.Manifest.ReadConfig("config.json")
+	if err != nil {
+		return 0, fmt.Errorf("read model vocabulary size: %w", err)
+	}
+	return parseModelVocabSize(data)
+}
+
+func parseModelVocabSize(data []byte) (int, error) {
+	var config struct {
+		VocabSize  int `json:"vocab_size"`
+		TextConfig struct {
+			VocabSize int `json:"vocab_size"`
+		} `json:"text_config"`
+	}
+	if err := json.Unmarshal(data, &config); err != nil {
+		return 0, fmt.Errorf("read model vocabulary size: %w", err)
+	}
+	if config.VocabSize < 0 || config.TextConfig.VocabSize < 0 {
+		return 0, fmt.Errorf("invalid negative model vocabulary size: %d/%d", config.VocabSize, config.TextConfig.VocabSize)
+	}
+	if config.VocabSize > 0 {
+		return config.VocabSize, nil
+	}
+	return config.TextConfig.VocabSize, nil
+}
+
+const maxConstraintVocabSize = 1 << 20
+
+func constraintVocabSize(configured, tokenizerSize int) (int, error) {
+	if tokenizerSize <= 0 {
+		return 0, fmt.Errorf("invalid tokenizer vocabulary size %d", tokenizerSize)
+	}
+	if configured == 0 {
+		configured = tokenizerSize
+	}
+	if configured < tokenizerSize {
+		return 0, fmt.Errorf("model vocabulary size %d is smaller than tokenizer vocabulary size %d", configured, tokenizerSize)
+	}
+	if configured > maxConstraintVocabSize {
+		return 0, fmt.Errorf("model vocabulary size %d exceeds structured output limit %d", configured, maxConstraintVocabSize)
+	}
+	return configured, nil
+}
+
+func (r *Runner) Close() {
+	if r.constraints != nil {
+		r.constraints.Close()
+		r.constraints = nil
+	}
+}

--- a/x/mlxrunner/constraints_test.go
+++ b/x/mlxrunner/constraints_test.go
@@ -1,0 +1,297 @@
+package mlxrunner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/constraint"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+func TestParseConstraint(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  string
+		kind    constraint.Kind
+		source  string
+		want    bool
+		wantErr bool
+	}{
+		{name: "unset"},
+		{name: "null", format: `null`},
+		{name: "empty", format: `""`},
+		{name: "json", format: `"json"`, kind: constraint.JSON, want: true},
+		{name: "schema", format: `{"type":"integer"}`, kind: constraint.JSONSchema, source: `{"type":"integer"}`, want: true},
+		{name: "unsupported string", format: `"xml"`, wantErr: true},
+		{name: "whitespace JSON", format: ` "json" `, wantErr: true},
+		{name: "whitespace schema", format: ` {"type":"integer"} `, wantErr: true},
+		{name: "array", format: `[]`, wantErr: true},
+		{name: "invalid json", format: `{`, wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseConstraint(json.RawMessage(tt.format))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseConstraint error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if (got != nil) != tt.want {
+				t.Fatalf("parseConstraint = %#v, want present %v", got, tt.want)
+			}
+			if got != nil && (got.kind != tt.kind || got.source != tt.source) {
+				t.Errorf("parseConstraint = %#v, want kind %v source %q", got, tt.kind, tt.source)
+			}
+		})
+	}
+}
+
+func TestParseConstraintDoesNotEchoOversizedInput(t *testing.T) {
+	format := json.RawMessage(strings.Repeat("x", maxConstraintSchemaBytes+1))
+	_, err := parseConstraint(format)
+	if err == nil || !strings.Contains(err.Error(), "input is 1048577 bytes") {
+		t.Fatalf("parseConstraint error = %v, want bounded size error", err)
+	}
+	if len(err.Error()) > 256 {
+		t.Fatalf("parseConstraint echoed oversized input in %d-byte error", len(err.Error()))
+	}
+}
+
+func nestedConstraintSchema(depth int) []byte {
+	return []byte(`{"value":` + strings.Repeat("[", depth-1) + `0` + strings.Repeat("]", depth-1) + `}`)
+}
+
+func constraintSchemaArray(entries int) []byte {
+	var b strings.Builder
+	b.WriteString(`{"enum":[`)
+	for i := range entries {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteByte('0')
+	}
+	b.WriteString(`]}`)
+	return []byte(b.String())
+}
+
+func TestValidateConstraintSchema(t *testing.T) {
+	invalidUTF8 := append([]byte(`{"value":"`), 0xff)
+	invalidUTF8 = append(invalidUTF8, []byte(`"}`)...)
+	tests := []struct {
+		name    string
+		schema  []byte
+		wantErr string
+	}{
+		{name: "object", schema: []byte(`{"type":"object","properties":{"answer":{"type":"string"}}}`)},
+		{name: "maximum depth", schema: nestedConstraintSchema(maxConstraintSchemaDepth)},
+		{name: "too deep", schema: nestedConstraintSchema(maxConstraintSchemaDepth + 1), wantErr: "nesting exceeds"},
+		{name: "too many tokens", schema: constraintSchemaArray(maxConstraintSchemaTokens), wantErr: "more than 4096 JSON tokens"},
+		{name: "too large", schema: []byte(`{"value":"` + strings.Repeat("x", maxConstraintSchemaBytes) + `"}`), wantErr: "limit is 1048576"},
+		{name: "invalid UTF-8", schema: invalidUTF8, wantErr: "not valid UTF-8"},
+		{name: "trailing value", schema: []byte(`{} {}`), wantErr: "more than one JSON value"},
+		{name: "malformed", schema: []byte(`{"type":`), wantErr: "unexpected end"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateConstraintSchema(tt.schema)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatal(err)
+				}
+				return
+			}
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validateConstraintSchema error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func BenchmarkValidateConstraintSchema(b *testing.B) {
+	schema := []byte(`{"type":"object","properties":{"answer":{"type":"string","enum":["ok"]}},"required":["answer"],"additionalProperties":false}`)
+	b.ReportAllocs()
+	for b.Loop() {
+		if err := validateConstraintSchema(schema); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func FuzzParseConstraint(f *testing.F) {
+	for _, format := range []string{
+		"",
+		`"json"`,
+		`{"type":"integer"}`,
+		`{`,
+	} {
+		f.Add(format)
+	}
+
+	f.Fuzz(func(t *testing.T, format string) {
+		spec, err := parseConstraint(json.RawMessage(format))
+		if err != nil || spec == nil {
+			return
+		}
+		switch spec.kind {
+		case constraint.JSON, constraint.JSONSchema:
+		default:
+			t.Fatalf("parseConstraint kind = %d", spec.kind)
+		}
+	})
+}
+
+func TestConstraintVocabSize(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		configured int
+		tokenizer  int
+		want       int
+		wantErr    bool
+	}{
+		{name: "tokenizer fallback", tokenizer: 32, want: 32},
+		{name: "padded model vocabulary", configured: 40, tokenizer: 32, want: 40},
+		{name: "model smaller than tokenizer", configured: 31, tokenizer: 32, wantErr: true},
+		{name: "invalid tokenizer", tokenizer: -1, wantErr: true},
+		{name: "allocation bound", configured: maxConstraintVocabSize + 1, tokenizer: 32, wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := constraintVocabSize(tt.configured, tt.tokenizer)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("constraintVocabSize(%d, %d) error = %v, wantErr %v", tt.configured, tt.tokenizer, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("constraintVocabSize(%d, %d) = %d, want %d", tt.configured, tt.tokenizer, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseModelVocabSize(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		config  string
+		want    int
+		wantErr bool
+	}{
+		{name: "top level", config: `{"vocab_size":40,"text_config":{"vocab_size":32}}`, want: 40},
+		{name: "text config", config: `{"text_config":{"vocab_size":32}}`, want: 32},
+		{name: "missing", config: `{}`},
+		{name: "negative top level", config: `{"vocab_size":-1}`, wantErr: true},
+		{name: "negative text config", config: `{"text_config":{"vocab_size":-1}}`, wantErr: true},
+		{name: "invalid JSON", config: `{`, wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseModelVocabSize([]byte(tt.config))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseModelVocabSize error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("parseModelVocabSize = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+type trackingConstraint struct {
+	closed chan struct{}
+	once   sync.Once
+}
+
+func (*trackingConstraint) VocabSize() int               { return 1 }
+func (*trackingConstraint) Fill() ([]int32, bool, error) { return []int32{1}, true, nil }
+func (*trackingConstraint) Accept(int32) error           { return nil }
+func (c *trackingConstraint) Close()                     { c.once.Do(func() { close(c.closed) }) }
+
+func TestRunRequestRetainsConstraintUntilPipelineReturns(t *testing.T) {
+	matcher := &trackingConstraint{closed: make(chan struct{})}
+	started := make(chan struct{})
+	release := make(chan struct{})
+	ctx, cancel := context.WithCancel(t.Context())
+	request := Request{
+		Ctx:        ctx,
+		Constraint: matcher,
+		Pipeline: func(context.Context, Request) error {
+			close(started)
+			<-release
+			return nil
+		},
+	}
+	done := make(chan error, 1)
+	go func() { done <- (&Runner{}).runRequest(request) }()
+
+	<-started
+	cancel()
+	select {
+	case <-matcher.closed:
+		t.Fatal("constraint closed while the pipeline was still running")
+	default:
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-matcher.closed:
+	default:
+		t.Fatal("constraint was not closed after the pipeline returned")
+	}
+}
+
+func TestPrepareConstraintUnavailable(t *testing.T) {
+	r := &Runner{
+		Model:         textOnlyModel{},
+		Tokenizer:     newTestTokenizer(t, []int32{7}),
+		contextLength: 32,
+		constraintErr: errors.New("library missing"),
+	}
+	request := &Request{CompletionRequest: CompletionRequest{
+		Prompt: "0",
+		Format: json.RawMessage(`"json"`),
+	}}
+	err := r.Prepare(request)
+	var statusErr api.StatusError
+	if !errors.As(err, &statusErr) {
+		t.Fatalf("Prepare error = %T %v, want api.StatusError", err, err)
+	}
+	if statusErr.StatusCode != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want %d", statusErr.StatusCode, http.StatusNotImplemented)
+	}
+}
+
+type constraintTestDrafter struct{}
+
+func (constraintTestDrafter) open([]any) draftSession { return constraintTestDraftSession{} }
+func (constraintTestDrafter) draftLimit() int         { return 0 }
+
+type constraintTestDraftSession struct{}
+
+func (constraintTestDraftSession) propose(*mlx.Array, int) *draftCandidates { return nil }
+func (constraintTestDraftSession) committed(*mlx.Array, *mlx.Array, int, []batch.MediaItem) {
+}
+func (constraintTestDraftSession) settle(*mlx.Array) {}
+func (constraintTestDraftSession) close()            {}
+
+func TestConstraintParksSpeculation(t *testing.T) {
+	s := &speculation{drafter: constraintTestDrafter{}, depth: newDepthController()}
+	constrained := s.open(Request{Constraint: &constraint.Matcher{}}, nil)
+	defer constrained.close()
+	if constrained.enabled {
+		t.Fatal("structured output request enabled speculative decoding")
+	}
+
+	unconstrained := s.open(Request{}, nil)
+	defer unconstrained.close()
+	if !unconstrained.enabled {
+		t.Fatal("ordinary request unexpectedly disabled speculative decoding")
+	}
+}

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -70,7 +70,7 @@ func (r *Runner) Prepare(request *Request) error {
 
 	request.Tokens = tokens
 	request.MediaItems = items
-	return nil
+	return r.prepareConstraint(request)
 }
 
 // The runner serializes requests today so we just use a fixed slot ID.
@@ -114,7 +114,12 @@ func (r *Runner) TextGenerationPipeline(ctx context.Context, request Request) er
 	r.Sampler.Add(pipelineSlot, request.SamplerOpts, inputs)
 
 	var d decoder
-	if spec != nil {
+	if request.Constraint != nil {
+		d, err = r.constrainedDecoder(spec, caches, seed, position, media.rowLayout(), request.Constraint)
+		if err != nil {
+			return err
+		}
+	} else if spec != nil {
 		d = spec.decoder(seed, position)
 	} else {
 		d = r.pipelinedDecoder(nil, caches, seed.ExpandDims(-1), position, media.rowLayout())
@@ -244,6 +249,7 @@ func (r *Runner) decode(ctx context.Context, request Request, session *cacheSess
 		tokenizer:       r.Tokenizer,
 		wantLogprobs:    request.SamplerOpts.Logprobs,
 		wantTopLogprobs: request.SamplerOpts.TopLogprobs,
+		constrained:     request.Constraint != nil,
 	}
 
 	final := CompletionResponse{Done: true, PromptEvalCount: len(request.Tokens), DoneReason: 1}
@@ -393,12 +399,17 @@ type detokenizer struct {
 	logprobs        []llm.Logprob
 	wantLogprobs    bool
 	wantTopLogprobs int
+	constrained     bool
 }
 
 func (d *detokenizer) detokenize(res sampler.Result) (CompletionResponse, bool) {
 	output := int32(res.Token.Int())
 	d.buf.WriteString(d.tokenizer.Decode([]int32{output}))
-	d.logprobs = append(d.logprobs, buildLogprob(res, d.wantLogprobs, d.wantTopLogprobs, d.tokenizer.Decode)...)
+	logprobs := buildLogprob(res, d.wantLogprobs, d.wantTopLogprobs, d.tokenizer.Decode)
+	if d.constrained {
+		removeMaskedTopLogprobs(logprobs)
+	}
+	d.logprobs = append(d.logprobs, logprobs...)
 
 	content := flushValidUTF8Prefix(&d.buf)
 	if content == "" {

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/x/internal/mlxthread"
 	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/constraint"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 	"github.com/ollama/ollama/x/mlxrunner/model"
 	"github.com/ollama/ollama/x/mlxrunner/model/base"
@@ -35,6 +36,7 @@ type Request struct {
 	MediaItems  []mediaItem
 	Layout      any // opaque PrepareMedia layout state, stamped on every batch
 	SamplerOpts sample.Options
+	Constraint  requestConstraint
 }
 
 type Runner struct {
@@ -45,6 +47,8 @@ type Runner struct {
 	cache         *prefixCache
 	contextLength int
 	mlxThread     *mlxthread.Thread
+	constraints   *constraint.Model
+	constraintErr error
 	// spec is the speculative-decoding subsystem. Nil when the model ships no
 	// draft head.
 	spec *speculation
@@ -115,6 +119,7 @@ func (r *Runner) Load(modelName string) error {
 	r.cache = newPrefixCache(slices.Concat(caches, draftCaches))
 	r.Sampler = sample.New(r.contextLength)
 	r.spec = newSpeculation(r, draftModel, caches, draftCaches)
+	r.loadConstraints(root)
 
 	mlx.EnableCompile()
 
@@ -257,6 +262,9 @@ func (r *Runner) Run(host, port string, mux http.Handler) error {
 }
 
 func (r *Runner) runRequest(request Request) error {
+	if request.Constraint != nil {
+		defer request.Constraint.Close()
+	}
 	if r.mlxThread == nil {
 		return request.Pipeline(request.Ctx, request)
 	}

--- a/x/mlxrunner/server.go
+++ b/x/mlxrunner/server.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -13,6 +14,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/logutil"
 	"github.com/ollama/ollama/x/internal/mlxthread"
@@ -68,6 +70,7 @@ func Execute(args []string) error {
 	}); err != nil {
 		return err
 	}
+	defer runner.Close()
 
 	readMemory := func() (uint64, error) {
 		return uint64(mlx.ActiveMemory() + mlx.CacheMemory()), nil
@@ -143,9 +146,20 @@ func Execute(args []string) error {
 		}
 
 		if err := runner.Prepare(&request); err != nil {
-			http.Error(w, err.Error(), http.StatusBadRequest)
+			var statusErr api.StatusError
+			if errors.As(err, &statusErr) {
+				http.Error(w, statusErr.ErrorMessage, statusErr.StatusCode)
+			} else {
+				http.Error(w, err.Error(), http.StatusBadRequest)
+			}
 			return
 		}
+		ownedConstraint := request.Constraint
+		defer func() {
+			if ownedConstraint != nil {
+				ownedConstraint.Close()
+			}
+		}()
 
 		var cancel context.CancelFunc
 		request.Ctx, cancel = context.WithCancel(r.Context())
@@ -155,6 +169,7 @@ func Execute(args []string) error {
 		case <-r.Context().Done():
 			return
 		case runner.Requests <- request:
+			ownedConstraint = nil
 		}
 
 		w.Header().Set("Content-Type", "application/jsonl")

--- a/x/mlxrunner/speculate.go
+++ b/x/mlxrunner/speculate.go
@@ -118,7 +118,7 @@ func (s *speculation) open(request Request, layout []any) *speculationSession {
 	// Logprobs are not yet supported, so a logprobs request keeps a speculationSession
 	// only to maintain a draft cache in lockstep (permanently parked).
 	opts := request.SamplerOpts
-	enabled := !opts.Logprobs && opts.TopLogprobs == 0
+	enabled := request.Constraint == nil && !opts.Logprobs && opts.TopLogprobs == 0
 
 	spec := &speculationSession{spec: s, drafter: d, layout: layout, enabled: enabled, prevDrafts: -1, roundDrafts: -1}
 	if enabled {


### PR DESCRIPTION
Propagate format and internal grammar constraints through the MLX runner and enforce them during sampling with XGrammar. Build model-scoped tokenizer metadata and request-scoped matchers for JSON, JSON Schema, and raw grammar constraints.

Keep constrained decoding on the normal one-token-ahead frontier by overlapping model forward work with host matcher updates. Apply allowed-token masks before sampling so penalties, stochastic sampling, and logprobs operate on the constrained distribution. Park speculative decoding for constrained requests without changing the unconstrained fast path.

Fetch tagged XGrammar sources at configure time and build the constraint engine as a dynamic MLX library. If the library is unavailable, keep ordinary MLX inference usable and return an explicit unsupported-feature error only for structured requests. Leave llama-server's existing structured output path unchanged.

Add unit coverage for request propagation, matcher behavior, constrained decoding, logprobs, cleanup, and error handling. Add release integration coverage exercising structured output with both llama-server and MLX models.

Testing across a selection of Mac/Linux/Windows systems, I see 4% or less performance impact.

Fixes #16563