### PR TITLE
server: log debug inference requests before handling them, not after

### DIFF
--- a/server/inference_request_log.go
+++ b/server/inference_request_log.go
@@ -79,8 +79,8 @@ func (l *inferenceRequestLogger) middleware(route string) gin.HandlerFunc {
 			}
 		}
 
-		c.Next()
 		l.log(route, method, scheme, host, contentType, body)
+		c.Next()
 	}
 }
 

--- a/server/routes_request_log_test.go
+++ b/server/routes_request_log_test.go
@@ -88,6 +88,42 @@ func TestInferenceRequestLoggerMiddlewareWritesReplayArtifacts(t *testing.T) {
 	}
 }
 
+func TestInferenceRequestLoggerMiddlewareLogsBeforeHandlerRuns(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	logDir := t.TempDir()
+	requestLogger := &inferenceRequestLogger{dir: logDir}
+
+	const route = "/api/generate"
+	const requestBody = `{"model":"test-model","prompt":"hello"}`
+
+	var bodyFilesWhenHandlerRan int
+
+	r := gin.New()
+	r.POST(route, requestLogger.middleware(route), func(c *gin.Context) {
+		bodyFiles, err := filepath.Glob(filepath.Join(logDir, "*_api_generate_body.json"))
+		if err != nil {
+			t.Fatalf("failed to glob body logs: %v", err)
+		}
+		bodyFilesWhenHandlerRan = len(bodyFiles)
+		c.Status(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, route, strings.NewReader(requestBody))
+	req.Host = "127.0.0.1:11434"
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d", w.Code)
+	}
+
+	if bodyFilesWhenHandlerRan != 1 {
+		t.Fatalf("expected the request to already be logged before the handler runs, found %d log files", bodyFilesWhenHandlerRan)
+	}
+}
+
 func TestNewInferenceRequestLoggerCreatesDirectory(t *testing.T) {
 	requestLogger, err := newInferenceRequestLogger()
 	if err != nil {


### PR DESCRIPTION
Fixes #17437

`OLLAMA_DEBUG_LOG_REQUESTS` wrote the request log after `c.Next()` returned, so for long-running inference requests the log entry (and replay curl script) only appeared once the response had already been sent. This made the debug log useless for observing requests while they were still in flight.

## Fix

Move `l.log(...)` before `c.Next()` in the middleware so the request is logged as soon as it's received, before the handler runs.

## Testing

- Added `TestInferenceRequestLoggerMiddlewareLogsBeforeHandlerRuns`, which asserts the log file already exists by the time the downstream handler runs. Verified it fails on the pre-fix code and passes after the fix.
- Existing tests in `server/routes_request_log_test.go` still pass.
- `go build ./server/...` succeeds.