### PR TITLE
cmd/launch: fix dsh local model maxTokens and contextWindow from served num_ctx

### DIFF
--- a/cmd/launch/deepseek_harness.go
+++ b/cmd/launch/deepseek_harness.go
@@ -1,6 +1,7 @@
 package launch
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"os/exec"
@@ -9,6 +10,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/cmd/config"
 	"github.com/ollama/ollama/cmd/internal/fileutil"
 	"github.com/ollama/ollama/envconfig"
@@ -184,6 +186,18 @@ func (d *DeepSeekHarness) ConfigureWithModels(primary string, models []LaunchMod
 	}
 	if selected, ok := findLaunchModel(models, primary); ok {
 		primary = selected.Name
+	}
+
+	// Use the served num_ctx (from ollama ps) instead of the GGUF native max,
+	// so contextWindow in settings.yaml matches what the server actually allocated.
+	if client, err := api.ClientFromEnvironment(); err == nil {
+		if served := LoadedContextWindow(context.Background(), client, primary); served > 0 {
+			for i, m := range models {
+				if SameModelRef(m.Name, primary) {
+					models[i].ContextLength = served
+				}
+			}
+		}
 	}
 
 	settingsPath, err := deepSeekHarnessSettingsPath()
@@ -378,8 +392,12 @@ func deepSeekHarnessModelConfigs(primary string, models []LaunchModel) []any {
 		if item.ContextLength > 0 {
 			entry["contextWindow"] = item.ContextLength
 		}
-		if item.MaxOutputTokens > 0 {
-			entry["maxTokens"] = item.MaxOutputTokens
+		maxOut := item.MaxOutputTokens
+		if maxOut <= 0 {
+			maxOut = item.ContextLength
+		}
+		if maxOut > 0 {
+			entry["maxTokens"] = maxOut
 		}
 		configs = append(configs, entry)
 	}

--- a/cmd/launch/deepseek_harness_test.go
+++ b/cmd/launch/deepseek_harness_test.go
@@ -16,6 +16,25 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
+func TestDeepSeekHarnessModelConfigsMaxTokensFallback(t *testing.T) {
+	// Local models have MaxOutputTokens==0; maxTokens should fall back to ContextLength.
+	configs := deepSeekHarnessModelConfigs("local-model:latest", []LaunchModel{
+		{Name: "local-model:latest", ContextLength: 32768, MaxOutputTokens: 0},
+		{Name: "cloud-model:cloud", ContextLength: 131072, MaxOutputTokens: 65536},
+	})
+	if len(configs) != 2 {
+		t.Fatalf("expected 2 configs, got %d", len(configs))
+	}
+	local, _ := configs[0].(map[string]any)
+	if local["maxTokens"] != 32768 {
+		t.Errorf("local maxTokens = %v, want 32768 (fallback to contextWindow)", local["maxTokens"])
+	}
+	cloud, _ := configs[1].(map[string]any)
+	if cloud["maxTokens"] != 65536 {
+		t.Errorf("cloud maxTokens = %v, want 65536 (explicit)", cloud["maxTokens"])
+	}
+}
+
 func TestDeepSeekHarnessRegistry(t *testing.T) {
 	spec, err := LookupIntegrationSpec("deepseek-harness")
 	if err != nil {


### PR DESCRIPTION
## Problem

\`ollama launch dsh\` generates \`settings.yaml\` with two bugs for local models:

**1. \`maxTokens\` missing for local models.** Cloud models get \`maxTokens\` from their known output limit, but local models have \`MaxOutputTokens == 0\` so the field is omitted entirely. dsh's small fallback causes agents to hit "Output token limit reached" mid-edit, with thinking tokens sharing the budget.

**2. \`contextWindow\` reflects the GGUF native maximum, not the served \`num_ctx\`.** When a user sets \`PARAMETER num_ctx 65536\` below the model's trained maximum (e.g. 262144), \`settings.yaml\` still reports 262144. dsh's context meter and compaction logic then plan against 4x the real budget.

Both bugs survive browser-connect re-syncs because settings.yaml is atomically rewritten on every connect from Ollama metadata.

## Fix

**\`maxTokens\` fallback** — in \`deepSeekHarnessModelConfigs\`, use \`ContextLength\` when \`MaxOutputTokens == 0\`. Local models serve up to their full context window.

**\`contextWindow\` from \`ollama ps\`** — in \`ConfigureWithModels\`, call \`LoadedContextWindow\` (existing helper) to read the served \`num_ctx\` for the primary model and update its \`ContextLength\` before writing settings. Silently skips when the server is unreachable (client error or model not yet loaded).

## Changes

- \`cmd/launch/deepseek_harness.go\` — +2 imports, +12 lines
- \`cmd/launch/deepseek_harness_test.go\` — \`TestDeepSeekHarnessModelConfigsMaxTokensFallback\` covers the fallback path

## Test plan

- [x] \`TestDeepSeekHarnessModelConfigsMaxTokensFallback\` — local model (MaxOutputTokens=0) gets maxTokens=ContextLength; cloud model keeps explicit value
- [x] All existing \`TestDeepSeekHarness*\` tests pass unchanged (served context window query returns 0 when server unreachable, no change to contextWindow in tests)
- [x] \`go test ./cmd/launch/...\` and \`go test ./...\` pass

Fixes #17800