### PR TITLE
server: add option to skip embedding normalization in /api/embed

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -610,6 +610,9 @@ type EmbedRequest struct {
 	// Truncate truncates the input to fit the model's max sequence length.
 	Truncate *bool `json:"truncate,omitempty"`
 
+	// Normalize normalizes the output embeddings. Defaults to true.
+	Normalize *bool `json:"normalize,omitempty"`
+
 	// Dimensions truncates the output embedding to the specified dimension.
 	Dimensions int `json:"dimensions,omitempty"`
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1701,6 +1701,7 @@ Generate embeddings from a model
 Advanced parameters:
 
 - `truncate`: truncates the end of each input to fit within context length. Returns error if `false` and context length is exceeded. Defaults to `true`
+- `normalize`: normalizes the output embeddings. Defaults to `true`
 - `options`: additional model parameters listed in the documentation for the [Modelfile](./modelfile.mdx#valid-parameters-and-values) such as `temperature`
 - `keep_alive`: controls how long the model will stay loaded into memory following the request (default: `5m`)
 - `dimensions`: number of dimensions for the embedding

--- a/integration/embed_test.go
+++ b/integration/embed_test.go
@@ -298,6 +298,59 @@ func runAllMiniLMBatchEmbed(t *testing.T) {
 	}
 }
 
+func runAllMiniLMEmbedNormalize(t *testing.T) {
+	if testModel != "" {
+		t.Skip("uses hardcoded model, not applicable with model override")
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	client, _, cleanup := InitServerConnection(ctx, t)
+	defer cleanup()
+
+	normalized, err := embedTestHelper(ctx, client, t, api.EmbedRequest{
+		Model: "all-minilm",
+		Input: "why is the sky blue?",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	noNormalize := false
+	raw, err := embedTestHelper(ctx, client, t, api.EmbedRequest{
+		Model:     "all-minilm",
+		Input:     "why is the sky blue?",
+		Normalize: &noNormalize,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(normalized.Embeddings) != 1 || len(raw.Embeddings) != 1 {
+		t.Fatalf("expected 1 embedding each, got %d and %d", len(normalized.Embeddings), len(raw.Embeddings))
+	}
+
+	l2Norm := func(v []float32) float64 {
+		var sum float64
+		for _, x := range v {
+			sum += float64(x) * float64(x)
+		}
+		return math.Sqrt(sum)
+	}
+
+	// The default response is L2-normalized (unit length)...
+	if n := l2Norm(normalized.Embeddings[0]); math.Abs(n-1) > 0.01 {
+		t.Fatalf("expected default embedding to be normalized (norm ~1), got %f", n)
+	}
+	// ...while normalize=false returns the raw, non-unit-length embedding.
+	if n := l2Norm(raw.Embeddings[0]); math.Abs(n-1) < 0.01 {
+		t.Fatalf("expected normalize=false embedding to not be unit length, got norm %f", n)
+	}
+	// Both point in the same direction regardless of normalization.
+	if sim := cosineSimilarity(normalized.Embeddings[0], raw.Embeddings[0]); sim < 0.99 {
+		t.Fatalf("expected same direction, cosine similarity %f", sim)
+	}
+}
+
 func runAllMiniLMEmbedTruncate(t *testing.T) {
 	if testModel != "" {
 		t.Skip("uses hardcoded model, not applicable with model override")

--- a/integration/reg_release_test.go
+++ b/integration/reg_release_test.go
@@ -83,6 +83,7 @@ func init() {
 		integrationTestCase("embedding-api", "all-minilm", runAllMiniLMEmbeddings),
 		integrationTestCase("embed-api", "all-minilm", runAllMiniLMEmbed),
 		integrationTestCase("embed-api-batch", "all-minilm", runAllMiniLMBatchEmbed),
+		integrationTestCase("embed-api-normalize", "all-minilm", runAllMiniLMEmbedNormalize),
 		integrationTestCase("embed-api-truncate", "all-minilm", runAllMiniLMEmbedTruncate),
 		integrationModelsTestCase("embed-truncation", releaseEmbedModels, runEmbedTruncation),
 		integrationModelsTestCase("embed-large-input", releaseEmbedModels, runEmbedLargeInput),

--- a/server/routes.go
+++ b/server/routes.go
@@ -968,15 +968,22 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 			if err != nil {
 				return err
 			}
-			// TODO: this first normalization should be done by the model
-			embedding, err = normalize(embedding)
-			if err != nil {
-				return err
-			}
-			if req.Dimensions > 0 && req.Dimensions < len(embedding) {
-				embedding, err = normalize(embedding[:req.Dimensions])
+			// Normalization defaults to true to preserve the previous behavior.
+			normalizeEmbeddings := req.Normalize == nil || *req.Normalize
+			if normalizeEmbeddings {
+				// TODO: this first normalization should be done by the model
+				embedding, err = normalize(embedding)
 				if err != nil {
 					return err
+				}
+			}
+			if req.Dimensions > 0 && req.Dimensions < len(embedding) {
+				embedding = embedding[:req.Dimensions]
+				if normalizeEmbeddings {
+					embedding, err = normalize(embedding)
+					if err != nil {
+						return err
+					}
 				}
 			}
 			embeddings[i] = embedding


### PR DESCRIPTION
Fixes #6496

Adds an optional `normalize` field to the `/api/embed` request. It defaults to `true`, so the current behavior is unchanged; setting it to `false` returns the raw (non-normalized) embedding. Dimensions truncation still applies in both cases.

This revives the approach from the stale-closed #8145 (which @gabe-l-hart said he was happy to revisit).

**Changes**
- `api`: `EmbedRequest.Normalize *bool`
- `server`: skip the L2 normalization in `EmbedHandler` when `normalize: false`
- `docs/api.md`: document the parameter
- integration test (`embed-api-normalize`): asserts the default response is unit-length, `normalize: false` is not, and both point the same direction

**Example**
```
curl http://localhost:11434/api/embed -d '{
  "model": "all-minilm",
  "input": "why is the sky blue?",
  "normalize": false
}'
```

Verified locally: `go build ./server/`, `go vet -tags integration ./integration/`, `gofmt`, and the existing `TestNormalize` unit test all pass. The integration test itself runs in CI (needs the `all-minilm` model).
