### PR TITLE
server: pull sharded GGUF models from Hugging Face

### DIFF
--- a/integration/pull_sharded_test.go
+++ b/integration/pull_sharded_test.go
@@ -1,0 +1,48 @@
+//go:build integration
+
+package integration
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ollama/ollama/api"
+)
+
+// SmolLM2-135M-Instruct-GGUF-Split is a small public repository whose only
+// quant is sharded, so pulling it exercises the sharded GGUF fallback against
+// the real registry for about 92 MB. The registry rejects the tag at manifest
+// resolution, the shards are fetched from Hugging Face directly, and the create
+// path merges them into a single model layer.
+const shardedModel = "hf.co/owalsh/SmolLM2-135M-Instruct-GGUF-Split:Q4_0"
+
+func TestPullShardedGGUF(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	client, _, cleanup := InitServerConnection(ctx, t)
+	defer cleanup()
+
+	if err := PullIfMissing(ctx, client, shardedModel); err != nil {
+		t.Fatalf("pulling sharded model: %v", err)
+	}
+
+	// The merged model must be usable, and must be a single model layer rather
+	// than one layer per shard.
+	show, err := client.Show(ctx, &api.ShowRequest{Model: shardedModel})
+	if err != nil {
+		t.Fatalf("show: %v", err)
+	}
+	if show.Details.Family == "" {
+		t.Error("merged model reports no family, suggesting a bad merge")
+	}
+
+	req := api.GenerateRequest{
+		Model:   shardedModel,
+		Prompt:  "why is the sky blue?",
+		Stream:  &stream,
+		Options: map[string]any{"temperature": 0, "seed": 123},
+	}
+	DoGenerate(ctx, t, client, req, []string{"rayleigh", "scatter", "blue", "light"}, 120*time.Second, 30*time.Second)
+}

