### PR TITLE
parsers: preserve tool-call parsing context in qwen3-vl client errors

### DIFF
--- a/model/parsers/qwen3vl.go
+++ b/model/parsers/qwen3vl.go
@@ -3,6 +3,7 @@ package parsers
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"strings"
 	"unicode"
@@ -88,7 +89,7 @@ func (p *Qwen3VLParser) Add(s string, done bool) (content string, thinking strin
 			toolCall, err := parseJSONToolCall(event, p.tools)
 			if err != nil {
 				slog.Warn("qwen tool call parsing failed", "error", err)
-				return "", "", nil, err
+				return "", "", nil, fmt.Errorf("failed to parse model-generated tool call: %w", err)
 			}
 			calls = append(calls, toolCall)
 		case qwenEventThinkingContent:

--- a/model/parsers/qwen3vl_nonthinking_test.go
+++ b/model/parsers/qwen3vl_nonthinking_test.go
@@ -2,6 +2,7 @@ package parsers
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -215,6 +216,19 @@ func TestQwen3VLNonThinkingParserStreaming(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestQwen3VLNonThinkingParserErrorIncludesContext(t *testing.T) {
+	parser := Qwen3VLParser{hasThinkingSupport: false}
+	parser.Init([]api.Tool{}, nil, nil)
+
+	_, _, _, err := parser.Add(`<tool_call>{malformed</tool_call>`, true)
+	if err == nil {
+		t.Fatal("expected error from malformed tool call")
+	}
+	if !strings.Contains(err.Error(), "failed to parse model-generated tool call") {
+		t.Fatalf("expected error to include parsing context, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
Fixes #17647

When the Qwen3-VL tool-call parser fails, only the low-level JSON error is returned to the client (\invalid character ']' after object key:value pair\), losing the context that a model-generated tool call failed to parse. This makes the failure look like a client bug.

Wrap the error with parsing context so the API response identifies the failure stage.