### PR TITLE
server: defer structured outputs until thinking completes in generate

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -502,6 +502,11 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 
 	prompt := req.Prompt
 	var leadingBOS string
+	// rebuildPrompt re-renders the prompt with the thinking produced so far appended as
+	// an assistant message, so a second constrained request can continue from there. it
+	// stays nil for flows that cannot be re-rendered (raw mode, suffix completion), which
+	// keeps structured outputs applied to the first request as before
+	var rebuildPrompt func(thinking string) (string, error)
 	if !req.Raw {
 		tmpl := m.Template
 		if req.Template != "" {
@@ -553,6 +558,14 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			b.WriteString(s)
 		}
 
+		// the detokenized req.Context, if any, prefixes whichever prompt we render
+		// TEMP(drifkin): req.Context will be removed very soon, but we're temporarily supporting it in this flow here
+		promptPrefix := b.String()
+
+		thinkingMessages := func(thinking string) []api.Message {
+			return append(slices.Clone(values.Messages), api.Message{Role: "assistant", Thinking: thinking})
+		}
+
 		// check that we're in the `api/chat`-like flow, and if so, generate the
 		// prompt the same way
 		// TEMP(drifkin): we should really just detect the chat-like flow and call
@@ -595,10 +608,24 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 					}
 					return
 				}
-				// TEMP(drifkin): req.Context will be removed very soon, but we're temporarily supporting it in this flow here
-				if req.Context != nil {
-					b.WriteString(prompt)
-					prompt = b.String()
+				prompt = promptPrefix + prompt
+
+				// ApplyChatTemplate drops api.Message.Thinking on its way to the runner, so
+				// the second request cannot be re-rendered with the reasoning. continue the
+				// assistant turn textually instead, which is exactly what the model emitted.
+				// the tags come from the Go template, the same source thinkingState parses
+				// the output with. a model that describes its thinking only in the GGUF chat
+				// template has neither, so there is no way to tell reasoning from content and
+				// the format keeps being applied to the first request
+				openingTag, closingTag := thinking.InferTags(m.Template.Template)
+				if openingTag != "" && closingTag != "" {
+					basePrompt := prompt
+					rebuildPrompt = func(thinking string) (string, error) {
+						if strings.HasSuffix(strings.TrimSpace(basePrompt), openingTag) {
+							return basePrompt + thinking + closingTag, nil
+						}
+						return basePrompt + openingTag + thinking + closingTag, nil
+					}
 				}
 			} else {
 				prompt, media, err = chatPrompt(c.Request.Context(), m, r.Tokenize, optionsForPrompt(opts, r), values.Messages, []api.Tool{}, req.Think, genTruncate)
@@ -606,12 +633,16 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 					c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 					return
 				}
-				// TEMP(drifkin): req.Context will be removed very soon, but we're temporarily supporting it in this flow here
-				if req.Context != nil {
-					b.WriteString(prompt)
-					prompt = b.String()
-				}
+				prompt = promptPrefix + prompt
 				leadingBOS = leadingBOSForModel(m)
+
+				rebuildPrompt = func(thinking string) (string, error) {
+					p, _, err := chatPrompt(c.Request.Context(), m, r.Tokenize, optionsForPrompt(opts, r), thinkingMessages(thinking), []api.Tool{}, req.Think, genTruncate)
+					if err != nil {
+						return "", err
+					}
+					return promptPrefix + p, nil
+				}
 			}
 		} else {
 			// Direct template execution flow.
@@ -621,6 +652,20 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			}
 
 			prompt = b.String()
+
+			if values.Messages != nil {
+				rebuildPrompt = func(thinking string) (string, error) {
+					v := values
+					v.Messages = thinkingMessages(thinking)
+
+					var b bytes.Buffer
+					b.WriteString(promptPrefix)
+					if err := tmpl.Execute(&b, v); err != nil {
+						return "", err
+					}
+					return b.String(), nil
+				}
+			}
 		}
 	}
 
@@ -651,93 +696,191 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		}
 	}
 
