### PR TITLE
server: don't default thinking on for raw generate requests

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -327,7 +327,7 @@ curl http://localhost:11434/api/generate -d '{
 
 #### Request (Raw Mode)
 
-In some cases, you may wish to bypass the templating system and provide a full prompt. In this case, you can use the `raw` parameter to disable templating. Also note that raw mode will not return a context.
+In some cases, you may wish to bypass the templating system and provide a full prompt. In this case, you can use the `raw` parameter to disable templating. Also note that raw mode will not return a context, and that thinking is not enabled by default: reasoning is returned as part of `response` unless `think` is set explicitly.
 
 ##### Request
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -458,7 +458,11 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	modelCaps := m.Capabilities()
 	if slices.Contains(modelCaps, model.CapabilityThinking) {
 		caps = append(caps, model.CapabilityThinking)
-		if req.Think == nil {
+		// raw mode passes the prompt through untouched, so the thinking tags
+		// inferred from the template describe a prompt the model was never given.
+		// splitting the output on them anyway hides it from clients that only read
+		// `response`. thinking stays available to callers that ask for it explicitly
+		if req.Think == nil && !req.Raw {
 			req.Think = &api.ThinkValue{Value: true}
 		}
 	} else {

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -2351,86 +2351,87 @@ func TestChatLogprobs(t *testing.T) {
 	})
 }
 
