### PR TITLE
model/parsers: preserve tool-call parsing context in qwen3vl errors

### DIFF
--- a/model/parsers/qwen3vl.go
+++ b/model/parsers/qwen3vl.go
@@ -3,6 +3,7 @@ package parsers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"strings"
 	"unicode"
@@ -259,7 +260,7 @@ func (p *Qwen3VLParser) eat() ([]qwenEvent, bool) {
 func parseJSONToolCall(raw qwenEventRawToolCall, tools []api.Tool) (api.ToolCall, error) {
 	var toolCallFunction api.ToolCallFunction
 	if err := json.Unmarshal([]byte(raw.raw), &toolCallFunction); err != nil {
-		return api.ToolCall{}, err
+		return api.ToolCall{}, fmt.Errorf("failed to parse model-generated tool call: %w", err)
 	}
 
 	toolCall := api.ToolCall{}


### PR DESCRIPTION
## model/parsers: preserve tool-call parsing context in qwen3vl errors

When `parseJSONToolCall` in `model/parsers/qwen3vl.go` fails, it returns the raw `json.Unmarshal` error. Clients only ever see the low-level message (e.g. `invalid character ']' after object key:value pair`) with no indication the failure came from parsing a model-generated tool call.

This wraps the error with context:

```
failed to parse model-generated tool call: invalid character ']' after object key:value pair
```

matching the pattern already used by qwen3.go and other parsers. Fixes #17647.