### PR TITLE
readme: add Atomic Agent to Community Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ console.log(response.message.content);
 - [LLM-X](https://github.com/mrdjohnson/llm-x) - Progressive web app for LLMs
 - [cmdh](https://github.com/pgibler/cmdh) - Natural language to shell commands
 - [VT](https://github.com/vinhnx/vt.ai) - Minimal multimodal AI chat app
+- [Atomic Agent](https://github.com/AtomicBot-ai/atomic-agent) - Local-first CLI and TUI coding agent, works with Ollama via its OpenAI-compatible endpoint
 
 ### Productivity & Apps
 


### PR DESCRIPTION
Adds Atomic Agent to the Terminal & CLI subsection of Community Integrations.

Atomic Agent is a local-first CLI and TUI coding agent. It works with Ollama by pointing at Ollama's OpenAI-compatible endpoint (http://localhost:11434/v1), so users can run their local Ollama models through it.

- Repo: https://github.com/AtomicBot-ai/atomic-agent
- Site: https://atomicagent.io

Single-line docs addition, appended to the end of the Terminal & CLI list.
