### PR TITLE
Add a model metadata cache to reduce Ollama’s per-request overhead

### DIFF
--- a/server/images.go
+++ b/server/images.go
@@ -80,6 +80,9 @@ type Model struct {
 	Messages           []api.Message
 
 	Template *template.Template
+
+	capabilities       []model.Capability
+	capabilitiesCached bool
 }
 
 func (m *Model) IsMLX() bool {
@@ -107,6 +110,10 @@ const (
 
 // Capabilities returns the capabilities that the model supports
 func (m *Model) Capabilities() []model.Capability {
+	if m.capabilitiesCached {
+		return slices.Clone(m.capabilities)
+	}
+
 	capabilities := m.capabilitiesForTemplate(templateCapabilitySelected, nil)
 	if len(capabilities) == 0 {
 		slog.Warn("unknown capabilities for model", "model", m.Name)

--- a/server/model_caches.go
+++ b/server/model_caches.go
@@ -6,6 +6,7 @@ type modelCaches struct {
 	recommendations *modelRecommendationsCache
 	show            *modelShowCache
 	modelList       *modelListCache
+	inference       *inferenceModelCache
 }
 
 func newModelCaches() *modelCaches {
@@ -13,6 +14,7 @@ func newModelCaches() *modelCaches {
 		recommendations: newModelRecommendationsCache(),
 		show:            newModelShowCache(),
 		modelList:       newModelListCache(),
+		inference:       newInferenceModelCache(),
 	}
 }
 

--- a/server/model_inference_cache.go
+++ b/server/model_inference_cache.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"maps"
+	"slices"
+	"strconv"
+	"sync"
+
+	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/manifest"
+	"github.com/ollama/ollama/types/model"
+	"golang.org/x/sync/singleflight"
+)
+
+// inferenceModelCache stores fully resolved model metadata and capabilities.
+// Model blobs are content-addressed, and the manifest digest is the freshness
+// boundary, so cached entries remain valid until the model is recreated or
+// pulled with different content.
+type inferenceModelCache struct {
+	mu      sync.RWMutex
+	entries map[inferenceModelCacheKey]inferenceModelCacheEntry
+	loads   singleflight.Group
+
+	loadModel func(string) (*Model, error)
+}
+
+type inferenceModelCacheKey struct {
+	name          string
+	goTemplate    bool
+	goTemplateSet bool
+}
+
+type inferenceModelCacheEntry struct {
+	digest string
+	model  *Model
+}
+
+func newInferenceModelCache() *inferenceModelCache {
+	return &inferenceModelCache{
+		entries:   make(map[inferenceModelCacheKey]inferenceModelCacheEntry),
+		loadModel: GetModel,
+	}
+}
+
+func (c *inferenceModelCache) Get(name string) (*Model, error) {
+	n := model.ParseName(name)
+	mf, err := manifest.ParseNamedManifest(n)
+	if err != nil {
+		return nil, err
+	}
+
+	key := inferenceModelCacheKey{
+		name:          n.String(),
+		goTemplate:    envconfig.GoTemplate(true),
+		goTemplateSet: goTemplateEnvSet(),
+	}
+	digest := mf.Digest()
+
+	c.mu.RLock()
+	entry, ok := c.entries[key]
+	c.mu.RUnlock()
+	if ok && entry.digest == digest {
+		return cloneInferenceModel(entry.model), nil
+	}
+
+	loadKey := key.name + "\x00" + digest + "\x00" + strconv.FormatBool(key.goTemplate) + "\x00" + strconv.FormatBool(key.goTemplateSet)
+	v, err, _ := c.loads.Do(loadKey, func() (any, error) {
+		c.mu.RLock()
+		entry, ok := c.entries[key]
+		c.mu.RUnlock()
+		if ok && entry.digest == digest {
+			return entry.model, nil
+		}
+
+		m, err := c.loadModel(name)
+		if err != nil {
+			return nil, err
+		}
+		m.capabilities = m.Capabilities()
+		m.capabilitiesCached = true
+
+		c.mu.Lock()
+		c.entries[key] = inferenceModelCacheEntry{digest: m.Digest, model: m}
+		c.mu.Unlock()
+		return m, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return cloneInferenceModel(v.(*Model)), nil
+}
+
+func cloneInferenceModel(src *Model) *Model {
+	if src == nil {
+		return nil
+	}
+
+	dst := *src
+	dst.Config.ModelFamilies = slices.Clone(src.Config.ModelFamilies)
+	dst.Config.Capabilities = slices.Clone(src.Config.Capabilities)
+	if src.Config.Draft != nil {
+		draft := *src.Config.Draft
+		dst.Config.Draft = &draft
+	}
+	dst.AdapterPaths = slices.Clone(src.AdapterPaths)
+	dst.ProjectorPaths = slices.Clone(src.ProjectorPaths)
+	dst.License = slices.Clone(src.License)
+	dst.Options = maps.Clone(src.Options)
+	dst.Messages = slices.Clone(src.Messages)
+	dst.capabilities = slices.Clone(src.capabilities)
+
+	return &dst
+}
+
+func (s *Server) getModel(name string) (*Model, error) {
+	if s != nil && s.modelCaches != nil && s.modelCaches.inference != nil {
+		return s.modelCaches.inference.Get(name)
+	}
+	return GetModel(name)
+}

--- a/server/model_inference_cache_test.go
+++ b/server/model_inference_cache_test.go
@@ -1,0 +1,121 @@
+package server
+
+import (
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ollama/ollama/fs/ggml"
+	"github.com/ollama/ollama/types/model"
+)
+
+func TestInferenceModelCache(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+	t.Setenv("OLLAMA_GO_TEMPLATE", "")
+
+	_, completionDigest := createBinFile(t, ggml.KV{
+		"general.architecture": "llama",
+	}, nil)
+	writeTestModelManifest(t, "inference-cache", completionDigest, "{{ .Prompt }}")
+
+	cache := newInferenceModelCache()
+	loadCount := 0
+	cache.loadModel = func(name string) (*Model, error) {
+		loadCount++
+		return GetModel(name)
+	}
+
+	first, err := cache.Get("inference-cache")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loadCount != 1 {
+		t.Fatalf("load count = %d, want 1", loadCount)
+	}
+	if !first.capabilitiesCached {
+		t.Fatal("capabilities were not cached")
+	}
+	if got := first.Capabilities(); !slices.Contains(got, model.CapabilityCompletion) {
+		t.Fatalf("capabilities = %v, want completion", got)
+	}
+
+	// Returned models are request-local clones. Mutating one must not alter the
+	// cached model or a later request.
+	first.Config.Parser = "mutated"
+	first.Config.ModelFamilies[0] = "mutated"
+	first.capabilities[0] = model.CapabilityImage
+
+	second, err := cache.Get("inference-cache")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loadCount != 1 {
+		t.Fatalf("cache hit load count = %d, want 1", loadCount)
+	}
+	if second.Config.Parser == "mutated" || slices.Contains(second.Config.ModelFamilies, "mutated") {
+		t.Fatalf("cached model was mutated: %#v", second.Config)
+	}
+	if got := second.Capabilities(); !slices.Contains(got, model.CapabilityCompletion) || slices.Contains(got, model.CapabilityImage) {
+		t.Fatalf("cached capabilities = %v, want completion only", got)
+	}
+
+	// Recreating the manifest changes its digest and invalidates the entry.
+	_, embeddingDigest := createBinFile(t, ggml.KV{
+		"general.architecture": "bert",
+		"bert.pooling_type":    uint32(1),
+	}, nil)
+	writeTestModelManifest(t, "inference-cache", embeddingDigest, "{{ .Prompt }}")
+
+	third, err := cache.Get("inference-cache")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loadCount != 2 {
+		t.Fatalf("invalidated load count = %d, want 2", loadCount)
+	}
+	if got := third.Capabilities(); !slices.Contains(got, model.CapabilityEmbedding) || slices.Contains(got, model.CapabilityCompletion) {
+		t.Fatalf("refreshed capabilities = %v, want embedding only", got)
+	}
+}
+
+func TestInferenceModelCacheConcurrentMiss(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+	t.Setenv("OLLAMA_GO_TEMPLATE", "")
+
+	_, digest := createBinFile(t, ggml.KV{
+		"general.architecture": "llama",
+	}, nil)
+	writeTestModelManifest(t, "inference-cache-concurrent", digest, "{{ .Prompt }}")
+
+	cache := newInferenceModelCache()
+	var loadCount atomic.Int32
+	cache.loadModel = func(name string) (*Model, error) {
+		loadCount.Add(1)
+		time.Sleep(10 * time.Millisecond)
+		return GetModel(name)
+	}
+
+	var wg sync.WaitGroup
+	errs := make(chan error, 8)
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := cache.Get("inference-cache-concurrent")
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+	if got := loadCount.Load(); got != 1 {
+		t.Fatalf("load count = %d, want 1", got)
+	}
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -199,14 +199,9 @@ func usesAutomaticNumBatch(model *Model, requestOpts map[string]any) bool {
 
 // scheduleRunner schedules a runner after validating inputs such as capabilities and model options.
 // It returns the allocated runner, model instance, and consolidated options if successful and error otherwise.
-func (s *Server) scheduleRunner(ctx context.Context, name string, caps []model.Capability, requestOpts map[string]any, keepAlive *api.Duration, shift *bool) (llm.LlamaServer, *Model, *api.Options, error) {
-	if name == "" {
+func (s *Server) scheduleRunner(ctx context.Context, model *Model, caps []model.Capability, requestOpts map[string]any, keepAlive *api.Duration, shift *bool) (llm.LlamaServer, *Model, *api.Options, error) {
+	if model == nil || model.Name == "" {
 		return nil, nil, nil, fmt.Errorf("model %w", errRequired)
-	}
-
-	model, err := GetModel(name)
-	if err != nil {
-		return nil, nil, nil, err
 	}
 
 	if slices.Contains(model.Config.ModelFamilies, "mllama") && len(model.ProjectorPaths) > 0 {
@@ -214,7 +209,7 @@ func (s *Server) scheduleRunner(ctx context.Context, name string, caps []model.C
 	}
 
 	if err := model.CheckCapabilities(caps...); err != nil {
-		return nil, nil, nil, fmt.Errorf("%s %w", name, err)
+		return nil, nil, nil, fmt.Errorf("%s %w", model.Name, err)
 	}
 
 	numCtxAuto := usesAutomaticNumCtx(model, requestOpts)
@@ -287,7 +282,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		return
 	}
 
-	m, err := GetModel(name.String())
+	m, err := s.getModel(name.String())
 	if err != nil {
 		switch {
 		case errors.Is(err, fs.ErrNotExist):
@@ -468,7 +463,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		}
 	}
 
-	r, m, opts, err := s.scheduleRunner(c.Request.Context(), name.String(), caps, req.Options, req.KeepAlive, req.Shift)
+	r, m, opts, err := s.scheduleRunner(c.Request.Context(), m, caps, req.Options, req.KeepAlive, req.Shift)
 	if errors.Is(err, errCapabilityCompletion) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%q does not support generate", req.Model)})
 		return
@@ -839,7 +834,13 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		return
 	}
 
-	r, m, opts, err := s.scheduleRunner(c.Request.Context(), name.String(), []model.Capability{}, req.Options, req.KeepAlive, nil)
+	m, err := s.getModel(name.String())
+	if err != nil {
+		handleScheduleError(c, req.Model, err)
+		return
+	}
+
+	r, m, opts, err := s.scheduleRunner(c.Request.Context(), m, []model.Capability{}, req.Options, req.KeepAlive, nil)
 	if err != nil {
 		handleScheduleError(c, req.Model, err)
 		return
@@ -1051,7 +1052,13 @@ func (s *Server) EmbeddingsHandler(c *gin.Context) {
 
 	name := modelRef.Name
 
-	r, m, _, err := s.scheduleRunner(c.Request.Context(), name.String(), []model.Capability{}, req.Options, req.KeepAlive, nil)
+	m, err := s.getModel(name.String())
+	if err != nil {
+		handleScheduleError(c, req.Model, err)
+		return
+	}
+
+	r, m, _, err := s.scheduleRunner(c.Request.Context(), m, []model.Capability{}, req.Options, req.KeepAlive, nil)
 	if err != nil {
 		handleScheduleError(c, req.Model, err)
 		return
@@ -2460,7 +2467,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		return
 	}
 
-	m, err := GetModel(name.String())
+	m, err := s.getModel(name.String())
 	if err != nil {
 		switch {
 		case os.IsNotExist(err):
@@ -2613,7 +2620,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 		}
 	}
 
-	r, m, opts, err := s.scheduleRunner(c.Request.Context(), name.String(), caps, req.Options, req.KeepAlive, req.Shift)
+	r, m, opts, err := s.scheduleRunner(c.Request.Context(), m, caps, req.Options, req.KeepAlive, req.Shift)
 	if errors.Is(err, errCapabilityCompletion) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("%q does not support chat", req.Model)})
 		return


### PR DESCRIPTION
Previously, a chat or generate request read GGUF metadata multiple time in every inference call. This caused an overhead of about ~300 ms in each inference call. This PR:
- Caches resolved model metadata and capabilities.
- Invalidates automatically when the model manifest changes.
- Prevents duplicate concurrent loads with singleflight.
- Returns request-local clones to avoid shared mutations.
- Removes the duplicate GetModel() call from runner scheduling.
- Applies to generate, chat, and embedding endpoints.
- Adds tests for cache hits, invalidation, isolation, and concurrency.

Performance
==========
Performance was measured using [aiperf](https://github.com/ai-dynamo/aiperf) with [speed-bench](https://github.com/ai-dynamo/aiperf/blob/main/docs/tutorials/speed-bench.md) dataset. TTFT goes down from 995 ms to 524 ms in this benchmark.
```
export ENDPOINT_URL='http://127.0.0.1:11434'
export MODEL_HANDLE='qwen3.6:35b-a3b-mtp-q4_K_M'
export TOKENIZER='Qwen/Qwen3.6-35B-A3B'
export SPEED_BENCH_DIR=<path to speed-bench dataset>
aiperf profile   --model "$MODEL_HANDLE"   --tokenizer "$TOKENIZER"   --endpoint-type chat   --streaming   --url "$ENDPOINT_URL"   --custom-dataset-type speed_bench_coding   --input-file "$SPEED_BENCH_DIR/qualitative.jsonl"   --request-count 10   --dataset-sampling-strategy sequential   --random-seed 42   --concurrency 1   --osl 512   --extra-inputs 'temperature:1.0' 'top_p:0.95' 'seed:42' 'top_k:20' 'presence_penalty:0.0'   --server-metrics "$ENDPOINT_URL/metrics"   --use-server-token-count   --output-artifact-dir artifacts/speed-bench-smoke/coding
```

Master:

```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓
┃                                        Metric ┃       avg ┃      min ┃        max ┃        p99 ┃       p90 ┃       p50 ┃       std ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━┩
│                      Time to First Token (ms) │    994.79 │   455.24 │   4,451.26 │   4,157.56 │  1,514.24 │    551.72 │  1,169.32 │
│                     Time to Second Token (ms) │     35.94 │    33.96 │      37.33 │      37.28 │     36.79 │     35.99 │      0.89 │
│               Time to First Output Token (ms) │ 38,026.17 │ 7,496.98 │ 104,871.89 │ 100,610.18 │ 62,254.81 │ 32,265.17 │ 26,162.77 │
│                          Request Latency (ms) │ 42,452.71 │ 9,880.78 │ 109,687.26 │ 105,371.05 │ 66,525.16 │ 38,442.89 │ 26,265.44 │
│                          Decode Duration (ms) │ 41,457.91 │ 8,692.87 │ 109,232.01 │ 104,906.18 │ 65,973.68 │ 35,898.20 │ 26,431.65 │
│                      Inter Token Latency (ms) │      9.49 │     8.52 │      10.74 │      10.65 │      9.87 │      9.36 │      0.54 │
│              Output Token Throughput Per User │    105.75 │    93.13 │     117.38 │     116.63 │    109.84 │    106.83 │      5.93 │
│                             (tokens/sec/user) │           │          │            │            │           │           │           │
│ E2E Output Token Throughput (tokens/sec/user) │    102.10 │    90.68 │     114.12 │     113.49 │    107.84 │    105.45 │      7.56 │
│               Output Sequence Length (tokens) │  4,273.20 │   896.00 │  10,174.00 │   9,840.73 │  6,841.30 │  3,810.00 │  2,426.92 │
│                Input Sequence Length (tokens) │  1,337.90 │    37.00 │  10,227.00 │   9,490.80 │  2,865.00 │    143.00 │  3,018.39 │
│          Output Token Throughput (tokens/sec) │    100.59 │      N/A │        N/A │        N/A │       N/A │       N/A │       N/A │
│           Input Token Throughput (tokens/sec) │     31.49 │      N/A │        N/A │        N/A │       N/A │       N/A │       N/A │
│             Request Throughput (requests/sec) │      0.02 │      N/A │        N/A │        N/A │       N/A │       N/A │       N/A │
│                        Request Error Rate (%) │      0.00 │      N/A │        N/A │        N/A │       N/A │       N/A │       N/A │
│                      Request Count (requests) │     10.00 │      N/A │        N/A │        N/A │       N/A │       N/A │       N/A │
└───────────────────────────────────────────────┴───────────┴──────────┴────────────┴────────────┴───────────┴───────────┴───────────┘

```

PR:
```
┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓
┃                                        Metric ┃       avg ┃       min ┃       max ┃       p99 ┃       p90 ┃       p50 ┃       std ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━┩
│                      Time to First Token (ms) │    524.15 │    180.47 │  2,134.94 │  2,035.07 │  1,136.23 │    283.88 │    584.82 │
│                     Time to Second Token (ms) │     38.16 │     34.82 │     56.18 │     54.52 │     39.56 │     36.07 │      6.06 │
│               Time to First Output Token (ms) │ 29,540.57 │  9,114.24 │ 46,664.44 │ 46,330.17 │ 43,321.75 │ 30,541.21 │ 12,500.96 │
│                          Request Latency (ms) │ 34,381.34 │ 12,436.19 │ 51,475.33 │ 51,267.02 │ 49,392.28 │ 34,450.00 │ 12,458.47 │
│                          Decode Duration (ms) │ 33,857.19 │ 11,410.93 │ 51,199.47 │ 50,999.75 │ 49,202.27 │ 34,150.43 │ 12,724.47 │
│                      Inter Token Latency (ms) │      9.47 │      8.58 │      9.97 │      9.97 │      9.92 │      9.66 │      0.47 │
│              Output Token Throughput Per User │    105.89 │    100.25 │    116.52 │    116.17 │    113.07 │    103.52 │      5.41 │
│                             (tokens/sec/user) │           │           │           │           │           │           │           │
│ E2E Output Token Throughput (tokens/sec/user) │    103.64 │     92.07 │    115.35 │    115.04 │    112.28 │    103.05 │      7.17 │
│               Output Sequence Length (tokens) │  3,584.10 │  1,145.00 │  5,497.00 │  5,450.92 │  5,036.20 │  3,494.00 │  1,343.88 │
│                Input Sequence Length (tokens) │    832.30 │     37.00 │  5,039.00 │  4,781.60 │  2,465.00 │    143.00 │  1,530.92 │
│          Output Token Throughput (tokens/sec) │    104.19 │       N/A │       N/A │       N/A │       N/A │       N/A │       N/A │
│           Input Token Throughput (tokens/sec) │     24.20 │       N/A │       N/A │       N/A │       N/A │       N/A │       N/A │
│             Request Throughput (requests/sec) │      0.03 │       N/A │       N/A │       N/A │       N/A │       N/A │       N/A │
│                        Request Error Rate (%) │      0.00 │       N/A │       N/A │       N/A │       N/A │       N/A │       N/A │
│                      Request Count (requests) │     10.00 │       N/A │       N/A │       N/A │       N/A │       N/A │       N/A │
└───────────────────────────────────────────────┴───────────┴───────────┴───────────┴───────────┴───────────┴───────────┴───────────┘
```
