### PR TITLE
Add Engram to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ console.log(response.message.content);
 - [Archyve](https://github.com/nickthecook/archyve) - RAG-enabling document library
 - [Casibase](https://casibase.org) - AI knowledge base with RAG and SSO
 - [BrainSoup](https://www.nurgo-software.com/products/brainsoup) - Native client with RAG and multi-agent automation
+- [Engram](https://github.com/hicka/engram) - Transparent proxy that gives models persistent cross-session memory
 
 ### Bots & Messaging
 


### PR DESCRIPTION
Adds Engram to the RAG & Knowledge Bases list.

Engram is a transparent memory proxy for Ollama. You point any client at it instead of :11434 and your models remember across sessions: it recalls relevant memories from past conversations, injects a small budgeted block, and summarizes exchanges in the background when the GPU is idle. No code changes on the client side, no separate vector database, everything lives in one SQLite file. Recall runs locally with no LLM calls on the request path and falls back to plain passthrough on any failure, so it never gets between Ollama and the client when something goes wrong.

Works with the Ollama chat API natively (also speaks the OpenAI-compatible route). MIT licensed.

Repo: https://github.com/hicka/engram
Docs: https://hicka.github.io/engram