--- a/server/images.go
+++ b/server/images.go
@@ -1015,6 +1015,12 @@ func PullModel(ctx context.Context, name string, regOpts *registryOptions, fn fu
 
 	mf, manifestData, err := pullModelManifest(ctx, n, regOpts)
 	if err != nil {
+		// The Hugging Face registry refuses sharded GGUF tags instead of
+		// serving a manifest, so fall back to fetching the shards directly and
+		// merging them through the create path. See ollama/ollama#5245.
+		if isShardedGGUFRefusal(err) && isHuggingFaceHost(n.Host) {
+			return pullShardedGGUF(ctx, n, fn)
+		}
 		return fmt.Errorf("pull model manifest: %s", err)
 	}
 	if hasTensorLayers(mf.Layers) {

--- a/server/images.go
+++ b/server/images.go
@@ -1018,8 +1018,8 @@ func PullModel(ctx context.Context, name string, regOpts *registryOptions, fn fu
 		// The Hugging Face registry refuses sharded GGUF tags instead of
 		// serving a manifest, so fall back to fetching the shards directly and
 		// merging them through the create path. See ollama/ollama#5245.
-		if isShardedGGUFRefusal(err) && isHuggingFaceHost(n.Host) {
-			return pullShardedGGUF(ctx, n, fn)
+		if shards, total, ok := shardedFallbackCandidate(ctx, n, err); ok {
+			return pullShardedGGUF(ctx, n, shards, total, fn)
 		}
 		return fmt.Errorf("pull model manifest: %s", err)
 	}

--- a/server/pull_sharded.go
+++ b/server/pull_sharded.go
@@ -50,12 +50,55 @@ func hfBase() string {
 	return hfEndpoint
 }
 
-var shardedRefusalRe = regexp.MustCompile(`(?i)sharded GGUF`)
+// shardedRefusalRe matches the registry's refusal to serve a sharded GGUF. The
+// wording has changed at least once (it was reworded on 2026-08-14 to point at
+// the `ollama create` workaround, and differs between a sharded tag and a
+// repository containing only sharded files), so match the stable part rather
+// than a whole sentence. shardedFallbackCandidate does not rely on this alone.
+var shardedRefusalRe = regexp.MustCompile(`(?is)shard(ed)?[^.]{0,60}gguf|gguf[^.]{0,60}shard(ed)?`)
 
-// isShardedGGUFRefusal reports whether err is the registry's refusal to serve a
+// isShardedGGUFRefusal reports whether err looks like the registry refusing a
 // sharded GGUF tag.
 func isShardedGGUFRefusal(err error) bool {
 	return err != nil && shardedRefusalRe.MatchString(err.Error())
+}
+
+// isManifestClientError reports whether err came back as a 4xx from the
+// registry, as opposed to a transport failure or a server error, so the
+// fallback is only considered for requests the registry actively rejected.
+func isManifestClientError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return true
+	}
+	return regexp.MustCompile(`^4\d\d:`).MatchString(strings.TrimSpace(err.Error()))
+}
+
+// shardedFallbackCandidate decides whether a failed manifest pull should be
+// retried by fetching shards directly, and returns the shard set if so.
+//
+// The registry's error wording is not a stable contract, so a prose match is
+// only used as a fast path: on any 4xx for a Hugging Face model the repository
+// is probed for a shard set matching the tag, and the fallback runs only if one
+// actually exists. That way a reworded refusal still works, and unrelated
+// rejections (an invalid quantization scheme, a genuinely missing tag) fall
+// through to the original error.
+func shardedFallbackCandidate(ctx context.Context, n model.Name, err error) ([]hfTreeEntry, int64, bool) {
+	if !isHuggingFaceHost(n.Host) {
+		return nil, 0, false
+	}
+	if !isShardedGGUFRefusal(err) && !isManifestClientError(err) {
+		return nil, 0, false
+	}
+
+	shards, total, listErr := hfShardSet(ctx, n.Namespace+"/"+n.Model, n.Tag)
+	if listErr != nil {
+		slog.Debug("no sharded GGUF fallback available", "model", n.DisplayShortest(), "error", listErr)
+		return nil, 0, false
+	}
+	return shards, total, true
 }
 
 // isHuggingFaceHost reports whether host is a Hugging Face registry host.
@@ -250,25 +293,21 @@ func downloadShard(ctx context.Context, repo string, e hfTreeEntry, fn func(api.
 	return layer.Digest, nil
 }
 
-// pullShardedGGUF downloads the shard set for n directly from Hugging Face and
+// pullShardedGGUF downloads the given shard set directly from Hugging Face and
 // creates the model from it, reusing the create path's merge. It is the
 // in-process equivalent of downloading the shards by hand and running
 // `ollama create` in that directory.
-func pullShardedGGUF(ctx context.Context, n model.Name, fn func(api.ProgressResponse)) error {
+func pullShardedGGUF(ctx context.Context, n model.Name, shards []hfTreeEntry, total int64, fn func(api.ProgressResponse)) error {
 	if !isHuggingFaceHost(n.Host) {
 		return errors.New("sharded GGUF pull is only supported for Hugging Face models")
 	}
+	if len(shards) == 0 {
+		return errors.New("no sharded GGUF files to pull")
+	}
 
 	repo := n.Namespace + "/" + n.Model
-	slog.Info("registry refused sharded GGUF tag, fetching shards directly", "repo", repo, "tag", n.Tag)
-
-	fn(api.ProgressResponse{Status: "pulling manifest"})
-
-	shards, total, err := hfShardSet(ctx, repo, n.Tag)
-	if err != nil {
-		return err
-	}
-	slog.Info("found sharded GGUF", "repo", repo, "tag", n.Tag, "shards", len(shards), "bytes", total)
+	slog.Info("registry refused sharded GGUF tag, fetching shards directly",
+		"repo", repo, "tag", n.Tag, "shards", len(shards), "bytes", total)
 
 	files := make(map[string]string, len(shards))
 	for _, e := range shards {

--- a/server/pull_sharded.go
+++ b/server/pull_sharded.go
@@ -182,11 +182,67 @@ func hfShardSet(ctx context.Context, repo, tag string) ([]hfTreeEntry, int64, er
 		return int(ai) - int(bi)
 	})
 
+	// Validate the set before anything is downloaded. The create path already
+	// rejects an unusable shard set, but only once every blob is in the store
+	// (see #17946), which on this path would mean paying for the whole transfer
+	// first. Everything checked here comes from the listing, so it costs
+	// nothing.
+	if err := validateShardSet(repo, tag, shards); err != nil {
+		return nil, 0, err
+	}
+
 	var total int64
 	for _, s := range shards {
 		total += s.Size
 	}
 	return shards, total, nil
+}
+
+// validateShardSet reports whether shards form exactly one complete split GGUF
+// set: a single prefix, a consistent count, and every shard present exactly
+// once. shards must be sorted by index.
+//
+// splitGGUFName returns a zero-based index, matching the split.no metadata,
+// while the filenames themselves are one-based, so indices run 0..count-1 here
+// and are reported one-based to match what a user sees.
+func validateShardSet(repo, tag string, shards []hfTreeEntry) error {
+	wantPrefix, _, wantCount, ok := splitGGUFName(shards[0].Path)
+	if !ok {
+		return fmt.Errorf("shard %q does not use the llama.cpp split filename pattern", shards[0].Path)
+	}
+
+	seen := make(map[uint16]string, len(shards))
+	for _, s := range shards {
+		prefix, index, count, ok := splitGGUFName(s.Path)
+		if !ok {
+			return fmt.Errorf("shard %q does not use the llama.cpp split filename pattern", s.Path)
+		}
+		if prefix != wantPrefix || count != wantCount {
+			return fmt.Errorf("tag %q in %s matches more than one shard set: %q and %q",
+				tag, repo, shards[0].Path, s.Path)
+		}
+		if index >= count {
+			return fmt.Errorf("shard %q is numbered %d of %d", s.Path, index+1, count)
+		}
+		if dup, exists := seen[index]; exists {
+			return fmt.Errorf("duplicate shard %d for tag %q in %s: %q and %q",
+				index+1, tag, repo, dup, s.Path)
+		}
+		seen[index] = s.Path
+	}
+
+	if len(seen) != int(wantCount) {
+		missing := make([]string, 0, int(wantCount)-len(seen))
+		for i := uint16(0); i < wantCount; i++ {
+			if _, exists := seen[i]; !exists {
+				missing = append(missing, fmt.Sprintf("%05d-of-%05d", i+1, wantCount))
+			}
+		}
+		return fmt.Errorf("incomplete shard set for tag %q in %s: found %d of %d shards, missing %s",
+			tag, repo, len(seen), wantCount, strings.Join(missing, ", "))
+	}
+
+	return nil
 }
 
 // hfNextPage returns the next tree API page from a standard HTTP Link header.

--- a/server/pull_sharded.go
+++ b/server/pull_sharded.go
@@ -74,32 +74,42 @@ type hfTreeEntry struct {
 
 // hfShardSet returns the ordered shard files in repo that belong to tag, along
 // with their total size. Shards are matched either as a quant subdirectory
-// (Q4_1/model-00001-of-00003.gguf) or as root level files whose name contains
-// the tag. Ordering follows the NNNNN-of-NNNNN suffix rather than the order the
+// (Q4_1/model-00001-of-00003.gguf) or as root level files with a matching tag
+// suffix. Ordering follows the NNNNN-of-NNNNN suffix rather than the order the
 // API happens to return.
 func hfShardSet(ctx context.Context, repo, tag string) ([]hfTreeEntry, int64, error) {
 	u := fmt.Sprintf("%s/api/models/%s/tree/main?recursive=true", hfBase(), repo)
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
-	if err != nil {
-		return nil, 0, err
-	}
-	if tok := hfToken(); tok != "" {
-		req.Header.Set("Authorization", "Bearer "+tok)
-	}
-
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		return nil, 0, err
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, 0, fmt.Errorf("listing %s: %s", repo, resp.Status)
-	}
-
 	var entries []hfTreeEntry
-	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
-		return nil, 0, err
+	for u != "" {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+		if err != nil {
+			return nil, 0, err
+		}
+		if tok := hfToken(); tok != "" {
+			req.Header.Set("Authorization", "Bearer "+tok)
+		}
+
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, 0, err
+		}
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			return nil, 0, fmt.Errorf("listing %s: %s", repo, resp.Status)
+		}
+
+		var page []hfTreeEntry
+		if err := json.NewDecoder(resp.Body).Decode(&page); err != nil {
+			resp.Body.Close()
+			return nil, 0, err
+		}
+		next, err := hfNextPage(resp)
+		resp.Body.Close()
+		if err != nil {
+			return nil, 0, err
+		}
+		entries = append(entries, page...)
+		u = next
 	}
 
 	lower := strings.ToLower(tag)
@@ -108,13 +118,14 @@ func hfShardSet(ctx context.Context, repo, tag string) ([]hfTreeEntry, int64, er
 		if !strings.HasSuffix(strings.ToLower(e.Path), ".gguf") {
 			continue
 		}
-		if _, _, _, ok := splitGGUFName(e.Path); !ok {
+		prefix, _, _, ok := splitGGUFName(e.Path)
+		if !ok {
 			continue
 		}
-		dir, base := path.Split(e.Path)
+		dir, _ := path.Split(e.Path)
 		dir = strings.TrimSuffix(dir, "/")
 		// quant directory (Q4_1/...) or a root file naming the quant
-		if strings.ToLower(dir) == lower || (dir == "" && strings.Contains(strings.ToLower(base), lower)) {
+		if strings.ToLower(dir) == lower || (dir == "" && strings.HasSuffix(strings.ToLower(prefix), "-"+lower)) {
 			shards = append(shards, e)
 		}
 	}
@@ -133,6 +144,38 @@ func hfShardSet(ctx context.Context, repo, tag string) ([]hfTreeEntry, int64, er
 		total += s.Size
 	}
 	return shards, total, nil
+}
+
+// hfNextPage returns the next tree API page from a standard HTTP Link header.
+func hfNextPage(resp *http.Response) (string, error) {
+	for _, header := range resp.Header.Values("Link") {
+		for _, link := range strings.Split(header, ",") {
+			parts := strings.Split(link, ";")
+			if len(parts) < 2 {
+				continue
+			}
+
+			for _, param := range parts[1:] {
+				name, value, ok := strings.Cut(strings.TrimSpace(param), "=")
+				if !ok || !strings.EqualFold(strings.TrimSpace(name), "rel") {
+					continue
+				}
+				for _, rel := range strings.Fields(strings.Trim(value, `"`)) {
+					if !strings.EqualFold(rel, "next") {
+						continue
+					}
+					target := strings.TrimSpace(parts[0])
+					target = strings.TrimPrefix(strings.TrimSuffix(target, ">"), "<")
+					next, err := resp.Request.URL.Parse(target)
+					if err != nil {
+						return "", fmt.Errorf("parsing next page URL: %w", err)
+					}
+					return next.String(), nil
+				}
+			}
+		}
+	}
+	return "", nil
 }
 
 // hfToken returns a Hugging Face token from the environment, if set, so private

--- a/server/pull_sharded.go
+++ b/server/pull_sharded.go
@@ -1,0 +1,257 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"os"
+	"path"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/manifest"
+	"github.com/ollama/ollama/types/model"
+)
+
+// The Hugging Face registry proxy refuses sharded (multi-part) GGUF tags at
+// manifest resolution rather than returning a manifest with one layer per
+// shard, so the shards never reach the client and the merge implemented on the
+// create path (mergeSplitGGUFLayers) is never given anything to work on.
+//
+// This falls back to fetching the shard files straight from Hugging Face and
+// handing them to the same code path `ollama create` uses for a local
+// directory of shards, which makes `ollama pull` work for those tags without
+// requiring a registry-side change.
+//
+// See https://github.com/ollama/ollama/issues/5245 and
+// https://github.com/huggingface/hub-docs/issues/2702.
+
+const hfEndpoint = "https://huggingface.co"
+
+// hfEndpointOverride is set by tests to point at a stub server.
+var hfEndpointOverride string
+
+// hfBase returns the Hugging Face endpoint to use, honouring HF_ENDPOINT the
+// same way the huggingface_hub tooling does.
+func hfBase() string {
+	if hfEndpointOverride != "" {
+		return hfEndpointOverride
+	}
+	if v := os.Getenv("HF_ENDPOINT"); v != "" {
+		return strings.TrimSuffix(v, "/")
+	}
+	return hfEndpoint
+}
+
+var shardedRefusalRe = regexp.MustCompile(`(?i)sharded GGUF`)
+
+// isShardedGGUFRefusal reports whether err is the registry's refusal to serve a
+// sharded GGUF tag.
+func isShardedGGUFRefusal(err error) bool {
+	return err != nil && shardedRefusalRe.MatchString(err.Error())
+}
+
+// isHuggingFaceHost reports whether host is a Hugging Face registry host.
+func isHuggingFaceHost(host string) bool {
+	switch strings.ToLower(host) {
+	case "hf.co", "huggingface.co":
+		return true
+	}
+	return false
+}
+
+type hfTreeEntry struct {
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+}
+
+// hfShardSet returns the ordered shard files in repo that belong to tag, along
+// with their total size. Shards are matched either as a quant subdirectory
+// (Q4_1/model-00001-of-00003.gguf) or as root level files whose name contains
+// the tag. Ordering follows the NNNNN-of-NNNNN suffix rather than the order the
+// API happens to return.
+func hfShardSet(ctx context.Context, repo, tag string) ([]hfTreeEntry, int64, error) {
+	u := fmt.Sprintf("%s/api/models/%s/tree/main?recursive=true", hfBase(), repo)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return nil, 0, err
+	}
+	if tok := hfToken(); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, 0, fmt.Errorf("listing %s: %s", repo, resp.Status)
+	}
+
+	var entries []hfTreeEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		return nil, 0, err
+	}
+
+	lower := strings.ToLower(tag)
+	var shards []hfTreeEntry
+	for _, e := range entries {
+		if !strings.HasSuffix(strings.ToLower(e.Path), ".gguf") {
+			continue
+		}
+		if _, _, _, ok := splitGGUFName(e.Path); !ok {
+			continue
+		}
+		dir, base := path.Split(e.Path)
+		dir = strings.TrimSuffix(dir, "/")
+		// quant directory (Q4_1/...) or a root file naming the quant
+		if strings.ToLower(dir) == lower || (dir == "" && strings.Contains(strings.ToLower(base), lower)) {
+			shards = append(shards, e)
+		}
+	}
+	if len(shards) == 0 {
+		return nil, 0, fmt.Errorf("no sharded GGUF files for tag %q in %s", tag, repo)
+	}
+
+	slices.SortFunc(shards, func(a, b hfTreeEntry) int {
+		_, ai, _, _ := splitGGUFName(a.Path)
+		_, bi, _, _ := splitGGUFName(b.Path)
+		return int(ai) - int(bi)
+	})
+
+	var total int64
+	for _, s := range shards {
+		total += s.Size
+	}
+	return shards, total, nil
+}
+
+// hfToken returns a Hugging Face token from the environment, if set, so private
+// repositories work the same way they do for the rest of the Hugging Face
+// tooling.
+func hfToken() string {
+	for _, k := range []string{"HF_TOKEN", "HUGGING_FACE_HUB_TOKEN"} {
+		if v := os.Getenv(k); v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// progressReader reports download progress for a single shard.
+type progressReader struct {
+	r         io.Reader
+	digest    string
+	total     int64
+	completed int64
+	fn        func(api.ProgressResponse)
+}
+
+func (p *progressReader) Read(b []byte) (int, error) {
+	n, err := p.r.Read(b)
+	p.completed += int64(n)
+	p.fn(api.ProgressResponse{
+		Status:    fmt.Sprintf("pulling %s", p.digest),
+		Digest:    p.digest,
+		Total:     p.total,
+		Completed: p.completed,
+	})
+	return n, err
+}
+
+// downloadShard fetches a single shard into the blob store and returns its
+// digest.
+func downloadShard(ctx context.Context, repo string, e hfTreeEntry, fn func(api.ProgressResponse)) (string, error) {
+	u := fmt.Sprintf("%s/%s/resolve/main/%s", hfBase(), repo, (&url.URL{Path: e.Path}).EscapedPath())
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+	if err != nil {
+		return "", err
+	}
+	if tok := hfToken(); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("downloading %s: %s", e.Path, resp.Status)
+	}
+
+	total := e.Size
+	if total == 0 {
+		total = resp.ContentLength
+	}
+
+	layer, err := manifest.NewLayer(&progressReader{
+		r:      resp.Body,
+		digest: path.Base(e.Path),
+		total:  total,
+		fn:     fn,
+	}, "application/vnd.ollama.image.model")
+	if err != nil {
+		return "", err
+	}
+	return layer.Digest, nil
+}
+
+// pullShardedGGUF downloads the shard set for n directly from Hugging Face and
+// creates the model from it, reusing the create path's merge. It is the
+// in-process equivalent of downloading the shards by hand and running
+// `ollama create` in that directory.
+func pullShardedGGUF(ctx context.Context, n model.Name, fn func(api.ProgressResponse)) error {
+	if !isHuggingFaceHost(n.Host) {
+		return errors.New("sharded GGUF pull is only supported for Hugging Face models")
+	}
+
+	repo := n.Namespace + "/" + n.Model
+	slog.Info("registry refused sharded GGUF tag, fetching shards directly", "repo", repo, "tag", n.Tag)
+
+	fn(api.ProgressResponse{Status: "pulling manifest"})
+
+	shards, total, err := hfShardSet(ctx, repo, n.Tag)
+	if err != nil {
+		return err
+	}
+	slog.Info("found sharded GGUF", "repo", repo, "tag", n.Tag, "shards", len(shards), "bytes", total)
+
+	files := make(map[string]string, len(shards))
+	for _, e := range shards {
+		digest, err := downloadShard(ctx, repo, e, fn)
+		if err != nil {
+			return err
+		}
+		files[path.Base(e.Path)] = digest
+	}
+
+	// Same entry point `ollama create` uses for a directory of shards: this is
+	// what groups them via splitGGUFGroupKey and merges them with
+	// mergeSplitGGUFLayers into a single model layer.
+	baseLayers, err := convertModelFromFiles(files, nil, false, fn)
+	if err != nil {
+		return err
+	}
+
+	config := &model.ConfigV2{
+		OS:           "linux",
+		Architecture: "amd64",
+	}
+	if err := createModel(api.CreateRequest{Model: n.DisplayShortest()}, n, baseLayers, config, fn); err != nil {
+		return err
+	}
+
+	fn(api.ProgressResponse{Status: "success"})
+	return nil
+}

--- a/server/pull_sharded_real_test.go
+++ b/server/pull_sharded_real_test.go
@@ -1,0 +1,130 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/ollama/ollama/types/model"
+)
+
+// Both wordings observed from the Hugging Face registry. The message was
+// reworded on 2026-08-14 to point at the `ollama create` workaround, which is
+// why detection must not depend on an exact sentence.
+const (
+	refusalOld  = `400: {"error":"The specified tag is a sharded GGUF. Ollama does not support this yet. Please use another tag or \"latest\". Follow this issue for more info: https://github.com/ollama/ollama/issues/5245"}`
+	refusalTag  = `400: {"error":"This tag is a sharded GGUF. Ollama does not yet support pulling sharded GGUF via the registry; please use a single-file quantization tag or \"latest\", or download the shards and merge them locally with ` + "`ollama create`" + ` (workaround detailed at https://github.com/ollama/ollama/issues/5245)."}`
+	refusalRepo = `400: {"error":"This repository only contains sharded GGUF files. Ollama does not yet support pulling sharded GGUF via the registry; please download the shards and merge them locally with ` + "`ollama create`" + ` (workaround detailed at https://github.com/ollama/ollama/issues/5245), or use a repository with single-file quantizations."}`
+)
+
+func TestIsShardedGGUFRefusalRealWordings(t *testing.T) {
+	for name, msg := range map[string]string{
+		"pre-2026-08-14 wording":      refusalOld,
+		"reworded, sharded tag":       refusalTag,
+		"reworded, sharded-only repo": refusalRepo,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if !isShardedGGUFRefusal(errors.New(msg)) {
+				t.Errorf("failed to recognise refusal: %s", msg)
+			}
+		})
+	}
+
+	if isShardedGGUFRefusal(errors.New(`400: {"error":"The specified tag is not a valid quantization scheme."}`)) {
+		t.Error("unrelated 400 must not be treated as a sharded refusal")
+	}
+}
+
+func TestIsManifestClientError(t *testing.T) {
+	cases := map[string]struct {
+		err  error
+		want bool
+	}{
+		"400":                {errors.New(refusalOld), true},
+		"404 as ErrNotExist": {os.ErrNotExist, true},
+		"500":                {errors.New(`500: {"error":"internal"}`), false},
+		"transport":          {errors.New("dial tcp: connection refused"), false},
+		"nil":                {nil, false},
+	}
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			if got := isManifestClientError(tt.err); got != tt.want {
+				t.Errorf("isManifestClientError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// realSmolLM2Tree is the actual tree API response shape for
+// owalsh/SmolLM2-135M-Instruct-GGUF-Split, a public repository containing only
+// a sharded quant, trimmed to the fields this code reads.
+const realSmolLM2Tree = `[
+  {"type":"directory","oid":"628e439b","size":0,"path":"Q4_0"},
+  {"type":"file","oid":"c5f2c12e","size":1783,"path":".gitattributes"},
+  {"type":"file","oid":"e1c8dcfb","size":41746880,"path":"Q4_0/SmolLM2-135M-Instruct-Q4_0-00001-of-00003.gguf"},
+  {"type":"file","oid":"f2cf445b","size":39916128,"path":"Q4_0/SmolLM2-135M-Instruct-Q4_0-00002-of-00003.gguf"},
+  {"type":"file","oid":"1359bb47","size":10230400,"path":"Q4_0/SmolLM2-135M-Instruct-Q4_0-00003-of-00003.gguf"},
+  {"type":"file","oid":"197cad52","size":171,"path":"README.md"}
+]`
+
+func TestShardedFallbackCandidate(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(realSmolLM2Tree))
+	}))
+	defer srv.Close()
+
+	old := hfEndpointOverride
+	hfEndpointOverride = srv.URL
+	defer func() { hfEndpointOverride = old }()
+
+	hf := model.ParseName("hf.co/owalsh/SmolLM2-135M-Instruct-GGUF-Split:Q4_0")
+	if !hf.IsValid() {
+		t.Fatal("test model name did not parse")
+	}
+
+	t.Run("real repo, reworded refusal", func(t *testing.T) {
+		shards, total, ok := shardedFallbackCandidate(context.Background(), hf, errors.New(refusalRepo))
+		if !ok {
+			t.Fatal("expected fallback to be offered")
+		}
+		if len(shards) != 3 {
+			t.Fatalf("got %d shards, want 3", len(shards))
+		}
+		if total != 41746880+39916128+10230400 {
+			t.Errorf("total = %d, unexpected", total)
+		}
+		if shards[0].Path != "Q4_0/SmolLM2-135M-Instruct-Q4_0-00001-of-00003.gguf" {
+			t.Errorf("wrong first shard: %s", shards[0].Path)
+		}
+	})
+
+	t.Run("wording we have never seen still works via probe", func(t *testing.T) {
+		if _, _, ok := shardedFallbackCandidate(context.Background(), hf, errors.New(`400: {"error":"totally new wording nobody predicted"}`)); !ok {
+			t.Error("a 4xx on a repo that does have a shard set should fall back regardless of wording")
+		}
+	})
+
+	t.Run("non-4xx is not probed", func(t *testing.T) {
+		if _, _, ok := shardedFallbackCandidate(context.Background(), hf, errors.New(`500: {"error":"internal"}`)); ok {
+			t.Error("server errors must not trigger the fallback")
+		}
+	})
+
+	t.Run("tag with no shard set falls through", func(t *testing.T) {
+		other := model.ParseName("hf.co/owalsh/SmolLM2-135M-Instruct-GGUF-Split:Q8_0")
+		if _, _, ok := shardedFallbackCandidate(context.Background(), other, errors.New(refusalRepo)); ok {
+			t.Error("a tag with no matching shards must not fall back")
+		}
+	})
+
+	t.Run("non-Hugging-Face host is never probed", func(t *testing.T) {
+		ollama := model.ParseName("registry.ollama.ai/library/llama3:latest")
+		if _, _, ok := shardedFallbackCandidate(context.Background(), ollama, errors.New(refusalOld)); ok {
+			t.Error("only Hugging Face models should use this fallback")
+		}
+	})
+}

