### PR TITLE
docs: API error conventions, uninstall command fix, and create example fix

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -28,6 +28,26 @@ Model names follow a `model:tag` format, where `model` can have an optional name
 
 All durations are returned in nanoseconds.
 
+### Errors
+
+Ollama uses standard HTTP status codes to report errors. When an error occurs, the response body contains a JSON object with a single `error` field holding a human-readable error message:
+
+```json
+{
+  "error": "model 'llama3' not found"
+}
+```
+
+Common status codes:
+
+| Code | Meaning |
+|------|---------|
+| 400 | Malformed request (invalid parameters, bad JSON body) |
+| 404 | Model or resource not found |
+| 500 | Internal server error |
+
+Streaming responses can fail mid-stream. In that case, the stream terminates and the final JSON object contains the `error` field instead of a normal chunk.
+
 ### Streaming responses
 
 Certain endpoints stream responses as JSON objects. Streaming can be disabled by providing `{"stream": false}` for these endpoints.

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -121,7 +121,7 @@ SYSTEM """You are a happy cat."""
 Then run `ollama create`:
 
 ```
-ollama create -f Modelfile
+ollama create my-model -f Modelfile
 ```
 
 ### List running models

--- a/docs/linux.mdx
+++ b/docs/linux.mdx
@@ -181,7 +181,7 @@ sudo rm /etc/systemd/system/ollama.service
 Remove ollama libraries from your lib directory (either `/usr/local/lib`, `/usr/lib`, or `/lib`):
 
 ```shell
-sudo rm -r $(which ollama | tr 'bin' 'lib')
+sudo rm -r $(which ollama | sed 's|bin/ollama$|lib/ollama|')
 ```
 
 Remove the ollama binary from your bin directory (either `/usr/local/bin`, `/usr/bin`, or `/bin`):


### PR DESCRIPTION
## Summary

Three documentation fixes:

### 1. API error reporting conventions (#9905)
Added an "Errors" section under "Conventions" in docs/api.md documenting HTTP status codes (400/404/500), the JSON error response format, and mid-stream error behavior.

### 2. Mangled Linux uninstall command (#14931)
docs/linux.mdx used `tr 'bin' 'lib'` which translates CHARACTERS (b→l, i→i, n→b), mangling paths like `/snap/bin/ollama` → `/sbap/lib/ollama`. Replaced with `sed 's|bin/ollama$|lib/ollama|'`.

### 3. Missing model name in create example (#17346)
docs/cli.mdx showed `ollama create -f Modelfile` which fails with "Error: accepts 1 arg(s), received 0". Added the required positional argument: `ollama create my-model -f Modelfile`.

Fixes #9905, #14931, #17346