### PR TITLE
feat: Add OLLAMA_NO_THINK global environment switch

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -263,6 +263,10 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		return
 	}
 
+	if os.Getenv("OLLAMA_NO_THINK") == "true" {
+		req.Think = &api.ThinkValue{Value: false}
+	}
+
 	modelRef, err := parseAndValidateModelRef(req.Model)
 	if err != nil {
 		writeModelRefParseError(c, err, http.StatusNotFound, fmt.Sprintf("model '%s' not found", req.Model))
@@ -2434,6 +2438,10 @@ func (s *Server) ChatHandler(c *gin.Context) {
 	if req.TopLogprobs < 0 || req.TopLogprobs > 20 {
 		c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": "top_logprobs must be between 0 and 20"})
 		return
+	}
+
+	if os.Getenv("OLLAMA_NO_THINK") == "true" {
+		req.Think = &api.ThinkValue{Value: false}
 	}
 
 	modelRef, err := parseAndValidateModelRef(req.Model)

--- a/server/routes.go
+++ b/server/routes.go
@@ -641,6 +641,21 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		return
 	}
 
+	var customStripper *thinkStripper
+	if os.Getenv("OLLAMA_NO_THINK") == "true" {
+		openingTag, closingTag := thinking.InferTags(m.Template.Template)
+		if openingTag == "" {
+			openingTag = "<think>"
+		}
+		if closingTag == "" {
+			closingTag = "</think>"
+		}
+		customStripper = &thinkStripper{
+			openingTag: openingTag,
+			closingTag: closingTag,
+		}
+	}
+
 	var thinkingState *thinking.Parser
 	if builtinParser == nil {
 		openingTag, closingTag := thinking.InferTags(m.Template.Template)
@@ -672,6 +687,13 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			PreservedTokens: preservedTokensForCompletion(builtinParser),
 			LeadingBOS:      leadingBOS,
 		}, func(cr llm.CompletionResponse) {
+			if customStripper != nil {
+				cr.Content = customStripper.process(cr.Content, cr.Done)
+				if cr.Content == "" && !cr.Done {
+					return
+				}
+			}
+
 			res := api.GenerateResponse{
 				Model:     req.Model,
 				CreatedAt: time.Now().UTC(),
@@ -2707,6 +2729,21 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		return
 	}
 
+	var customStripper *thinkStripper
+	if os.Getenv("OLLAMA_NO_THINK") == "true" {
+		openingTag, closingTag := thinking.InferTags(m.Template.Template)
+		if openingTag == "" {
+			openingTag = "<think>"
+		}
+		if closingTag == "" {
+			closingTag = "</think>"
+		}
+		customStripper = &thinkStripper{
+			openingTag: openingTag,
+			closingTag: closingTag,
+		}
+	}
+
 	var thinkingState *thinking.Parser
 	openingTag, closingTag := thinking.InferTags(m.Template.Template)
 	if req.Think != nil && req.Think.Bool() && openingTag != "" && closingTag != "" {
@@ -2772,6 +2809,13 @@ func (s *Server) ChatHandler(c *gin.Context) {
 				ToolCallTag:     toolCallTagForCompletion(toolParser),
 				LeadingBOS:      leadingBOSForModel(m),
 			}, func(r llm.CompletionResponse) {
+				if customStripper != nil {
+					r.Content = customStripper.process(r.Content, r.Done)
+					if r.Content == "" && !r.Done {
+						return
+					}
+				}
+
 				res := api.ChatResponse{
 					Model:     req.Model,
 					CreatedAt: time.Now().UTC(),
@@ -3128,4 +3172,68 @@ func filterThinkTags(msgs []api.Message, m *Model) []api.Message {
 		}
 	}
 	return msgs
+}
+
+type thinkStripper struct {
+	streamBuf  string
+	inThink    bool
+	openingTag string
+	closingTag string
+}
+
+func (s *thinkStripper) process(content string, done bool) string {
+	if s.openingTag == "" || s.closingTag == "" {
+		return content
+	}
+	s.streamBuf += content
+	var out string
+	for {
+		if !s.inThink {
+			idx := strings.Index(s.streamBuf, s.openingTag)
+			if idx >= 0 {
+				out += s.streamBuf[:idx]
+				s.streamBuf = s.streamBuf[idx+len(s.openingTag):]
+				s.inThink = true
+				continue
+			}
+			overlapLen := overlapString(s.streamBuf, s.openingTag)
+			if overlapLen > 0 {
+				out += s.streamBuf[:len(s.streamBuf)-overlapLen]
+				s.streamBuf = s.streamBuf[len(s.streamBuf)-overlapLen:]
+			} else {
+				out += s.streamBuf
+				s.streamBuf = ""
+			}
+			break
+		} else {
+			idx := strings.Index(s.streamBuf, s.closingTag)
+			if idx >= 0 {
+				s.streamBuf = s.streamBuf[idx+len(s.closingTag):]
+				s.inThink = false
+				continue
+			}
+			if len(s.streamBuf) > len(s.closingTag) {
+				s.streamBuf = s.streamBuf[len(s.streamBuf)-len(s.closingTag):]
+			}
+			break
+		}
+	}
+	if done {
+		out += s.streamBuf
+		s.streamBuf = ""
+	}
+	return out
+}
+
+func overlapString(s, delim string) int {
+	max := len(delim)
+	if len(s) < max {
+		max = len(s)
+	}
+	for i := max; i > 0; i-- {
+		if strings.HasSuffix(s, delim[:i]) {
+			return i
+		}
+	}
+	return 0
 }

--- a/server/routes.go
+++ b/server/routes.go
@@ -748,6 +748,9 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 				// Emit chunks that carry logprobs even if the parser is still buffering
 				// visible content, otherwise generate logprobs disappear for models with
 				// builtin thinking/tool parsers.
+				if os.Getenv("OLLAMA_NO_THINK") == "true" {
+					res.Thinking = ""
+				}
 				if res.Response != "" || res.Thinking != "" || res.Done || len(res.ToolCalls) > 0 || len(res.Logprobs) > 0 {
 					ch <- res
 				}
@@ -755,7 +758,12 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 				return
 			}
 
-			ch <- res
+			if os.Getenv("OLLAMA_NO_THINK") == "true" {
+				res.Thinking = ""
+			}
+			if res.Response != "" || res.Thinking != "" || res.Done || len(res.ToolCalls) > 0 || len(res.Logprobs) > 0 {
+				ch <- res
+			}
 		}); err != nil {
 			s.sched.expireRunnersForRuntimeOOM(m, err)
 			var serr api.StatusError
@@ -2861,6 +2869,9 @@ func (s *Server) ChatHandler(c *gin.Context) {
 					}
 
 					if res.Message.Content != "" || res.Message.Thinking != "" || len(res.Message.ToolCalls) > 0 || r.Done || len(res.Logprobs) > 0 {
+						if os.Getenv("OLLAMA_NO_THINK") == "true" {
+							res.Message.Thinking = ""
+						}
 						slog.Log(context.TODO(), logutil.LevelTrace, "builtin parser output", "parser", m.Config.Parser, "content", content, "thinking", thinking, "toolCalls", toolCalls, "done", r.Done)
 						ch <- res
 					} else {
@@ -2917,8 +2928,13 @@ func (s *Server) ChatHandler(c *gin.Context) {
 						return
 					}
 				}
+				if os.Getenv("OLLAMA_NO_THINK") == "true" {
+					res.Message.Thinking = ""
+				}
 
-				ch <- res
+				if res.Message.Content != "" || res.Message.Thinking != "" || len(res.Message.ToolCalls) > 0 || r.Done || len(res.Logprobs) > 0 {
+					ch <- res
+				}
 			})
 			if err != nil {
 				if structuredOutputsState == structuredOutputsState_ReadyToApply && strings.Contains(err.Error(), "context canceled") && c.Request.Context().Err() == nil {


### PR DESCRIPTION
This patch adds a global environment variable `OLLAMA_NO_THINK=true` that globally overrides the `Think` parameter to `false` on all Chat and Generate requests.