--- a/server/pull_sharded_test.go
+++ b/server/pull_sharded_test.go
@@ -121,6 +121,37 @@ func TestHFShardSet(t *testing.T) {
 		}
 	})
 
+	t.Run("matches root-level quant exactly", func(t *testing.T) {
+		rootSrv := treeServer(t, `[
+			{"path":"model-Q4_0-00001-of-00002.gguf","size":100},
+			{"path":"model-Q4_0-00002-of-00002.gguf","size":200},
+			{"path":"model-IQ4_0-00001-of-00002.gguf","size":300},
+			{"path":"model-IQ4_0-00002-of-00002.gguf","size":400}
+		]`)
+		defer rootSrv.Close()
+
+		oldEndpoint := hfEndpointOverride
+		hfEndpointOverride = rootSrv.URL
+		defer func() { hfEndpointOverride = oldEndpoint }()
+
+		shards, _, err := hfShardSet(context.Background(), "r", "Q4_0")
+		if err != nil {
+			t.Fatalf("hfShardSet() error = %v", err)
+		}
+		if len(shards) != 2 {
+			t.Fatalf("got %d shards, want 2", len(shards))
+		}
+		want := []string{
+			"model-Q4_0-00001-of-00002.gguf",
+			"model-Q4_0-00002-of-00002.gguf",
+		}
+		for i, shard := range shards {
+			if shard.Path != want[i] {
+				t.Errorf("shard[%d] = %q, want %q", i, shard.Path, want[i])
+			}
+		}
+	})
+
 	t.Run("unsharded tag is rejected", func(t *testing.T) {
 		if _, _, err := hfShardSet(context.Background(), "r", "UD-TQ1_0"); err == nil {
 			t.Error("expected error for a single-file tag, got nil")
@@ -132,4 +163,36 @@ func TestHFShardSet(t *testing.T) {
 			t.Error("expected error for unknown tag, got nil")
 		}
 	})
+}
+
+func TestHFShardSetFollowsPagination(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Query().Get("cursor") == "next" {
+			fmt.Fprint(w, `[
+				{"path":"Q4_0/model-Q4_0-00001-of-00002.gguf","size":100},
+				{"path":"Q4_0/model-Q4_0-00002-of-00002.gguf","size":200}
+			]`)
+			return
+		}
+
+		w.Header().Set("Link", `</api/models/r/tree/main?recursive=true&cursor=next>; rel="next"`)
+		fmt.Fprint(w, `[{"path":"README.md","size":1000}]`)
+	}))
+	defer srv.Close()
+
+	old := hfEndpointOverride
+	hfEndpointOverride = srv.URL
+	defer func() { hfEndpointOverride = old }()
+
+	shards, total, err := hfShardSet(context.Background(), "r", "Q4_0")
+	if err != nil {
+		t.Fatalf("hfShardSet() error = %v", err)
+	}
+	if len(shards) != 2 {
+		t.Fatalf("got %d shards, want 2", len(shards))
+	}
+	if total != 300 {
+		t.Errorf("total = %d, want 300", total)
+	}
 }

