### PR TITLE
openai: finish responses after search limit

### DIFF
--- a/middleware/openai.go
+++ b/middleware/openai.go
@@ -895,10 +895,59 @@ func (w *WebSearchResponsesWriter) runLoop(ctx context.Context, initial api.Chat
 		currentOutputStreamed = followUpOutputStreamed
 	}
 
+	// The model asked for another search after consuming the search budget.
+	// Close that tool call with a limit result, then let the model continue with
+	// the original tools. The search budget controls execution, not which tools
+	// the model can select.
+	if w.inner.stream && currentOutputStreamed {
+		for _, event := range w.inner.converter.FinishMessageItem() {
+			if err := w.inner.writeEvent(event.Event, event.Data); err != nil {
+				return api.ChatResponse{}, calls, usage, err
+			}
+		}
+	}
+	if !w.inner.stream {
+		if current.Message.Thinking != "" {
+			if preSearchThinking.Len() > 0 {
+				preSearchThinking.WriteString("\n")
+			}
+			preSearchThinking.WriteString(current.Message.Thinking)
+		}
+		if current.Message.Content != "" {
+			if preSearchContent.Len() > 0 {
+				preSearchContent.WriteString("\n")
+			}
+			preSearchContent.WriteString(current.Message.Content)
+		}
+		for _, tc := range current.Message.ToolCalls {
+			if tc.Function.Name != "web_search" {
+				otherToolCalls = append(otherToolCalls, tc)
+			}
+		}
+	}
+	messages = append(messages,
+		buildWebSearchAssistantMessage(current, currentCall),
+		api.Message{Role: "tool", ToolCallID: currentCall.ID, Content: "Web search limit reached."},
+	)
+	var final api.ChatResponse
+	var finalOutputStreamed bool
+	var err error
+	if w.inner.stream {
+		final, finalOutputStreamed, err = w.callFollowUpStream(ctx, messages, tools)
+	} else {
+		final, err = w.callFollowUp(ctx, messages, tools)
+	}
+	if err != nil {
+		return api.ChatResponse{}, calls, usage, err
+	}
+	usage.PromptEvalCount += final.Metrics.PromptEvalCount
+	usage.EvalCount += final.Metrics.EvalCount
 	w.preSearchThinking = preSearchThinking.String()
 	w.preSearchContent = preSearchContent.String()
 	w.otherToolCalls = otherToolCalls
-	return current, calls, usage, fmt.Errorf("web_search exceeded the maximum of %d calls", maxWebSearchLoops)
+	w.finalOutputStreamed = finalOutputStreamed
+	final.Metrics = usage
+	return final, calls, usage, nil
 }
 
 func (w *WebSearchResponsesWriter) loopContext() (context.Context, context.CancelFunc) {

--- a/middleware/responses_web_search_test.go
+++ b/middleware/responses_web_search_test.go
@@ -681,7 +681,7 @@ func TestWebSearchResponsesWriterStreamingSplitInitialToolsDoNotLatchFinalText(t
 	}
 }
 