+	type structuredOutputsState int
+	const (
+		structuredOutputsState_None structuredOutputsState = iota
+		structuredOutputsState_ReadyToApply
+		structuredOutputsState_Applying
+	)
+
+	// json.RawMessage is non-nil for `null` and `""` too, which the runner treats as
+	// no format at all - deferring for those would cost a second request for nothing
+	constrainsOutput := req.Format != nil && string(req.Format) != "null" && string(req.Format) != `""`
+
 	ch := make(chan any)
 	go func() {
-		// TODO (jmorganca): avoid building the response twice both here and below
-		var sb strings.Builder
 		defer close(ch)
-		if err := r.Completion(c.Request.Context(), llm.CompletionRequest{
-			Prompt:          prompt,
-			Media:           media,
-			Format:          req.Format,
-			Options:         opts,
-			Shift:           req.Shift == nil || *req.Shift,
-			Truncate:        req.Truncate == nil || *req.Truncate,
-			Logprobs:        req.Logprobs,
-			TopLogprobs:     req.TopLogprobs,
-			PreservedTokens: preservedTokensForCompletion(builtinParser),
-			LeadingBOS:      leadingBOS,
-		}, func(cr llm.CompletionResponse) {
-			res := api.GenerateResponse{
-				Model:     req.Model,
-				CreatedAt: time.Now().UTC(),
-				Response:  cr.Content,
-				Done:      cr.Done,
-				Metrics: api.Metrics{
-					PromptEvalCount:    cr.PromptEvalCount,
-					PromptEvalDuration: cr.PromptEvalDuration,
-					EvalCount:          cr.EvalCount,
-					EvalDuration:       cr.EvalDuration,
-				},
-				Logprobs: toAPILogprobs(cr.Logprobs),
+
+		structuredOutputsState := structuredOutputsState_None
+
+		for {
+			// TODO (jmorganca): avoid building the response twice both here and below
+			var sb strings.Builder
+			var tb strings.Builder
+
+			currentFormat := req.Format
+			// structured outputs via double request is enabled when:
+			// 1. the model supports the thinking capability,
+			// 2. it uses a built-in parser or our generic thinking parser and
+			// 3. the prompt can be re-rendered with the thinking as a prefill
+			// constraining from the first token otherwise leaves the model nowhere to
+			// reason, so `think` ends up silently ignored
+
+			// Note that the current approach does not work for (potential future)
+			// non-thinking models that emit anything before actual content. This
+			// current approach uses the first parsed content as the signal to turn
+			// constraining on
+
+			// deferredFormat records that the grammar was dropped for this request, so a
+			// restart has to apply it before any content reaches the client, even if
+			// nothing was thought
+			var deferredFormat bool
+
+			forceImmediate := builtinParser != nil && builtinParser.HasThinkingSupport() && req.Think != nil && !req.Think.Bool()
+			if constrainsOutput && structuredOutputsState == structuredOutputsState_None && !forceImmediate && rebuildPrompt != nil && ((builtinParser != nil || thinkingState != nil) && slices.Contains(m.Capabilities(), model.CapabilityThinking)) {
+				currentFormat = nil
+				deferredFormat = true
 			}
 
-			if builtinParser != nil {
-				content, thinking, toolCalls, err := builtinParser.Add(cr.Content, cr.Done)
-				if err != nil {
-					ch <- gin.H{"error": err.Error()}
-					return
+			// sets up new context given parent context per request
+			ctx, cancel := context.WithCancel(c.Request.Context())
+
+			err := r.Completion(ctx, llm.CompletionRequest{
+				Prompt:          prompt,
+				Media:           media,
+				Format:          currentFormat,
+				Options:         opts,
+				Shift:           req.Shift == nil || *req.Shift,
+				Truncate:        req.Truncate == nil || *req.Truncate,
+				Logprobs:        req.Logprobs,
+				TopLogprobs:     req.TopLogprobs,
+				PreservedTokens: preservedTokensForCompletion(builtinParser),
+				LeadingBOS:      leadingBOS,
+			}, func(cr llm.CompletionResponse) {
+				res := api.GenerateResponse{
+					Model:     req.Model,
+					CreatedAt: time.Now().UTC(),
+					Response:  cr.Content,
+					Done:      cr.Done,
+					Metrics: api.Metrics{
+						PromptEvalCount:    cr.PromptEvalCount,
+						PromptEvalDuration: cr.PromptEvalDuration,
+						EvalCount:          cr.EvalCount,
+						EvalDuration:       cr.EvalDuration,
+					},
+					Logprobs: toAPILogprobs(cr.Logprobs),
 				}
-				res.Response = content
-				res.Thinking = thinking
-				if cr.Done && len(toolCalls) > 0 {
-					res.ToolCalls = toolCalls
-				}
-			} else if thinkingState != nil {
-				thinking, content := thinkingState.AddContent(cr.Content)
-				res.Thinking = thinking
-				res.Response = content
-			}
 
-			if _, err := sb.WriteString(cr.Content); err != nil {
-				ch <- gin.H{"error": err.Error()}
-			}
-
-			if cr.Done {
-				res.DoneReason = cr.DoneReason.String()
-				res.TotalDuration = time.Since(checkpointStart)
-				res.LoadDuration = checkpointLoaded.Sub(checkpointStart)
-
-				if !req.Raw {
-					tokens, err := r.Tokenize(c.Request.Context(), prompt+sb.String())
+				if builtinParser != nil {
+					content, thinking, toolCalls, err := builtinParser.Add(cr.Content, cr.Done)
 					if err != nil {
 						ch <- gin.H{"error": err.Error()}
 						return
 					}
-					res.Context = tokens
+					res.Response = content
+					res.Thinking = thinking
+					if cr.Done && len(toolCalls) > 0 {
+						res.ToolCalls = toolCalls
+					}
+
+					tb.WriteString(thinking)
+				} else if thinkingState != nil {
+					thinking, content := thinkingState.AddContent(cr.Content)
+					res.Thinking = thinking
+					res.Response = content
+
+					tb.WriteString(thinking)
+				}
+
+				// we are now receiving content from the model - we should start applying
+				// structured outputs. both parsers can return thinking and content from a
+				// single call, so emit the thinking before restarting. nothing else from
+				// that chunk survives: the content, tool calls, logprobs and metrics all
+				// describe the answer the constrained request regenerates, and that
+				// request reports the completion
+				if deferredFormat && structuredOutputsState == structuredOutputsState_None && res.Response != "" {
+					structuredOutputsState = structuredOutputsState_ReadyToApply
+					if res.Thinking != "" {
+						ch <- api.GenerateResponse{
+							Model:     res.Model,
+							CreatedAt: res.CreatedAt,
+							Thinking:  res.Thinking,
+						}
+					}
+					cancel()
+					return
+				}
+
+				if _, err := sb.WriteString(cr.Content); err != nil {
+					ch <- gin.H{"error": err.Error()}
+				}
+
+				if cr.Done {
+					res.DoneReason = cr.DoneReason.String()
+					res.TotalDuration = time.Since(checkpointStart)
+					res.LoadDuration = checkpointLoaded.Sub(checkpointStart)
+
+					if !req.Raw {
+						tokens, err := r.Tokenize(c.Request.Context(), prompt+sb.String())
+						if err != nil {
+							ch <- gin.H{"error": err.Error()}
+							return
+						}
+						res.Context = tokens
+					}
+				}
+
+				if builtinParser != nil {
+					// Emit chunks that carry logprobs even if the parser is still buffering
+					// visible content, otherwise generate logprobs disappear for models with
+					// builtin thinking/tool parsers.
+					if res.Response != "" || res.Thinking != "" || res.Done || len(res.ToolCalls) > 0 || len(res.Logprobs) > 0 {
+						ch <- res
+					}
+
+					return
+				}
+
+				ch <- res
+			})
+			if err != nil {
+				if structuredOutputsState == structuredOutputsState_ReadyToApply && strings.Contains(err.Error(), "context canceled") && c.Request.Context().Err() == nil {
+					// only ignores error if it's a context cancellation due to setting structured outputs
+				} else {
+					s.sched.expireRunnersForRuntimeOOM(m, err)
+					var serr api.StatusError
+					if errors.As(err, &serr) {
+						ch <- gin.H{"error": serr.ErrorMessage, "status": serr.StatusCode}
+					} else {
+						ch <- gin.H{"error": err.Error()}
+					}
+					return
 				}
 			}
 
-			if builtinParser != nil {
-				// Emit chunks that carry logprobs even if the parser is still buffering
-				// visible content, otherwise generate logprobs disappear for models with
-				// builtin thinking/tool parsers.
-				if res.Response != "" || res.Thinking != "" || res.Done || len(res.ToolCalls) > 0 || len(res.Logprobs) > 0 {
-					ch <- res
+			// ignored structured outputs cancellation falls through to here, start a new request with the structured outputs and updated prompt
+			if structuredOutputsState == structuredOutputsState_ReadyToApply {
+				structuredOutputsState = structuredOutputsState_Applying
+				// with no thinking to prime it with, the second request re-runs the
+				// original prompt rather than appending an empty assistant turn
+				if thinking := tb.String(); thinking != "" {
+					prompt, err = rebuildPrompt(thinking)
+					if err != nil {
+						slog.Error("generate prompt error applying structured outputs", "error", err)
+						ch <- gin.H{"error": err.Error()}
+						return
+					}
+					// force constraining by terminating thinking header, the parser is already at this state
+					// when the last message is thinking, the renderer for gpt-oss cannot disambiguate between having the
+					// model continue thinking or ending thinking and outputting the final message.
+					if shouldUseHarmony(m) || (builtinParser != nil && m.Config.Parser == "harmony") {
+						prompt += "<|end|><|start|>assistant<|channel|>final<|message|>"
+					}
 				}
-
-				return
+				continue
 			}
 
-			ch <- res
-		}); err != nil {
-			s.sched.expireRunnersForRuntimeOOM(m, err)
-			var serr api.StatusError
-			if errors.As(err, &serr) {
-				ch <- gin.H{"error": serr.ErrorMessage, "status": serr.StatusCode}
-			} else {
-				ch <- gin.H{"error": err.Error()}
-			}
+			break
 		}
 	}()
 

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -2351,86 +2351,87 @@ func TestChatLogprobs(t *testing.T) {
 	})
 }
 
-func TestChatWithPromptEndingInThinkTag(t *testing.T) {
-	t.Setenv("OLLAMA_GO_TEMPLATE", "1")
-	gin.SetMode(gin.TestMode)
+// setupThinkingTest creates a standard thinking test setup: a server serving a
+// model whose template adds <think> at the end of the prompt.
+func setupThinkingTest(t *testing.T) (*mockRunner, *Server) {
+	mock := &mockRunner{
+		CompletionResponse: llm.CompletionResponse{
+			Done:               true,
+			DoneReason:         llm.DoneReasonStop,
+			PromptEvalCount:    1,
+			PromptEvalDuration: 1,
+			EvalCount:          1,
+			EvalDuration:       1,
+		},
+	}
 
-	// Helper to create a standard thinking test setup
-	setupThinkingTest := func(t *testing.T) (*mockRunner, *Server) {
-		mock := &mockRunner{
-			CompletionResponse: llm.CompletionResponse{
-				Done:               true,
-				DoneReason:         llm.DoneReasonStop,
-				PromptEvalCount:    1,
-				PromptEvalDuration: 1,
-				EvalCount:          1,
-				EvalDuration:       1,
+	s := &Server{
+		sched: &Scheduler{
+			pendingReqCh:    make(chan *LlmRequest, 1),
+			finishedReqCh:   make(chan *LlmRequest, 1),
+			expiredCh:       make(chan *runnerRef, 1),
+			unloadedCh:      make(chan any, 1),
+			loaded:          make(map[string]*runnerRef),
+			newServerFn:     newMockServer(mock),
+			getGpuFn:        getGpuFn,
+			getSystemInfoFn: getSystemInfoFn,
+			waitForRecovery: 250 * time.Millisecond,
+			loadFn: func(req *LlmRequest, _ ml.SystemInfo, _ []ml.DeviceInfo, _ bool) bool {
+				time.Sleep(time.Millisecond)
+				req.successCh <- &runnerRef{llama: mock}
+				return false
 			},
-		}
+		},
+	}
 
-		s := &Server{
-			sched: &Scheduler{
-				pendingReqCh:    make(chan *LlmRequest, 1),
-				finishedReqCh:   make(chan *LlmRequest, 1),
-				expiredCh:       make(chan *runnerRef, 1),
-				unloadedCh:      make(chan any, 1),
-				loaded:          make(map[string]*runnerRef),
-				newServerFn:     newMockServer(mock),
-				getGpuFn:        getGpuFn,
-				getSystemInfoFn: getSystemInfoFn,
-				waitForRecovery: 250 * time.Millisecond,
-				loadFn: func(req *LlmRequest, _ ml.SystemInfo, _ []ml.DeviceInfo, _ bool) bool {
-					time.Sleep(time.Millisecond)
-					req.successCh <- &runnerRef{llama: mock}
-					return false
-				},
-			},
-		}
+	go s.sched.Run(t.Context())
 
-		go s.sched.Run(t.Context())
+	// Create a model with thinking support
+	_, digest := createBinFile(t, ggml.KV{
+		"general.architecture":          "llama",
+		"llama.block_count":             uint32(1),
+		"llama.context_length":          uint32(8192),
+		"llama.embedding_length":        uint32(4096),
+		"llama.attention.head_count":    uint32(32),
+		"llama.attention.head_count_kv": uint32(8),
+		"tokenizer.ggml.tokens":         []string{""},
+		"tokenizer.ggml.scores":         []float32{0},
+		"tokenizer.ggml.token_type":     []int32{0},
+	}, []*ggml.Tensor{
+		{Name: "token_embd.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_norm.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_down.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_gate.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_up.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_norm.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_k.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_output.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_q.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_v.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "output.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+	})
 
-		// Create a model with thinking support
-		_, digest := createBinFile(t, ggml.KV{
-			"general.architecture":          "llama",
-			"llama.block_count":             uint32(1),
-			"llama.context_length":          uint32(8192),
-			"llama.embedding_length":        uint32(4096),
-			"llama.attention.head_count":    uint32(32),
-			"llama.attention.head_count_kv": uint32(8),
-			"tokenizer.ggml.tokens":         []string{""},
-			"tokenizer.ggml.scores":         []float32{0},
-			"tokenizer.ggml.token_type":     []int32{0},
-		}, []*ggml.Tensor{
-			{Name: "token_embd.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "blk.0.attn_norm.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "blk.0.ffn_down.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "blk.0.ffn_gate.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "blk.0.ffn_up.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "blk.0.ffn_norm.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "blk.0.attn_k.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "blk.0.attn_output.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "blk.0.attn_q.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "blk.0.attn_v.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "output.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-		})
-
-		// Create model with thinking template that adds <think> at the end
-		w := createRequest(t, s.CreateHandler, api.CreateRequest{
-			Model: "test-thinking",
-			Files: map[string]string{"file.gguf": digest},
-			Template: `{{- range .Messages }}
+	// Create model with thinking template that adds <think> at the end
+	w := createRequest(t, s.CreateHandler, api.CreateRequest{
+		Model: "test-thinking",
+		Files: map[string]string{"file.gguf": digest},
+		Template: `{{- range .Messages }}
 {{- if eq .Role "user" }}user: {{ .Content }}
 {{ else if eq .Role "assistant" }}assistant: {{ if .Thinking }}<think>{{ .Thinking }}</think>{{ end }}{{ .Content }}
 {{ end }}{{ end }}<think>`,
-			Stream: &stream,
-		})
+		Stream: &stream,
+	})
 
-		if w.Code != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", w.Code)
-		}
-
-		return mock, s
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
 	}
+
+	return mock, s
+}
+
+func TestChatWithPromptEndingInThinkTag(t *testing.T) {
+	t.Setenv("OLLAMA_GO_TEMPLATE", "1")
+	gin.SetMode(gin.TestMode)
 
 	mock, s := setupThinkingTest(t)
 
@@ -2935,6 +2936,893 @@ func TestChatFormatWithThinkFalse(t *testing.T) {
 				t.Errorf("expected first completion format to match the request format, got %q", string(requests[0].Format))
 			}
 		})
+	}
+}
+
+// TestGenerateFormatWithThinking verifies that /api/generate defers the format
+// grammar until thinking is done, the same way /api/chat does. Applying it from
+// the first token leaves the model no room to reason, so `think` was silently
+// ignored. See https://github.com/ollama/ollama/issues/17544.
+func TestGenerateFormatWithThinking(t *testing.T) {
+	t.Setenv("OLLAMA_GO_TEMPLATE", "1")
+	gin.SetMode(gin.TestMode)
+
+	mock, s := setupThinkingTest(t)
+
+	format := json.RawMessage(`{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}`)
+	const thinkingChunk = " I am thinking through this problem. </think> {\"answer\":\"42\"}"
+
+	// restartOnFormat replays firstChunk, then blocks until the handler cancels
+	// the first request to apply structured outputs
+	restartOnFormat := func(t *testing.T, requests *[]llm.CompletionRequest, requestsMu *sync.Mutex, firstChunk string) func(context.Context, llm.CompletionRequest, func(llm.CompletionResponse)) error {
+		return func(ctx context.Context, r llm.CompletionRequest, fn func(r llm.CompletionResponse)) error {
+			requestsMu.Lock()
+			*requests = append(*requests, r)
+			callNum := len(*requests)
+			requestsMu.Unlock()
+
+			switch callNum {
+			case 1:
+				fn(llm.CompletionResponse{
+					Content:            firstChunk,
+					Done:               false,
+					PromptEvalCount:    1,
+					PromptEvalDuration: 1,
+				})
+
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(time.Second):
+					t.Errorf("timeout waiting for structured outputs cancellation")
+					return nil
+				}
+			case 2:
+				fn(llm.CompletionResponse{
+					Content:            `{"answer":"42"}`,
+					Done:               true,
+					DoneReason:         llm.DoneReasonStop,
+					PromptEvalCount:    1,
+					PromptEvalDuration: 1,
+					EvalCount:          1,
+					EvalDuration:       1,
+				})
+				return nil
+			default:
+				t.Errorf("unexpected number of completion calls: %d", callNum)
+				return nil
+			}
+		}
+	}
+
+	// the second request must carry the format and be primed with the thinking
+	// the model already produced
+	checkRestartedRequests := func(t *testing.T, requests []llm.CompletionRequest) {
+		t.Helper()
+
+		if len(requests) != 2 {
+			t.Fatalf("expected two completion calls, got %d", len(requests))
+		}
+
+		if requests[0].Format != nil {
+			t.Errorf("expected first completion format to be nil, got %q", requests[0].Format)
+		}
+
+		if !bytes.Equal([]byte(format), []byte(requests[1].Format)) {
+			t.Errorf("expected second completion format to match original format, got %q", requests[1].Format)
+		}
+
+		if !strings.Contains(requests[1].Prompt, "user: Please respond in JSON.") {
+			t.Errorf("expected second completion prompt to keep the original prompt, got %q", requests[1].Prompt)
+		}
+
+		if !strings.Contains(requests[1].Prompt, "<think>I am thinking through this problem. </think>") {
+			t.Errorf("expected second completion prompt to carry the thinking, got %q", requests[1].Prompt)
+		}
+	}
+
+	t.Run("structured outputs restart non-stream", func(t *testing.T) {
+		var (
+			requestsMu sync.Mutex
+			requests   []llm.CompletionRequest
+		)
+
+		mock.CompletionFn = restartOnFormat(t, &requests, &requestsMu, thinkingChunk)
+		t.Cleanup(func() { mock.CompletionFn = nil })
+
+		streamRequest := false
+		w := createRequest(t, s.GenerateHandler, api.GenerateRequest{
+			Model:   "test-thinking",
+			Prompt:  "Please respond in JSON.",
+			Think:   &api.ThinkValue{Value: true},
+			Stream:  &streamRequest,
+			Format:  format,
+			Options: map[string]any{"num_ctx": 4096},
+		})
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+
+		checkRestartedRequests(t, requests)
+
+		var resp api.GenerateResponse
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatal(err)
+		}
+
+		if resp.Thinking != "I am thinking through this problem. " {
+			t.Errorf("expected thinking %q, got %q", "I am thinking through this problem. ", resp.Thinking)
+		}
+
+		if resp.Response != `{"answer":"42"}` {
+			t.Errorf("expected response %q, got %q", `{"answer":"42"}`, resp.Response)
+		}
+
+		if !resp.Done {
+			t.Error("expected response to be done")
+		}
+
+		if resp.DoneReason != "stop" {
+			t.Errorf("expected done reason stop, got %s", resp.DoneReason)
+		}
+	})
+
+	t.Run("structured outputs restart streaming", func(t *testing.T) {
+		var (
+			requestsMu sync.Mutex
+			requests   []llm.CompletionRequest
+		)
+
+		mock.CompletionFn = restartOnFormat(t, &requests, &requestsMu, thinkingChunk)
+		t.Cleanup(func() { mock.CompletionFn = nil })
+
+		streamRequest := true
+		w := createRequest(t, s.GenerateHandler, api.GenerateRequest{
+			Model:   "test-thinking",
+			Prompt:  "Please respond in JSON.",
+			Think:   &api.ThinkValue{Value: true},
+			Stream:  &streamRequest,
+			Format:  format,
+			Options: map[string]any{"num_ctx": 4096},
+		})
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+
+		checkRestartedRequests(t, requests)
+
+		decoder := json.NewDecoder(w.Body)
+		var events []api.GenerateResponse
+		for {
+			var event api.GenerateResponse
+			if err := decoder.Decode(&event); err == io.EOF {
+				break
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			events = append(events, event)
+			if event.Done {
+				break
+			}
+		}
+
+		if len(events) < 2 {
+			t.Fatalf("expected at least two streaming events, got %d", len(events))
+		}
+
+		first := events[0]
+		if first.Thinking != "I am thinking through this problem. " {
+			t.Errorf("expected first event thinking %q, got %q", "I am thinking through this problem. ", first.Thinking)
+		}
+
+		if first.Response != "" {
+			t.Errorf("expected first event response to be empty, got %q", first.Response)
+		}
+
+		if first.Done {
+			t.Error("expected first event to be non-terminal")
+		}
+
+		last := events[len(events)-1]
+		if last.Response != `{"answer":"42"}` {
+			t.Errorf("expected final event response %q, got %q", `{"answer":"42"}`, last.Response)
+		}
+
+		if !last.Done {
+			t.Error("expected final event to be done")
+		}
+
+		if last.DoneReason != "stop" {
+			t.Errorf("expected final done reason stop, got %s", last.DoneReason)
+		}
+	})
+
+	// a model that emits no thinking at all still has to end up constrained: the
+	// format was deferred for the first request, so it must be applied by a restart
+	t.Run("empty thinking still applies format", func(t *testing.T) {
+		var (
+			requestsMu sync.Mutex
+			requests   []llm.CompletionRequest
+		)
+
+		mock.CompletionFn = restartOnFormat(t, &requests, &requestsMu, `</think>{"answer":"42"}`)
+		t.Cleanup(func() { mock.CompletionFn = nil })
+
+		streamRequest := false
+		w := createRequest(t, s.GenerateHandler, api.GenerateRequest{
+			Model:   "test-thinking",
+			Prompt:  "Please respond in JSON.",
+			Think:   &api.ThinkValue{Value: true},
+			Stream:  &streamRequest,
+			Format:  format,
+			Options: map[string]any{"num_ctx": 4096},
+		})
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+
+		if len(requests) != 2 {
+			t.Fatalf("expected two completion calls, got %d", len(requests))
+		}
+
+		if !bytes.Equal([]byte(format), []byte(requests[1].Format)) {
+			t.Errorf("expected second completion format to match original format, got %q", requests[1].Format)
+		}
+
+		// nothing was thought, so there is no prefill to add to the prompt
+		if requests[1].Prompt != requests[0].Prompt {
+			t.Errorf("expected second completion prompt %q, got %q", requests[0].Prompt, requests[1].Prompt)
+		}
+
+		var resp api.GenerateResponse
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatal(err)
+		}
+
+		if resp.Response != `{"answer":"42"}` {
+			t.Errorf("expected response %q, got %q", `{"answer":"42"}`, resp.Response)
+		}
+	})
+
+	// the restart makes the chunk that triggered it non-terminal, otherwise a client
+	// that stops at the first done would never see the constrained answer
+	t.Run("transitional chunk is not terminal", func(t *testing.T) {
+		var (
+			requestsMu sync.Mutex
+			requests   []llm.CompletionRequest
+		)
+
+		mock.CompletionFn = func(ctx context.Context, r llm.CompletionRequest, fn func(r llm.CompletionResponse)) error {
+			requestsMu.Lock()
+			requests = append(requests, r)
+			callNum := len(requests)
+			requestsMu.Unlock()
+
+			switch callNum {
+			case 1:
+				// thinking, content and done all arrive in a single chunk
+				fn(llm.CompletionResponse{
+					Content:            thinkingChunk,
+					Done:               true,
+					DoneReason:         llm.DoneReasonStop,
+					PromptEvalCount:    1,
+					PromptEvalDuration: 1,
+					EvalCount:          1,
+					EvalDuration:       1,
+					Logprobs: []llm.Logprob{
+						{TokenLogprob: llm.TokenLogprob{Token: "42", Logprob: -0.5}},
+					},
+				})
+
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-time.After(time.Second):
+					t.Errorf("timeout waiting for structured outputs cancellation")
+					return nil
+				}
+			case 2:
+				fn(llm.CompletionResponse{
+					Content:            `{"answer":"42"}`,
+					Done:               true,
+					DoneReason:         llm.DoneReasonStop,
+					PromptEvalCount:    1,
+					PromptEvalDuration: 1,
+					EvalCount:          1,
+					EvalDuration:       1,
+				})
+				return nil
+			default:
+				t.Errorf("unexpected number of completion calls: %d", callNum)
+				return nil
+			}
+		}
+		t.Cleanup(func() { mock.CompletionFn = nil })
+
+		streamRequest := true
+		w := createRequest(t, s.GenerateHandler, api.GenerateRequest{
+			Model:    "test-thinking",
+			Prompt:   "Please respond in JSON.",
+			Think:    &api.ThinkValue{Value: true},
+			Stream:   &streamRequest,
+			Format:   format,
+			Logprobs: true,
+			Options:  map[string]any{"num_ctx": 4096},
+		})
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+
+		checkRestartedRequests(t, requests)
+
+		decoder := json.NewDecoder(w.Body)
+		var events []api.GenerateResponse
+		for {
+			var event api.GenerateResponse
+			if err := decoder.Decode(&event); err == io.EOF {
+				break
+			} else if err != nil {
+				t.Fatal(err)
+			}
+			events = append(events, event)
+		}
+
+		var done int
+		var thinking, content strings.Builder
+		for _, event := range events {
+			thinking.WriteString(event.Thinking)
+			content.WriteString(event.Response)
+			if event.Done {
+				done++
+			}
+		}
+
+		if done != 1 {
+			t.Errorf("expected exactly one terminal event, got %d of %d", done, len(events))
+		}
+
+		if !events[len(events)-1].Done {
+			t.Error("expected the last event to be the terminal one")
+		}
+
+		// the transitional event describes nothing but the thinking: the metrics and
+		// logprobs of the discarded answer must not reach the client
+		transitional := events[0]
+		if transitional.Response != "" || len(transitional.ToolCalls) > 0 {
+			t.Errorf("expected transitional event to carry only thinking, got %#v", transitional)
+		}
+
+		if transitional.Metrics != (api.Metrics{}) {
+			t.Errorf("expected transitional event to carry no metrics, got %#v", transitional.Metrics)
+		}
+
+		if len(transitional.Logprobs) > 0 {
+			t.Errorf("expected transitional event to carry no logprobs, got %#v", transitional.Logprobs)
+		}
+
+		if transitional.DoneReason != "" {
+			t.Errorf("expected transitional event to carry no done reason, got %q", transitional.DoneReason)
+		}
+
+		if thinking.String() != "I am thinking through this problem. " {
+			t.Errorf("expected thinking %q, got %q", "I am thinking through this problem. ", thinking.String())
+		}
+
+		if content.String() != `{"answer":"42"}` {
+			t.Errorf("expected content %q, got %q", `{"answer":"42"}`, content.String())
+		}
+	})
+
+	// requests with no thinking to wait for, and flows that cannot be re-rendered
+	// with a thinking prefill, keep applying the format to the first and only request
+	for _, tc := range []struct {
+		name string
+		req  api.GenerateRequest
+	}{
+		{
+			name: "thinking disabled",
+			req: api.GenerateRequest{
+				Model:  "test-thinking",
+				Prompt: "Please respond in JSON.",
+				Think:  &api.ThinkValue{Value: false},
+				Format: format,
+			},
+		},
+		{
+			name: "raw mode",
+			req: api.GenerateRequest{
+				Model:  "test-thinking",
+				Prompt: "Please respond in JSON.",
+				Raw:    true,
+				Think:  &api.ThinkValue{Value: true},
+				Format: format,
+			},
+		},
+		{
+			// json.RawMessage is non-nil here, but the runner ignores both values
+			name: "null format",
+			req: api.GenerateRequest{
+				Model:  "test-thinking",
+				Prompt: "Please respond in JSON.",
+				Think:  &api.ThinkValue{Value: true},
+				Format: json.RawMessage("null"),
+			},
+		},
+		{
+			name: "empty format",
+			req: api.GenerateRequest{
+				Model:  "test-thinking",
+				Prompt: "Please respond in JSON.",
+				Think:  &api.ThinkValue{Value: true},
+				Format: json.RawMessage(`""`),
+			},
+		},
+	} {
+		t.Run("no restart with "+tc.name, func(t *testing.T) {
+			var (
+				requestsMu sync.Mutex
+				requests   []llm.CompletionRequest
+			)
+
+			mock.CompletionFn = func(ctx context.Context, r llm.CompletionRequest, fn func(r llm.CompletionResponse)) error {
+				requestsMu.Lock()
+				requests = append(requests, r)
+				requestsMu.Unlock()
+
+				// a thinking turn: a restart would show up as a second call
+				fn(llm.CompletionResponse{
+					Content:            thinkingChunk,
+					Done:               true,
+					DoneReason:         llm.DoneReasonStop,
+					PromptEvalCount:    1,
+					PromptEvalDuration: 1,
+					EvalCount:          1,
+					EvalDuration:       1,
+				})
+				return nil
+			}
+			t.Cleanup(func() { mock.CompletionFn = nil })
+
+			streamRequest := false
+			req := tc.req
+			req.Stream = &streamRequest
+			req.Options = map[string]any{"num_ctx": 4096}
+			w := createRequest(t, s.GenerateHandler, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+			}
+
+			if len(requests) != 1 {
+				t.Fatalf("expected a single completion call, got %d", len(requests))
+			}
+
+			if !bytes.Equal([]byte(tc.req.Format), []byte(requests[0].Format)) {
+				t.Errorf("expected first completion format to match the request format, got %q", requests[0].Format)
+			}
+		})
+	}
+}
+
+// TestGenerateFormatWithThinkingNativeChatTemplate covers the deferral when the
+// prompt is rendered by the runner's own chat template. ApplyChatTemplate drops
+// Message.Thinking, so the restart continues the assistant turn textually.
+func TestGenerateFormatWithThinkingNativeChatTemplate(t *testing.T) {
+	t.Setenv("OLLAMA_GO_TEMPLATE", "0")
+	gin.SetMode(gin.TestMode)
+
+	const basePrompt = "native-template: Please respond in JSON.<think>"
+
+	mock := &mockRunner{
+		TemplateFn: func(_ context.Context, req llm.ChatRequest) (string, error) {
+			return basePrompt, nil
+		},
+	}
+
+	s := newServerWithMockRunner(t, mock)
+	// the chat template is the selected one, so the thinking capability comes from
+	// it, while the unselected Go template still supplies the thinking tags
+	createMinimalGGUFModel(t, s, "generate-native-thinking", ggml.KV{
+		"tokenizer.chat_template": "{{ messages[0]['content'] }}<think></think>",
+	}, `{{- range .Messages }}{{ .Role }}: {{ if .Thinking }}<think>{{ .Thinking }}</think>{{ end }}{{ .Content }}
+{{ end }}<think>`, nil)
+
+	if m, err := GetModel("generate-native-thinking"); err != nil {
+		t.Fatal(err)
+	} else if chatModeForModel(m) != chatExecutionModeNative {
+		t.Fatalf("expected the native chat template route, got %v", chatModeForModel(m))
+	}
+
+	format := json.RawMessage(`{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}`)
+
+	var (
+		requestsMu sync.Mutex
+		requests   []llm.CompletionRequest
+	)
+
+	mock.CompletionFn = func(ctx context.Context, r llm.CompletionRequest, fn func(r llm.CompletionResponse)) error {
+		requestsMu.Lock()
+		requests = append(requests, r)
+		callNum := len(requests)
+		requestsMu.Unlock()
+
+		switch callNum {
+		case 1:
+			fn(llm.CompletionResponse{
+				Content:            ` I am thinking through this problem. </think> {"answer":"42"}`,
+				Done:               false,
+				PromptEvalCount:    1,
+				PromptEvalDuration: 1,
+			})
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Second):
+				t.Errorf("timeout waiting for structured outputs cancellation")
+				return nil
+			}
+		case 2:
+			fn(llm.CompletionResponse{
+				Content:            `{"answer":"42"}`,
+				Done:               true,
+				DoneReason:         llm.DoneReasonStop,
+				PromptEvalCount:    1,
+				PromptEvalDuration: 1,
+				EvalCount:          1,
+				EvalDuration:       1,
+			})
+			return nil
+		default:
+			t.Errorf("unexpected number of completion calls: %d", callNum)
+			return nil
+		}
+	}
+
+	streamRequest := false
+	w := createRequest(t, s.GenerateHandler, api.GenerateRequest{
+		Model:   "generate-native-thinking",
+		Prompt:  "Please respond in JSON.",
+		Think:   &api.ThinkValue{Value: true},
+		Stream:  &streamRequest,
+		Format:  format,
+		Options: map[string]any{"num_ctx": 4096},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if len(requests) != 2 {
+		t.Fatalf("expected two completion calls, got %d", len(requests))
+	}
+
+	if requests[0].Format != nil {
+		t.Errorf("expected first completion format to be nil, got %q", requests[0].Format)
+	}
+
+	if !bytes.Equal([]byte(format), []byte(requests[1].Format)) {
+		t.Errorf("expected second completion format to match original format, got %q", requests[1].Format)
+	}
+
+	// the rendered prompt already opened the thinking block, so the restart only
+	// appends what the model produced plus the closing tag
+	if want := basePrompt + "I am thinking through this problem. </think>"; requests[1].Prompt != want {
+		t.Errorf("expected second completion prompt %q, got %q", want, requests[1].Prompt)
+	}
+
+	var resp api.GenerateResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Thinking != "I am thinking through this problem. " {
+		t.Errorf("expected thinking %q, got %q", "I am thinking through this problem. ", resp.Thinking)
+	}
+
+	if resp.Response != `{"answer":"42"}` {
+		t.Errorf("expected response %q, got %q", `{"answer":"42"}`, resp.Response)
+	}
+}
+
+// TestGenerateThinkingNativeChatTemplateOnly pins the boundary of the deferral.
+// A model whose thinking capability comes from its GGUF chat template alone gives
+// ollama no tags to parse the output with, so /api/generate cannot tell reasoning
+// from content: the thinking is left inline in the response and the format keeps
+// being applied to the first and only request. Deferring without a parser would
+// only restart on the very first token.
+func TestGenerateThinkingNativeChatTemplateOnly(t *testing.T) {
+	t.Setenv("OLLAMA_GO_TEMPLATE", "0")
+	gin.SetMode(gin.TestMode)
+
+	mock := &mockRunner{
+		TemplateFn: func(_ context.Context, req llm.ChatRequest) (string, error) {
+			return "native-template: Please respond in JSON.", nil
+		},
+	}
+
+	s := newServerWithMockRunner(t, mock)
+	createMinimalGGUFModel(t, s, "generate-native-thinking-only", ggml.KV{
+		"tokenizer.chat_template": "{{ messages[0]['content'] }}<think></think>",
+	}, "", nil)
+
+	m, err := GetModel("generate-native-thinking-only")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if chatModeForModel(m) != chatExecutionModeNative {
+		t.Fatalf("expected the native chat template route, got %v", chatModeForModel(m))
+	}
+	if !slices.Contains(m.Capabilities(), model.CapabilityThinking) {
+		t.Fatal("expected the chat template to grant the thinking capability")
+	}
+
+	format := json.RawMessage(`{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}`)
+
+	// answer replays a single completion and records the requests it was given
+	answer := func(t *testing.T, content string) *[]llm.CompletionRequest {
+		var (
+			requestsMu sync.Mutex
+			requests   []llm.CompletionRequest
+		)
+
+		mock.CompletionFn = func(ctx context.Context, r llm.CompletionRequest, fn func(r llm.CompletionResponse)) error {
+			requestsMu.Lock()
+			requests = append(requests, r)
+			requestsMu.Unlock()
+
+			fn(llm.CompletionResponse{
+				Content:            content,
+				Done:               true,
+				DoneReason:         llm.DoneReasonStop,
+				PromptEvalCount:    1,
+				PromptEvalDuration: 1,
+				EvalCount:          1,
+				EvalDuration:       1,
+			})
+			return nil
+		}
+		t.Cleanup(func() { mock.CompletionFn = nil })
+
+		return &requests
+	}
+
+	// without a format the model is free to emit its tags, and nothing parses them
+	// out of the response - this is the gap that makes the deferral impossible
+	t.Run("thinking is left inline in the response", func(t *testing.T) {
+		requests := answer(t, `<think>I am thinking through this problem.</think>The answer is 42.`)
+
+		streamRequest := false
+		w := createRequest(t, s.GenerateHandler, api.GenerateRequest{
+			Model:   "generate-native-thinking-only",
+			Prompt:  "What is 17 * 23?",
+			Think:   &api.ThinkValue{Value: true},
+			Stream:  &streamRequest,
+			Options: map[string]any{"num_ctx": 4096},
+		})
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		if len(*requests) != 1 {
+			t.Fatalf("expected a single completion call, got %d", len(*requests))
+		}
+
+		var resp api.GenerateResponse
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatal(err)
+		}
+
+		if resp.Thinking != "" {
+			t.Errorf("expected no parsed thinking, got %q", resp.Thinking)
+		}
+
+		if !strings.Contains(resp.Response, "<think>") {
+			t.Errorf("expected the raw thinking tags to stay in the response, got %q", resp.Response)
+		}
+	})
+
+	// so the format is applied to the first and only request, and the answer it
+	// constrains is all the model gets to produce
+	t.Run("format is applied to the first request", func(t *testing.T) {
+		requests := answer(t, `{"answer":"42"}`)
+
+		streamRequest := false
+		w := createRequest(t, s.GenerateHandler, api.GenerateRequest{
+			Model:   "generate-native-thinking-only",
+			Prompt:  "Please respond in JSON.",
+			Think:   &api.ThinkValue{Value: true},
+			Stream:  &streamRequest,
+			Format:  format,
+			Options: map[string]any{"num_ctx": 4096},
+		})
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+		}
+
+		if len(*requests) != 1 {
+			t.Fatalf("expected a single completion call, got %d", len(*requests))
+		}
+
+		if !bytes.Equal([]byte(format), []byte((*requests)[0].Format)) {
+			t.Errorf("expected the format to be applied to the first request, got %q", (*requests)[0].Format)
+		}
+
+		var resp api.GenerateResponse
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatal(err)
+		}
+
+		if resp.Thinking != "" {
+			t.Errorf("expected no parsed thinking, got %q", resp.Thinking)
+		}
+
+		if resp.Response != `{"answer":"42"}` {
+			t.Errorf("expected response %q, got %q", `{"answer":"42"}`, resp.Response)
+		}
+	})
+}
+
+// TestGenerateFormatWithBuiltinParserThinking covers the same deferral for models
+// with a builtin thinking parser, which can return thinking and content from a
+// single Add call - that thinking still has to reach the client.
+func TestGenerateFormatWithBuiltinParserThinking(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	mock := &mockRunner{}
+
+	s := &Server{
+		sched: &Scheduler{
+			pendingReqCh:    make(chan *LlmRequest, 1),
+			finishedReqCh:   make(chan *LlmRequest, 1),
+			expiredCh:       make(chan *runnerRef, 1),
+			unloadedCh:      make(chan any, 1),
+			loaded:          make(map[string]*runnerRef),
+			newServerFn:     newMockServer(mock),
+			getGpuFn:        getGpuFn,
+			getSystemInfoFn: getSystemInfoFn,
+			waitForRecovery: 250 * time.Millisecond,
+			loadFn: func(req *LlmRequest, _ ml.SystemInfo, _ []ml.DeviceInfo, _ bool) bool {
+				time.Sleep(time.Millisecond)
+				req.successCh <- &runnerRef{llama: mock}
+				return false
+			},
+		},
+	}
+
+	go s.sched.Run(t.Context())
+
+	_, digest := createBinFile(t, ggml.KV{
+		"general.architecture":          "llama",
+		"llama.block_count":             uint32(1),
+		"llama.context_length":          uint32(8192),
+		"llama.embedding_length":        uint32(4096),
+		"llama.attention.head_count":    uint32(32),
+		"llama.attention.head_count_kv": uint32(8),
+		"tokenizer.ggml.tokens":         []string{""},
+		"tokenizer.ggml.scores":         []float32{0},
+		"tokenizer.ggml.token_type":     []int32{0},
+	}, []*ggml.Tensor{
+		{Name: "token_embd.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_norm.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_down.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_gate.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_up.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_norm.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_k.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_output.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_q.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_v.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "output.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+	})
+
+	w := createRequest(t, s.CreateHandler, api.CreateRequest{
+		Model:  "test-qwen3-thinking",
+		Files:  map[string]string{"file.gguf": digest},
+		Parser: "qwen3-thinking",
+		Template: `{{- range .Messages }}{{ .Role }}: {{ if .Thinking }}<think>{{ .Thinking }}</think>{{ end }}{{ .Content }}
+{{ end }}`,
+		Stream: &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("create: expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	format := json.RawMessage(`{"type":"object","properties":{"answer":{"type":"string"}},"required":["answer"]}`)
+
+	var (
+		requestsMu sync.Mutex
+		requests   []llm.CompletionRequest
+	)
+
+	// the parser returns the whole turn - thinking and content - from one Add call
+	mock.CompletionFn = func(ctx context.Context, r llm.CompletionRequest, fn func(r llm.CompletionResponse)) error {
+		requestsMu.Lock()
+		requests = append(requests, r)
+		callNum := len(requests)
+		requestsMu.Unlock()
+
+		switch callNum {
+		case 1:
+			fn(llm.CompletionResponse{
+				Content:            `I am thinking through this problem. </think>{"answer":"42"}`,
+				Done:               false,
+				PromptEvalCount:    1,
+				PromptEvalDuration: 1,
+			})
+
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(time.Second):
+				t.Errorf("timeout waiting for structured outputs cancellation")
+				return nil
+			}
+		case 2:
+			fn(llm.CompletionResponse{
+				Content:            `{"answer":"42"}`,
+				Done:               true,
+				DoneReason:         llm.DoneReasonStop,
+				PromptEvalCount:    1,
+				PromptEvalDuration: 1,
+				EvalCount:          1,
+				EvalDuration:       1,
+			})
+			return nil
+		default:
+			t.Errorf("unexpected number of completion calls: %d", callNum)
+			return nil
+		}
+	}
+
+	streamRequest := false
+	w = createRequest(t, s.GenerateHandler, api.GenerateRequest{
+		Model:   "test-qwen3-thinking",
+		Prompt:  "Please respond in JSON.",
+		Think:   &api.ThinkValue{Value: true},
+		Stream:  &streamRequest,
+		Format:  format,
+		Options: map[string]any{"num_ctx": 4096},
+	})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if len(requests) != 2 {
+		t.Fatalf("expected two completion calls, got %d", len(requests))
+	}
+
+	if requests[0].Format != nil {
+		t.Errorf("expected first completion format to be nil, got %q", requests[0].Format)
+	}
+
+	if !bytes.Equal([]byte(format), []byte(requests[1].Format)) {
+		t.Errorf("expected second completion format to match original format, got %q", requests[1].Format)
+	}
+
+	// the qwen3 parser trims the whitespace around thinking
+	if !strings.Contains(requests[1].Prompt, "<think>I am thinking through this problem.</think>") {
+		t.Errorf("expected second completion prompt to carry the thinking, got %q", requests[1].Prompt)
+	}
+
+	var resp api.GenerateResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.Thinking != "I am thinking through this problem." {
+		t.Errorf("expected thinking %q, got %q", "I am thinking through this problem.", resp.Thinking)
+	}
+
+	if resp.Response != `{"answer":"42"}` {
+		t.Errorf("expected response %q, got %q", `{"answer":"42"}`, resp.Response)
 	}
 }
 


### PR DESCRIPTION
Fixes #17544

`/api/generate` passed `Format` straight to `Completion`, so the JSON grammar applied from the first token and thinking-capable models had nowhere to reason. `think` was silently ignored and the answer degraded, while `/api/chat` handled the same request correctly:

```
/api/generate  think=true format=set -> thinking=    0 chars  response={"answer": "user_answer"}
/api/chat      think=true format=set -> thinking= 1650 chars  content ={ "answer": "391" }
```

## What this does

Ports the double request path from `ChatHandler`. The first request runs without the grammar; once the model starts emitting content the request is cancelled and restarted with the grammar and a prompt primed with the thinking produced so far. The chunk that triggers the restart carries the thinking and nothing else, since the content it came with is regenerated by the constrained request, which also reports the completion.

The prompt is re-rendered through a closure captured while the original prompt is built, so each of the generate flows rebuilds itself the way it was rendered:

| flow | rebuild |
| --- | --- |
| rendered chat-like | `chatPrompt` with the thinking as an assistant message |
| direct template | the same template with the thinking as an assistant message |
| native chat template | textual continuation of the assistant turn |

The native flow cannot be re-rendered because `ApplyChatTemplate` drops `Message.Thinking` on its way to the runner, so it appends the model's own thinking tags instead - which is exactly the text the model just produced.

## Where the format is still applied immediately

Flows that cannot tell reasoning from content keep the current behaviour:

- raw mode and suffix completion have no prompt to rebuild
- a model that describes its thinking only in its GGUF chat template leaves ollama without tags to parse the output with, so `/api/generate` does not split thinking out of the response there at all - a separate gap, covered by `TestGenerateThinkingNativeChatTemplateOnly`
- `null` and `""`, which are non-nil `json.RawMessage` values that the runner treats as no format at all

## Tests

`TestGenerateFormatWithThinking` covers the restart for streaming and non-streaming, an empty thinking turn, a transitional chunk that must not look terminal, and the cases that must stay single-request. `TestGenerateFormatWithThinkingNativeChatTemplate` and `TestGenerateFormatWithBuiltinParserThinking` cover the other two prompt sources.

`setupThinkingTest` was lifted out of `TestChatWithPromptEndingInThinkTag` so the generate tests can reuse it; the diff there is a reindent.