--- a/server/pull_sharded_test.go
+++ b/server/pull_sharded_test.go
@@ -1,0 +1,135 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestIsShardedGGUFRefusal(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{
+			"hf refusal verbatim",
+			errors.New(`400: {"error":"The specified tag is a sharded GGUF. Ollama does not support this yet. Please use another tag or \"latest\". Follow this issue for more info: https://github.com/ollama/ollama/issues/5245"}`),
+			true,
+		},
+		{"case insensitive", errors.New("400: the specified tag is a Sharded GGUF"), true},
+		{"unrelated 400", errors.New(`400: {"error":"The specified tag is not a valid quantization scheme."}`), false},
+		{"not found", errors.New("file does not exist"), false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isShardedGGUFRefusal(tt.err); got != tt.want {
+				t.Errorf("isShardedGGUFRefusal() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsHuggingFaceHost(t *testing.T) {
+	for host, want := range map[string]bool{
+		"hf.co":              true,
+		"huggingface.co":     true,
+		"HF.CO":              true,
+		"registry.ollama.ai": false,
+		"":                   false,
+	} {
+		if got := isHuggingFaceHost(host); got != want {
+			t.Errorf("isHuggingFaceHost(%q) = %v, want %v", host, got, want)
+		}
+	}
+}
+
+// treeServer serves a Hugging Face style file listing.
+func treeServer(t *testing.T, body string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, body)
+	}))
+}
+
+const qwenTree = `[
+  {"path":"README.md","size":1000},
+  {"path":"Qwen3-Coder-Next-UD-TQ1_0.gguf","size":18940000000},
+  {"path":"Q4_1/Qwen3-Coder-Next-Q4_1-00003-of-00003.gguf","size":340000000},
+  {"path":"Q4_1/Qwen3-Coder-Next-Q4_1-00001-of-00003.gguf","size":10000000},
+  {"path":"Q4_1/Qwen3-Coder-Next-Q4_1-00002-of-00003.gguf","size":49720000000},
+  {"path":"Q8_0/Qwen3-Coder-Next-Q8_0-00001-of-00003.gguf","size":100},
+  {"path":"Q8_0/Qwen3-Coder-Next-Q8_0-00002-of-00003.gguf","size":200},
+  {"path":"Q8_0/Qwen3-Coder-Next-Q8_0-00003-of-00003.gguf","size":300}
+]`
+
+func TestHFShardSet(t *testing.T) {
+	srv := treeServer(t, qwenTree)
+	defer srv.Close()
+
+	old := hfEndpointOverride
+	hfEndpointOverride = srv.URL
+	defer func() { hfEndpointOverride = old }()
+
+	t.Run("orders shards and sums size", func(t *testing.T) {
+		shards, total, err := hfShardSet(context.Background(), "unsloth/Qwen3-Coder-Next-GGUF", "Q4_1")
+		if err != nil {
+			t.Fatalf("hfShardSet() error = %v", err)
+		}
+		if len(shards) != 3 {
+			t.Fatalf("got %d shards, want 3", len(shards))
+		}
+		want := []string{
+			"Q4_1/Qwen3-Coder-Next-Q4_1-00001-of-00003.gguf",
+			"Q4_1/Qwen3-Coder-Next-Q4_1-00002-of-00003.gguf",
+			"Q4_1/Qwen3-Coder-Next-Q4_1-00003-of-00003.gguf",
+		}
+		for i, w := range want {
+			if shards[i].Path != w {
+				t.Errorf("shard[%d] = %q, want %q", i, shards[i].Path, w)
+			}
+		}
+		if total != 340000000+10000000+49720000000 {
+			t.Errorf("total = %d, unexpected", total)
+		}
+	})
+
+	t.Run("tag is case insensitive", func(t *testing.T) {
+		shards, _, err := hfShardSet(context.Background(), "r", "q4_1")
+		if err != nil {
+			t.Fatalf("hfShardSet() error = %v", err)
+		}
+		if len(shards) != 3 {
+			t.Errorf("got %d shards, want 3", len(shards))
+		}
+	})
+
+	t.Run("does not mix quants", func(t *testing.T) {
+		shards, _, err := hfShardSet(context.Background(), "r", "Q8_0")
+		if err != nil {
+			t.Fatalf("hfShardSet() error = %v", err)
+		}
+		for _, s := range shards {
+			if got := s.Path[:5]; got != "Q8_0/" {
+				t.Errorf("leaked non-Q8_0 shard: %q", s.Path)
+			}
+		}
+	})
+
+	t.Run("unsharded tag is rejected", func(t *testing.T) {
+		if _, _, err := hfShardSet(context.Background(), "r", "UD-TQ1_0"); err == nil {
+			t.Error("expected error for a single-file tag, got nil")
+		}
+	})
+
+	t.Run("unknown tag is rejected", func(t *testing.T) {
+		if _, _, err := hfShardSet(context.Background(), "r", "NOPE"); err == nil {
+			t.Error("expected error for unknown tag, got nil")
+		}
+	})
+}

