### PR TITLE
convert: set llama4 pre-tokenizer type

### DIFF
--- a/convert/convert_llama4.go
+++ b/convert/convert_llama4.go
@@ -38,6 +38,7 @@ type llama4Model struct {
 func (p *llama4Model) KV(t *Tokenizer) KV {
 	kv := p.ModelParameters.KV(t)
 	kv["general.architecture"] = "llama4"
+	kv["tokenizer.ggml.pre"] = "llama4"
 
 	for k, v := range p.TextModel.KV(t) {
 		if strings.HasPrefix(k, "llama.") {

--- a/convert/convert_llama4_test.go
+++ b/convert/convert_llama4_test.go
@@ -1,0 +1,22 @@
+package convert
+
+import "testing"
+
+func TestLlama4SetsPreTokenizer(t *testing.T) {
+	m := &llama4Model{}
+	m.TextModel.HiddenSize = 5120
+	m.TextModel.NumAttentionHeads = 40
+	m.TextModel.NumKeyValueHeads = 8
+	m.TextModel.IntermediateSizeMLP = 16384
+
+	kv := m.KV(&Tokenizer{Vocabulary: &Vocabulary{Model: "gpt2"}, Pre: "default"})
+
+	for k, want := range map[string]any{
+		"general.architecture": "llama4",
+		"tokenizer.ggml.pre":   "llama4",
+	} {
+		if got := kv[k]; got != want {
+			t.Errorf("kv[%q] = %v, want %v", k, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #17698
 
Llama 4 GGUFs come out of the converter with `tokenizer.ggml.pre = "default"` instead of `"llama4"`, which makes llama.cpp use its GPT-2 fallback pre-tokenizer. Same vocab and merges, but text is split differently, so the token IDs differ from the reference Llama 4 tokenizer (e.g. `" ="` becomes `[220, 41]` instead of `[319]`, `"don't"` becomes `[21414, 19, 96]` instead of `[127161]`). A typical prompt ends up ~10% longer and roughly 22k vocab entries become unreachable. Nothing errors at load, so it's silent.
 
Cause: `convert/tokenizer.go` detects the pre-tokenizer by hashing its `Split` regex(es) against a fixed digest list. Llama 4's isn't in that list, so it falls back to `default`, and `convert_llama4.go` doesn't set `tokenizer.ggml.pre` itself (unlike `convert_gptoss.go` → `gpt-4o` or `convert_gemma4.go` → `gemma4`).

This sets it explicitly to `llama4`, which is what llama.cpp's own `convert_hf_to_gguf.py` writes. Added TestLlama4SetsPreTokenizer`; `go test ./convert/` and `go vet ./convert/` pass.

Note: this fixes newly converted models. The GGUFs already published under `library/llama4` would need to be regenerated for existing users to get the corrected tokenizer.