### PR TITLE
openai: accept reasoning_effort=minimal and map to low

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -680,6 +680,9 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 	}
 
 	if effort != "" {
+		if effort == "minimal" {
+			effort = "low"
+		}
 		if !slices.Contains([]string{"high", "medium", "low", "max", "none"}, effort) {
 			return nil, fmt.Errorf("invalid reasoning value: '%s' (must be \"high\", \"medium\", \"low\", \"max\", or \"none\")", effort)
 		}

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -71,6 +71,7 @@ func TestFromChatRequest_ReasoningEffort(t *testing.T) {
 		{name: "low", effort: effort("low"), want: "low"},
 		{name: "max", effort: effort("max"), want: "max"},
 		{name: "none disables", effort: effort("none"), want: false},
+		{name: "minimal maps to low", effort: effort("minimal"), want: "low"},
 		{name: "invalid", effort: effort("extreme"), wantErr: true},
 	}
 


### PR DESCRIPTION
## Summary

Accept `reasoning_effort="minimal"` on the OpenAI-compatible `/v1/chat/completions` endpoint and map it to `"low"` instead of returning a 400.

## Problem

The OpenAI-compat request translation layer in `openai.FromChatRequest` validates `reasoning_effort` against a closed allow-list of `high`, `medium`, `low`, `max`, and `none`. That list does not include `"minimal"`, which is a valid value in the OpenAI API for reasoning models, so requests that include `reasoning_effort="minimal"` fail with:

```
invalid reasoning value: 'minimal' (must be "high", "medium", "low", "max", or "none")
```

This breaks OpenAI SDKs and agent frameworks that send `"minimal"` by default when targeting the OpenAI API generically. The same code path also handles the `reasoning.effort` form, so both fail identically.

## Why this mapping

`"minimal"` is a valid `reasoning.effort` value in the OpenAI API. Ollama does not have a distinct `"minimal"` think tier, and the most compatible behavior is to treat it as the lowest enabled effort level, which is `"low"`. Mapping server-side preserves existing Ollama behavior for supported values while avoiding unnecessary 400s for clients that send `"minimal"`.

## Changes

- `openai/openai.go`: in `FromChatRequest`, normalize `effort == "minimal"` to `"low"` before the allow-list validation, so the existing validation, `none` special-case, and `ThinkValue` wiring remain unchanged.
- `openai/openai_test.go`: add a `minimal maps to low` case to `TestFromChatRequest_ReasoningEffort`.

## Test plan

- `go test ./openai/... -run TestFromChatRequest_ReasoningEffort -v` passes, including the new `minimal_maps_to_low` case.
- Existing cases (`high`, `medium`, `low`, `max`, `none`, `unset`, `invalid`) remain green.
- No runtime model or GPU needed; this is a request-translation fix.

## Breaking changes

None. This only broadens accepted input; it does not change behavior for any existing valid value.

Fixes #17140