--- a/server/pull_sharded_validate_test.go
+++ b/server/pull_sharded_validate_test.go
@@ -1,0 +1,128 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/types/model"
+)
+
+// The create path rejects an unusable shard set only after every blob is in the
+// store (#17946). On the pull path that would mean paying for the whole
+// download first, so the set is validated from the listing instead. These tests
+// pin that the rejection happens at discovery.
+func TestShardSetValidatedBeforeDownload(t *testing.T) {
+	cases := []struct {
+		name    string
+		tree    string
+		tag     string
+		wantErr string
+	}{
+		{
+			name: "incomplete set names the missing shards",
+			tree: `[
+			  {"path":"Q4_0/m-Q4_0-00001-of-00003.gguf","size":100},
+			  {"path":"Q4_0/m-Q4_0-00003-of-00003.gguf","size":300}
+			]`,
+			tag:     "Q4_0",
+			wantErr: "found 2 of 3 shards, missing 00002-of-00003",
+		},
+		{
+			name: "duplicate index is rejected",
+			tree: `[
+			  {"path":"Q4_0/m-Q4_0-00001-of-00002.gguf","size":100},
+			  {"path":"Q4_0/a-Q4_0-00001-of-00002.gguf","size":100},
+			  {"path":"Q4_0/m-Q4_0-00002-of-00002.gguf","size":200}
+			]`,
+			tag: "Q4_0",
+			// differing prefixes are caught first, which is the same class of problem
+			wantErr: "more than one shard set",
+		},
+		{
+			name: "two shard sets under one tag are rejected",
+			tree: `[
+			  {"path":"Q4_0/alpha-Q4_0-00001-of-00002.gguf","size":100},
+			  {"path":"Q4_0/alpha-Q4_0-00002-of-00002.gguf","size":200},
+			  {"path":"Q4_0/beta-Q4_0-00001-of-00002.gguf","size":300},
+			  {"path":"Q4_0/beta-Q4_0-00002-of-00002.gguf","size":400}
+			]`,
+			tag:     "Q4_0",
+			wantErr: "more than one shard set",
+		},
+		{
+			name: "inconsistent count between shards is rejected",
+			tree: `[
+			  {"path":"Q4_0/m-Q4_0-00001-of-00002.gguf","size":100},
+			  {"path":"Q4_0/m-Q4_0-00002-of-00003.gguf","size":200}
+			]`,
+			tag:     "Q4_0",
+			wantErr: "more than one shard set",
+		},
+		{
+			name: "complete set passes",
+			tree: `[
+			  {"path":"Q4_0/m-Q4_0-00001-of-00002.gguf","size":100},
+			  {"path":"Q4_0/m-Q4_0-00002-of-00002.gguf","size":200}
+			]`,
+			tag:     "Q4_0",
+			wantErr: "",
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.Write([]byte(tt.tree))
+			}))
+			defer srv.Close()
+
+			old := hfEndpointOverride
+			hfEndpointOverride = srv.URL
+			defer func() { hfEndpointOverride = old }()
+
+			shards, _, err := hfShardSet(context.Background(), "owner/repo", tt.tag)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if len(shards) != 2 {
+					t.Errorf("got %d shards, want 2", len(shards))
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected an error containing %q, got a set of %d shards", tt.wantErr, len(shards))
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+// An incomplete set must not reach the download loop at all: the fallback
+// should decline so the registry's original error is surfaced instead.
+func TestIncompleteSetDoesNotOfferFallback(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`[{"path":"Q4_0/m-Q4_0-00001-of-00003.gguf","size":100}]`))
+	}))
+	defer srv.Close()
+
+	old := hfEndpointOverride
+	hfEndpointOverride = srv.URL
+	defer func() { hfEndpointOverride = old }()
+
+	n := model.ParseName("hf.co/owner/repo:Q4_0")
+	if !n.IsValid() {
+		t.Fatal("test model name did not parse")
+	}
+	if _, _, ok := shardedFallbackCandidate(context.Background(), n, errors.New(refusalRepo)); ok {
+		t.Error("an incomplete shard set must not be offered as a fallback")
+	}
+}


