### PR TITLE
x/mlxrunner: add graceful shutdown to prevent Metal GPU process leak on macOS

### DIFF
--- a/x/mlxrunner/server.go
+++ b/x/mlxrunner/server.go
@@ -10,7 +10,9 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
 	"time"
 
 	"github.com/ollama/ollama/envconfig"
@@ -57,6 +59,19 @@ func Execute(args []string) error {
 	})
 	runnerCtx, cancelRunner := context.WithCancel(context.Background())
 	defer cancelRunner()
+
+	// os.Exit(2) on SIGINT skips defer, leaving Metal GPU resources unreleased; catch it and clean up first.
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigCh
+		cancelRunner()
+		_ = worker.Stop(context.Background(), func() {
+			mlx.Sweep()
+			mlx.ClearCache()
+		})
+		os.Exit(0)
+	}()
 
 	runner := Runner{
 		Requests:  make(chan Request),


### PR DESCRIPTION
## Problem

After \`ollama stop\`, the MLX runner subprocess stays resident on macOS and holds GPU RAM for minutes. \`ollama ps\` shows the model as unloaded and \`ollama stop\` reports success, but \`ps -p <pid>\` shows the process is still running.

Root cause: Go's default SIGINT handler calls \`os.Exit(2)\`, which skips all \`defer\` statements. This means \`mlx.Sweep()\` and \`mlx.ClearCache()\` never run. On macOS, Metal GPU framework appears to keep the process resident until GPU resources are explicitly released via those calls.

On Linux this is not observed because the GPU resource lifecycle is managed differently.

## Fix

Register an explicit signal handler for \`SIGINT\` and \`SIGTERM\` in \`Execute()\` that:
1. Cancels in-flight requests via \`cancelRunner()\`
2. Runs the MLX cleanup (\`mlx.Sweep()\` + \`mlx.ClearCache()\`) on the locked OS thread via \`worker.Stop()\`
3. Exits cleanly with \`os.Exit(0)\`

**File changed:** \`x/mlxrunner/server.go\` (+15 lines)

## Test plan

- [ ] \`go test ./x/mlxrunner/...\` passes
- [ ] \`go test ./...\` passes (pre-existing \`app/dist\` failures only)
- [ ] On macOS with Apple Silicon: load an MLX model, run \`ollama stop <model>\`, verify the subprocess PID is gone from \`ps\` within a few seconds

Fixes #17792