### PR TITLE
parser: count a CRLF as one line ending, not two

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -455,6 +455,7 @@ func ParseFile(r io.Reader) (*Modelfile, error) {
 	var cmd Command
 	var curr state
 	var currLine int = 1
+	var prev rune
 	var b bytes.Buffer
 	var role string
 
@@ -471,9 +472,13 @@ func ParseFile(r io.Reader) (*Modelfile, error) {
 			return nil, err
 		}
 
-		if isNewline(r) {
+		// A CRLF is one line ending, not two, so do not count the \n that
+		// follows a \r again. Counting both doubled every line number a
+		// Windows-authored Modelfile reported in a parse error.
+		if isNewline(r) && !(r == '\n' && prev == '\r') {
 			currLine++
 		}
+		prev = r
 
 		next, r, err := parseRuneForState(r, curr)
 		if errors.Is(err, io.ErrUnexpectedEOF) {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -1254,3 +1254,27 @@ func TestFilesForModel(t *testing.T) {
 		})
 	}
 }
+
+func TestParseFileErrorLineNumberLineEndings(t *testing.T) {
+	// The bad command sits on line 4 whichever line ending is used.
+	lines := []string{"FROM foo", "PARAMETER temperature 1", "", "BADCOMMAND x"}
+
+	cases := []struct {
+		name string
+		sep  string
+	}{
+		{"lf", "\n"},
+		{"crlf", "\r\n"},
+		{"cr", "\r"},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseFile(strings.NewReader(strings.Join(lines, tt.sep)))
+
+			var pe *ParserError
+			require.ErrorAs(t, err, &pe)
+			assert.Equal(t, 4, pe.LineNumber)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`ParseFile` counts lines with:

```go
if isNewline(r) {
    currLine++
}
```

and `isNewline` accepts both endings:

```go
func isNewline(r rune) bool {
	return r == '\r' || r == '\n'
}
```

A Modelfile saved with CRLF endings, which is the default on Windows, therefore counts **two** lines per line, and every `ParserError` reports a line number roughly double the real one. The further into the file the error is, the further off the number.

Same four-line Modelfile, bad command on line 4, only the line ending differs:

```
LF    error reported at line 4   (correct)
CRLF  error reported at line 7   (actual line 4)
```

The error text itself is right, so the message is confidently pointing the user at the wrong line, and on a longer Modelfile the reported line may not exist at all.

`isNewline` is also used by the parsing state machine at lines 591, 607 and 634, where treating `\r` as a newline is correct. Only the counter is wrong.

## Fix

Track the previous rune and skip the `\n` that follows a `\r`, so a CRLF counts once.

```go
if isNewline(r) && !(r == '\n' && prev == '\r') {
    currLine++
}
prev = r
```

A lone `\r` still counts, so classic Mac line endings keep working, and the state machine is untouched. Content parses identically either way today; this only changes the number reported in an error.

## Test

`TestParseFileErrorLineNumberLineEndings` parses the same content with `\n`, `\r\n` and `\r` and asserts the error lands on line 4 in all three.

```
                                          before        after
TestParseFileErrorLineNumberLineEndings/lf    pass       pass
TestParseFileErrorLineNumberLineEndings/crlf  FAIL       pass
                                              expected: 4
                                              actual  : 7
TestParseFileErrorLineNumberLineEndings/cr    pass       pass
```

`lf` and `cr` pass either way on purpose: they pin the two behaviours this change could have broken. There was no CRLF coverage in `parser_test.go` before, which is why this survived.

`go test ./parser/... ./server/... ./cmd/...` is green, and `go vet ./parser/...` is clean. `gofmt` clean on both files.