### PR DESCRIPTION
## Problem

`ollama pull` cannot fetch any sharded (multi-part) GGUF model from Hugging Face. Every sharded tag fails before a single byte is transferred:

```console
$ ollama pull hf.co/owalsh/SmolLM2-135M-Instruct-GGUF-Split:Q4_0
pulling manifest
Error: pull model manifest: 400: {"error":"This repository only contains sharded GGUF files. Ollama does not yet support pulling sharded GGUF via the registry; please download the shards and merge them locally with `ollama create` (workaround detailed at https://github.com/ollama/ollama/issues/5245), or use a repository with single-file quantizations."}
```

The refusal comes from the registry, not from here — that error string does not exist in this repository.

The merge needed to handle shards already exists and works, but it is only reachable from `create`:

```
convertModelFromFiles        create.go:403  <- r.Files      (:192)
                                           <- r.Adapters   (:230)
convertDraftModelFromFiles   create.go:407  <- r.DraftFiles (:215)
  both -> convertModelFromFilesWithMediaType (:411) -> mergeSplitGGUFLayers (:456)
```

`PullModel` reaches none of it, so today users are told to download the shards by hand and run `ollama create` — the workaround in the first message of #5245.

Note that having the registry emit one layer per shard would **not** be sufficient on its own: `GetModel` assigns `m.ModelPath = filename` once per `image.model` layer (`images.go:711`, the only assignment, with no count validation), so an N-shard manifest would silently leave `ModelPath` pointing at the last shard rather than erroring.

