### PR TITLE
docs: add protoAgent to Terminal & CLI integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ console.log(response.message.content);
 - [LLM-X](https://github.com/mrdjohnson/llm-x) - Progressive web app for LLMs
 - [cmdh](https://github.com/pgibler/cmdh) - Natural language to shell commands
 - [VT](https://github.com/vinhnx/vt.ai) - Minimal multimodal AI chat app
+- [protoAgent](https://github.com/protoLabsAI/protoAgent) - LangGraph agent runtime with an operator console, A2A, and drop-in plugins; runs any Ollama model via its OpenAI endpoint
 
 ### Productivity & Apps
 


### PR DESCRIPTION
Adds [protoAgent](https://github.com/protoLabsAI/protoAgent) to the Terminal & CLI section — a LangGraph agent runtime with an operator console, A2A, and drop-in plugins that runs any Ollama model via its OpenAI-compatible endpoint (`protoagent model use --base-url http://127.0.0.1:11434/v1 --model <name>`).