### PR TITLE
Add an MLX KV connector framework with a file-backed example connector

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,3 +19,10 @@ go run . serve
 
 See `docs/development.md` for prerequisites, platform notes, GPU backends, and
 the full development workflow.
+
+## Testing
+
+For full-repo Go validation, `go test ./...` expects the frontend bundle at
+`app/dist` because `app/ui/app.go` embeds it. If that bundle has not been built
+yet, either generate it first or exclude `./app/cmd/app` and `./app/ui` from
+Go-only test runs.

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -236,6 +236,10 @@ var (
 	EnableIntegratedGPU = BoolWithDefault("OLLAMA_IGPU_ENABLE")
 	// NoCloudEnv checks the OLLAMA_NO_CLOUD environment variable.
 	NoCloudEnv = Bool("OLLAMA_NO_CLOUD")
+	// MLXKVConnector selects the optional MLX KV connector implementation.
+	MLXKVConnector = String("OLLAMA_MLX_KV_CONNECTOR")
+	// MLXKVConnectorDir overrides where the MLX KV connector stores its data.
+	MLXKVConnectorDir = String("OLLAMA_MLX_KV_CONNECTOR_DIR")
 )
 
 func String(s string) func() string {

--- a/x/mlxrunner/cache/persist.go
+++ b/x/mlxrunner/cache/persist.go
@@ -1,0 +1,183 @@
+package cache
+
+import (
+	"fmt"
+	"strconv"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+const snapshotFormatVersion = "1"
+
+// PersistedSnapshots is a restorable set of cache snapshots stored on disk.
+type PersistedSnapshots struct {
+	Offset    int
+	Snapshots []Snapshot
+}
+
+// SaveSnapshots persists a restorable snapshot set to a safetensors file.
+func SaveSnapshots(path string, offset int, snapshots []Snapshot) error {
+	arrays := make(map[string]*mlx.Array)
+	metadata := map[string]string{
+		"ollama.kvconnector.version": snapshotFormatVersion,
+		"ollama.kvconnector.offset":  strconv.Itoa(offset),
+		"ollama.kvconnector.count":   strconv.Itoa(len(snapshots)),
+	}
+
+	var state []*mlx.Array
+	for i, snap := range snapshots {
+		prefix := fmt.Sprintf("snapshot.%d", i)
+		switch s := snap.(type) {
+		case nil:
+			metadata[prefix+".kind"] = "nil"
+		case *kvSnapshot:
+			s.copyOut()
+			if s.keys == nil || s.values == nil {
+				return fmt.Errorf("snapshot %d: kv snapshot has no data", i)
+			}
+			metadata[prefix+".kind"] = "kv"
+			metadata[prefix+".from"] = strconv.Itoa(s.fromOffset)
+			metadata[prefix+".to"] = strconv.Itoa(s.toOffset)
+			arrays[prefix+".keys"] = s.keys
+			arrays[prefix+".values"] = s.values
+			state = append(state, s.keys, s.values)
+		case *rotatingSnapshot:
+			s.copyOut()
+			if s.keys == nil || s.values == nil {
+				return fmt.Errorf("snapshot %d: rotating snapshot has no data", i)
+			}
+			metadata[prefix+".kind"] = "rotating"
+			metadata[prefix+".from"] = strconv.Itoa(s.fromOffset)
+			metadata[prefix+".to"] = strconv.Itoa(s.toOffset)
+			metadata[prefix+".idx"] = strconv.Itoa(s.idx)
+			arrays[prefix+".keys"] = s.keys
+			arrays[prefix+".values"] = s.values
+			state = append(state, s.keys, s.values)
+		case *recurrentSnapshot:
+			if s.convState == nil || s.deltaState == nil {
+				return fmt.Errorf("snapshot %d: recurrent snapshot has no data", i)
+			}
+			metadata[prefix+".kind"] = "recurrent"
+			metadata[prefix+".offset"] = strconv.Itoa(s.offset)
+			arrays[prefix+".conv"] = s.convState
+			arrays[prefix+".delta"] = s.deltaState
+			state = append(state, s.convState, s.deltaState)
+		default:
+			return fmt.Errorf("snapshot %d: unsupported snapshot type %T", i, snap)
+		}
+	}
+
+	if len(state) > 0 {
+		mlx.Eval(state...)
+	}
+
+	return mlx.SaveSafetensorsWithMetadata(path, arrays, metadata)
+}
+
+// LoadSnapshots restores a snapshot set from a safetensors file.
+func LoadSnapshots(path string) (_ *PersistedSnapshots, err error) {
+	sf, err := mlx.LoadSafetensorsNative(path)
+	if err != nil {
+		return nil, err
+	}
+	defer sf.Free()
+
+	if got := sf.GetMetadata("ollama.kvconnector.version"); got != snapshotFormatVersion {
+		return nil, fmt.Errorf("unsupported kvconnector snapshot version %q", got)
+	}
+
+	offset, err := parseSnapshotMetadataInt(sf, "ollama.kvconnector.offset")
+	if err != nil {
+		return nil, err
+	}
+	count, err := parseSnapshotMetadataInt(sf, "ollama.kvconnector.count")
+	if err != nil {
+		return nil, err
+	}
+
+	out := &PersistedSnapshots{
+		Offset:    offset,
+		Snapshots: make([]Snapshot, count),
+	}
+	defer func() {
+		if err != nil {
+			for _, snap := range out.Snapshots {
+				if snap != nil {
+					snap.Close()
+				}
+			}
+		}
+	}()
+
+	for i := range count {
+		prefix := fmt.Sprintf("snapshot.%d", i)
+		switch kind := sf.GetMetadata(prefix + ".kind"); kind {
+		case "", "nil":
+			continue
+		case "kv":
+			from, err := parseSnapshotMetadataInt(sf, prefix+".from")
+			if err != nil {
+				return nil, err
+			}
+			to, err := parseSnapshotMetadataInt(sf, prefix+".to")
+			if err != nil {
+				return nil, err
+			}
+			keys := sf.Get(prefix + ".keys")
+			values := sf.Get(prefix + ".values")
+			if keys == nil || values == nil {
+				return nil, fmt.Errorf("snapshot %d: missing kv arrays", i)
+			}
+			mlx.Pin(keys, values)
+			out.Snapshots[i] = &kvSnapshot{keys: keys, values: values, fromOffset: from, toOffset: to}
+		case "rotating":
+			from, err := parseSnapshotMetadataInt(sf, prefix+".from")
+			if err != nil {
+				return nil, err
+			}
+			to, err := parseSnapshotMetadataInt(sf, prefix+".to")
+			if err != nil {
+				return nil, err
+			}
+			idx, err := parseSnapshotMetadataInt(sf, prefix+".idx")
+			if err != nil {
+				return nil, err
+			}
+			keys := sf.Get(prefix + ".keys")
+			values := sf.Get(prefix + ".values")
+			if keys == nil || values == nil {
+				return nil, fmt.Errorf("snapshot %d: missing rotating arrays", i)
+			}
+			mlx.Pin(keys, values)
+			out.Snapshots[i] = &rotatingSnapshot{keys: keys, values: values, fromOffset: from, toOffset: to, idx: idx}
+		case "recurrent":
+			snapOffset, err := parseSnapshotMetadataInt(sf, prefix+".offset")
+			if err != nil {
+				return nil, err
+			}
+			conv := sf.Get(prefix + ".conv")
+			delta := sf.Get(prefix + ".delta")
+			if conv == nil || delta == nil {
+				return nil, fmt.Errorf("snapshot %d: missing recurrent arrays", i)
+			}
+			mlx.Pin(conv, delta)
+			out.Snapshots[i] = &recurrentSnapshot{convState: conv, deltaState: delta, offset: snapOffset}
+		default:
+			return nil, fmt.Errorf("snapshot %d: unsupported snapshot kind %q", i, kind)
+		}
+	}
+
+	return out, nil
+}
+
+func parseSnapshotMetadataInt(sf *mlx.SafetensorsFile, key string) (int, error) {
+	raw := sf.GetMetadata(key)
+	if raw == "" {
+		return 0, fmt.Errorf("missing kvconnector metadata %q", key)
+	}
+	v, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, fmt.Errorf("invalid kvconnector metadata %q: %w", key, err)
+	}
+	return v, nil
+}

--- a/x/mlxrunner/cache/persist_test.go
+++ b/x/mlxrunner/cache/persist_test.go
@@ -1,0 +1,83 @@
+package cache
+
+import (
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+)
+
+func TestPersistedSnapshotsRoundTrip(t *testing.T) {
+	skipIfNoMLX(t)
+
+	path := filepath.Join(t.TempDir(), "snapshots.safetensors")
+
+	kvKeys := mlx.FromValues([]float32{1, 2, 3, 4}, 1, 1, 2, 2)
+	kvVals := mlx.FromValues([]float32{5, 6, 7, 8}, 1, 1, 2, 2)
+	rotKeys := mlx.FromValues([]float32{9, 10, 11, 12}, 1, 1, 2, 2)
+	rotVals := mlx.FromValues([]float32{13, 14, 15, 16}, 1, 1, 2, 2)
+	conv := mlx.FromValues([]float32{1, 2, 3, 4, 5, 6}, 1, 2, 3)
+	delta := mlx.FromValues([]float32{7, 8, 9, 10, 11, 12}, 1, 1, 2, 3)
+	mlx.Pin(kvKeys, kvVals, rotKeys, rotVals, conv, delta)
+
+	original := []Snapshot{
+		&kvSnapshot{keys: kvKeys, values: kvVals, fromOffset: 0, toOffset: 2},
+		&rotatingSnapshot{keys: rotKeys, values: rotVals, fromOffset: 2, toOffset: 6, idx: 2},
+		&recurrentSnapshot{convState: conv, deltaState: delta, offset: 6},
+	}
+	defer func() {
+		for _, snap := range original {
+			if snap != nil {
+				snap.Close()
+			}
+		}
+	}()
+
+	if err := SaveSnapshots(path, 6, original); err != nil {
+		t.Fatalf("SaveSnapshots() error = %v", err)
+	}
+
+	loaded, err := LoadSnapshots(path)
+	if err != nil {
+		t.Fatalf("LoadSnapshots() error = %v", err)
+	}
+	defer func() {
+		for _, snap := range loaded.Snapshots {
+			if snap != nil {
+				snap.Close()
+			}
+		}
+	}()
+
+	if loaded.Offset != 6 {
+		t.Fatalf("loaded offset = %d, want 6", loaded.Offset)
+	}
+	if len(loaded.Snapshots) != len(original) {
+		t.Fatalf("loaded %d snapshots, want %d", len(loaded.Snapshots), len(original))
+	}
+
+	kv := NewKVCache()
+	if !kv.Restore(loaded.Snapshots[0], 2) {
+		t.Fatal("restoring KV snapshot failed")
+	}
+	if got := kv.State()[0].Floats(); !slices.Equal(got, []float32{1, 2, 3, 4}) {
+		t.Fatalf("kv keys = %v", got)
+	}
+
+	rot := NewRotatingKVCache(4)
+	if !rot.Restore(loaded.Snapshots[1], 6) {
+		t.Fatal("restoring rotating snapshot failed")
+	}
+	if got := rot.State()[0].Floats(); !slices.Equal(got, []float32{9, 10, 11, 12}) {
+		t.Fatalf("rotating keys = %v", got)
+	}
+
+	rec := NewRecurrentCache(2, 3, 1, 2, 3)
+	if !rec.Restore(loaded.Snapshots[2], 6) {
+		t.Fatal("restoring recurrent snapshot failed")
+	}
+	if got := rec.State()[0].Floats(); !slices.Equal(got, []float32{1, 2, 3, 4, 5, 6}) {
+		t.Fatalf("recurrent conv = %v", got)
+	}
+}

--- a/x/mlxrunner/kvconnector.go
+++ b/x/mlxrunner/kvconnector.go
@@ -1,0 +1,187 @@
+package mlxrunner
+
+import (
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+)
+
+// KVConnector loads and stores restorable MLX prefix-cache snapshots.
+type KVConnector interface {
+	Lookup(keys []trieKey) (*KVConnectorMatch, error)
+	SnapshotOffsets(inputs []int32, draftLookahead int) []int
+	Store(entry *KVConnectorEntry) error
+}
+
+// KVConnectorMatch is a reusable external prefix match for the current request.
+type KVConnectorMatch struct {
+	Offset    int
+	Snapshots []cache.Snapshot
+}
+
+// KVConnectorEntry is a restorable prefix-cache snapshot that can be stored.
+type KVConnectorEntry struct {
+	Offset    int
+	Keys      []trieKey
+	Snapshots []cache.Snapshot
+}
+
+// ExampleConnector stores paged-out prefix-cache snapshots as local files so
+// the framework can be wired end to end before remote backends are added.
+type ExampleConnector struct {
+	modelDir string
+}
+
+func newKVConnector(modelName string) (KVConnector, error) {
+	switch kind := strings.TrimSpace(envconfig.MLXKVConnector()); kind {
+	case "", "off", "none":
+		return nil, nil
+	case "example", "file":
+		return newExampleConnector(modelName)
+	default:
+		return nil, fmt.Errorf("unsupported OLLAMA_MLX_KV_CONNECTOR %q", kind)
+	}
+}
+
+func newExampleConnector(modelName string) (*ExampleConnector, error) {
+	root := strings.TrimSpace(envconfig.MLXKVConnectorDir())
+	if root == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		root = filepath.Join(home, ".ollama", "kvconnector", "mlx")
+	}
+
+	modelDir := filepath.Join(root, modelCacheID(modelName))
+	if err := os.MkdirAll(modelDir, 0o755); err != nil {
+		return nil, err
+	}
+
+	return &ExampleConnector{modelDir: modelDir}, nil
+}
+
+func (c *ExampleConnector) Lookup(keys []trieKey) (*KVConnectorMatch, error) {
+	if len(keys) == 0 {
+		return nil, nil
+	}
+
+	digests := keyPrefixDigests(keys)
+	for offset := len(keys); offset > 0; offset-- {
+		path := c.snapshotPath(offset, digests[offset-1])
+		if _, err := os.Stat(path); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				continue
+			}
+			return nil, err
+		}
+		persisted, err := cache.LoadSnapshots(path)
+		if err == nil {
+			if persisted.Offset != offset {
+				closeSnapshots(persisted.Snapshots)
+				return nil, fmt.Errorf("kvconnector snapshot %s stored offset %d, want %d", path, persisted.Offset, offset)
+			}
+			return &KVConnectorMatch{Offset: persisted.Offset, Snapshots: persisted.Snapshots}, nil
+		}
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (c *ExampleConnector) SnapshotOffsets(inputs []int32, draftLookahead int) []int {
+	if len(inputs) <= 1 {
+		return nil
+	}
+
+	var offsets []int
+	for offset := 8192; offset < len(inputs); offset += 8192 {
+		offsets = append(offsets, offset)
+	}
+	offsets = append(offsets, len(inputs)-1+draftLookahead)
+	slices.Sort(offsets)
+	return slices.Compact(offsets)
+}
+
+func (c *ExampleConnector) Store(entry *KVConnectorEntry) error {
+	if entry == nil || entry.Offset <= 0 || len(entry.Keys) == 0 {
+		return nil
+	}
+	if entry.Offset != len(entry.Keys) {
+		return fmt.Errorf("kvconnector entry offset %d does not match %d keys", entry.Offset, len(entry.Keys))
+	}
+
+	digest := keyPrefixDigests(entry.Keys)[len(entry.Keys)-1]
+	path := c.snapshotPath(entry.Offset, digest)
+	tmp := filepath.Join(c.modelDir, fmt.Sprintf(".%s.%d.tmp", filepath.Base(path), time.Now().UnixNano()))
+
+	if err := cache.SaveSnapshots(tmp, entry.Offset, entry.Snapshots); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+func (c *ExampleConnector) snapshotPath(offset int, digest string) string {
+	return filepath.Join(c.modelDir, fmt.Sprintf("%06d-%s.safetensors", offset, digest[:16]))
+}
+
+func modelCacheID(modelName string) string {
+	sum := sha256.Sum256([]byte(modelName))
+	label := strings.Map(func(r rune) rune {
+		switch {
+		case r >= 'a' && r <= 'z':
+			return r
+		case r >= 'A' && r <= 'Z':
+			return r + ('a' - 'A')
+		case r >= '0' && r <= '9':
+			return r
+		case r == '-', r == '_':
+			return r
+		default:
+			return '-'
+		}
+	}, filepath.Base(modelName))
+	label = strings.Trim(label, "-")
+	if label == "" {
+		label = "model"
+	}
+	return fmt.Sprintf("%s-%s", label, hex.EncodeToString(sum[:6]))
+}
+
+func keyPrefixDigests(keys []trieKey) []string {
+	h := sha256.New()
+	digests := make([]string, len(keys))
+	var buf [8]byte
+	for i, key := range keys {
+		binary.LittleEndian.PutUint64(buf[:], uint64(key))
+		_, _ = h.Write(buf[:])
+		digests[i] = hex.EncodeToString(h.Sum(nil))
+	}
+	return digests
+}
+
+func closeSnapshots(snaps []cache.Snapshot) {
+	for _, snap := range snaps {
+		if snap != nil {
+			snap.Close()
+		}
+	}
+}

--- a/x/mlxrunner/kvconnector_test.go
+++ b/x/mlxrunner/kvconnector_test.go
@@ -1,0 +1,100 @@
+package mlxrunner
+
+import (
+	"fmt"
+	"slices"
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+)
+
+type memoryKVConnector struct {
+	entries map[string]*KVConnectorMatch
+	stores  int
+}
+
+func newMemoryKVConnector() *memoryKVConnector {
+	return &memoryKVConnector{entries: make(map[string]*KVConnectorMatch)}
+}
+
+func (c *memoryKVConnector) Lookup(keys []trieKey) (*KVConnectorMatch, error) {
+	for offset := len(keys); offset > 0; offset-- {
+		if match := c.entries[memoryConnectorKey(keys[:offset])]; match != nil {
+			return &KVConnectorMatch{
+				Offset:    match.Offset,
+				Snapshots: cloneFakeSnapshots(match.Snapshots),
+			}, nil
+		}
+	}
+	return nil, nil
+}
+
+func (c *memoryKVConnector) SnapshotOffsets(inputs []int32, draftLookahead int) []int {
+	if len(inputs) <= 1 {
+		return nil
+	}
+	return []int{len(inputs) - 1 + draftLookahead}
+}
+
+func (c *memoryKVConnector) Store(entry *KVConnectorEntry) error {
+	c.stores++
+	c.entries[memoryConnectorKey(entry.Keys)] = &KVConnectorMatch{
+		Offset:    entry.Offset,
+		Snapshots: cloneFakeSnapshots(entry.Snapshots),
+	}
+	return nil
+}
+
+func memoryConnectorKey(keys []trieKey) string {
+	return fmt.Sprint(keys)
+}
+
+func cloneFakeSnapshots(snaps []cache.Snapshot) []cache.Snapshot {
+	out := make([]cache.Snapshot, len(snaps))
+	for i, snap := range snaps {
+		if snap == nil {
+			continue
+		}
+		fs := snap.(*fakeSnapshot)
+		out[i] = &fakeSnapshot{
+			tokens:   slices.Clone(fs.tokens),
+			from:     fs.from,
+			to:       fs.to,
+			byteSize: fs.byteSize,
+		}
+	}
+	return out
+}
+
+func TestKVConnectorPersistsAndRestoresPromptPrefix(t *testing.T) {
+	inputs := []int32{1, 2, 3, 4, 5}
+	connector := newMemoryKVConnector()
+
+	storeEnv := newTransformerEnv()
+	storeEnv.pc.connector = connector
+
+	storeSession := storeEnv.pc.begin(inputs, nil)
+	storeSession.schedulePrefillSnapshots(nil)
+	seed := len(inputs) - 1
+	if base := storeEnv.pc.minCacheOffset(); base < seed {
+		feedAll(storeEnv.pc.caches, inputs[base:seed])
+	}
+	storeSession.attachPrefillSnapshots()
+	storeSession.close()
+
+	if connector.stores == 0 {
+		t.Fatal("connector did not store any snapshots")
+	}
+
+	restoreEnv := newTransformerEnv()
+	restoreEnv.pc.connector = connector
+
+	restoreSession := restoreEnv.pc.begin(inputs, nil)
+	defer restoreSession.close()
+
+	if want := []int32{5}; !slices.Equal(restoreSession.remaining, want) {
+		t.Fatalf("remaining = %v, want %v", restoreSession.remaining, want)
+	}
+
+	restoreEnv.assertAllTokens(t, "restored prefix", inputs[:4])
+}

--- a/x/mlxrunner/prefix_cache.go
+++ b/x/mlxrunner/prefix_cache.go
@@ -35,6 +35,7 @@ type prefixCache struct {
 	root          *trieNode   // root of the prefix trie
 	activePath    []*trieNode // current root→leaf path with live MLX arrays
 	caches        []cache.Cache
+	connector     KVConnector
 	pagedOutBytes int64 // total bytes in paged-out snapshots across the trie
 
 	// draftLookahead is how far the draft caches' entries reference past
@@ -44,8 +45,9 @@ type prefixCache struct {
 
 // pendingSnapshot is a snapshot scheduled to be taken during prefill.
 type pendingSnapshot struct {
-	offset int
-	user   bool
+	offset    int
+	user      bool
+	connector bool
 }
 
 // cacheSession manages caches for a single pipeline run.
@@ -67,8 +69,8 @@ type cacheSession struct {
 }
 
 // newPrefixCache manages the given cache slots for the model's life.
-func newPrefixCache(caches []cache.Cache) *prefixCache {
-	return &prefixCache{caches: caches}
+func newPrefixCache(caches []cache.Cache, connector KVConnector) *prefixCache {
+	return &prefixCache{caches: caches, connector: connector}
 }
 
 func (c *prefixCache) ensureRoot() {
@@ -88,16 +90,23 @@ func (c *prefixCache) begin(inputs []int32, items []mediaItem) *cacheSession {
 	effInputs := effectiveKeyTokens(inputs, items)
 	keys := c.key(effInputs)
 	matchPath, matched := findBestMatch(c.root, keys)
+	restored := false
+
+	if c.connector != nil && matched < len(inputs) {
+		matchPath, matched, restored = c.maybeRestoreConnectorMatch(keys, matched)
+	}
 	originalMatched := matched
 
 	// Always keep at least one token to re-evaluate so the
 	// pipeline can seed token generation from it.
-	if matched == len(inputs) && matched > 0 {
+	if !restored && matched == len(inputs) && matched > 0 {
 		matchPath, matched = findBestMatch(c.root, keys[:matched-1])
 	}
 
 	// Switch to the matched path, paging in/out as needed.
-	c.switchToPath(matchPath, matched)
+	if !restored {
+		c.switchToPath(matchPath, matched)
+	}
 
 	// switchToPath aligns caches to a common offset
 	prefix := c.minCacheOffset()
@@ -124,6 +133,75 @@ func (c *prefixCache) begin(inputs []int32, items []mediaItem) *cacheSession {
 	slog.Info(msg, "total", len(inputs), "matched", originalMatched, "cached", prefix, "left", len(remaining))
 
 	return session
+}
+
+func (c *prefixCache) maybeRestoreConnectorMatch(keys []trieKey, matched int) ([]*trieNode, int, bool) {
+	match, err := c.connector.Lookup(keys)
+	if err != nil {
+		slog.Warn("mlx kv connector lookup failed", "error", err)
+		path, matched := findBestMatch(c.root, keys)
+		return path, matched, false
+	}
+	if match == nil {
+		path, matched := findBestMatch(c.root, keys)
+		return path, matched, false
+	}
+	defer closeSnapshots(match.Snapshots)
+
+	if match.Offset <= matched || match.Offset >= len(keys)+1 {
+		path, matched := findBestMatch(c.root, keys)
+		return path, matched, false
+	}
+	if len(match.Snapshots) != len(c.caches) {
+		slog.Warn("mlx kv connector returned wrong snapshot count", "got", len(match.Snapshots), "want", len(c.caches))
+		path, matched := findBestMatch(c.root, keys)
+		return path, matched, false
+	}
+
+	if !c.restoreConnectorMatch(match) {
+		slog.Warn("mlx kv connector restore failed", "offset", match.Offset)
+		path, matched := findBestMatch(c.root, keys)
+		return path, matched, false
+	}
+
+	slog.Debug("restored prefix from kv connector", "offset", match.Offset)
+	return []*trieNode{c.root}, c.minCacheOffset(), true
+}
+
+func (c *prefixCache) restoreConnectorMatch(match *KVConnectorMatch) bool {
+	if match == nil || match.Offset <= 0 {
+		return false
+	}
+
+	c.switchToPath([]*trieNode{c.root}, 0)
+
+	ok := true
+	for i, kv := range c.caches {
+		if kv == nil {
+			continue
+		}
+		if i >= len(match.Snapshots) || match.Snapshots[i] == nil || !kv.Restore(match.Snapshots[i], match.Offset) {
+			ok = false
+			break
+		}
+	}
+	if !ok {
+		c.freeAll()
+		c.activePath = []*trieNode{c.root}
+		return false
+	}
+
+	minOff := c.minCacheOffset()
+	for _, kv := range c.caches {
+		if kv != nil && kv.Offset() != minOff && !kv.Restore(nil, minOff) {
+			c.freeAll()
+			c.activePath = []*trieNode{c.root}
+			return false
+		}
+	}
+
+	c.activePath = []*trieNode{c.root}
+	return true
 }
 
 // effectiveKeyTokens returns the per-position key alphabet: the token ID
@@ -332,6 +410,27 @@ func (s *cacheSession) schedulePrefillSnapshots(offsets []int) {
 			s.pendingSnapshots = append(s.pendingSnapshots, pendingSnapshot{offset: offset, user: true})
 		}
 	}
+
+	if c.connector != nil {
+		for _, offset := range c.connector.SnapshotOffsets(s.inputs, c.draftLookahead) {
+			offset -= c.draftLookahead
+			if offset <= base || offset > len(s.inputs) {
+				continue
+			}
+			found := false
+			for i := range s.pendingSnapshots {
+				if s.pendingSnapshots[i].offset == offset {
+					s.pendingSnapshots[i].connector = true
+					found = true
+					break
+				}
+			}
+			if !found {
+				s.pendingSnapshots = append(s.pendingSnapshots, pendingSnapshot{offset: offset, connector: true})
+			}
+		}
+	}
+
 	slices.SortFunc(s.pendingSnapshots, func(a, b pendingSnapshot) int {
 		return a.offset - b.offset
 	})
@@ -433,6 +532,9 @@ func (s *cacheSession) attachPrefillSnapshots() {
 			frontier.user = true
 		}
 		s.attachCapturedSnapshots(frontier, rows[i])
+		if p.connector {
+			s.persistConnectorSnapshot(frontier, stored)
+		}
 	}
 }
 
@@ -447,6 +549,25 @@ func (s *cacheSession) attachCapturedSnapshots(node *trieNode, snaps []cache.Sna
 	node.lastUsed = time.Now()
 	slog.Debug("created snapshot", "offset", node.endOffset)
 	c.enforceEvictionPolicy()
+}
+
+func (s *cacheSession) persistConnectorSnapshot(node *trieNode, stored []trieKey) {
+	c := s.cache
+	if c.connector == nil || node == nil || node.endOffset <= 0 || node.endOffset > len(stored) {
+		return
+	}
+	if !hasAllSnapshots(node, c.caches) {
+		return
+	}
+
+	entry := &KVConnectorEntry{
+		Offset:    node.endOffset,
+		Keys:      slices.Clone(stored[:node.endOffset]),
+		Snapshots: node.snapshots,
+	}
+	if err := c.connector.Store(entry); err != nil {
+		slog.Warn("mlx kv connector store failed", "offset", node.endOffset, "error", err)
+	}
 }
 
 // advancePath advances the active path from the current frontier by matching

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -112,7 +112,11 @@ func (r *Runner) Load(modelName string) error {
 	r.contextLength = m.MaxContextLength()
 	caches := m.NewCaches()
 	draftCaches := newDraftCaches(draftModel)
-	r.cache = newPrefixCache(slices.Concat(caches, draftCaches))
+	connector, err := newKVConnector(modelName)
+	if err != nil {
+		return err
+	}
+	r.cache = newPrefixCache(slices.Concat(caches, draftCaches), connector)
 	r.Sampler = sample.New(r.contextLength)
 	r.spec = newSpeculation(r, draftModel, caches, draftCaches)
 


### PR DESCRIPTION
## Summary
- add an MLX KV connector framework around MLX prefix-cache restore points
- add a file-backed ExampleConnector that persists restorable snapshots as safetensors and can restore the longest saved prompt prefix
- add envconfig switches and tests covering connector lifecycle plus snapshot round-tripping

## Testing
- Run test locally

Closes #17696