### PR TITLE
convert/llama4: set tokenizer.ggml.pre to llama4

### DIFF
--- a/convert/convert_llama4.go
+++ b/convert/convert_llama4.go
@@ -38,6 +38,7 @@ type llama4Model struct {
 func (p *llama4Model) KV(t *Tokenizer) KV {
 	kv := p.ModelParameters.KV(t)
 	kv["general.architecture"] = "llama4"
+	kv["tokenizer.ggml.pre"] = "llama4"
 
 	for k, v := range p.TextModel.KV(t) {
 		if strings.HasPrefix(k, "llama.") {

--- a/convert/convert_llama4_test.go
+++ b/convert/convert_llama4_test.go
@@ -1,0 +1,20 @@
+package convert
+
+import "testing"
+
+func TestLlama4TokenizerPre(t *testing.T) {
+	p := llama4Model{}
+	p.ModelParameters.VocabSize = 200000
+	p.TextModel.NumHiddenLayers = 4
+	p.TextModel.HiddenSize = 2048
+	p.TextModel.NumAttentionHeads = 16
+
+	kv := p.KV(&Tokenizer{Vocabulary: &Vocabulary{Model: "gpt2"}})
+
+	if got, want := kv["general.architecture"], "llama4"; got != want {
+		t.Fatalf("general.architecture = %v, want %v", got, want)
+	}
+	if got, want := kv["tokenizer.ggml.pre"], "llama4"; got != want {
+		t.Fatalf("tokenizer.ggml.pre = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Fixes #17698

Llama 4 GGUFs were converted with `tokenizer.ggml.pre = "default"` instead of `"llama4"`, because `parseTokenizer` identifies the pre-tokenizer by hashing its Split regex and matching a fixed digest list that does not include Llama 4. With `default`, llama.cpp uses its GPT-2 fallback pre-tokenizer regex, splitting text differently and producing ~8-10% more tokens than llama.cpp-converted GGUFs for identical prompts.

This sets `tokenizer.ggml.pre = "llama4"` explicitly in `llama4Model.KV`, matching the pattern already used by `convert_gptoss.go` (`gpt-4o`), `convert_gemma4.go` (`gemma4`), `convert_lfm2.go` (`lfm2`), and what llama.cpp's `convert_hf_to_gguf.py` writes for Llama 4.

Test: `TestLlama4TokenizerPre` asserts `tokenizer.ggml.pre = llama4` in the converted KV.

Note: this only fixes newly converted models; existing GGUFs published under `library/llama4` will need regeneration to pick up the correct tokenizer.