-func TestWebSearchResponsesWriterStreamingLoopExhaustionFails(t *testing.T) {
+func TestWebSearchResponsesWriterStreamingLoopExhaustionReturnsToolResult(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()
 	ctx, _ := gin.CreateTestContext(recorder)
@@ -689,14 +689,29 @@ func TestWebSearchResponsesWriterStreamingLoopExhaustionFails(t *testing.T) {
 	request := openai.ResponsesRequest{Model: "test-model", Stream: &stream, Tools: []openai.ResponsesTool{{Type: "web_search"}}}
 	inner := &ResponsesWriter{BaseWriter: BaseWriter{ResponseWriter: ctx.Writer}, converter: openai.NewResponsesStreamConverter("resp_test", "msg_test", request.Model, request), model: request.Model, stream: true, responseID: "resp_test", itemID: "msg_test", request: request}
 	searches := 0
+	followUps := 0
+	tools := api.Tools{openai.WebSearchFunctionTool(), {Type: "function", Function: api.ToolFunction{Name: "get_weather"}}}
 	writer := &WebSearchResponsesWriter{
 		BaseWriter: BaseWriter{ResponseWriter: ctx.Writer}, inner: inner, req: request,
-		chat: &api.ChatRequest{Model: request.Model, Tools: api.Tools{openai.WebSearchFunctionTool()}},
+		chat: &api.ChatRequest{Model: request.Model, Tools: tools},
 		search: func(context.Context, string) (*api.WebSearchResponse, error) {
 			searches++
 			return &api.WebSearchResponse{}, nil
 		},
-		followUpStream: func(_ context.Context, _ []api.Message, _ api.Tools, yield func(api.ChatResponse) error) error {
+		followUpStream: func(_ context.Context, messages []api.Message, gotTools api.Tools, yield func(api.ChatResponse) error) error {
+			followUps++
+			if len(messages) > 0 && strings.Contains(messages[len(messages)-1].Content, "limit reached") {
+				if len(gotTools) != len(tools) {
+					t.Fatalf("final follow-up tools = %#v, want %#v", gotTools, tools)
+				}
+				if len(messages) == 0 || messages[len(messages)-1].Role != "tool" || !strings.Contains(messages[len(messages)-1].Content, "limit reached") {
+					t.Fatalf("final follow-up messages = %#v", messages)
+				}
+				if err := yield(api.ChatResponse{Message: api.Message{Role: "assistant", Content: "answer from existing results"}, Metrics: api.Metrics{PromptEvalCount: 2, EvalCount: 1}}); err != nil {
+					return err
+				}
+				return yield(api.ChatResponse{Done: true})
+			}
 			call := api.ToolCall{ID: "call_next", Function: api.ToolCallFunction{Name: "web_search", Arguments: testArgs(map[string]any{"query": "again"})}}
 			if err := yield(api.ChatResponse{Message: api.Message{Role: "assistant", ToolCalls: []api.ToolCall{call}}}); err != nil {
 				return err
@@ -711,8 +726,53 @@ func TestWebSearchResponsesWriterStreamingLoopExhaustionFails(t *testing.T) {
 		t.Fatal(err)
 	}
 	body := recorder.Body.String()
-	if searches != maxWebSearchLoops || !strings.Contains(body, "response.failed") || !strings.Contains(body, "exceeded the maximum") || strings.Contains(body, "response.completed") {
-		t.Fatalf("loop exhaustion was not a terminal failure: searches=%d body=%s", searches, body)
+	if searches != maxWebSearchLoops || followUps != maxWebSearchLoops+1 || !strings.Contains(body, `"delta":"answer from existing results"`) || !strings.Contains(body, "response.completed") || strings.Contains(body, "response.failed") {
+		t.Fatalf("loop exhaustion did not finish gracefully: searches=%d followUps=%d body=%s", searches, followUps, body)
+	}
+}
+
+func TestWebSearchResponsesWriterNonStreamingLoopExhaustionReturnsToolResult(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	request := openai.ResponsesRequest{Model: "test-model", Tools: []openai.ResponsesTool{{Type: "web_search"}}}
+	inner := &ResponsesWriter{BaseWriter: BaseWriter{ResponseWriter: ctx.Writer}, model: request.Model, responseID: "resp_test", itemID: "msg_test", request: request}
+	searches := 0
+	followUps := 0
+	tools := api.Tools{openai.WebSearchFunctionTool(), {Type: "function", Function: api.ToolFunction{Name: "get_weather"}}}
+	writer := &WebSearchResponsesWriter{
+		BaseWriter: BaseWriter{ResponseWriter: ctx.Writer}, inner: inner, req: request,
+		chat: &api.ChatRequest{Model: request.Model, Tools: tools},
+		search: func(context.Context, string) (*api.WebSearchResponse, error) {
+			searches++
+			return &api.WebSearchResponse{}, nil
+		},
+		followUpChat: func(_ context.Context, messages []api.Message, gotTools api.Tools) (api.ChatResponse, error) {
+			followUps++
+			if len(messages) > 0 && strings.Contains(messages[len(messages)-1].Content, "limit reached") {
+				if len(gotTools) != len(tools) {
+					t.Fatalf("final follow-up tools = %#v, want %#v", gotTools, tools)
+				}
+				if len(messages) == 0 || messages[len(messages)-1].Role != "tool" || !strings.Contains(messages[len(messages)-1].Content, "limit reached") {
+					t.Fatalf("final follow-up messages = %#v", messages)
+				}
+				return api.ChatResponse{Done: true, Message: api.Message{Role: "assistant", Content: "answer from existing results"}}, nil
+			}
+			return api.ChatResponse{Done: true, Message: api.Message{Role: "assistant", ToolCalls: []api.ToolCall{{ID: "call_next", Function: api.ToolCallFunction{Name: "web_search", Arguments: testArgs(map[string]any{"query": "again"})}}}}}, nil
+		},
+	}
+
+	initial := api.ChatResponse{Done: true, Message: api.Message{ToolCalls: []api.ToolCall{{ID: "call_1", Function: api.ToolCallFunction{Name: "web_search", Arguments: testArgs(map[string]any{"query": "first"})}}}}}
+	data, _ := json.Marshal(initial)
+	if _, err := writer.Write(data); err != nil {
+		t.Fatal(err)
+	}
+	var response openai.ResponsesResponse
+	if err := json.Unmarshal(recorder.Body.Bytes(), &response); err != nil {
+		t.Fatalf("decode response: %v: %s", err, recorder.Body.String())
+	}
+	if searches != maxWebSearchLoops || followUps != maxWebSearchLoops+1 || response.Status != "completed" || len(response.Output) != maxWebSearchLoops+1 || response.Output[len(response.Output)-1].Content[0].Text != "answer from existing results" {
+		t.Fatalf("loop exhaustion did not finish gracefully: searches=%d followUps=%d response=%#v", searches, followUps, response)
 	}
 }
 


### PR DESCRIPTION
## Summary

When a model reaches the web-search limit, Ollama returns a tool result instead of failing the Responses request.

## Behavior

Within one `/v1/responses` request:

1. Ollama executes up to three web searches.
2. If the model requests another search, Ollama does not execute it.
3. Ollama returns `Web search limit reached.` as the tool result.
4. The model continues with the original tools and available search results.
5. The Responses request completes normally.

This change preserves client tools and prevents completed search work from being discarded.

## Testing

- `go test ./middleware ./openai ./server -count=1`
- `go build .`
- Headless Codex with `kimi-k3:cloud` and a temporary one-search limit. Codex requested two searches within one Responses request. Ollama executed the first search, returned the limit result for the second request, and completed normally.