## Change

When the registry refuses a sharded tag, fetch the shard files directly from Hugging Face and hand them to the same entry point `ollama create` uses for a local directory of shards. This automates the documented workaround in-process, which is roughly what was suggested in [#5245 (comment)](https://github.com/ollama/ollama/issues/5245#issuecomment-5235098362).

The merge itself is not reimplemented — `pullShardedGGUF` calls `convertModelFromFiles` and `createModel`, so there is no second copy of the shard logic to drift.

- `server/pull_sharded.go` (new): fallback decision, Hugging Face tree listing, shard download, hand-off to the create path
- `server/images.go` (+6): the fallback hook in `PullModel`

**The fallback is decided by capability, not by error wording.** The registry's message is not a stable contract — it was reworded on 2026-08-14, while this PR was open, from `The specified tag is a sharded GGUF…` to text pointing at `ollama create`, and it differs again for a repository that contains only sharded files. So the wording is only a fast path: on any 4xx for a Hugging Face model the repository is probed for a shard set matching the tag, and the fallback runs only if one actually exists.

```go
if !isShardedGGUFRefusal(err) && !isManifestClientError(err) {
    return nil, 0, false                        // 5xx and transport errors are never probed
}
shards, total, listErr := hfShardSet(ctx, n.Namespace+"/"+n.Model, n.Tag)
if listErr != nil {
    return nil, 0, false                        // no shard set: the original error surfaces
}
```

Unrelated rejections (an invalid quantization scheme, a genuinely missing tag) still return the registry's error unchanged, and non-Hugging-Face hosts are never probed. The shard set found while deciding is passed into the pull, so the tree is listed once.

Other behaviour:

- shards are ordered by their `NNNNN-of-NNNNN` suffix, not by listing order
- matches both quant subdirectories (`Q4_1/…`) and root-level shard files, and will not confuse `Q4_0` with `IQ4_0`
- follows `Link: rel="next"` pagination on the tree API, so repositories with many files do not silently lose shards
- single-file tags are never treated as sharded, so the normal path is untouched
- honours `HF_TOKEN` / `HUGGING_FACE_HUB_TOKEN` for private repositories, and `HF_ENDPOINT` as the `huggingface_hub` tooling does
- shards go straight into the blob store, so peak disk is the model size rather than double it as the manual workaround requires

## Testing

Unit tests (`server/pull_sharded_*_test.go`) run offline against `httptest` stubs and cover shard ordering, exact quant matching, pagination, rejection of single-file and unknown tags, host matching, and the fallback decision. Fixtures are captured from the real `owalsh/SmolLM2-135M-Instruct-GGUF-Split` repository, and all three refusal wordings observed from the registry are asserted, plus an unseen wording that still works via the probe.

`integration/pull_sharded_test.go` performs a genuine sharded pull behind the existing `//go:build integration` tag, using that repository because it is public, contains only a sharded quant, and is about 92 MB.

Real end to end against the live registry and Hugging Face:

```console
# stock ollama 0.32.9
$ ollama pull hf.co/owalsh/SmolLM2-135M-Instruct-GGUF-Split:Q4_0
Error: pull model manifest: 400: {"error":"This repository only contains sharded GGUF files. …"}

# with this change
$ ollama pull hf.co/owalsh/SmolLM2-135M-Instruct-GGUF-Split:Q4_0
pulling SmolLM2-135M-Instruct-Q4_0-00001-of-00003.gguf: 100%
pulling SmolLM2-135M-Instruct-Q4_0-00002-of-00003.gguf: 100%
pulling SmolLM2-135M-Instruct-Q4_0-00003-of-00003.gguf: 100%
parsing GGUF
verifying conversion
creating new layer sha256:a857d7fd6b6945bc71b1deb1e3b1875f8a3a678e259b91e87793d9176f55300a
using autodetected template chatml
writing manifest
success

$ ollama list
hf.co/owalsh/SmolLM2-135M-Instruct-GGUF-Split:Q4_0    91 MB
# manifest: 3 layers - model 91893088, template, params
```

The model generates normally afterwards. Tested separately against a deliberately split 415 MB model where the resulting layer digest is byte-identical to running the documented `hf download` + `ollama create` workaround by hand on the same shards, which is the clearest evidence this is the same merge producing the artifact. `go test ./server/` passes.

## Known limitations, and things to push back on

- **No resume.** Shard downloads do not use the chunked, resumable machinery in `downloadBlob`; an interrupted 50 GB pull restarts the shard it was on. This is the main thing I would want to fix before merge, and I am happy to do so — I did not want to build it on top of an approach maintainers may not want in the first place.
- **One extra request on failure.** Deciding by capability costs a tree listing on 4xx responses for Hugging Face models where the wording did not match. That seemed a better trade than depending on prose that has already changed once.
- **Hugging Face specific.** It adds a second, non-registry download route, which is exactly the kind of surface area CONTRIBUTING warns about. If the preference is to keep pull registry-only, this should be closed.
- **Alternative approach already proposed.** #16223 and #13259 instead keep N model layers and teach the runtime to load across multiple files (`ModelPaths()`, `MetaGGML`). That is the more general design and would also help shard sets too large to merge into one blob; this PR is the smaller change that reuses the merge that already shipped. They are currently unmerged and conflicting, but maintainers may prefer that direction, in which case this is redundant. For what it is worth, RamaLama takes that same shape — it downloads the parts and points llama.cpp at `-00001-of-`, relying on the runtime's native split support rather than merging.

Per CONTRIBUTING I recognise this is non-trivial and that #5245 is the discussion venue rather than a maintainer sign-off. Happy to close this if the approach is unwanted, or convert to draft while resume support is added.

For #5245
