### PR TITLE
docs: add usage fields to ChatStreamEvent OpenAPI schema

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -401,6 +401,27 @@ components:
         done:
           type: boolean
           description: True for the final event in the stream
+        done_reason:
+          type: string
+          description: Reason streaming finished
+        total_duration:
+          type: integer
+          description: Time spent generating the response in nanoseconds
+        load_duration:
+          type: integer
+          description: Time spent loading the model in nanoseconds
+        prompt_eval_count:
+          type: integer
+          description: Number of input tokens in the prompt
+        prompt_eval_duration:
+          type: integer
+          description: Time spent evaluating the prompt in nanoseconds
+        eval_count:
+          type: integer
+          description: Number of output tokens generated in the response
+        eval_duration:
+          type: integer
+          description: Time spent generating tokens in nanoseconds
     StatusEvent:
       type: object
       properties:


### PR DESCRIPTION
## Summary

Fixes #14680 — ChatStreamEvent was missing the usage/timing fields that the API actually returns in the final streaming chunk.

## What changed

Added 7 fields to the `ChatStreamEvent` schema in docs/openapi.yaml, matching `GenerateStreamEvent` and `ChatResponse`:

- done_reason
- total_duration
- load_duration
- prompt_eval_count
- prompt_eval_duration
- eval_count
- eval_duration

## Why

SDK generators using the OpenAPI spec currently produce chat-streaming types that cannot capture usage metrics, forcing users to bypass the typed API and parse raw NDJSON. The fields are already returned by the server — only the spec was missing them.