### PR TITLE
x/create: preserve MLX quantization metadata for prequantized imports

### DIFF
--- a/x/create/create.go
+++ b/x/create/create.go
@@ -1,6 +1,7 @@
 package create
 
 import (
+	"cmp"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
@@ -359,6 +360,30 @@ func ExpertGroupPrefix(tensorName string) string {
 	return ""
 }
 
+// moduleQuantization is one of MLX's per-module quantization overrides. MLX
+// applies its own defaults for the fields an override leaves out: it hands the
+// override straight to to_quantized, which fills the rest in from the mode
+// rather than from the model-wide values (mlx/nn/layers/quantized.py,
+// _defaults_for_mode).
+type moduleQuantization struct {
+	Bits      int    `json:"bits"`
+	GroupSize int    `json:"group_size"`
+	Mode      string `json:"mode"`
+}
+
+// resolve returns the quant_type and group_size this override describes, with
+// the fields it leaves out filled in the way MLX fills them. quantType is ""
+// when the override states a quantization we cannot map.
+func (m moduleQuantization) resolve() (quantType, groupSize string) {
+	mode := cmp.Or(m.Mode, "affine") // to_quantized's default
+	defaultGroupSize, defaultBits := mlxQuantDefaults(mode)
+	quantType = sourceQuantType(mode, cmp.Or(m.Bits, defaultBits))
+	if quantType == "" {
+		return "", ""
+	}
+	return quantType, strconv.Itoa(cmp.Or(m.GroupSize, defaultGroupSize))
+}
+
 type sourceQuantization struct {
 	Bits            int     `json:"bits"`
 	GroupSize       int     `json:"group_size"`
@@ -374,6 +399,49 @@ type sourceQuantization struct {
 			Type           string  `json:"type"`
 		} `json:"weights"`
 	} `json:"config_groups"`
+
+	// Modules holds MLX's per-module quantization overrides, keyed by module
+	// path. MLX writes them into the same object as the model-wide defaults,
+	// so a mixed-precision checkpoint looks like:
+	//
+	//	"quantization": {
+	//	  "group_size": 64, "bits": 4,
+	//	  "model.layers.0.self_attn.q_proj": {"bits": 8, "group_size": 64}
+	//	}
+	//
+	// Modules that are absent take the model-wide defaults above.
+	Modules map[string]moduleQuantization `json:"-"`
+}
+
+// UnmarshalJSON reads the model-wide quantization fields and, from the same
+// object, MLX's per-module overrides. Every model-wide field is a scalar apart
+// from config_groups, so an override is an entry that is neither: an object
+// carrying at least one quantization field.
+func (q *sourceQuantization) UnmarshalJSON(data []byte) error {
+	type fields sourceQuantization // a type without this method, so no recursion
+	if err := json.Unmarshal(data, (*fields)(q)); err != nil {
+		return err
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	for name, value := range raw {
+		if name == "config_groups" {
+			continue
+		}
+		var module moduleQuantization
+		if err := json.Unmarshal(value, &module); err != nil || module == (moduleQuantization{}) {
+			// A model-wide scalar, or a nested object of some other shape.
+			continue
+		}
+		if q.Modules == nil {
+			q.Modules = make(map[string]moduleQuantization)
+		}
+		q.Modules[name] = module
+	}
+	return nil
 }
 
 type sourceModelConfig struct {
@@ -419,17 +487,11 @@ func (cfg sourceModelConfig) Architecture() string {
 	return cfg.TextConfig.ModelType
 }
 
-func (cfg sourceModelConfig) QuantMetadata() map[string]string {
-	// Use the first non-empty quantization config found
-	var q sourceQuantization
-	for _, candidate := range cfg.quantizationConfigs() {
-		if candidate.Bits != 0 {
-			q = candidate
-			break
-		}
-	}
-
-	quantType := sourceQuantType(q.Mode, q.Bits)
+// metadata returns the blob metadata recording the quantization the source
+// declares. defaultMode is the mode to assume when the source states a bit
+// width but no mode; producers that always state one pass "".
+func (q sourceQuantization) metadata(defaultMode string) map[string]string {
+	quantType := sourceQuantType(cmp.Or(q.Mode, defaultMode), q.Bits)
 	if quantType == "" {
 		return nil
 	}
@@ -439,6 +501,17 @@ func (cfg sourceModelConfig) QuantMetadata() map[string]string {
 		metadata["group_size"] = strconv.Itoa(q.GroupSize)
 	}
 	return metadata
+}
+
+// quantization returns the first quantization config the source declares, or
+// the zero value when it declares none.
+func (cfg sourceModelConfig) quantization() sourceQuantization {
+	for _, candidate := range cfg.quantizationConfigs() {
+		if candidate.Bits != 0 {
+			return candidate
+		}
+	}
+	return sourceQuantization{}
 }
 
 func (cfg sourceModelConfig) quantizationConfigs() []sourceQuantization {

--- a/x/create/dtype.go
+++ b/x/create/dtype.go
@@ -93,6 +93,22 @@ func EncodeFloatTensor(dtype string, values []float32) ([]byte, error) {
 	}
 }
 
+// mlxQuantDefaults returns MLX's default group size and bit width for a
+// quantization mode, which is what MLX uses for any field a quantization
+// config leaves out (mlx/nn/layers/quantized.py, _defaults_for_mode).
+func mlxQuantDefaults(mode string) (groupSize, bits int) {
+	switch strings.ToLower(mode) {
+	case "mxfp4":
+		return 32, 4
+	case "nvfp4":
+		return 16, 4
+	case "mxfp8":
+		return 32, 8
+	default:
+		return 64, 4 // affine
+	}
+}
+
 func sourceQuantType(mode string, bits int) string {
 	switch strings.ToLower(mode) {
 	case "affine":

--- a/x/create/prequant.go
+++ b/x/create/prequant.go
@@ -31,6 +31,7 @@ type prequantPattern struct {
 
 	forceQuantType   string // override the blob's quant_type metadata
 	defaultGroupSize string // set group_size metadata only when the config did not
+	defaultQuantMode string // assume this quantization mode when the config states none
 }
 
 // prequantPatterns is consulted in order; the first whose weight suffix matches
@@ -43,6 +44,9 @@ var prequantPatterns = []prequantPattern{
 		weightSuffix: ".weight",
 		scaleSuffix:  ".scales",
 		biasSuffix:   ".biases",
+		// mlx-lm omits "mode" for its default affine quantization, so a
+		// config that states only {"group_size": 64, "bits": 4} is affine.
+		defaultQuantMode: "affine",
 	},
 	{
 		name:             "compressed-tensors-nvfp4",
@@ -73,10 +77,11 @@ var prequantPatterns = []prequantPattern{
 // and any remaining tensors (norms, embeddings) pass through at source
 // precision.
 func planPrequantized(inv Inventory) ([]BlobSpec, error) {
+	quant := inv.Config.quantization()
 	fused := make(map[string]BlobSpec)
 	consumed := make(map[string]bool)
 	for _, name := range sortedTensorNames(inv) {
-		spec, sources, ok := matchPrequant(name, inv)
+		spec, sources, ok := matchPrequant(name, inv, quant)
 		if !ok {
 			continue
 		}
@@ -105,7 +110,7 @@ func planPrequantized(inv Inventory) ([]BlobSpec, error) {
 // prequantized producer, along with the source names it consumes. It returns
 // ok=false when name is not a prequantized weight (a companion or a plain
 // tensor).
-func matchPrequant(name string, inv Inventory) (BlobSpec, []string, bool) {
+func matchPrequant(name string, inv Inventory, quant sourceQuantization) (BlobSpec, []string, bool) {
 	for _, p := range prequantPatterns {
 		base, ok := strings.CutSuffix(name, p.weightSuffix)
 		if !ok {
@@ -162,21 +167,38 @@ func matchPrequant(name string, inv Inventory) (BlobSpec, []string, bool) {
 			}
 		}
 
-		return BlobSpec{Name: outWeight, Tensors: tensors, Metadata: prequantMetadata(inv, p)}, consumed, true
+		return BlobSpec{Name: outWeight, Tensors: tensors, Metadata: prequantMetadata(quant, p, outWeight)}, consumed, true
 	}
 	return BlobSpec{}, nil, false
 }
 
 // prequantMetadata builds the fused blob's metadata: the source config's quant
 // metadata, with the pattern's quant_type override and group_size default
-// applied. Returns nil when there is nothing to record.
-func prequantMetadata(inv Inventory, p prequantPattern) map[string]string {
+// applied, plus the weight's own metadata when the source quantized that
+// module differently from the model default. Returns nil when there is nothing
+// to record.
+func prequantMetadata(q sourceQuantization, p prequantPattern, weightName string) map[string]string {
 	md := make(map[string]string)
-	for k, v := range inv.Config.QuantMetadata() {
+	for k, v := range q.metadata(p.defaultQuantMode) {
 		md[k] = v
 	}
 	if p.forceQuantType != "" {
+		// A producer with a fixed format has no per-module overrides to read.
 		md["quant_type"] = p.forceQuantType
+	} else if module, ok := q.Modules[strings.TrimSuffix(weightName, ".weight")]; ok {
+		// MLX mixed precision: this module was quantized on its own terms, so
+		// record what it differs in per tensor. The runtime prefers the
+		// per-tensor entries, and it cannot fall back to the stored shapes,
+		// which do not tell the formats apart: a 4-bit group-64 weight and an
+		// 8-bit group-32 weight pack to identical weight and scale shapes.
+		if quantType, groupSize := module.resolve(); quantType != "" {
+			if quantType != md["quant_type"] {
+				md[weightName+".quant_type"] = quantType
+			}
+			if groupSize != md["group_size"] {
+				md[weightName+".group_size"] = groupSize
+			}
+		}
 	}
 	if p.defaultGroupSize != "" {
 		if _, ok := md["group_size"]; !ok {

--- a/x/create/prequant_test.go
+++ b/x/create/prequant_test.go
@@ -1,6 +1,8 @@
 package create
 
 import (
+	"encoding/json"
+	"maps"
 	"slices"
 	"testing"
 )
@@ -179,5 +181,172 @@ func TestPlanPrequantizedCompressedNVFP4(t *testing.T) {
 	}
 	if w.Metadata["quant_type"] != "nvfp4" || w.Metadata["group_size"] != "16" {
 		t.Errorf("metadata = %v, want quant_type=nvfp4 group_size=16", w.Metadata)
+	}
+}
+
+// mlxQuantConfig parses a config.json "quantization" object the way the
+// importer does, so these tests exercise the real JSON shape MLX writes rather
+// than a hand-built struct.
+func mlxQuantConfig(t *testing.T, quantization string) sourceModelConfig {
+	t.Helper()
+	var cfg sourceModelConfig
+	if err := json.Unmarshal([]byte(`{"quantization": `+quantization+`}`), &cfg); err != nil {
+		t.Fatalf("parse config: %v", err)
+	}
+	return cfg
+}
+
+func TestPlanPrequantizedMLXImplicitAffineMode(t *testing.T) {
+	// mlx-lm omits "mode" for its default affine quantization. Without it the
+	// blob used to carry no quant_type at all, and the runtime cannot infer
+	// one: a 4-bit group-64 weight and an 8-bit group-32 weight pack to the
+	// same shapes.
+	inv := newInventory(mlxQuantConfig(t, `{"group_size": 64, "bits": 4}`), map[string]string{
+		"l.weight": "U32",
+		"l.scales": "BF16",
+		"l.biases": "BF16",
+	})
+
+	specs, err := Plan(inv, Classification{Kind: SourcePrequantized}, defaultQuantPolicy{})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	w, ok := specByName(specs, "l.weight")
+	if !ok {
+		t.Fatal("missing l.weight blob")
+	}
+	if w.Metadata["quant_type"] != "int4" || w.Metadata["group_size"] != "64" {
+		t.Errorf("metadata = %v, want quant_type=int4 group_size=64", w.Metadata)
+	}
+}
+
+func TestPlanPrequantizedMLXMixedPrecision(t *testing.T) {
+	// MLX records per-module overrides beside the defaults, keyed by module
+	// path, and fills in what an override omits from the mode's defaults
+	// (affine: 4 bits, group size 64) rather than from the model-wide values.
+	cfg := mlxQuantConfig(t, `{
+		"group_size": 64,
+		"bits": 4,
+		"model.layers.0.self_attn.q_proj": {"bits": 8, "group_size": 32},
+		"model.layers.0.self_attn.k_proj": {"group_size": 32},
+		"model.layers.0.mlp.experts": {"bits": 4, "group_size": 64},
+		"model.layers.0.mlp.up_proj": {"bits": 8}
+	}`)
+	inv := newInventory(cfg, map[string]string{
+		"model.layers.0.self_attn.q_proj.weight": "U32",
+		"model.layers.0.self_attn.q_proj.scales": "BF16",
+		"model.layers.0.self_attn.q_proj.biases": "BF16",
+		"model.layers.0.self_attn.k_proj.weight": "U32",
+		"model.layers.0.self_attn.k_proj.scales": "BF16",
+		"model.layers.0.self_attn.k_proj.biases": "BF16",
+		"model.layers.0.mlp.experts.weight":      "U32",
+		"model.layers.0.mlp.experts.scales":      "BF16",
+		"model.layers.0.mlp.experts.biases":      "BF16",
+		"model.layers.0.mlp.up_proj.weight":      "U32",
+		"model.layers.0.mlp.up_proj.scales":      "BF16",
+		"model.layers.0.mlp.up_proj.biases":      "BF16",
+		"model.layers.0.mlp.gate_proj.weight":    "U32",
+		"model.layers.0.mlp.gate_proj.scales":    "BF16",
+		"model.layers.0.mlp.gate_proj.biases":    "BF16",
+	})
+
+	specs, err := Plan(inv, Classification{Kind: SourcePrequantized}, defaultQuantPolicy{})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+
+	tests := []struct {
+		blob          string
+		wantQuantType string
+		wantGroupSize string
+	}{
+		// Promoted to 8 bits at a different group size.
+		{"model.layers.0.self_attn.q_proj.weight", "int8", "32"},
+		// Regrouped at the model's bit width: only the group size differs.
+		{"model.layers.0.self_attn.k_proj.weight", "", "32"},
+		// Promoted to 8 bits at MLX's default group size, which happens to be
+		// the model's: only the bit width differs.
+		{"model.layers.0.mlp.up_proj.weight", "int8", ""},
+		// Overridden, but to what the blob already says.
+		{"model.layers.0.mlp.experts.weight", "", ""},
+		// No override at all.
+		{"model.layers.0.mlp.gate_proj.weight", "", ""},
+	}
+	for _, tt := range tests {
+		w, ok := specByName(specs, tt.blob)
+		if !ok {
+			t.Errorf("missing %s blob", tt.blob)
+			continue
+		}
+		if w.Metadata["quant_type"] != "int4" || w.Metadata["group_size"] != "64" {
+			t.Errorf("%s: blob defaults = %v, want quant_type=int4 group_size=64", tt.blob, w.Metadata)
+		}
+		if got := w.Metadata[tt.blob+".quant_type"]; got != tt.wantQuantType {
+			t.Errorf("%s: per-tensor quant_type = %q, want %q", tt.blob, got, tt.wantQuantType)
+		}
+		if got := w.Metadata[tt.blob+".group_size"]; got != tt.wantGroupSize {
+			t.Errorf("%s: per-tensor group_size = %q, want %q", tt.blob, got, tt.wantGroupSize)
+		}
+	}
+}
+
+func TestPlanPrequantizedUnmappableQuantization(t *testing.T) {
+	// A bit width we cannot map records no quant_type, as before: the runtime
+	// falls back to inferring one from the shapes.
+	inv := newInventory(mlxQuantConfig(t, `{"group_size": 64, "bits": 3}`), map[string]string{
+		"l.weight": "U32",
+		"l.scales": "BF16",
+		"l.biases": "BF16",
+	})
+
+	specs, err := Plan(inv, Classification{Kind: SourcePrequantized}, defaultQuantPolicy{})
+	if err != nil {
+		t.Fatalf("Plan() error = %v", err)
+	}
+	w, ok := specByName(specs, "l.weight")
+	if !ok {
+		t.Fatal("missing l.weight blob")
+	}
+	if len(w.Metadata) != 0 {
+		t.Errorf("metadata = %v, want none", w.Metadata)
+	}
+}
+
+func TestSourceQuantizationModules(t *testing.T) {
+	tests := []struct {
+		name         string
+		quantization string
+		want         map[string]moduleQuantization
+	}{
+		{
+			name:         "mlx overrides",
+			quantization: `{"group_size": 64, "bits": 4, "model.layers.0.self_attn.q_proj": {"bits": 8, "group_size": 32}}`,
+			want: map[string]moduleQuantization{
+				"model.layers.0.self_attn.q_proj": {Bits: 8, GroupSize: 32},
+			},
+		},
+		{
+			name:         "model-wide fields only",
+			quantization: `{"group_size": 64, "bits": 4, "mode": "mxfp4"}`,
+		},
+		{
+			// compressed-tensors nests objects of its own; they are not
+			// module overrides and must not be read as any.
+			name: "compressed-tensors config groups",
+			quantization: `{
+				"quant_method": "compressed-tensors",
+				"format": "nvfp4-pack-quantized",
+				"config_groups": {"group_0": {"format": "nvfp4-pack-quantized", "weights": {"num_bits": 4, "type": "float", "group_size": 16}}},
+				"kv_cache_scheme": {"num_bits": 8, "type": "float"}
+			}`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := mlxQuantConfig(t, tt.quantization).Quantization.Modules
+			if !maps.Equal(got, tt.want) {
+				t.Errorf("modules = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## Problem

Importing a prequantized MLX checkpoint with `ollama create --experimental` can report success and produce a model that cannot load. On an MLX mixed-precision (MSQ) requant of Qwen3.5-MoE:

```
$ cat Modelfile
FROM /path/to/mlx-community/Huihui-Qwen3.6-35B-A3B-abliterated-4.4bit-msq
$ ollama create qwen3.6-abliterated -f Modelfile --experimental
...
successfully imported qwen3.6-abliterated with 1076 layers

$ curl -s localhost:11434/api/generate -d '{"model":"qwen3.6-abliterated","prompt":"hi","stream":false}'
{"error":"mlx runner failed: Error: layer language_model.model.layers.0: missing switch expert weights (exit: exit status 1)"}
```

The blobs are all there — the manifest has `language_model.model.layers.0.mlp.switch_mlp.{gate,up,down}_proj.weight` with their `.scale` and `.bias` companions, correctly shaped. What is missing is the metadata saying how they are quantized. The server log shows it:

```
WARN source=qwen3_5.go:586 msg="dequantizing expert weights: no gather kernel for format"
     tensor=language_model.model.layers.0.mlp.switch_mlp.gate_proj.weight mode="" bits=0
Error: layer language_model.model.layers.0: missing switch expert weights
```

`bits=0` / `mode=""` means `mlx.Dequantize` gets a zero bit width and returns nil, `fuseGateUpProjections` sees a nil weight and returns nil, and `loadSwitchMLP` reports the misleading "missing switch expert weights".

## Root cause

The runtime cannot recover a weight's bit width from its stored shapes. A 4-bit group-64 weight and an 8-bit group-32 weight pack to *identical* weight and scale shapes, so `inferQuantTypeFromShapes` deliberately gives up on that case unless the blob's `__metadata__` supplies a hint. Two importer bugs left that metadata out.

**1. A missing `mode` was treated as an unknown format.** mlx-lm omits `"mode"` for its default affine quantization, so this model's `config.json` says only:

```json
"quantization": {"group_size": 64, "bits": 4, ...}
```

`sourceQuantType("", 4)` returned `""`, so the blob metadata was nil and every fused blob was written with no `__metadata__` at all.

**2. Per-module overrides were never read.** MLX records mixed precision beside the defaults in the same object, keyed by module path:

```json
"quantization": {
  "group_size": 64, "bits": 4,
  "language_model.model.layers.0.linear_attn.in_proj_qkv": {"bits": 8, "group_size": 64},
  "language_model.model.layers.0.mlp.shared_expert.gate_proj": {"bits": 8, "group_size": 64}
}
```

This checkpoint has 312 such 8-bit overrides; only the MoE experts stay at the 4-bit default. The importer read only the top-level scalars, so fixing (1) alone would have stamped every tensor `int4` and mis-decoded all 312 promoted weights.

Together these explain why layer 0 in particular failed: every non-expert weight in this model is 8-bit group-64, a shape combination `inferQuantTypeFromShapes` resolves unambiguously, so they all loaded. The 4-bit group-64 experts are the only ambiguous ones — and layer 0 is the first MoE layer.

## Fix

- The MLX prequant pattern gains `defaultQuantMode: "affine"`, so a config that states a bit width but no mode is read as affine. `sourceQuantType` itself is unchanged, so the other producers — which always state their format — cannot pick up an MLX-specific default by accident.
- `sourceQuantization` parses MLX's per-module overrides, and `prequantMetadata` writes them as per-tensor `<name>.quant_type` / `<name>.group_size` keys. The runtime already prefers those over the blob-wide value (`readBlobTensorQuantInfo`), so no runtime change was needed. Only the fields the module actually differs in are written, so a checkpoint whose overrides restate the defaults produces the same blobs as before.
- What an override leaves out is filled in the way MLX fills it. mlx-lm stores whatever dict its quant predicate returned and hands it straight back to `to_quantized`, which resolves the absent fields from the mode's defaults (`_defaults_for_mode`: affine 64/4, mxfp4 32/4, nvfp4 16/4, mxfp8 32/8) — not from the model-wide values. So `{"group_size": 32}` alone means 4-bit group-32, not "the model's bit width at group 32".

Per-tensor keys rather than a blob-wide `quant_type`: each fused prequant blob does hold exactly one main tensor, so the blob-wide key would be enough for the loader. But `Root.Open` takes the model-level quant type from the first tensor blob that declares one, and in this checkpoint that is `language_model.lm_head.weight`, an 8-bit override. Writing the override blob-wide would flip the whole model's reported quantization to INT8 and change the fallback `cfg.QuantBits`/`QuantMode` handed to the model. Keeping the blob-wide value at the model default and recording exceptions per tensor leaves that untouched, and matches what `quantizeBlob` already does for mixed-precision packed blobs.

## Not in this change

An earlier revision of this PR also rejected, at create time, a source that states a quantization we cannot map (say an MLX 3-bit checkpoint), on the grounds that it can only fail later at load. That turns imports that currently succeed into hard failures, which is a policy change rather than part of restoring dropped metadata — and shape inference does still rescue some of those sources. It is dropped here and can be proposed separately. Unmappable quantizations import exactly as they do today.

## Testing

`go test ./x/create/... ./x/safetensors/... ./x/quant/... ./x/mlxrunner/...`, `go vet`, `gofmt` all clean.

Unit tests in `x/create/prequant_test.go` parse real `config.json` quantization JSON rather than hand-built structs, and cover the implicit affine mode; overrides that change bits, group size, both, or nothing; a source with no override; an unmappable bit width importing unchanged; and `config_groups` and other nested producer objects not being mistaken for module overrides.

End to end on an M5 Max, importing the 20GB checkpoint above and running it:

```
$ python3 -c 'print(header["__metadata__"])'   # layers.0.mlp.switch_mlp.gate_proj.weight
{"group_size": "64", "quant_type": "int4"}
                                               # lm_head.weight (8-bit override)
{"group_size": "64", "quant_type": "int4",
 "language_model.lm_head.weight.quant_type": "int8"}

$ curl -s localhost:11434/api/generate -d '{"model":"qwen36-rework-check","prompt":"What is the capital of France? Answer in one short sentence.","stream":false}'
"The capital of France is Paris."
```

113 tok/s, and the "dequantizing expert weights" warnings are gone — the experts now load as native 4-bit affine and take the gather-QMM kernel instead of being dequantized.