### PR TITLE
fix: return 400 when /api/chat messages contain audios/audio fields

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"iter"
 	"log/slog"
@@ -211,6 +212,17 @@ func (m *Message) UnmarshalJSON(b []byte) error {
 	var a Alias
 	if err := json.Unmarshal(b, &a); err != nil {
 		return err
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return err
+	}
+	if _, ok := raw["audios"]; ok {
+		return errors.New("audio input is not supported on the chat API; use the /v1/chat/completions endpoint with input_audio instead")
+	}
+	if _, ok := raw["audio"]; ok {
+		return errors.New("audio input is not supported on the chat API; use the /v1/chat/completions endpoint with input_audio instead")
 	}
 
 	*m = Message(a)

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"math"
+	"strings"
 	"testing"
 	"time"
 
@@ -303,6 +304,29 @@ func TestMessage_UnmarshalJSON(t *testing.T) {
 		if msg.Role != test.expected {
 			t.Errorf("role not lowercased: got %v, expected %v", msg.Role, test.expected)
 		}
+	}
+}
+
+func TestMessage_UnmarshalJSONRejectsAudio(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{"audios", `{"role": "user", "content": "hi", "audios": ["data:audio/wav;base64,AAAA"]}`},
+		{"audio", `{"role": "user", "content": "hi", "audio": "data:audio/wav;base64,AAAA"}`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var msg Message
+			err := json.Unmarshal([]byte(test.input), &msg)
+			if err == nil {
+				t.Fatalf("expected error for %s field, got nil", test.name)
+			}
+			if !strings.Contains(err.Error(), "audio input is not supported") {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
Fixes #17730

When a message sent to /api/chat includes an \udios\ (or \udio\) field, the field is silently dropped during JSON unmarshalling and the model answers without ever receiving the audio, producing a plausible but blind response.

This change makes Message.UnmarshalJSON detect the \udios\/\udio\ keys and return a clear error, so the request fails with HTTP 400 explaining that audio input is unsupported on /api/chat and pointing to /v1/chat/completions with input_audio (which already works).

Adds coverage in api/types_test.go (TestMessage_UnmarshalJSONRejectsAudio).