### PR TITLE
cmd: fall back to running model in /save when parent is not locally available

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -1798,6 +1798,75 @@ func TestNewCreateRequest(t *testing.T) {
 	}
 }
 
+func TestResolveParentForSave(t *testing.T) {
+	loaded := []api.Message{{Role: "assistant", Content: "loaded"}}
+
+	t.Run("parent not locally available falls back to running model", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "not found", http.StatusNotFound)
+		}))
+		defer srv.Close()
+		t.Setenv("OLLAMA_HOST", srv.URL)
+
+		client, err := api.ClientFromEnvironment()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		opts := runOptions{
+			Model:          "nemotron-3.5-lightning:30b",
+			ParentModel:    "nemotron3.5:30b-a3b-q4_K_M",
+			LoadedMessages: loaded,
+		}
+		got := resolveParentForSave(t.Context(), client, opts)
+		if got.ParentModel != "" {
+			t.Errorf("ParentModel = %q, want empty", got.ParentModel)
+		}
+		if got.LoadedMessages != nil {
+			t.Errorf("LoadedMessages should be nil on fallback, got %v", got.LoadedMessages)
+		}
+		if got.Model != "nemotron-3.5-lightning:30b" {
+			t.Errorf("Model = %q, want unchanged", got.Model)
+		}
+	})
+
+	t.Run("parent locally available is preserved", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if err := json.NewEncoder(w).Encode(api.ShowResponse{}); err != nil {
+				t.Fatal(err)
+			}
+		}))
+		defer srv.Close()
+		t.Setenv("OLLAMA_HOST", srv.URL)
+
+		client, err := api.ClientFromEnvironment()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		opts := runOptions{
+			Model:          "mymodel",
+			ParentModel:    "parentmodel",
+			LoadedMessages: loaded,
+		}
+		got := resolveParentForSave(t.Context(), client, opts)
+		if got.ParentModel != "parentmodel" {
+			t.Errorf("ParentModel = %q, want %q", got.ParentModel, "parentmodel")
+		}
+		if len(got.LoadedMessages) != 1 {
+			t.Errorf("LoadedMessages should be preserved, got %v", got.LoadedMessages)
+		}
+	})
+
+	t.Run("no parent model is a no-op", func(t *testing.T) {
+		opts := runOptions{Model: "mymodel"}
+		got := resolveParentForSave(t.Context(), nil, opts)
+		if got.Model != "mymodel" || got.ParentModel != "" {
+			t.Errorf("unexpected change: %+v", got)
+		}
+	})
+}
+
 func TestApplyShowResponseToRunOptions(t *testing.T) {
 	opts := runOptions{}
 	info := &api.ShowResponse{

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -264,7 +264,18 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 				return err
 			}
 
-			req := NewCreateRequest(args[1], opts)
+			// If the parent model is not locally available, fall back to the
+			// running model so /save doesn't try to pull an internal variant
+			// name that may not exist in the registry.
+			saveOpts := opts
+			if saveOpts.ParentModel != "" {
+				if _, showErr := client.Show(cmd.Context(), &api.ShowRequest{Model: saveOpts.ParentModel}); showErr != nil {
+					saveOpts.ParentModel = ""
+					saveOpts.LoadedMessages = nil
+				}
+			}
+
+			req := NewCreateRequest(args[1], saveOpts)
 			fn := func(resp api.ProgressResponse) error { return nil }
 			err = client.Create(cmd.Context(), req, fn)
 			if err != nil {

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"cmp"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -264,18 +265,7 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 				return err
 			}
 
-			// If the parent model is not locally available, fall back to the
-			// running model so /save doesn't try to pull an internal variant
-			// name that may not exist in the registry.
-			saveOpts := opts
-			if saveOpts.ParentModel != "" {
-				if _, showErr := client.Show(cmd.Context(), &api.ShowRequest{Model: saveOpts.ParentModel}); showErr != nil {
-					saveOpts.ParentModel = ""
-					saveOpts.LoadedMessages = nil
-				}
-			}
-
-			req := NewCreateRequest(args[1], saveOpts)
+			req := NewCreateRequest(args[1], resolveParentForSave(cmd.Context(), client, opts))
 			fn := func(resp api.ProgressResponse) error { return nil }
 			err = client.Create(cmd.Context(), req, fn)
 			if err != nil {
@@ -554,6 +544,19 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 			sb.Reset()
 		}
 	}
+}
+
+// resolveParentForSave clears ParentModel and LoadedMessages when the parent is not locally reachable,
+// so /save falls back to the running model alias instead of 404ing on an internal registry variant.
+func resolveParentForSave(ctx context.Context, client *api.Client, opts runOptions) runOptions {
+	if opts.ParentModel == "" {
+		return opts
+	}
+	if _, err := client.Show(ctx, &api.ShowRequest{Model: opts.ParentModel}); err != nil {
+		opts.ParentModel = ""
+		opts.LoadedMessages = nil
+	}
+	return opts
 }
 
 func NewCreateRequest(name string, opts runOptions) *api.CreateRequest {


### PR DESCRIPTION
## Problem

\`/save\` reads \`ParentModel\` from the model's metadata, which can be an internal variant name (e.g. \`nemotron3.5:30b-a3b-q4_K_M\`) that has no local manifest and no public registry entry. The create path then attempts to pull it, receives a 404, and surfaces:

\`\`\`
Error: pull model manifest: file does not exist
\`\`\`

This happens even though the alias the user originally pulled (e.g. \`nemotron-3.5-lightning:30b\`) exists locally and works fine with \`ollama show\` and \`ollama cp\`.

## Fix

Extract \`resolveParentForSave\` in \`cmd/interactive.go\`. Before building the create request, it calls \`Show\` on the parent model. If the parent is not locally reachable, \`ParentModel\` and \`LoadedMessages\` are cleared so \`NewCreateRequest\` falls back to the running model alias. \`LoadedMessages\` are cleared because they are already embedded in the running model's manifest and would otherwise be duplicated.

## Changes

- \`cmd/interactive.go\`: extract \`resolveParentForSave\` helper; \`/save\` case is now one line
- \`cmd/cmd_test.go\`: add \`TestResolveParentForSave\` covering parent unavailable (fallback), parent available (preserved), no parent (no-op)

## Test plan

- [ ] \`go test ./cmd/...\` — \`TestResolveParentForSave\` passes (three sub-tests via mock HTTP server)
- [ ] \`ollama run nemotron-3.5-lightning:30b\` then \`/save test-name\` — succeeds instead of erroring
- [ ] Models with a locally-available parent (user-created derivative) — \`/save\` continues to use the parent as \`From\`

Fixes #17735