### PR TITLE
readme: add AmicoScript to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ console.log(response.message.content);
 - [Serene Pub](https://github.com/doolijb/serene-pub) - AI roleplaying app
 - [Mayan EDMS](https://gitlab.com/mayan-edms/mayan-edms) - Document management with Ollama workflows
 - [TagSpaces](https://www.tagspaces.org) - File management with [AI tagging](https://docs.tagspaces.org/ai/)
+- [AmicoScript](https://github.com/sim186/AmicoScript) - Local audio and video transcription with Ollama-powered summaries and translations
 
 ### Observability & Monitoring
 


### PR DESCRIPTION
Adds AmicoScript to `Community Integrations > Productivity & Apps`.

AmicoScript transcribes audio and video locally with Whisper, then sends the transcript to an Ollama server to generate summaries, action items, translations and custom analyses. Ollama is the default provider: the app ships `http://localhost:11434` as the default endpoint (rewritten to `host.docker.internal` when running in a container), lists models through the OpenAI-compatible `/v1/models` endpoint, chats through `/v1/chat/completions`, and can pull new models from the UI via Ollama's native `/api/pull` with streaming progress.

- Repo: https://github.com/sim186/AmicoScript
- License: MIT
- One line added to the README, no code changes.
