### PR TITLE
server: auto-detect qwen3-coder renderer/parser for qwen3moe architecture

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -810,6 +810,9 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 					case "laguna":
 						config.Renderer = cmp.Or(config.Renderer, "laguna")
 						config.Parser = cmp.Or(config.Parser, "laguna")
+					case "qwen3moe":
+						config.Renderer = cmp.Or(config.Renderer, "qwen3-coder")
+						config.Parser = cmp.Or(config.Parser, "qwen3-coder")
 					case "nemotron_h", "nemotron_h_moe", "nemotron_h_omni":
 						config.Renderer = cmp.Or(config.Renderer, "nemotron-3-nano")
 						config.Parser = cmp.Or(config.Parser, "nemotron-3-nano")

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -1731,6 +1731,35 @@ func TestCreateNemotronHDefaultsKeepExplicitRendererParser(t *testing.T) {
 	}
 }
 
+func TestCreateQwen3MoeDefaultsRendererParser(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	p := t.TempDir()
+	t.Setenv("OLLAMA_MODELS", p)
+	var s Server
+
+	_, digest := createBinFile(t, ggml.KV{
+		"general.architecture": "qwen3moe",
+	}, nil)
+
+	w := createRequest(t, s.CreateHandler, api.CreateRequest{
+		Name:   "test",
+		Files:  map[string]string{"test.gguf": digest},
+		Stream: &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status code 200, actual %d", w.Code)
+	}
+
+	cfg := readCreatedModelConfig(t, "test")
+	if cfg.Renderer != "qwen3-coder" {
+		t.Fatalf("expected renderer %q, got %q", "qwen3-coder", cfg.Renderer)
+	}
+	if cfg.Parser != "qwen3-coder" {
+		t.Fatalf("expected parser %q, got %q", "qwen3-coder", cfg.Parser)
+	}
+}
+
 func TestDetectModelTypeFromFiles(t *testing.T) {
 	t.Run("gguf file", func(t *testing.T) {
 		_, digest := createBinFile(t, nil, nil)


### PR DESCRIPTION
Fixes #17636

When a GGUF is pulled directly from Hugging Face (\ollama pull hf.co/...\) with the \qwen3moe\ architecture (e.g. Qwen3-Coder-30B-A3B-Instruct), the built-in \qwen3-coder\ RENDERER/PARSER pair is not assigned, so the model falls back to the auto-generated generic template and tool-calling becomes unreliable.

This extends the existing architecture-based auto-detection in \createModel\ (already present for gemma4, laguna, nemotron_h) to \qwen3moe\, matching what the official library \qwen3-coder\ model ships with.