### PR TITLE
server: reject empty host header in allowedHost check

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1729,7 +1729,7 @@ func isLocalIP(ip netip.Addr) bool {
 func allowedHost(host string) bool {
 	host = strings.ToLower(host)
 
-	if host == "" || host == "localhost" {
+	if host == "localhost" {
 		return true
 	}
 


### PR DESCRIPTION
## Overview

Remove empty string from allowedHost check. An empty Host header (e.g. `Host: :11434`) bypasses the DNS-rebind protection on servers bound to loopback.

## Fix

```go
// Before
if host == "" || host == "localhost" {

// After  
if host == "localhost" {
```

Empty host is never a legitimate local hostname. Removing it closes a bypass vector where `net.SplitHostPort(":11434")` returns an empty host string that passes the check.