### PR TITLE
fix(harmony): accept array-wrapped tool call arguments

### DIFF
--- a/harmony/harmonyparser.go
+++ b/harmony/harmonyparser.go
@@ -442,6 +442,15 @@ func (h *HarmonyMessageHandler) Add(s string, done bool) (content string, thinki
 			name = h.FunctionNameMap.OriginalFromConverted(name)
 			var args api.ToolCallFunctionArguments
 			if err := json.Unmarshal([]byte(raw), &args); err != nil {
+				// Some models wrap a single tool call in an array, e.g.
+				// `[{"key": "value"}]`. Retry by extracting the first element.
+				var wrapped []json.RawMessage
+				if innerErr := json.Unmarshal([]byte(raw), &wrapped); innerErr == nil && len(wrapped) > 0 {
+					if innerErr = json.Unmarshal(wrapped[0], &args); innerErr == nil {
+						calls = append(calls, api.ToolCall{Function: api.ToolCallFunction{Name: name, Arguments: args}})
+						return content, thinking, calls, nil
+					}
+				}
 				return "", "", nil, fmt.Errorf("error parsing tool call: raw='%s', err=%w", raw, err)
 			}
 			calls = append(calls, api.ToolCall{Function: api.ToolCallFunction{Name: name, Arguments: args}})

--- a/harmony/harmonyparser_test.go
+++ b/harmony/harmonyparser_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+
+	"github.com/ollama/ollama/api"
 )
 
 func TestHeaderParsing(t *testing.T) {
@@ -534,5 +536,60 @@ func TestFunctionConvertAndAdd(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestHarmonyToolCallArrayWrapped(t *testing.T) {
+	handler := NewHarmonyMessageHandler()
+	handler.Init([]api.Tool{
+		{Function: api.ToolFunction{Name: "get_weather"}},
+	}, nil, nil)
+
+	// Stream a tool call whose arguments are wrapped in a JSON array, which
+	// some models emit despite a single call. The parser should extract the
+	// first element instead of failing to parse.
+	content, thinking, calls, err := handler.Add(
+		`<|start|>assistant<|channel|>analysis to=functions.get_weather<|message|>[{"location": "NYC"}]<|end|>`,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("Add() returned error for array-wrapped tool call: %v", err)
+	}
+	if content != "" || thinking != "" {
+		t.Errorf("expected empty content/thinking, got content=%q thinking=%q", content, thinking)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if calls[0].Function.Name != "get_weather" {
+		t.Errorf("got function name %q, want get_weather", calls[0].Function.Name)
+	}
+	if got, ok := calls[0].Function.Arguments.Get("location"); !ok || got != "NYC" {
+		t.Errorf("got arguments %v, want location=NYC", calls[0].Function.Arguments)
+	}
+}
+
+func TestHarmonyToolCallObjectArguments(t *testing.T) {
+	handler := NewHarmonyMessageHandler()
+	handler.Init([]api.Tool{
+		{Function: api.ToolFunction{Name: "get_weather"}},
+	}, nil, nil)
+
+	// Plain object arguments continue to parse correctly.
+	content, thinking, calls, err := handler.Add(
+		`<|start|>assistant<|channel|>analysis to=functions.get_weather<|message|>{"location": "Boston"}<|end|>`,
+		true,
+	)
+	if err != nil {
+		t.Fatalf("Add() returned error for object tool call: %v", err)
+	}
+	if content != "" || thinking != "" {
+		t.Errorf("expected empty content/thinking, got content=%q thinking=%q", content, thinking)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if got, ok := calls[0].Function.Arguments.Get("location"); !ok || got != "Boston" {
+		t.Errorf("got arguments %v, want location=Boston", calls[0].Function.Arguments)
 	}
 }


### PR DESCRIPTION
Fixes #17638

Some models wrap a single tool call's arguments in a JSON array (`[{"location": "NYC"}]`) rather than a plain object, causing `error parsing tool call` and an HTTP 500. When the direct unmarshal into `api.ToolCallFunctionArguments` fails, retry by extracting the first array element before erroring.

Adds regression tests for both the array-wrapped and plain-object forms.