### PR TITLE
cmd: strip wrapping single-quotes from drag-dropped image paths

### DIFF
--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -583,7 +583,7 @@ func NewCreateRequest(name string, opts runOptions) *api.CreateRequest {
 }
 
 func normalizeFilePath(fp string) string {
-	return strings.NewReplacer(
+	fp = strings.NewReplacer(
 		"\\ ", " ", // Escaped space
 		"\\(", "(", // Escaped left parenthesis
 		"\\)", ")", // Escaped right parenthesis
@@ -600,6 +600,7 @@ func normalizeFilePath(fp string) string {
 		"\\?", "?", // Escaped question mark
 		"\\~", "~", // Escaped tilde
 	).Replace(fp)
+	return strings.Trim(fp, "'") // Strip wrapping single-quotes added by shell drag-drop
 }
 
 func extractFileNames(input string) []string {

--- a/cmd/interactive_test.go
+++ b/cmd/interactive_test.go
@@ -114,3 +114,47 @@ func TestExtractFileDataWAV(t *testing.T) {
 	assert.Len(t, imgs, 1)
 	assert.Equal(t, "before  after", cleaned)
 }
+
+// TestNormalizeFilePath verifies that shell-escaped and quoted paths are
+// resolved to plain filesystem paths. Covers the drag-drop single-quote
+// wrapping case reported in https://github.com/ollama/ollama/issues/10333.
+func TestNormalizeFilePath(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "path wrapped in single quotes (linux drag-drop)",
+			in:   "'/home/user/photo.jpg'",
+			want: "/home/user/photo.jpg",
+		},
+		{
+			name: "path with spaces wrapped in single quotes",
+			in:   "'/home/user/my photos/vacation.png'",
+			want: "/home/user/my photos/vacation.png",
+		},
+		{
+			name: "escaped space without quotes",
+			in:   "/home/user/my\\ photo.jpg",
+			want: "/home/user/my photo.jpg",
+		},
+		{
+			name: "escaped tilde",
+			in:   "\\~/pictures/image.png",
+			want: "~/pictures/image.png",
+		},
+		{
+			name: "no quotes or escapes",
+			in:   "/home/user/plain.jpg",
+			want: "/home/user/plain.jpg",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeFilePath(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/cmd/internal/filedata/filedata.go
+++ b/cmd/internal/filedata/filedata.go
@@ -39,6 +39,7 @@ func NormalizePath(fp string) string {
 		"\\?", "?",
 		"\\~", "~",
 	).Replace(fp)
+	fp = strings.Trim(fp, "'") // Strip wrapping single-quotes added by shell drag-drop
 
 	if u, err := url.Parse(fp); err == nil && strings.EqualFold(u.Scheme, "file") {
 		return normalizeFileURL(u)

--- a/cmd/internal/filedata/filedata_test.go
+++ b/cmd/internal/filedata/filedata_test.go
@@ -221,3 +221,49 @@ func assertNotContainsSlice(t *testing.T, ss []string, want string) {
 		}
 	}
 }
+
+// TestNormalizePathSingleQuotes verifies that paths wrapped in single-quotes
+// by the shell during drag-and-drop are handled correctly.
+// Regression test for https://github.com/ollama/ollama/issues/10333.
+func TestNormalizePathSingleQuotes(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "path wrapped in single quotes (linux drag-drop)",
+			in:   "'/home/user/photo.jpg'",
+			want: "/home/user/photo.jpg",
+		},
+		{
+			name: "path with spaces wrapped in single quotes",
+			in:   "'/home/user/my photos/vacation.png'",
+			want: "/home/user/my photos/vacation.png",
+		},
+		{
+			name: "double-quoted path still stripped",
+			in:   "\"/home/user/photo.jpg\"",
+			want: "/home/user/photo.jpg",
+		},
+		{
+			name: "escaped space without quotes",
+			in:   "/home/user/my\\ photo.jpg",
+			want: "/home/user/my photo.jpg",
+		},
+		{
+			name: "no quotes or escapes",
+			in:   "/home/user/plain.jpg",
+			want: "/home/user/plain.jpg",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := NormalizePath(tc.in)
+			if got != tc.want {
+				t.Fatalf("NormalizePath(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What

When a file is dragged into a terminal on Linux, the shell wraps the path in single-quotes (e.g. `'/home/rick/photo.jpg'`). The CLI regex matches from `/` onward, leaving a trailing `'` in the path, causing `os.Open` to fail with `ErrNotExist` — so the image is silently ignored.

### Why

`normalizeFilePath` in `cmd/interactive.go` already handles a rich set of shell escape sequences via `strings.NewReplacer` but did not strip outer single-quote wrapping. The same logic exists verbatim in `cmd/internal/filedata/filedata.NormalizePath` (added after #11472) and had the same gap.

### Changes

Two one-line additions — no new dependencies:
- `cmd/interactive.go` — `normalizeFilePath`: assign replacer result, then return `strings.Trim(fp, "'")`.
- `cmd/internal/filedata/filedata.go` — `NormalizePath`: same `strings.Trim(fp, "'")` after the replacer and before the `file://` URL check.

### Testing

Added `TestNormalizeFilePath` (5 table-driven cases) to `cmd/interactive_test.go` and `TestNormalizePathSingleQuotes` (5 table-driven cases) to `cmd/internal/filedata/filedata_test.go`. Cases cover: fully-quoted path, quoted path with spaces, escaped space without quotes, escaped tilde, and plain path (regression guard).

Fixes #10333