### PR TITLE
fix: honor Modelfile temperature on /v1/chat/completions

### DIFF
--- a/middleware/openai_test.go
+++ b/middleware/openai_test.go
@@ -839,8 +839,7 @@ func TestChatMiddleware(t *testing.T) {
 					},
 				},
 				Options: map[string]any{
-					"temperature": 1.0,
-					"top_p":       1.0,
+					"top_p": 1.0,
 				},
 				Stream: &False,
 			},
@@ -962,8 +961,7 @@ func TestChatMiddleware(t *testing.T) {
 					},
 				},
 				Options: map[string]any{
-					"temperature": 1.0,
-					"top_p":       1.0,
+					"top_p": 1.0,
 				},
 				Stream: &False,
 			},
@@ -1001,8 +999,7 @@ func TestChatMiddleware(t *testing.T) {
 					},
 				},
 				Options: map[string]any{
-					"temperature": 1.0,
-					"top_p":       1.0,
+					"top_p": 1.0,
 				},
 				Stream: &False,
 			},
@@ -1041,8 +1038,7 @@ func TestChatMiddleware(t *testing.T) {
 					},
 				},
 				Options: map[string]any{
-					"temperature": 1.0,
-					"top_p":       1.0,
+					"top_p": 1.0,
 				},
 				Stream: &False,
 			},
@@ -1080,8 +1076,7 @@ func TestChatMiddleware(t *testing.T) {
 					},
 				},
 				Options: map[string]any{
-					"temperature": 1.0,
-					"top_p":       1.0,
+					"top_p": 1.0,
 				},
 				Stream: &False,
 			},
@@ -1120,8 +1115,7 @@ func TestChatMiddleware(t *testing.T) {
 					},
 				},
 				Options: map[string]any{
-					"temperature": 1.0,
-					"top_p":       1.0,
+					"top_p": 1.0,
 				},
 				Stream: &False,
 			},
@@ -1166,8 +1160,7 @@ func TestChatMiddleware(t *testing.T) {
 					},
 				},
 				Options: map[string]any{
-					"temperature": 1.0,
-					"top_p":       1.0,
+					"top_p": 1.0,
 				},
 				Stream: &False,
 			},
@@ -1211,8 +1204,7 @@ func TestChatMiddleware(t *testing.T) {
 					},
 				},
 				Options: map[string]any{
-					"temperature": 1.0,
-					"top_p":       1.0,
+					"top_p": 1.0,
 				},
 				Stream: &False,
 			},
@@ -1279,8 +1271,7 @@ func TestChatMiddleware(t *testing.T) {
 					},
 				},
 				Options: map[string]any{
-					"temperature": 1.0,
-					"top_p":       1.0,
+					"top_p": 1.0,
 				},
 				Stream: &True,
 			},

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -659,8 +659,6 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 
 	if r.Temperature != nil {
 		options["temperature"] = *r.Temperature
-	} else {
-		options["temperature"] = 1.0
 	}
 
 	if r.Seed != nil {

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -56,6 +56,35 @@ func TestFromChatRequest_Basic(t *testing.T) {
 	}
 }
 
+func TestFromChatRequest_TemperatureFallback(t *testing.T) {
+	req := ChatCompletionRequest{
+		Model: "test-model",
+		Messages: []Message{
+			{Role: "user", Content: "Hello"},
+		},
+	}
+
+	result, err := FromChatRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, ok := result.Options["temperature"]; ok {
+		t.Errorf("expected temperature to be unset when omitted from the request, got %v", result.Options["temperature"])
+	}
+
+	temp := 0.2
+	req.Temperature = &temp
+	result, err = FromChatRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if tempVal, ok := result.Options["temperature"].(float64); !ok || tempVal != 0.2 {
+		t.Errorf("expected temperature 0.2, got %v", result.Options["temperature"])
+	}
+}
+
 func TestFromChatRequest_ReasoningEffort(t *testing.T) {
 	effort := func(s string) *string { return &s }
 


### PR DESCRIPTION
Fixes #17744

When a request to /v1/chat/completions omits temperature, the OpenAI-compat layer injected a hardcoded default of 1.0 into the options map, which overrode the model's Modelfile PARAMETER temperature. Other manifest parameters (e.g. num_ctx) are honored because the request options only override the model options when explicitly set.

Remove the fallback: temperature is now only set when the request provides it, so the model's manifest value (or the default 0.8) applies — matching /api/chat behavior.