-func TestChatWithPromptEndingInThinkTag(t *testing.T) {
-	t.Setenv("OLLAMA_GO_TEMPLATE", "1")
-	gin.SetMode(gin.TestMode)
+// setupThinkingTest creates a standard thinking test setup: a server serving a
+// model whose template adds <think> at the end of the prompt.
+func setupThinkingTest(t *testing.T) (*mockRunner, *Server) {
+	mock := &mockRunner{
+		CompletionResponse: llm.CompletionResponse{
+			Done:               true,
+			DoneReason:         llm.DoneReasonStop,
+			PromptEvalCount:    1,
+			PromptEvalDuration: 1,
+			EvalCount:          1,
+			EvalDuration:       1,
+		},
+	}
 
-	// Helper to create a standard thinking test setup
-	setupThinkingTest := func(t *testing.T) (*mockRunner, *Server) {
-		mock := &mockRunner{
-			CompletionResponse: llm.CompletionResponse{
-				Done:               true,
-				DoneReason:         llm.DoneReasonStop,
-				PromptEvalCount:    1,
-				PromptEvalDuration: 1,
-				EvalCount:          1,
-				EvalDuration:       1,
+	s := &Server{
+		sched: &Scheduler{
+			pendingReqCh:    make(chan *LlmRequest, 1),
+			finishedReqCh:   make(chan *LlmRequest, 1),
+			expiredCh:       make(chan *runnerRef, 1),
+			unloadedCh:      make(chan any, 1),
+			loaded:          make(map[string]*runnerRef),
+			newServerFn:     newMockServer(mock),
+			getGpuFn:        getGpuFn,
+			getSystemInfoFn: getSystemInfoFn,
+			waitForRecovery: 250 * time.Millisecond,
+			loadFn: func(req *LlmRequest, _ ml.SystemInfo, _ []ml.DeviceInfo, _ bool) bool {
+				time.Sleep(time.Millisecond)
+				req.successCh <- &runnerRef{llama: mock}
+				return false
 			},
-		}
+		},
+	}
 
-		s := &Server{
-			sched: &Scheduler{
-				pendingReqCh:    make(chan *LlmRequest, 1),
-				finishedReqCh:   make(chan *LlmRequest, 1),
-				expiredCh:       make(chan *runnerRef, 1),
-				unloadedCh:      make(chan any, 1),
-				loaded:          make(map[string]*runnerRef),
-				newServerFn:     newMockServer(mock),
-				getGpuFn:        getGpuFn,
-				getSystemInfoFn: getSystemInfoFn,
-				waitForRecovery: 250 * time.Millisecond,
-				loadFn: func(req *LlmRequest, _ ml.SystemInfo, _ []ml.DeviceInfo, _ bool) bool {
-					time.Sleep(time.Millisecond)
-					req.successCh <- &runnerRef{llama: mock}
-					return false
-				},
-			},
-		}
+	go s.sched.Run(t.Context())
 
-		go s.sched.Run(t.Context())
+	// Create a model with thinking support
+	_, digest := createBinFile(t, ggml.KV{
+		"general.architecture":          "llama",
+		"llama.block_count":             uint32(1),
+		"llama.context_length":          uint32(8192),
+		"llama.embedding_length":        uint32(4096),
+		"llama.attention.head_count":    uint32(32),
+		"llama.attention.head_count_kv": uint32(8),
+		"tokenizer.ggml.tokens":         []string{""},
+		"tokenizer.ggml.scores":         []float32{0},
+		"tokenizer.ggml.token_type":     []int32{0},
+	}, []*ggml.Tensor{
+		{Name: "token_embd.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_norm.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_down.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_gate.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_up.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.ffn_norm.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_k.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_output.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_q.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "blk.0.attn_v.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+		{Name: "output.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+	})
 
-		// Create a model with thinking support
-		_, digest := createBinFile(t, ggml.KV{
-			"general.architecture":          "llama",
-			"llama.block_count":             uint32(1),
-			"llama.context_length":          uint32(8192),
-			"llama.embedding_length":        uint32(4096),
-			"llama.attention.head_count":    uint32(32),
-			"llama.attention.head_count_kv": uint32(8),
-			"tokenizer.ggml.tokens":         []string{""},
-			"tokenizer.ggml.scores":         []float32{0},
-			"tokenizer.ggml.token_type":     []int32{0},
-		}, []*ggml.Tensor{
-			{Name: "token_embd.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "blk.0.attn_norm.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "blk.0.ffn_down.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "blk.0.ffn_gate.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "blk.0.ffn_up.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "blk.0.ffn_norm.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "blk.0.attn_k.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "blk.0.attn_output.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "blk.0.attn_q.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "blk.0.attn_v.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-			{Name: "output.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
-		})
-
-		// Create model with thinking template that adds <think> at the end
-		w := createRequest(t, s.CreateHandler, api.CreateRequest{
-			Model: "test-thinking",
-			Files: map[string]string{"file.gguf": digest},
-			Template: `{{- range .Messages }}
+	// Create model with thinking template that adds <think> at the end
+	w := createRequest(t, s.CreateHandler, api.CreateRequest{
+		Model: "test-thinking",
+		Files: map[string]string{"file.gguf": digest},
+		Template: `{{- range .Messages }}
 {{- if eq .Role "user" }}user: {{ .Content }}
 {{ else if eq .Role "assistant" }}assistant: {{ if .Thinking }}<think>{{ .Thinking }}</think>{{ end }}{{ .Content }}
 {{ end }}{{ end }}<think>`,
-			Stream: &stream,
-		})
+		Stream: &stream,
+	})
 
-		if w.Code != http.StatusOK {
-			t.Fatalf("expected status 200, got %d", w.Code)
-		}
-
-		return mock, s
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
 	}
+
+	return mock, s
+}
+
+func TestChatWithPromptEndingInThinkTag(t *testing.T) {
+	t.Setenv("OLLAMA_GO_TEMPLATE", "1")
+	gin.SetMode(gin.TestMode)
 
 	mock, s := setupThinkingTest(t)
 
@@ -2933,6 +2934,78 @@ func TestChatFormatWithThinkFalse(t *testing.T) {
 
 			if !bytes.Equal([]byte(format), []byte(requests[0].Format)) {
 				t.Errorf("expected first completion format to match the request format, got %q", string(requests[0].Format))
+			}
+		})
+	}
+}
+
+// TestGenerateRawThinkingDefault verifies that `raw` requests don't turn
+// thinking on by themselves. Raw mode bypasses the template, so the thinking
+// tags inferred from it don't describe what the model was asked to emit, and
+// splitting the output on them leaves text completion clients with an empty
+// `response`. See https://github.com/ollama/ollama/issues/17700.
+func TestGenerateRawThinkingDefault(t *testing.T) {
+	t.Setenv("OLLAMA_GO_TEMPLATE", "1")
+	gin.SetMode(gin.TestMode)
+
+	mock, s := setupThinkingTest(t)
+
+	const modelOutput = "<think>reasoning</think>answer"
+
+	for _, tc := range []struct {
+		name             string
+		think            *api.ThinkValue
+		expectedThinking string
+		expectedResponse string
+	}{
+		{
+			// what SillyTavern's text completion sends: no `think` at all
+			name:             "unset",
+			expectedResponse: modelOutput,
+		},
+		{
+			name:             "explicitly enabled",
+			think:            &api.ThinkValue{Value: true},
+			expectedThinking: "reasoning",
+			expectedResponse: "answer",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mock.CompletionResponse = llm.CompletionResponse{
+				Content:            modelOutput,
+				Done:               true,
+				DoneReason:         llm.DoneReasonStop,
+				PromptEvalCount:    1,
+				PromptEvalDuration: 1,
+				EvalCount:          1,
+				EvalDuration:       1,
+			}
+
+			streamRequest := false
+			w := createRequest(t, s.GenerateHandler, api.GenerateRequest{
+				Model:   "test-thinking",
+				Prompt:  "user: Please respond.\n",
+				Raw:     true,
+				Think:   tc.think,
+				Stream:  &streamRequest,
+				Options: map[string]any{"num_ctx": 4096},
+			})
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+			}
+
+			var resp api.GenerateResponse
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatal(err)
+			}
+
+			if resp.Thinking != tc.expectedThinking {
+				t.Errorf("expected thinking %q, got %q", tc.expectedThinking, resp.Thinking)
+			}
+
+			if resp.Response != tc.expectedResponse {
+				t.Errorf("expected response %q, got %q", tc.expectedResponse, resp.Response)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #17700

## The problem

SillyTavern's Text Completion with `api_type: ollama` posts to `/api/generate` with `raw: true` and no `think` field. The reply comes back empty, while Chat Completion with the same model works.

In `GenerateHandler`:

- if the model has the thinking capability and the request didn't set `think`, thinking is turned on by default
- with no builtin parser, a thinking parser is then built from the tags inferred from the model's **template** - the template `raw: true` just told the handler to skip

So everything the model emits inside `<think>...</think>` is split off into `thinking` and never reaches `response`. For a reasoning model with `num_predict: 1024` the budget is regularly used up before the closing tag, so `response` stays empty for the whole stream: no error, the stream just finishes with nothing in it. Chat is unaffected because there reasoning is a first-class field the client renders.

Repro with any reasoning-capable model, passing a fully templated prompt (which is what `raw` is for):

```
curl localhost:11434/api/generate -d '{
  "model": "qwen3",
  "prompt": "<|im_start|>user\nhi<|im_end|>\n<|im_start|>assistant\n",
  "raw": true,
  "stream": false
}'
```

`response` comes back empty or truncated and the text sits in `thinking`. Adding `"think": false` brings it back, but a text completion client has no way to send that field.

## The change

Keep `think` unset for raw requests. Raw mode passes the prompt through untouched, so the output comes back untouched too, reasoning included, tags and all - clients that render raw completions already parse those themselves. Callers that want reasoning split out can still pass `think` explicitly, so that path is unchanged.

## Tests

`TestGenerateRawThinkingDefault` covers both `think` unset (the whole output stays in `response`) and `think: true` (the split still happens). It fails without the handler change:

```
--- FAIL: TestGenerateRawThinkingDefault/unset
    expected thinking "", got "reasoning"
    expected response "<think>reasoning</think>answer", got "answer"
```

The bulk of the test diff is moving `setupThinkingTest` out of `TestChatWithPromptEndingInThinkTag` to package level so the new test can reuse it; the helper body is unchanged.
