### PR TITLE
nn: speed up prefill on double-scale nvfp4 models

### DIFF
--- a/x/models/nn/nn.go
+++ b/x/models/nn/nn.go
@@ -112,6 +112,14 @@ func NewQuantizedLinear(weight *mlx.Array, bias *mlx.Array, groupSize, bits int,
 	}
 }
 
+var quantizedLinearOutputScale = mlx.Compile2(
+	"QuantizedLinearOutputScale",
+	func(out, scale *mlx.Array) *mlx.Array {
+		return mlx.Mul(out, scale).AsType(out.DType())
+	},
+	mlx.Shapeless(),
+)
+
 func (ql *QuantizedLinear) Forward(x *mlx.Array) *mlx.Array {
 	out := mlx.QuantizedMatmul(x, ql.Weight, ql.Scales, ql.QBiases, true, ql.GroupSize, ql.Bits, ql.Mode)
 	if ql.GlobalScale != nil {
@@ -120,8 +128,7 @@ func (ql *QuantizedLinear) Forward(x *mlx.Array) *mlx.Array {
 		// (weight_scale_2 in NVIDIA's format) or per-row.
 		// TODO: switch to a fused double-scale matmul once MLX has kernel
 		// coverage for this path.
-		outDType := out.DType()
-		out = mlx.Mul(out, ql.GlobalScale).AsType(outDType)
+		out = quantizedLinearOutputScale(out, ql.GlobalScale)
 	}
 	if ql.Bias != nil && ql.Bias.Valid() {
 		bias := ql.Bias


### PR DESCRIPTION
ModelOpt checkpoints apply a float32 global scale to every projection output on top of the per-group quantization scales. Running the multiply and the cast back to the activation dtype as separate eager ops costs an extra kernel launch and a materialized intermediate per projection.

Compile the multiply and cast into one kernel. On an M5 Max (medians of order-swapped A/B runs against main; greedy outputs byte-identical):

    qwen3.6:27b        prefill  703 -> 769 t/s  +7.9%
    muse-glimmer:30b   prefill  790 -> 843 t/s  +6.7%

Speculative decode is unchanged within noise on both models. Only checkpoints with a global scale are affected; single-scale nvfp4, mxfp8, and affine checkpoints take the unchanged path.