### PR TITLE
⚡ Projects & @-mentions: bring your codebase into the chat

### DIFF
--- a/app/docs/README.md
+++ b/app/docs/README.md
@@ -1,0 +1,5 @@
+# Documentação do app desktop
+
+Documentação interna das funcionalidades customizadas deste fork.
+
+- [Projetos e menções de arquivos com `@`](./projetos-e-mencoes.md) — abertura de pasta como "projeto ativo" (árvore de arquivos, AGENTS.md, skills) e menção de arquivos com `@` no chat.

--- a/app/docs/projetos-e-mencoes.md
+++ b/app/docs/projetos-e-mencoes.md
@@ -2,7 +2,7 @@
 
 Este documento descreve duas funcionalidades adicionadas ao app desktop:
 
-1. **Projeto ativo** — abrir uma pasta local como projeto (estilo "Open Folder" do VSCode), com árvore de arquivos lateral, persistência do último projeto, recentes e carregamento automático de `AGENTS.md` e `.agents/skills/`.
+1. **Projeto ativo** — abrir uma pasta local como projeto (estilo "Open Folder" do VSCode), com árvore de arquivos lateral, visualizador de arquivos, persistência do último projeto, recentes e carregamento automático de `AGENTS.md` e `.agents/skills/`.
 2. **Menção de arquivos com `@`** — autocomplete fuzzy de arquivos do projeto no campo de chat, com injeção do conteúdo dos arquivos mencionados no contexto da LLM.
 
 O modo "chat livre" (sem projeto aberto) continua funcionando normalmente: sem árvore, sem menções, sem contexto de pasta.
@@ -15,8 +15,8 @@ O modo "chat livre" (sem projeto aberto) continua funcionando normalmente: sem �
 ┌────────────────────────── Frontend (React/Vite) ──────────────────────────┐
 │                                                                           │
 │  ProjectButton (pill no header)      ProjectPanel (árvore lateral)        │
-│        │  abrir/recentes/fechar            │  clique insere @path        │
-│        ▼                                   ▼                              │
+│        │  abrir/recentes/fechar            │  clique abre FileViewer     │
+│        ▼                                   ▼  botão @ menciona          │
 │  useProject / useProjectFiles  ◄── cache react-query (staleTime: ∞)      │
 │        │                                                                  │
 │  ChatForm ── detecta "@" ── FileMentionMenu (fuzzy + teclado)            │
@@ -31,6 +31,7 @@ O modo "chat livre" (sem projeto aberto) continua funcionando normalmente: sem �
 │    • scanner com .gitignore + pastas pesadas ignoradas                    │
 │    • AGENTS.md + .agents/skills → system prompt                           │
 │    • resolveFileRefs: file_refs → attachments (com truncamento)           │
+│    • getProjectFile: conteúdo de um arquivo para o visualizador           │
 │                                                                           │
 │  store (SQLite): project_dir + recent_projects (schema v17)               │
 └───────────────────────────────────────────────────────────────────────────┘
@@ -56,6 +57,7 @@ O modo "chat livre" (sem projeto aberto) continua funcionando normalmente: sem �
 | `POST` | `/api/v1/project/open` | Body `{"path": "/abs/path"}`. Ativa o projeto, escaneia, persiste e retorna `ProjectResponse`. |
 | `POST` | `/api/v1/project/close` | Fecha o projeto ativo (limpa `project_dir`; os recentes são mantidos). |
 | `GET` | `/api/v1/project/files` | Listagem cacheada de arquivos. Com `?refresh=1`, re-escaneia o disco. |
+| `GET` | `/api/v1/project/file` | Conteúdo de um arquivo (`?path=rel/ativo.ts`) para o visualizador. |
 
 Formas de resposta (em `app/ui/responses/types.go`, espelhadas em `gotypes.gen.ts`):
 
@@ -68,6 +70,10 @@ Formas de resposta (em `app/ui/responses/types.go`, espelhadas em `gotypes.gen.t
 // ProjectFilesResponse
 { "files": [{ "path": "src/main.ts", "size": 1234, "isDir": false }, ...],
   "truncated": false }
+
+// ProjectFileResponse
+{ "path": "src/main.ts", "size": 1234, "content": "export {}\n",
+  "truncated": false, "binary": false, "mimeType": "" }
 ```
 
 ### Scanner de arquivos (`app/ui/project.go`)
@@ -99,8 +105,19 @@ O system message resultante contém: nome/path do projeto, conteúdo do AGENTS.m
 ### UI
 
 - **`ProjectButton.tsx`** — pill no header (área de drag da janela; usa `stopPropagation` no `mousedown` para não iniciar drag). Mostra o nome da pasta ativa; menu com "Open folder…", recentes e "Close project". Tooltip mostra o path completo.
-- **`ProjectPanel.tsx`** — coluna lateral (renderizada pelo `SidebarLayout` quando há projeto): árvore colapsável (pastas primeiro, ordem alfabética), botão de refresh (re-scan) e fechar. Clicar num arquivo dispara o evento `project:mention-file`, que o `ChatForm` escuta para inserir `@path` no input.
+- **`ProjectPanel.tsx`** — coluna lateral (renderizada pelo `SidebarLayout` quando há projeto): árvore colapsável (pastas primeiro, ordem alfabética), botão de refresh (re-scan) e fechar. Clicar num arquivo **abre o visualizador** (`FileViewer`); mencionar no chat é uma ação explícita (botão `@` que aparece no hover da linha, ou clique com ⌘/Ctrl), que dispara o evento `project:mention-file` ouvido pelo `ChatForm`.
 - **`layout.tsx`** — nota para Windows: o header superior era `xl:hidden`; agora fica sempre visível para abrigar o pill do projeto.
+
+### Visualizador de arquivos (`FileViewer.tsx`)
+
+Clicar num arquivo da árvore abre um **modal de preview** sobre a UI (fecha no `Esc`, no clique fora ou no `X`).
+
+- **Backend** (`getProjectFile` em `project.go`): valida o path com o mesmo `resolvePath` usado pelas menções (rejeita path absoluto, `..` e qualquer coisa fora da raiz) e responde conforme o tipo do arquivo:
+  - **texto**: conteúdo cru, limitado a `maxViewFileBytes` (512 KB); acima disso vem `truncated: true` (o corte é aparado para não deixar rune UTF-8 pela metade);
+  - **imagem** (`.png`, `.jpg`, `.jpeg`, `.gif`, `.webp`, `.bmp`, `.svg`, `.ico`): base64 em `content` + `mimeType`, até `maxViewImageBytes` (8 MB);
+  - **binário** (byte `NUL` ou UTF-8 inválido): `binary: true` e `content` vazio — nada é enviado pela rede à toa.
+- **Frontend**: `useProjectFileContent(path)` (react-query, `staleTime: 0` para não mostrar preview velho de um arquivo que mudou no disco). O modal mostra nome, diretório, tamanho e aviso de truncamento; imagens são renderizadas inline; texto ganha numeração de linhas e destaque de sintaxe reaproveitando o `highlighter` (shiki) já carregado pelo chat — acima de 100 KB o destaque é desligado para não travar a UI, e extensões fora da lista de linguagens carregadas caem em texto puro.
+- No topo do modal: botão **Mention** (insere `@path` no chat e fecha o preview) e botão de copiar o conteúdo.
 
 ---
 
@@ -157,10 +174,11 @@ No frontend, a soma dos tamanhos dos arquivos mencionados (os `size` já vêm na
 |---|---|
 | `app/ui/project.go` | Estado do projeto, scanner + gitignore, skills/AGENTS.md, resolução de `file_refs`, handlers HTTP |
 | `app/ui/project_test.go` | Testes: scanner/gitignore, resolveFileRefs, frontmatter, system prompt, endpoints + persistência |
-| `app/ui/app/src/hooks/useProject.ts` | Hooks `useProject`/`useProjectFiles` (react-query) + `MENTION_TOTAL_BYTES` |
+| `app/ui/app/src/hooks/useProject.ts` | Hooks `useProject`/`useProjectFiles`/`useProjectFileContent` (react-query) + `MENTION_TOTAL_BYTES` |
 | `app/ui/app/src/components/ProjectButton.tsx` | Pill do header com menu abrir/recentes/fechar |
-| `app/ui/app/src/components/ProjectPanel.tsx` | Árvore de arquivos lateral |
+| `app/ui/app/src/components/ProjectPanel.tsx` | Árvore de arquivos lateral (clique abre o preview, botão `@` menciona) |
 | `app/ui/app/src/components/FileMentionMenu.tsx` | Dropdown de autocomplete do `@` |
+| `app/ui/app/src/components/FileViewer.tsx` | Modal de preview do arquivo (texto com destaque, imagem, binário) |
 | `app/ui/app/src/utils/fuzzyMatch.ts` | Ranking fuzzy (`fuzzyScore`/`fuzzyFilter`) |
 
 ### Modificados
@@ -172,7 +190,7 @@ No frontend, a soma dos tamanhos dos arquivos mencionados (os `size` já vêm na
 | `app/ui/ui.go` | Campos de projeto no `Server`, rotas `/api/v1/project*`, `file_refs` → attachments no `chat`, system prompt no `buildChatRequest` |
 | `app/ui/responses/types.go` | `ChatRequest.FileRefs` + `ProjectFile`/`ProjectSkill`/`ProjectResponse`/`ProjectFilesResponse` |
 | `app/ui/app/codegen/gotypes.gen.ts` | Regenerado (idêntico à saída do `tscriptify`) |
-| `app/ui/app/src/api.ts` | `getProject`/`openProject`/`closeProject`/`getProjectFiles`; `sendMessage` aceita `fileRefs` |
+| `app/ui/app/src/api.ts` | `getProject`/`openProject`/`closeProject`/`getProjectFiles`/`getProjectFile`; `sendMessage` aceita `fileRefs` |
 | `app/ui/app/src/hooks/useChats.ts` | Propaga `fileRefs` na mutation de envio |
 | `app/ui/app/src/components/Chat.tsx` | Propaga `fileRefs` do form para a mutation |
 | `app/ui/app/src/components/ChatForm.tsx` | Detecção do `@`, menu, teclado, destaque, aviso de orçamento, evento da árvore |
@@ -199,13 +217,16 @@ OLLAMA_DEBUG=1 go run ./app/cmd/app -dev  # terminal 2, a partir de app/
 Roteiro manual rápido:
 
 1. Abrir o pill "Open project" → escolher uma pasta com `.gitignore`, `AGENTS.md` e `.agents/skills/` → conferir árvore (sem `node_modules`/ignorados) e nome no header.
-2. Digitar `@` no chat → filtrar, navegar com setas, selecionar com Enter → menção destacada em azul.
-3. Enviar mensagem mencionando um arquivo → a resposta do modelo deve refletir o conteúdo do arquivo; a mensagem mostra o chip do anexo.
-4. Fechar e reabrir o app → o projeto reabre sozinho; "Close project" volta ao chat livre e mantém os recentes.
+2. Clicar num arquivo da árvore → o preview abre com destaque de sintaxe; clicar numa imagem → ela aparece inline; `Esc` fecha.
+3. Passar o mouse numa linha da árvore → botão `@` insere a menção no chat (⌘/Ctrl+clique faz o mesmo).
+4. Digitar `@` no chat → filtrar, navegar com setas, selecionar com Enter → menção destacada em azul.
+5. Enviar mensagem mencionando um arquivo → a resposta do modelo deve refletir o conteúdo do arquivo; a mensagem mostra o chip do anexo.
+6. Fechar e reabrir o app → o projeto reabre sozinho; "Close project" volta ao chat livre e mantém os recentes.
 
 ## Limitações conhecidas
 
 - O matcher de `.gitignore` é um subconjunto prático do formato do git (sem escapes exóticos; negação não recupera conteúdo de diretórios já pulados).
 - Arquivos com espaço no nome só são reconhecidos como menção quando inseridos pelo dropdown/árvore (a digitação manual usa token sem espaços).
-- A listagem só atualiza no refresh manual ou na reabertura do projeto (sem file watcher).
+- A listagem só atualiza no refresh manual ou na reabertura do projeto (sem file watcher). O preview, esse sim, relê o arquivo do disco a cada abertura.
+- O preview é somente leitura: não há edição nem busca dentro do arquivo.
 - O título nativo da janela não muda; o indicador do projeto é o pill no header da UI.

--- a/app/docs/projetos-e-mencoes.md
+++ b/app/docs/projetos-e-mencoes.md
@@ -1,0 +1,211 @@
+# Projetos e menções de arquivos com `@`
+
+Este documento descreve duas funcionalidades adicionadas ao app desktop:
+
+1. **Projeto ativo** — abrir uma pasta local como projeto (estilo "Open Folder" do VSCode), com árvore de arquivos lateral, persistência do último projeto, recentes e carregamento automático de `AGENTS.md` e `.agents/skills/`.
+2. **Menção de arquivos com `@`** — autocomplete fuzzy de arquivos do projeto no campo de chat, com injeção do conteúdo dos arquivos mencionados no contexto da LLM.
+
+O modo "chat livre" (sem projeto aberto) continua funcionando normalmente: sem árvore, sem menções, sem contexto de pasta.
+
+---
+
+## Visão geral da arquitetura
+
+```
+┌────────────────────────── Frontend (React/Vite) ──────────────────────────┐
+│                                                                           │
+│  ProjectButton (pill no header)      ProjectPanel (árvore lateral)        │
+│        │  abrir/recentes/fechar            │  clique insere @path        │
+│        ▼                                   ▼                              │
+│  useProject / useProjectFiles  ◄── cache react-query (staleTime: ∞)      │
+│        │                                                                  │
+│  ChatForm ── detecta "@" ── FileMentionMenu (fuzzy + teclado)            │
+│        │                                                                  │
+│        └── submit envia ChatRequest { prompt, file_refs: [...] }         │
+└───────────────────────────────────┬───────────────────────────────────────┘
+                                    │ HTTP (mesmos endpoints /api/v1)
+┌───────────────────────────────────▼───────────────────────────────────────┐
+│                            Backend (Go, app/ui)                           │
+│                                                                           │
+│  project.go: estado do projeto ativo (Server.project)                     │
+│    • scanner com .gitignore + pastas pesadas ignoradas                    │
+│    • AGENTS.md + .agents/skills → system prompt                           │
+│    • resolveFileRefs: file_refs → attachments (com truncamento)           │
+│                                                                           │
+│  store (SQLite): project_dir + recent_projects (schema v17)               │
+└───────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Funcionalidade 1: Projeto ativo
+
+### Fluxo de abertura
+
+1. O usuário clica no pill **"Open project"** no header (`ProjectButton.tsx`) e escolhe "Open folder…".
+2. O frontend chama `window.webview.selectWorkingDirectory()` — binding nativo **já existente** em `app/cmd/app/webview.go` que abre o diálogo de seleção de pasta do sistema operacional.
+3. Com o path retornado, o frontend faz `POST /api/v1/project/open {"path": "..."}`.
+4. O backend valida o diretório, escaneia os arquivos, carrega `AGENTS.md`/skills, persiste o path no SQLite e adiciona aos recentes.
+5. A UI passa a exibir a árvore de arquivos e o nome da pasta no pill do header.
+
+### Endpoints (registrados em `app/ui/ui.go`)
+
+| Método | Rota | Descrição |
+|---|---|---|
+| `GET` | `/api/v1/project` | Projeto ativo (ou `root: ""`) + lista de recentes. Restaura o último projeto do store na primeira chamada (reabertura automática). |
+| `POST` | `/api/v1/project/open` | Body `{"path": "/abs/path"}`. Ativa o projeto, escaneia, persiste e retorna `ProjectResponse`. |
+| `POST` | `/api/v1/project/close` | Fecha o projeto ativo (limpa `project_dir`; os recentes são mantidos). |
+| `GET` | `/api/v1/project/files` | Listagem cacheada de arquivos. Com `?refresh=1`, re-escaneia o disco. |
+
+Formas de resposta (em `app/ui/responses/types.go`, espelhadas em `gotypes.gen.ts`):
+
+```jsonc
+// ProjectResponse
+{ "root": "/Users/x/proj", "name": "proj", "hasAgentsMd": true,
+  "skills": [{ "name": "deploy", "description": "..." }],
+  "recent": ["/Users/x/proj", "/Users/x/outro"] }
+
+// ProjectFilesResponse
+{ "files": [{ "path": "src/main.ts", "size": 1234, "isDir": false }, ...],
+  "truncated": false }
+```
+
+### Scanner de arquivos (`app/ui/project.go`)
+
+- `filepath.WalkDir` a partir da raiz, produzindo uma lista **flat** de arquivos e diretórios (paths relativos com `/`); a árvore é montada no frontend.
+- **`.gitignore`**: suporte a arquivos `.gitignore` na raiz e aninhados, com comentários, negação (`!`), padrões ancorados (`/foo`, `a/b`), sufixo de diretório (`dir/`), globs por segmento (`*.log`) e `**`. Implementação própria e enxuta (`parseGitignore`, `ignoreRule.matches`, `matchSegs`) — a "última regra que casa" vence, como no git.
+- **Pastas sempre ignoradas** (independente do `.gitignore`): `.git`, `node_modules`, `build`, `dist`, `out`, `target`, `vendor`, `.next`, `.nuxt`, `.venv`, `venv`, `__pycache__`, `.cache`, `coverage`, `DerivedData`, `.gradle` (ver `defaultIgnoredDirs`).
+- Também ignora `.DS_Store`, symlinks e arquivos não-regulares.
+- **Limite**: `maxProjectFiles = 20000` entradas; ao estourar, a resposta marca `truncated: true` e a UI avisa.
+- Limitação conhecida: uma regra de negação (`!`) não "ressuscita" arquivos dentro de um diretório que já foi pulado pelo walk — mesmo comportamento de implementações simplificadas.
+
+### `AGENTS.md` e `.agents/skills/`
+
+Carregados na abertura do projeto e injetados como **system message** em toda requisição de chat enquanto o projeto estiver aberto (ver `buildChatRequest` em `app/ui/ui.go`):
+
+- `AGENTS.md` da raiz: conteúdo completo, limitado a `maxAgentsFileBytes = 32KB`.
+- `.agents/skills/`: aceita os layouts `skills/<nome>/SKILL.md` e `skills/<nome>.md`. O frontmatter YAML (`name:`, `description:`) é lido de forma simples (`parseFrontmatter`); apenas nome + descrição entram no system prompt (não o corpo, para não estourar contexto).
+
+O system message resultante contém: nome/path do projeto, conteúdo do AGENTS.md e a lista de skills. Ele **não é persistido** no histórico — é montado a cada request, então fechar o projeto remove o contexto imediatamente.
+
+### Persistência (SQLite, `app/store`)
+
+- Migração de schema **v16 → v17** (`migrateV16ToV17` em `database.go`), adicionando à tabela `settings`:
+  - `project_dir TEXT` — último projeto aberto (vazio = nenhum);
+  - `recent_projects TEXT` — array JSON, mais recente primeiro, máx. 8 (`maxRecentProjects`).
+- Acesso via métodos dedicados do store: `ProjectDir()/SetProjectDir()` e `RecentProjects()/SetRecentProjects()`.
+- **Decisão importante**: esses campos ficam *fora* do objeto `Settings` de propósito. O `POST /api/v1/settings` reescreve o objeto inteiro vindo do frontend; se o projeto morasse em `Settings`, qualquer salvamento de configuração antiga apagaria o projeto ativo.
+
+### UI
+
+- **`ProjectButton.tsx`** — pill no header (área de drag da janela; usa `stopPropagation` no `mousedown` para não iniciar drag). Mostra o nome da pasta ativa; menu com "Open folder…", recentes e "Close project". Tooltip mostra o path completo.
+- **`ProjectPanel.tsx`** — coluna lateral (renderizada pelo `SidebarLayout` quando há projeto): árvore colapsável (pastas primeiro, ordem alfabética), botão de refresh (re-scan) e fechar. Clicar num arquivo dispara o evento `project:mention-file`, que o `ChatForm` escuta para inserir `@path` no input.
+- **`layout.tsx`** — nota para Windows: o header superior era `xl:hidden`; agora fica sempre visível para abrigar o pill do projeto.
+
+---
+
+## Funcionalidade 2: Menção de arquivos com `@`
+
+Ativa **somente** com projeto aberto e listagem carregada.
+
+### Detecção e autocomplete
+
+- Ao digitar, `detectMention(value, caret)` (em `ChatForm.tsx`) procura o último `@` antes do caret que inicia um token (início do texto ou após espaço/parêntese/aspas) e sem espaço até o caret — isso vira a query.
+- A busca roda sobre a listagem **em memória** (cache react-query com `staleTime: Infinity` — nenhum acesso a disco por tecla). Ranking em `utils/fuzzyMatch.ts`:
+  1. substring no nome do arquivo (quanto mais cedo, melhor);
+  2. substring no path completo;
+  3. subsequência no path (penalizada pela dispersão).
+  Empates favorecem paths mais curtos. Até 50 resultados (dropdown com scroll).
+- **Teclado**: `↑`/`↓` navegam, `Enter`/`Tab` selecionam, `Esc` fecha o menu (com `stopPropagation` para não acionar o Esc global de cancelar streaming/edição). Clique também seleciona (`FileMentionMenu.tsx`).
+- Ao selecionar, o texto vira `@src/main.ts ` (com espaço) e o caret vai para depois da menção.
+
+### Destaque visual
+
+Um overlay (`div` posicionado atrás do `<textarea>`, mesmas métricas de fonte/line-height/wrap) renderiza o texto com `text-transparent` e pinta um **fundo azul arredondado** sob cada `@path` válido. O scroll é sincronizado via `onScroll`. Essa técnica evita trocar o textarea por um contenteditable (caret, seleção e IME continuam nativos).
+
+`getMentionRanges()` é a fonte única de verdade: encontra todo `@token` do texto que existe na listagem (`filePathSet`) e também menções selecionadas explicitamente cujo path contém espaço. Os mesmos ranges alimentam o destaque, o cálculo do orçamento e o `file_refs` do submit.
+
+### Injeção no prompt (backend)
+
+- O submit envia `file_refs: ["src/main.ts", ...]` no `ChatRequest` (novo campo em `responses/types.go`).
+- No handler `chat` (`app/ui/ui.go`), com projeto ativo, `resolveFileRefs()`:
+  - normaliza e valida cada path (**rejeita** path absoluto, `..` e qualquer coisa fora da raiz do projeto);
+  - pula refs cujo filename já está nos attachments da mensagem (evita duplicar em edição de mensagem);
+  - lê o conteúdo e o anexa como **attachment** da mensagem do usuário.
+- Reusar o pipeline de attachments dá de graça: injeção no formato `--- File: path --- ... --- End of path ---` já existente, persistência no SQLite, chips na UI da mensagem e suporte a edição/reenvio. Imagens mencionadas (`.png`, `.jpg`, etc.) seguem o fluxo de imagem normal.
+
+### Limites de contexto e truncamento
+
+Constantes em `app/ui/project.go` (backend) — o frontend espelha o total em `MENTION_TOTAL_BYTES` (`useProject.ts`):
+
+| Constante | Valor | Efeito |
+|---|---|---|
+| `maxMentionFileBytes` | 64 KB | Máximo injetado por arquivo; o excedente vira `... [truncated]`. |
+| `maxMentionTotalBytes` | 128 KB (~32k tokens a ~4 bytes/token) | Orçamento total por mensagem; refs além do orçamento são truncadas/ignoradas. |
+
+No frontend, a soma dos tamanhos dos arquivos mencionados (os `size` já vêm na listagem) é comparada ao orçamento; ao estourar, aparece um **aviso amarelo** sob o input ("Mentioned files exceed the context budget…"). O envio não é bloqueado — o backend trunca.
+
+> Para alterar o orçamento, mude `maxMentionTotalBytes` (Go) **e** `MENTION_TOTAL_BYTES` (TS) juntos.
+
+---
+
+## Mapa de arquivos
+
+### Novos
+
+| Arquivo | Papel |
+|---|---|
+| `app/ui/project.go` | Estado do projeto, scanner + gitignore, skills/AGENTS.md, resolução de `file_refs`, handlers HTTP |
+| `app/ui/project_test.go` | Testes: scanner/gitignore, resolveFileRefs, frontmatter, system prompt, endpoints + persistência |
+| `app/ui/app/src/hooks/useProject.ts` | Hooks `useProject`/`useProjectFiles` (react-query) + `MENTION_TOTAL_BYTES` |
+| `app/ui/app/src/components/ProjectButton.tsx` | Pill do header com menu abrir/recentes/fechar |
+| `app/ui/app/src/components/ProjectPanel.tsx` | Árvore de arquivos lateral |
+| `app/ui/app/src/components/FileMentionMenu.tsx` | Dropdown de autocomplete do `@` |
+| `app/ui/app/src/utils/fuzzyMatch.ts` | Ranking fuzzy (`fuzzyScore`/`fuzzyFilter`) |
+
+### Modificados
+
+| Arquivo | Mudança |
+|---|---|
+| `app/store/database.go` | Schema v17 (`project_dir`, `recent_projects`), migração e accessors |
+| `app/store/store.go` | `ProjectDir`, `SetProjectDir`, `RecentProjects`, `SetRecentProjects` |
+| `app/ui/ui.go` | Campos de projeto no `Server`, rotas `/api/v1/project*`, `file_refs` → attachments no `chat`, system prompt no `buildChatRequest` |
+| `app/ui/responses/types.go` | `ChatRequest.FileRefs` + `ProjectFile`/`ProjectSkill`/`ProjectResponse`/`ProjectFilesResponse` |
+| `app/ui/app/codegen/gotypes.gen.ts` | Regenerado (idêntico à saída do `tscriptify`) |
+| `app/ui/app/src/api.ts` | `getProject`/`openProject`/`closeProject`/`getProjectFiles`; `sendMessage` aceita `fileRefs` |
+| `app/ui/app/src/hooks/useChats.ts` | Propaga `fileRefs` na mutation de envio |
+| `app/ui/app/src/components/Chat.tsx` | Propaga `fileRefs` do form para a mutation |
+| `app/ui/app/src/components/ChatForm.tsx` | Detecção do `@`, menu, teclado, destaque, aviso de orçamento, evento da árvore |
+| `app/ui/app/src/components/layout/layout.tsx` | Renderiza `ProjectButton` no header e `ProjectPanel` como coluna; header não é mais `xl:hidden` no Windows |
+
+---
+
+## Como testar
+
+```bash
+# testes
+go test ./app/ui/ ./app/store/
+cd app/ui/app && npx vitest run
+
+# rodar o app (o dist do frontend precisa existir)
+cd app/ui/app && npm run build
+cd ../../.. && go run ./app/cmd/app
+
+# modo dev com hot-reload da UI
+cd app/ui/app && npm run dev            # terminal 1
+OLLAMA_DEBUG=1 go run ./app/cmd/app -dev  # terminal 2, a partir de app/
+```
+
+Roteiro manual rápido:
+
+1. Abrir o pill "Open project" → escolher uma pasta com `.gitignore`, `AGENTS.md` e `.agents/skills/` → conferir árvore (sem `node_modules`/ignorados) e nome no header.
+2. Digitar `@` no chat → filtrar, navegar com setas, selecionar com Enter → menção destacada em azul.
+3. Enviar mensagem mencionando um arquivo → a resposta do modelo deve refletir o conteúdo do arquivo; a mensagem mostra o chip do anexo.
+4. Fechar e reabrir o app → o projeto reabre sozinho; "Close project" volta ao chat livre e mantém os recentes.
+
+## Limitações conhecidas
+
+- O matcher de `.gitignore` é um subconjunto prático do formato do git (sem escapes exóticos; negação não recupera conteúdo de diretórios já pulados).
+- Arquivos com espaço no nome só são reconhecidos como menção quando inseridos pelo dropdown/árvore (a digitação manual usa token sem espaços).
+- A listagem só atualiza no refresh manual ou na reabertura do projeto (sem file watcher).
+- O título nativo da janela não muda; o indicador do projeto é o pill no header da UI.

--- a/app/store/database.go
+++ b/app/store/database.go
@@ -14,7 +14,7 @@ import (
 
 // currentSchemaVersion defines the current database schema version.
 // Increment this when making schema changes that require migrations.
-const currentSchemaVersion = 16
+const currentSchemaVersion = 17
 
 // database wraps the SQLite connection.
 // SQLite handles its own locking for concurrent access:
@@ -88,6 +88,8 @@ func (db *database) init() error {
 		cloud_setting_migrated BOOLEAN NOT NULL DEFAULT 0,
 		remote TEXT NOT NULL DEFAULT '', -- deprecated
 		auto_update_enabled BOOLEAN NOT NULL DEFAULT 1,
+		project_dir TEXT NOT NULL DEFAULT '',
+		recent_projects TEXT NOT NULL DEFAULT '[]',
 		schema_version INTEGER NOT NULL DEFAULT %d
 	);
 
@@ -271,6 +273,12 @@ func (db *database) migrate() error {
 				return fmt.Errorf("migrate v15 to v16: %w", err)
 			}
 			version = 16
+		case 16:
+			// add project_dir and recent_projects columns to settings table
+			if err := db.migrateV16ToV17(); err != nil {
+				return fmt.Errorf("migrate v16 to v17: %w", err)
+			}
+			version = 17
 		default:
 			// If we have a version we don't recognize, just set it to current
 			// This might happen during development
@@ -533,6 +541,26 @@ func (db *database) migrateV15ToV16() error {
 	}
 
 	_, err = db.conn.Exec(`UPDATE settings SET schema_version = 16`)
+	if err != nil {
+		return fmt.Errorf("update schema version: %w", err)
+	}
+
+	return nil
+}
+
+// migrateV16ToV17 adds the project_dir and recent_projects columns to the settings table
+func (db *database) migrateV16ToV17() error {
+	_, err := db.conn.Exec(`ALTER TABLE settings ADD COLUMN project_dir TEXT NOT NULL DEFAULT ''`)
+	if err != nil && !duplicateColumnError(err) {
+		return fmt.Errorf("add project_dir column: %w", err)
+	}
+
+	_, err = db.conn.Exec(`ALTER TABLE settings ADD COLUMN recent_projects TEXT NOT NULL DEFAULT '[]'`)
+	if err != nil && !duplicateColumnError(err) {
+		return fmt.Errorf("add recent_projects column: %w", err)
+	}
+
+	_, err = db.conn.Exec(`UPDATE settings SET schema_version = 17`)
 	if err != nil {
 		return fmt.Errorf("update schema version: %w", err)
 	}
@@ -1252,6 +1280,52 @@ func (db *database) getAirplaneMode() (bool, error) {
 		return false, fmt.Errorf("get airplane_mode: %w", err)
 	}
 	return airplaneMode, nil
+}
+
+func (db *database) getProjectDir() (string, error) {
+	var dir string
+	err := db.conn.QueryRow("SELECT project_dir FROM settings").Scan(&dir)
+	if err != nil {
+		return "", fmt.Errorf("get project_dir: %w", err)
+	}
+	return dir, nil
+}
+
+func (db *database) setProjectDir(dir string) error {
+	_, err := db.conn.Exec("UPDATE settings SET project_dir = ?", dir)
+	if err != nil {
+		return fmt.Errorf("set project_dir: %w", err)
+	}
+	return nil
+}
+
+func (db *database) getRecentProjects() ([]string, error) {
+	var raw string
+	err := db.conn.QueryRow("SELECT recent_projects FROM settings").Scan(&raw)
+	if err != nil {
+		return nil, fmt.Errorf("get recent_projects: %w", err)
+	}
+
+	var recents []string
+	if raw != "" {
+		if err := json.Unmarshal([]byte(raw), &recents); err != nil {
+			return nil, fmt.Errorf("parse recent_projects: %w", err)
+		}
+	}
+	return recents, nil
+}
+
+func (db *database) setRecentProjects(recents []string) error {
+	raw, err := json.Marshal(recents)
+	if err != nil {
+		return fmt.Errorf("marshal recent_projects: %w", err)
+	}
+
+	_, err = db.conn.Exec("UPDATE settings SET recent_projects = ?", string(raw))
+	if err != nil {
+		return fmt.Errorf("set recent_projects: %w", err)
+	}
+	return nil
 }
 
 func (db *database) getWindowSize() (int, int, error) {

--- a/app/store/store.go
+++ b/app/store/store.go
@@ -476,6 +476,42 @@ func (s *Store) SetWindowSize(width, height int) error {
 	return s.db.setWindowSize(width, height)
 }
 
+// ProjectDir returns the path of the last opened project folder, or an
+// empty string if no project is open.
+func (s *Store) ProjectDir() (string, error) {
+	if err := s.ensureDB(); err != nil {
+		return "", err
+	}
+
+	return s.db.getProjectDir()
+}
+
+func (s *Store) SetProjectDir(dir string) error {
+	if err := s.ensureDB(); err != nil {
+		return err
+	}
+
+	return s.db.setProjectDir(dir)
+}
+
+// RecentProjects returns the list of recently opened project folders,
+// most recent first.
+func (s *Store) RecentProjects() ([]string, error) {
+	if err := s.ensureDB(); err != nil {
+		return nil, err
+	}
+
+	return s.db.getRecentProjects()
+}
+
+func (s *Store) SetRecentProjects(recents []string) error {
+	if err := s.ensureDB(); err != nil {
+		return err
+	}
+
+	return s.db.setRecentProjects(recents)
+}
+
 func (s *Store) UpdateLastMessage(chatID string, message Message) error {
 	if err := s.ensureDB(); err != nil {
 		return err

--- a/app/ui/app/codegen/gotypes.gen.ts
+++ b/app/ui/app/codegen/gotypes.gen.ts
@@ -619,6 +619,24 @@ export class ProjectResponse {
 	    return a;
 	}
 }
+export class ProjectFileResponse {
+    path: string;
+    size: number;
+    content: string;
+    truncated: boolean;
+    binary: boolean;
+    mimeType: string;
+
+    constructor(source: any = {}) {
+        if ('string' === typeof source) source = JSON.parse(source);
+        this.path = source["path"];
+        this.size = source["size"];
+        this.content = source["content"];
+        this.truncated = source["truncated"];
+        this.binary = source["binary"];
+        this.mimeType = source["mimeType"];
+    }
+}
 export class ProjectFilesResponse {
     files: ProjectFile[];
     truncated: boolean;

--- a/app/ui/app/codegen/gotypes.gen.ts
+++ b/app/ui/app/codegen/gotypes.gen.ts
@@ -512,6 +512,7 @@ export class ChatRequest {
     file_tools?: boolean;
     forceUpdate?: boolean;
     think?: any;
+    file_refs?: string[];
 
     constructor(source: any = {}) {
         if ('string' === typeof source) source = JSON.parse(source);
@@ -523,6 +524,7 @@ export class ChatRequest {
         this.file_tools = source["file_tools"];
         this.forceUpdate = source["forceUpdate"];
         this.think = source["think"];
+        this.file_refs = source["file_refs"];
     }
 
 	convertValues(a: any, classs: any, asMap: boolean = false): any {
@@ -560,6 +562,90 @@ export class ModelUpstreamResponse {
         this.stale = source["stale"];
         this.error = source["error"];
     }
+}
+export class ProjectFile {
+    path: string;
+    size: number;
+    isDir: boolean;
+
+    constructor(source: any = {}) {
+        if ('string' === typeof source) source = JSON.parse(source);
+        this.path = source["path"];
+        this.size = source["size"];
+        this.isDir = source["isDir"];
+    }
+}
+export class ProjectSkill {
+    name: string;
+    description: string;
+
+    constructor(source: any = {}) {
+        if ('string' === typeof source) source = JSON.parse(source);
+        this.name = source["name"];
+        this.description = source["description"];
+    }
+}
+export class ProjectResponse {
+    root: string;
+    name: string;
+    hasAgentsMd: boolean;
+    skills: ProjectSkill[];
+    recent: string[];
+
+    constructor(source: any = {}) {
+        if ('string' === typeof source) source = JSON.parse(source);
+        this.root = source["root"];
+        this.name = source["name"];
+        this.hasAgentsMd = source["hasAgentsMd"];
+        this.skills = this.convertValues(source["skills"], ProjectSkill);
+        this.recent = source["recent"];
+    }
+
+	convertValues(a: any, classs: any, asMap: boolean = false): any {
+	    if (!a) {
+	        return a;
+	    }
+	    if (Array.isArray(a)) {
+	        return (a as any[]).map(elem => this.convertValues(elem, classs));
+	    } else if ("object" === typeof a) {
+	        if (asMap) {
+	            for (const key of Object.keys(a)) {
+	                a[key] = new classs(a[key]);
+	            }
+	            return a;
+	        }
+	        return new classs(a);
+	    }
+	    return a;
+	}
+}
+export class ProjectFilesResponse {
+    files: ProjectFile[];
+    truncated: boolean;
+
+    constructor(source: any = {}) {
+        if ('string' === typeof source) source = JSON.parse(source);
+        this.files = this.convertValues(source["files"], ProjectFile);
+        this.truncated = source["truncated"];
+    }
+
+	convertValues(a: any, classs: any, asMap: boolean = false): any {
+	    if (!a) {
+	        return a;
+	    }
+	    if (Array.isArray(a)) {
+	        return (a as any[]).map(elem => this.convertValues(elem, classs));
+	    } else if ("object" === typeof a) {
+	        if (asMap) {
+	            for (const key of Object.keys(a)) {
+	                a[key] = new classs(a[key]);
+	            }
+	            return a;
+	        }
+	        return new classs(a);
+	    }
+	    return a;
+	}
 }
 export class Page {
     url: string;

--- a/app/ui/app/src/api.ts
+++ b/app/ui/app/src/api.ts
@@ -8,6 +8,8 @@ import {
   ModelCapabilitiesResponse,
   Model,
   ChatRequest,
+  ProjectFilesResponse,
+  ProjectResponse,
   Settings,
   User,
 } from "@/gotypes";
@@ -207,6 +209,7 @@ export async function* sendMessage(
   fileTools?: boolean,
   forceUpdate?: boolean,
   think?: boolean | string,
+  fileRefs?: string[],
 ): AsyncGenerator<ChatEventUnion> {
   // Convert Uint8Array to base64 for JSON serialization
   const serializedAttachments = attachments?.map((att) => ({
@@ -237,6 +240,7 @@ export async function* sendMessage(
         file_tools: fileTools ?? false,
         ...(forceUpdate !== undefined ? { forceUpdate } : {}),
         ...(shouldSendThink ? { think } : {}),
+        ...(fileRefs && fileRefs.length > 0 ? { file_refs: fileRefs } : {}),
       }),
     ),
     signal,
@@ -255,6 +259,56 @@ export async function* sendMessage(
         break;
     }
   }
+}
+
+export async function getProject(): Promise<ProjectResponse> {
+  const response = await fetch(`${API_BASE}/api/v1/project`);
+  if (!response.ok) {
+    throw new Error("Failed to fetch project");
+  }
+  const data = await response.json();
+  return new ProjectResponse(data);
+}
+
+export async function openProject(path: string): Promise<ProjectResponse> {
+  const response = await fetch(`${API_BASE}/api/v1/project/open`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ path }),
+  });
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(error || "Failed to open project");
+  }
+  const data = await response.json();
+  return new ProjectResponse(data);
+}
+
+export async function closeProject(): Promise<ProjectResponse> {
+  const response = await fetch(`${API_BASE}/api/v1/project/close`, {
+    method: "POST",
+  });
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(error || "Failed to close project");
+  }
+  const data = await response.json();
+  return new ProjectResponse(data);
+}
+
+export async function getProjectFiles(
+  refresh = false,
+): Promise<ProjectFilesResponse> {
+  const response = await fetch(
+    `${API_BASE}/api/v1/project/files${refresh ? "?refresh=1" : ""}`,
+  );
+  if (!response.ok) {
+    throw new Error("Failed to fetch project files");
+  }
+  const data = await response.json();
+  return new ProjectFilesResponse(data);
 }
 
 export async function getSettings(): Promise<{
@@ -418,7 +472,9 @@ export interface ModelRecommendationsResponse {
   recommendations: ModelRecommendation[];
 }
 
-export async function getModelRecommendations(): Promise<ModelRecommendation[]> {
+export async function getModelRecommendations(): Promise<
+  ModelRecommendation[]
+> {
   const response = await fetch(
     `${API_BASE}/api/experimental/model-recommendations`,
   );

--- a/app/ui/app/src/api.ts
+++ b/app/ui/app/src/api.ts
@@ -8,6 +8,7 @@ import {
   ModelCapabilitiesResponse,
   Model,
   ChatRequest,
+  ProjectFileResponse,
   ProjectFilesResponse,
   ProjectResponse,
   Settings,
@@ -309,6 +310,20 @@ export async function getProjectFiles(
   }
   const data = await response.json();
   return new ProjectFilesResponse(data);
+}
+
+export async function getProjectFile(
+  path: string,
+): Promise<ProjectFileResponse> {
+  const response = await fetch(
+    `${API_BASE}/api/v1/project/file?path=${encodeURIComponent(path)}`,
+  );
+  if (!response.ok) {
+    const error = await response.text();
+    throw new Error(error || "Failed to read file");
+  }
+  const data = await response.json();
+  return new ProjectFileResponse(data);
 }
 
 export async function getSettings(): Promise<{

--- a/app/ui/app/src/components/Chat.tsx
+++ b/app/ui/app/src/components/Chat.tsx
@@ -133,6 +133,7 @@ export default function Chat({ chatId }: { chatId: string }) {
       webSearch?: boolean;
       fileTools?: boolean;
       think?: boolean | string;
+      fileRefs?: string[];
     },
   ) => {
     // Clear any existing errors when sending a new message
@@ -154,6 +155,7 @@ export default function Chat({ chatId }: { chatId: string }) {
       webSearch: options.webSearch,
       fileTools: options.fileTools,
       think: options.think,
+      fileRefs: options.fileRefs,
       onChatEvent: (event) => {
         if (event.eventName === "chat_created" && event.chatId) {
           navigate({

--- a/app/ui/app/src/components/ChatForm.tsx
+++ b/app/ui/app/src/components/ChatForm.tsx
@@ -9,6 +9,7 @@ import {
   useEffect,
   useLayoutEffect,
   useCallback,
+  useMemo,
 } from "react";
 import {
   useSendMessage,
@@ -31,6 +32,13 @@ import { ErrorMessage } from "./ErrorMessage";
 import { processFiles } from "@/utils/fileValidation";
 import type { ImageData } from "@/types/webview";
 import { PlusIcon } from "@heroicons/react/24/outline";
+import {
+  useProject,
+  useProjectFiles,
+  MENTION_TOTAL_BYTES,
+} from "@/hooks/useProject";
+import { fuzzyFilter } from "@/utils/fuzzyMatch";
+import { FileMentionMenu } from "@/components/FileMentionMenu";
 
 export type ThinkingLevel = "low" | "medium" | "high";
 
@@ -50,6 +58,70 @@ interface MessageInput {
   fileErrors: Array<{ filename: string; error: string }>;
 }
 
+interface MentionRange {
+  start: number;
+  end: number;
+  path: string;
+}
+
+// detectMention returns the active "@query" being typed at the caret, if any
+function detectMention(
+  value: string,
+  caret: number,
+): { start: number; query: string } | null {
+  const upto = value.slice(0, caret);
+  const at = upto.lastIndexOf("@");
+  if (at === -1) return null;
+  // "@" must start a token (beginning of text or after whitespace/brackets)
+  if (at > 0 && !/[\s([{'"`]/.test(upto[at - 1])) return null;
+  const query = upto.slice(at + 1);
+  if (/\s/.test(query)) return null;
+  return { start: at, query };
+}
+
+// getMentionRanges finds every "@path" in the content that resolves to a real
+// project file, so the same ranges drive highlighting and prompt injection
+function getMentionRanges(
+  content: string,
+  filePathSet: Set<string>,
+  selectedMentions: Set<string>,
+): MentionRange[] {
+  const ranges: MentionRange[] = [];
+
+  for (const match of content.matchAll(/@([^\s@]+)/g)) {
+    if (match.index !== undefined && filePathSet.has(match[1])) {
+      ranges.push({
+        start: match.index,
+        end: match.index + match[0].length,
+        path: match[1],
+      });
+    }
+  }
+
+  // Paths containing whitespace can only come from explicit selections
+  for (const path of selectedMentions) {
+    if (!/\s/.test(path)) continue;
+    const needle = `@${path}`;
+    let idx = content.indexOf(needle);
+    while (idx !== -1) {
+      ranges.push({ start: idx, end: idx + needle.length, path });
+      idx = content.indexOf(needle, idx + needle.length);
+    }
+  }
+
+  ranges.sort((a, b) => a.start - b.start);
+
+  // Drop overlapping ranges (longer/earlier one wins)
+  const merged: MentionRange[] = [];
+  for (const range of ranges) {
+    const last = merged[merged.length - 1];
+    if (!last || range.start >= last.end) {
+      merged.push(range);
+    }
+  }
+  return merged;
+}
+
 interface ChatFormProps {
   hasMessages: boolean;
   onSubmit?: (
@@ -60,6 +132,7 @@ interface ChatFormProps {
       webSearch?: boolean;
       fileTools?: boolean;
       think?: boolean | string;
+      fileRefs?: string[];
     },
   ) => void;
   autoFocus?: boolean;
@@ -121,6 +194,122 @@ function ChatForm({
   const [fileUploadError, setFileUploadError] = useState<ErrorEvent | null>(
     null,
   );
+
+  // "@" file mention state (only active while a project is open)
+  const { project } = useProject();
+  const { filePathSet, fileSizes } = useProjectFiles();
+  const [mention, setMention] = useState<{
+    start: number;
+    query: string;
+  } | null>(null);
+  const [mentionIndex, setMentionIndex] = useState(0);
+  const [selectedMentions, setSelectedMentions] = useState<Set<string>>(
+    new Set(),
+  );
+  const highlightRef = useRef<HTMLDivElement>(null);
+
+  const filePaths = useMemo(() => Array.from(filePathSet), [filePathSet]);
+
+  const mentionResults = useMemo(() => {
+    if (!project || !mention) return [];
+    return fuzzyFilter(mention.query, filePaths, 50);
+  }, [project, mention, filePaths]);
+
+  useEffect(() => {
+    setMentionIndex(0);
+  }, [mention?.query]);
+
+  const mentionRanges = useMemo(() => {
+    if (!project) return [];
+    return getMentionRanges(message.content, filePathSet, selectedMentions);
+  }, [project, message.content, filePathSet, selectedMentions]);
+
+  const mentionedFiles = useMemo(
+    () => Array.from(new Set(mentionRanges.map((r) => r.path))),
+    [mentionRanges],
+  );
+
+  const mentionedBytes = useMemo(
+    () =>
+      mentionedFiles.reduce((sum, path) => sum + (fileSizes.get(path) ?? 0), 0),
+    [mentionedFiles, fileSizes],
+  );
+  const mentionOverBudget = mentionedBytes > MENTION_TOTAL_BYTES;
+
+  const updateMentionFromTextarea = useCallback(
+    (el: HTMLTextAreaElement) => {
+      if (!project || filePathSet.size === 0) {
+        setMention(null);
+        return;
+      }
+      setMention(detectMention(el.value, el.selectionStart ?? el.value.length));
+    },
+    [project, filePathSet],
+  );
+
+  const resizeTextarea = (el: HTMLTextAreaElement) => {
+    el.style.height = "auto";
+    el.style.height = Math.min(el.scrollHeight, 24 * 8) + "px";
+  };
+
+  const insertMention = useCallback(
+    (path: string) => {
+      const el = textareaRef.current;
+      if (!el || !mention) return;
+      const caret = el.selectionStart ?? message.content.length;
+      const before = message.content.slice(0, mention.start);
+      const after = message.content.slice(caret);
+      const inserted = `@${path} `;
+
+      setMessage((prev) => ({ ...prev, content: before + inserted + after }));
+      setSelectedMentions((prev) => new Set(prev).add(path));
+      setMention(null);
+
+      requestAnimationFrame(() => {
+        const textarea = textareaRef.current;
+        if (textarea) {
+          const pos = before.length + inserted.length;
+          textarea.focus();
+          textarea.setSelectionRange(pos, pos);
+          resizeTextarea(textarea);
+        }
+      });
+    },
+    [mention, message.content],
+  );
+
+  // Insert a mention when a file is clicked in the project tree
+  useEffect(() => {
+    const handleMentionFile = (e: Event) => {
+      const path = (e as CustomEvent<{ path?: string }>).detail?.path;
+      if (!path) return;
+
+      setMessage((prev) => {
+        const needsSpace = prev.content.length > 0 && !/\s$/.test(prev.content);
+        return {
+          ...prev,
+          content: `${prev.content}${needsSpace ? " " : ""}@${path} `,
+        };
+      });
+      setSelectedMentions((prev) => new Set(prev).add(path));
+
+      requestAnimationFrame(() => {
+        const textarea = textareaRef.current;
+        if (textarea) {
+          textarea.focus();
+          textarea.setSelectionRange(
+            textarea.value.length,
+            textarea.value.length,
+          );
+          resizeTextarea(textarea);
+        }
+      });
+    };
+
+    window.addEventListener("project:mention-file", handleMentionFile);
+    return () =>
+      window.removeEventListener("project:mention-file", handleMentionFile);
+  }, []);
 
   const handleThinkingLevelDropdownToggle = (isOpen: boolean) => {
     if (
@@ -264,6 +453,8 @@ function ChatForm({
       attachments: [],
       fileErrors: [],
     });
+    setMention(null);
+    setSelectedMentions(new Set());
 
     if (textareaRef.current) {
       textareaRef.current.style.height = "auto";
@@ -482,9 +673,7 @@ function ChatForm({
 
     // Prepare attachments for submission, excluding unsupported images
     const attachmentsToSend: FileAttachment[] = message.attachments
-      .filter(
-        (att) => hasVisionCapability || !isImageFile(att.filename),
-      )
+      .filter((att) => hasVisionCapability || !isImageFile(att.filename))
       .map((att) => ({
         filename: att.filename,
         data: att.data || new Uint8Array(0), // Empty data for existing files
@@ -498,12 +687,15 @@ function ChatForm({
         ? thinkEnabled
         : undefined;
 
+    const fileRefs = mentionedFiles.length > 0 ? mentionedFiles : undefined;
+
     if (onSubmit) {
       onSubmit(message.content, {
         attachments: attachmentsToSend,
         index: undefined,
         webSearch: useWebSearch,
         think: useThink,
+        fileRefs,
       });
     } else {
       sendMessageMutation({
@@ -511,6 +703,7 @@ function ChatForm({
         attachments: attachmentsToSend,
         webSearch: useWebSearch,
         think: useThink,
+        fileRefs,
         onChatEvent: (event) => {
           if (event.eventName === "chat_created" && event.chatId) {
             navigate({
@@ -530,6 +723,8 @@ function ChatForm({
       attachments: [],
       fileErrors: [],
     });
+    setMention(null);
+    setSelectedMentions(new Set());
 
     // Reset textarea height and refocus after submit
     setTimeout(() => {
@@ -541,6 +736,33 @@ function ChatForm({
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // While the "@" mention menu is open it captures navigation keys
+    if (mention && mentionResults.length > 0) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setMentionIndex((i) => (i + 1) % mentionResults.length);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setMentionIndex(
+          (i) => (i - 1 + mentionResults.length) % mentionResults.length,
+        );
+        return;
+      }
+      if ((e.key === "Enter" && !e.shiftKey) || e.key === "Tab") {
+        e.preventDefault();
+        insertMention(mentionResults[mentionIndex]);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        e.stopPropagation();
+        setMention(null);
+        return;
+      }
+    }
+
     // Handle Enter to submit
     if (e.key === "Enter" && !e.shiftKey && !isEditing) {
       e.preventDefault();
@@ -628,6 +850,7 @@ function ChatForm({
   // Auto-resize textarea function
   const handleTextareaChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setMessage((prev) => ({ ...prev, content: e.target.value }));
+    updateMentionFromTextarea(e.target);
 
     // Reset height to auto to get the correct scrollHeight, then cap at 8 lines
     e.target.style.height = "auto";
@@ -742,68 +965,70 @@ function ChatForm({
               const isUnsupportedImage =
                 !hasVisionCapability && isImageFile(attachment.filename);
               return (
-              <div
-                key={attachment.id}
-                className={`group flex items-center gap-2 py-2 px-3 rounded-lg transition-colors flex-shrink-0 ${
-                  isUnsupportedImage
-                    ? "bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800"
-                    : "bg-neutral-50 dark:bg-neutral-700/50 hover:bg-neutral-100 dark:hover:bg-neutral-700"
-                }`}
-              >
-                {isImageFile(attachment.filename) ? (
-                  <ImageThumbnail
-                    image={{
-                      filename: attachment.filename,
-                      data: attachment.data || new Uint8Array(0),
-                    }}
-                    className="w-8 h-8 object-cover rounded-md flex-shrink-0"
-                  />
-                ) : (
-                  <svg
-                    className="w-4 h-4 text-neutral-400 dark:text-neutral-500 flex-shrink-0"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={1.5}
-                      d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
-                    />
-                  </svg>
-                )}
-                <div className="flex flex-col min-w-0">
-                  <span className={`text-sm max-w-36 truncate ${isUnsupportedImage ? "text-red-700 dark:text-red-300" : "text-neutral-700 dark:text-neutral-300"}`}>
-                    {attachment.filename}
-                  </span>
-                  {isUnsupportedImage && (
-                    <span className="text-xs text-red-600 dark:text-red-400 opacity-75">
-                      This model does not support images
-                    </span>
-                  )}
-                </div>
-                <button
-                  type="button"
-                  onClick={() => removeFile(index)}
-                  className="opacity-0 group-hover:opacity-100 transition-opacity text-neutral-400 hover:text-neutral-600 dark:text-neutral-500 dark:hover:text-neutral-300 -mr-1 cursor-pointer"
-                  aria-label={`Remove ${attachment.filename}`}
+                <div
+                  key={attachment.id}
+                  className={`group flex items-center gap-2 py-2 px-3 rounded-lg transition-colors flex-shrink-0 ${
+                    isUnsupportedImage
+                      ? "bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800"
+                      : "bg-neutral-50 dark:bg-neutral-700/50 hover:bg-neutral-100 dark:hover:bg-neutral-700"
+                  }`}
                 >
-                  <svg
-                    className="w-4 h-4"
-                    fill="none"
-                    viewBox="0 0 24 24"
-                    stroke="currentColor"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M6 18L18 6M6 6l12 12"
+                  {isImageFile(attachment.filename) ? (
+                    <ImageThumbnail
+                      image={{
+                        filename: attachment.filename,
+                        data: attachment.data || new Uint8Array(0),
+                      }}
+                      className="w-8 h-8 object-cover rounded-md flex-shrink-0"
                     />
-                  </svg>
-                </button>
-              </div>
+                  ) : (
+                    <svg
+                      className="w-4 h-4 text-neutral-400 dark:text-neutral-500 flex-shrink-0"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={1.5}
+                        d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+                      />
+                    </svg>
+                  )}
+                  <div className="flex flex-col min-w-0">
+                    <span
+                      className={`text-sm max-w-36 truncate ${isUnsupportedImage ? "text-red-700 dark:text-red-300" : "text-neutral-700 dark:text-neutral-300"}`}
+                    >
+                      {attachment.filename}
+                    </span>
+                    {isUnsupportedImage && (
+                      <span className="text-xs text-red-600 dark:text-red-400 opacity-75">
+                        This model does not support images
+                      </span>
+                    )}
+                  </div>
+                  <button
+                    type="button"
+                    onClick={() => removeFile(index)}
+                    className="opacity-0 group-hover:opacity-100 transition-opacity text-neutral-400 hover:text-neutral-600 dark:text-neutral-500 dark:hover:text-neutral-300 -mr-1 cursor-pointer"
+                    aria-label={`Remove ${attachment.filename}`}
+                  >
+                    <svg
+                      className="w-4 h-4"
+                      fill="none"
+                      viewBox="0 0 24 24"
+                      stroke="currentColor"
+                    >
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M6 18L18 6M6 6l12 12"
+                      />
+                    </svg>
+                  </button>
+                </div>
               );
             })}
             {message.fileErrors.map((fileError, index) => (
@@ -856,21 +1081,76 @@ function ChatForm({
         )}
 
         <div className="relative w-full px-5">
+          {mention && !isDisabled && (
+            <FileMentionMenu
+              results={mentionResults}
+              selectedIndex={mentionIndex}
+              onSelect={insertMention}
+              onHover={setMentionIndex}
+            />
+          )}
+          {mentionRanges.length > 0 && (
+            // Backdrop that paints a highlight behind each valid @mention;
+            // its text is transparent and only span backgrounds are visible
+            <div
+              ref={highlightRef}
+              aria-hidden
+              className="pointer-events-none absolute inset-x-5 inset-y-0 overflow-hidden whitespace-pre-wrap break-words text-transparent min-h-[24px] leading-6"
+            >
+              {(() => {
+                const parts: React.ReactNode[] = [];
+                let last = 0;
+                mentionRanges.forEach((range, i) => {
+                  if (range.start > last) {
+                    parts.push(message.content.slice(last, range.start));
+                  }
+                  parts.push(
+                    <span
+                      key={i}
+                      className="rounded bg-blue-100 dark:bg-blue-500/25"
+                    >
+                      {message.content.slice(range.start, range.end)}
+                    </span>,
+                  );
+                  last = range.end;
+                });
+                if (last < message.content.length) {
+                  parts.push(message.content.slice(last));
+                }
+                return parts;
+              })()}
+            </div>
+          )}
           <textarea
             ref={textareaRef}
             value={message.content}
             onChange={handleTextareaChange}
             placeholder="Send a message"
             disabled={isDisabled}
-            className={`allow-context-menu w-full overflow-y-auto text-neutral-700 outline-none resize-none border-none bg-transparent dark:text-white placeholder:text-neutral-400 dark:placeholder:text-neutral-500 min-h-[24px] leading-6 transition-opacity duration-300 ${
+            className={`allow-context-menu relative z-[1] w-full overflow-y-auto text-neutral-700 outline-none resize-none border-none bg-transparent dark:text-white placeholder:text-neutral-400 dark:placeholder:text-neutral-500 min-h-[24px] leading-6 transition-opacity duration-300 ${
               editingMessage ? "animate-fade-in" : ""
             }`}
             rows={1}
             onKeyDown={handleKeyDown}
+            onClick={(e) => updateMentionFromTextarea(e.currentTarget)}
+            onScroll={(e) => {
+              if (highlightRef.current) {
+                highlightRef.current.scrollTop = e.currentTarget.scrollTop;
+              }
+            }}
             onCompositionStart={handleCompositionStart}
             onCompositionEnd={handleCompositionEnd}
           />
         </div>
+        {mentionOverBudget && (
+          <div className="w-full px-5 pt-1">
+            <p className="text-xs text-amber-600 dark:text-amber-400">
+              Mentioned files exceed the context budget (~
+              {Math.round(MENTION_TOTAL_BYTES / 4 / 1000)}k tokens) — their
+              content will be truncated.
+            </p>
+          </div>
+        )}
 
         {/* Controls */}
         <div className="flex w-full items-center justify-end gap-2 px-3 pt-2">

--- a/app/ui/app/src/components/FileMentionMenu.tsx
+++ b/app/ui/app/src/components/FileMentionMenu.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useRef } from "react";
+import { DocumentIcon } from "@heroicons/react/24/outline";
+
+// Dropdown listing fuzzy-matched project files while typing "@" in the chat
+// input. Rendered above the textarea; keyboard handling lives in ChatForm.
+export function FileMentionMenu({
+  results,
+  selectedIndex,
+  onSelect,
+  onHover,
+}: {
+  results: string[];
+  selectedIndex: number;
+  onSelect: (path: string) => void;
+  onHover: (index: number) => void;
+}) {
+  const listRef = useRef<HTMLDivElement>(null);
+
+  // Keep the selected row visible while navigating with the keyboard
+  useEffect(() => {
+    const list = listRef.current;
+    const item = list?.children[selectedIndex] as HTMLElement | undefined;
+    if (item && list) {
+      const itemTop = item.offsetTop;
+      const itemBottom = itemTop + item.offsetHeight;
+      if (itemTop < list.scrollTop) {
+        list.scrollTop = itemTop;
+      } else if (itemBottom > list.scrollTop + list.clientHeight) {
+        list.scrollTop = itemBottom - list.clientHeight;
+      }
+    }
+  }, [selectedIndex]);
+
+  if (results.length === 0) return null;
+
+  return (
+    <div className="absolute bottom-full left-0 right-0 z-40 mb-2 overflow-hidden rounded-xl border border-neutral-200 bg-white shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
+      <div ref={listRef} className="max-h-64 overflow-y-auto p-1">
+        {results.map((path, index) => {
+          const slash = path.lastIndexOf("/");
+          const dir = slash === -1 ? "" : path.slice(0, slash);
+          const name = slash === -1 ? path : path.slice(slash + 1);
+          return (
+            <button
+              key={path}
+              type="button"
+              // preventDefault keeps focus in the textarea
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => onSelect(path)}
+              onMouseEnter={() => onHover(index)}
+              className={`flex w-full items-center gap-2 rounded-lg px-3 py-1.5 text-left text-sm cursor-pointer ${
+                index === selectedIndex
+                  ? "bg-neutral-100 dark:bg-neutral-700"
+                  : ""
+              }`}
+            >
+              <DocumentIcon className="h-4 w-4 flex-shrink-0 text-neutral-400" />
+              <span className="truncate text-neutral-700 dark:text-neutral-200">
+                {name}
+              </span>
+              {dir && (
+                <span className="min-w-0 flex-1 truncate text-xs text-neutral-400">
+                  {dir}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/ui/app/src/components/FileViewer.tsx
+++ b/app/ui/app/src/components/FileViewer.tsx
@@ -1,0 +1,266 @@
+import { useEffect, useMemo, useState } from "react";
+import { XMarkIcon, AtSymbolIcon } from "@heroicons/react/24/outline";
+import type { BundledLanguage, ThemedToken, ThemeRegistrationAny } from "shiki";
+import CopyButton from "./CopyButton";
+import { useProjectFileContent } from "@/hooks/useProject";
+import { highlighter, highlighterPromise } from "@/lib/highlighter";
+
+// Extensions mapped to the languages loaded in lib/highlighter; anything else
+// renders as plain text
+const LANGUAGE_BY_EXTENSION: Record<string, BundledLanguage> = {
+  js: "javascript",
+  mjs: "javascript",
+  cjs: "javascript",
+  jsx: "jsx",
+  ts: "typescript",
+  mts: "typescript",
+  cts: "typescript",
+  tsx: "tsx",
+  py: "python",
+  sh: "bash",
+  bash: "bash",
+  zsh: "shell",
+  json: "json",
+  html: "html",
+  htm: "html",
+  css: "css",
+  go: "go",
+  rs: "rust",
+  java: "java",
+  c: "c",
+  h: "c",
+  cpp: "cpp",
+  cc: "cpp",
+  hpp: "cpp",
+  sql: "sql",
+  swift: "swift",
+  yaml: "yaml",
+  yml: "yaml",
+  md: "markdown",
+  markdown: "markdown",
+};
+
+// lib/highlighter registers these themes by name, but shiki only types the
+// names it bundles itself
+const LIGHT_THEME = "one-light" as unknown as ThemeRegistrationAny;
+const DARK_THEME = "one-dark" as unknown as ThemeRegistrationAny;
+
+// Highlighting every token of a very large file blocks the UI, so past this
+// size the viewer falls back to plain text
+const MAX_HIGHLIGHT_CHARS = 100 * 1024;
+
+function languageOf(path: string): BundledLanguage | null {
+  const name = path.slice(path.lastIndexOf("/") + 1);
+  const dot = name.lastIndexOf(".");
+  if (dot <= 0) return null;
+  return LANGUAGE_BY_EXTENSION[name.slice(dot + 1).toLowerCase()] ?? null;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function CodeLines({
+  lines,
+  fallback,
+}: {
+  lines: ThemedToken[][] | undefined;
+  fallback: string;
+}) {
+  if (!lines) return <>{fallback}</>;
+  return (
+    <>
+      {lines.map((tokens, i) => (
+        <div key={i} className="min-h-5">
+          {tokens.map((token, j) => (
+            <span key={j} style={{ color: token.color }}>
+              {token.content}
+            </span>
+          ))}
+        </div>
+      ))}
+    </>
+  );
+}
+
+// FileViewer previews a file of the active project in a modal, with syntax
+// highlighting for code, inline rendering for images, and a shortcut to
+// mention the file in the chat.
+export function FileViewer({
+  path,
+  onClose,
+  onMention,
+}: {
+  path: string;
+  onClose: () => void;
+  onMention: (path: string) => void;
+}) {
+  const { file, isLoading, error } = useProjectFileContent(path);
+  const [highlighterReady, setHighlighterReady] = useState(!!highlighter);
+
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        onClose();
+      }
+    };
+    window.addEventListener("keydown", onKeyDown, true);
+    return () => window.removeEventListener("keydown", onKeyDown, true);
+  }, [onClose]);
+
+  // The highlighter loads asynchronously at boot; re-render once it's ready
+  useEffect(() => {
+    if (highlighter) return;
+    let cancelled = false;
+    highlighterPromise.then(() => {
+      if (!cancelled) setHighlighterReady(true);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const content = file?.binary ? "" : (file?.content ?? "");
+  const language = useMemo(() => languageOf(path), [path]);
+
+  const tokens = useMemo(() => {
+    if (!highlighterReady || !highlighter) return null;
+    if (!language || !content || content.length > MAX_HIGHLIGHT_CHARS) {
+      return null;
+    }
+    try {
+      return {
+        light: highlighter.codeToTokensBase(content, {
+          lang: language,
+          theme: LIGHT_THEME,
+        }),
+        dark: highlighter.codeToTokensBase(content, {
+          lang: language,
+          theme: DARK_THEME,
+        }),
+      };
+    } catch {
+      // unknown language for the loaded highlighter: render as plain text
+      return null;
+    }
+  }, [content, language, highlighterReady]);
+
+  const lineCount = useMemo(
+    () => (content ? content.split("\n").length : 0),
+    [content],
+  );
+
+  const slash = path.lastIndexOf("/");
+  const name = slash === -1 ? path : path.slice(slash + 1);
+  const dir = slash === -1 ? "" : path.slice(0, slash);
+  const imageSrc =
+    file?.mimeType && file.content
+      ? `data:${file.mimeType};base64,${file.content}`
+      : null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-6"
+      onClick={onClose}
+    >
+      <div
+        className="flex max-h-[85vh] w-full max-w-4xl flex-col overflow-hidden rounded-2xl border border-neutral-200 bg-white shadow-xl dark:border-neutral-700 dark:bg-neutral-900"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex flex-none items-center gap-3 border-b border-neutral-200 px-4 py-3 dark:border-neutral-800">
+          <div className="min-w-0 flex-1">
+            <p className="truncate text-sm font-semibold text-neutral-800 dark:text-neutral-100">
+              {name}
+            </p>
+            <p
+              className="truncate text-xs text-neutral-500 dark:text-neutral-400"
+              title={path}
+            >
+              {dir || "."}
+              {file ? ` · ${formatBytes(file.size)}` : ""}
+              {file?.truncated ? " · preview truncated" : ""}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => onMention(path)}
+            title="Mention this file in the chat"
+            className="flex items-center gap-1 rounded-lg px-2 py-1 text-xs text-neutral-600 hover:bg-neutral-100 dark:text-neutral-300 dark:hover:bg-neutral-800 cursor-pointer"
+          >
+            <AtSymbolIcon className="h-4 w-4" />
+            Mention
+          </button>
+          {content && (
+            <CopyButton
+              content={content}
+              className="text-neutral-500 dark:text-neutral-400"
+              title="Copy file contents"
+            />
+          )}
+          <button
+            type="button"
+            onClick={onClose}
+            title="Close"
+            className="rounded-lg p-1 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300 cursor-pointer"
+          >
+            <XMarkIcon className="h-4 w-4" />
+          </button>
+        </div>
+
+        <div className="min-h-0 flex-1 overflow-auto bg-neutral-50 dark:bg-neutral-800/40">
+          {isLoading && (
+            <p className="p-4 text-sm text-neutral-400">Loading file…</p>
+          )}
+          {error && <p className="p-4 text-sm text-red-500">{error}</p>}
+          {!isLoading && !error && file && (
+            <>
+              {imageSrc ? (
+                <div className="flex h-full items-center justify-center p-4">
+                  <img
+                    src={imageSrc}
+                    alt={name}
+                    className="max-h-[70vh] max-w-full object-contain"
+                  />
+                </div>
+              ) : file.binary ? (
+                <p className="p-4 text-sm text-neutral-500 dark:text-neutral-400">
+                  Binary file — no preview available.
+                </p>
+              ) : content === "" ? (
+                <p className="p-4 text-sm text-neutral-400">Empty file.</p>
+              ) : (
+                <div className="flex min-w-0 font-mono text-[13px] leading-5">
+                  <div className="flex-none select-none py-3 pl-4 pr-3 text-right text-neutral-400 dark:text-neutral-600">
+                    {Array.from({ length: lineCount }, (_, i) => (
+                      <div key={i}>{i + 1}</div>
+                    ))}
+                  </div>
+                  <div className="min-w-0 flex-1 overflow-x-auto py-3 pr-4">
+                    <pre className="m-0 whitespace-pre dark:hidden">
+                      <code>
+                        <CodeLines lines={tokens?.light} fallback={content} />
+                      </code>
+                    </pre>
+                    <pre className="m-0 hidden whitespace-pre dark:block">
+                      <code>
+                        <CodeLines lines={tokens?.dark} fallback={content} />
+                      </code>
+                    </pre>
+                  </div>
+                </div>
+              )}
+              {file.truncated && (
+                <p className="px-4 pb-3 text-xs text-neutral-400">
+                  Showing the first {formatBytes(content.length)} of the file.
+                </p>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/ui/app/src/components/ProjectButton.tsx
+++ b/app/ui/app/src/components/ProjectButton.tsx
@@ -1,0 +1,139 @@
+import { useEffect, useRef, useState } from "react";
+import {
+  FolderIcon,
+  FolderOpenIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
+import { useProject } from "@/hooks/useProject";
+
+// Header pill showing the active project, with a menu to open a folder,
+// reopen a recent project, or close the current one
+export function ProjectButton() {
+  const {
+    project,
+    recentProjects,
+    openProjectDialog,
+    openProjectPath,
+    closeProject,
+    isOpening,
+  } = useProject();
+  const [isOpen, setIsOpen] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (!containerRef.current?.contains(e.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isOpen]);
+
+  const run = async (action: () => Promise<unknown>) => {
+    setIsOpen(false);
+    setError(null);
+    try {
+      await action();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to open project");
+    }
+  };
+
+  const recents = recentProjects.filter((r) => r !== project?.root);
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative"
+      onMouseDown={(e) => e.stopPropagation()}
+      onDoubleClick={(e) => e.stopPropagation()}
+    >
+      <button
+        type="button"
+        onClick={() => setIsOpen((open) => !open)}
+        disabled={isOpening}
+        title={project ? project.root : "Open a project folder"}
+        className={`flex max-w-56 items-center gap-1.5 rounded-full px-3 py-1.5 text-sm cursor-pointer transition-colors ${
+          project
+            ? "bg-neutral-100 text-neutral-700 hover:bg-neutral-200 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
+            : "text-neutral-500 hover:bg-neutral-100 dark:text-neutral-400 dark:hover:bg-neutral-800"
+        }`}
+      >
+        {project ? (
+          <FolderOpenIcon className="h-4 w-4 flex-shrink-0" />
+        ) : (
+          <FolderIcon className="h-4 w-4 flex-shrink-0" />
+        )}
+        <span className="truncate">
+          {isOpening ? "Opening…" : project ? project.name : "Open project"}
+        </span>
+      </button>
+
+      {isOpen && (
+        <div className="absolute right-0 top-full z-50 mt-1 w-72 rounded-xl border border-neutral-200 bg-white p-1 shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
+          <button
+            type="button"
+            onClick={() => run(openProjectDialog)}
+            className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-neutral-700 hover:bg-neutral-100 dark:text-neutral-200 dark:hover:bg-neutral-700 cursor-pointer"
+          >
+            <FolderIcon className="h-4 w-4 flex-shrink-0 text-neutral-400" />
+            Open folder…
+          </button>
+
+          {recents.length > 0 && (
+            <>
+              <div className="my-1 border-t border-neutral-200 dark:border-neutral-700" />
+              <p className="px-3 py-1 text-xs font-semibold uppercase tracking-wide text-neutral-400">
+                Recent
+              </p>
+              {recents.map((path) => (
+                <button
+                  key={path}
+                  type="button"
+                  onClick={() => run(() => openProjectPath(path))}
+                  title={path}
+                  className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-neutral-700 hover:bg-neutral-100 dark:text-neutral-200 dark:hover:bg-neutral-700 cursor-pointer"
+                >
+                  <FolderIcon className="h-4 w-4 flex-shrink-0 text-neutral-400" />
+                  <span className="min-w-0 flex-1 truncate" dir="rtl">
+                    {path}
+                  </span>
+                </button>
+              ))}
+            </>
+          )}
+
+          {project && (
+            <>
+              <div className="my-1 border-t border-neutral-200 dark:border-neutral-700" />
+              <button
+                type="button"
+                onClick={() => run(closeProject)}
+                className="flex w-full items-center gap-2 rounded-lg px-3 py-2 text-left text-sm text-neutral-700 hover:bg-neutral-100 dark:text-neutral-200 dark:hover:bg-neutral-700 cursor-pointer"
+              >
+                <XMarkIcon className="h-4 w-4 flex-shrink-0 text-neutral-400" />
+                Close project
+              </button>
+            </>
+          )}
+        </div>
+      )}
+
+      {error && (
+        <div className="absolute right-0 top-full z-50 mt-1 w-72 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700 shadow-lg dark:border-red-800 dark:bg-red-900/40 dark:text-red-300">
+          {error}
+          <button
+            type="button"
+            onClick={() => setError(null)}
+            className="ml-2 underline cursor-pointer"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/ui/app/src/components/ProjectPanel.tsx
+++ b/app/ui/app/src/components/ProjectPanel.tsx
@@ -1,0 +1,207 @@
+import { useMemo, useState } from "react";
+import {
+  ChevronRightIcon,
+  ChevronDownIcon,
+  FolderIcon,
+  DocumentIcon,
+  ArrowPathIcon,
+  XMarkIcon,
+} from "@heroicons/react/24/outline";
+import { useProject, useProjectFiles } from "@/hooks/useProject";
+import { ProjectFile } from "@/gotypes";
+
+interface TreeNode {
+  name: string;
+  path: string;
+  isDir: boolean;
+  children: TreeNode[];
+}
+
+function buildTree(files: ProjectFile[]): TreeNode[] {
+  const root: TreeNode = { name: "", path: "", isDir: true, children: [] };
+  const nodes = new Map<string, TreeNode>([["", root]]);
+
+  // Files come sorted by path, so parents always appear before children
+  for (const file of files) {
+    const idx = file.path.lastIndexOf("/");
+    const parentPath = idx === -1 ? "" : file.path.slice(0, idx);
+    const name = idx === -1 ? file.path : file.path.slice(idx + 1);
+
+    const node: TreeNode = {
+      name,
+      path: file.path,
+      isDir: file.isDir,
+      children: [],
+    };
+
+    // Parent may be missing if its dir entry was filtered out; skip orphans
+    const parent = nodes.get(parentPath);
+    if (!parent) continue;
+
+    parent.children.push(node);
+    if (file.isDir) {
+      nodes.set(file.path, node);
+    }
+  }
+
+  const sortChildren = (node: TreeNode) => {
+    node.children.sort((a, b) => {
+      if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+    node.children.forEach(sortChildren);
+  };
+  sortChildren(root);
+
+  return root.children;
+}
+
+function TreeEntry({
+  node,
+  depth,
+  expanded,
+  onToggle,
+  onFileClick,
+}: {
+  node: TreeNode;
+  depth: number;
+  expanded: Set<string>;
+  onToggle: (path: string) => void;
+  onFileClick: (path: string) => void;
+}) {
+  const isExpanded = expanded.has(node.path);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() =>
+          node.isDir ? onToggle(node.path) : onFileClick(node.path)
+        }
+        title={node.path}
+        className="flex w-full items-center gap-1 rounded-md px-2 py-1 text-left text-sm text-neutral-700 hover:bg-neutral-200/60 dark:text-neutral-300 dark:hover:bg-neutral-700/60 cursor-pointer"
+        style={{ paddingLeft: `${depth * 12 + 8}px` }}
+      >
+        {node.isDir ? (
+          <>
+            {isExpanded ? (
+              <ChevronDownIcon className="h-3 w-3 flex-shrink-0 text-neutral-400" />
+            ) : (
+              <ChevronRightIcon className="h-3 w-3 flex-shrink-0 text-neutral-400" />
+            )}
+            <FolderIcon className="h-4 w-4 flex-shrink-0 text-neutral-400" />
+          </>
+        ) : (
+          <DocumentIcon className="ml-4 h-4 w-4 flex-shrink-0 text-neutral-400" />
+        )}
+        <span className="truncate">{node.name}</span>
+      </button>
+      {node.isDir &&
+        isExpanded &&
+        node.children.map((child) => (
+          <TreeEntry
+            key={child.path}
+            node={child}
+            depth={depth + 1}
+            expanded={expanded}
+            onToggle={onToggle}
+            onFileClick={onFileClick}
+          />
+        ))}
+    </>
+  );
+}
+
+export function ProjectPanel() {
+  const { project, closeProject } = useProject();
+  const { files, truncated, isLoading, refresh } = useProjectFiles();
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [isRefreshing, setIsRefreshing] = useState(false);
+
+  const tree = useMemo(() => buildTree(files), [files]);
+
+  if (!project) return null;
+
+  const handleToggle = (path: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(path)) {
+        next.delete(path);
+      } else {
+        next.add(path);
+      }
+      return next;
+    });
+  };
+
+  const handleFileClick = (path: string) => {
+    window.dispatchEvent(
+      new CustomEvent("project:mention-file", { detail: { path } }),
+    );
+  };
+
+  const handleRefresh = async () => {
+    setIsRefreshing(true);
+    try {
+      await refresh();
+    } finally {
+      setIsRefreshing(false);
+    }
+  };
+
+  return (
+    <div className="flex h-full min-h-0 flex-col">
+      <div className="flex items-center justify-between px-3 pb-1">
+        <span
+          className="truncate text-xs font-semibold uppercase tracking-wide text-neutral-500 dark:text-neutral-400"
+          title={project.root}
+        >
+          {project.name}
+        </span>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={handleRefresh}
+            title="Refresh file list"
+            className="rounded-md p-1 text-neutral-400 hover:bg-neutral-200/60 hover:text-neutral-600 dark:hover:bg-neutral-700/60 dark:hover:text-neutral-300 cursor-pointer"
+          >
+            <ArrowPathIcon
+              className={`h-3.5 w-3.5 ${isRefreshing ? "animate-spin" : ""}`}
+            />
+          </button>
+          <button
+            type="button"
+            onClick={() => closeProject()}
+            title="Close project"
+            className="rounded-md p-1 text-neutral-400 hover:bg-neutral-200/60 hover:text-neutral-600 dark:hover:bg-neutral-700/60 dark:hover:text-neutral-300 cursor-pointer"
+          >
+            <XMarkIcon className="h-3.5 w-3.5" />
+          </button>
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto px-1 pb-2">
+        {isLoading ? (
+          <p className="px-3 py-2 text-sm text-neutral-400">Loading files…</p>
+        ) : (
+          <>
+            {tree.map((node) => (
+              <TreeEntry
+                key={node.path}
+                node={node}
+                depth={0}
+                expanded={expanded}
+                onToggle={handleToggle}
+                onFileClick={handleFileClick}
+              />
+            ))}
+            {truncated && (
+              <p className="px-3 py-2 text-xs text-neutral-400">
+                File list truncated — project is very large.
+              </p>
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/ui/app/src/components/ProjectPanel.tsx
+++ b/app/ui/app/src/components/ProjectPanel.tsx
@@ -5,9 +5,11 @@ import {
   FolderIcon,
   DocumentIcon,
   ArrowPathIcon,
+  AtSymbolIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
 import { useProject, useProjectFiles } from "@/hooks/useProject";
+import { FileViewer } from "@/components/FileViewer";
 import { ProjectFile } from "@/gotypes";
 
 interface TreeNode {
@@ -62,40 +64,59 @@ function TreeEntry({
   expanded,
   onToggle,
   onFileClick,
+  onMention,
 }: {
   node: TreeNode;
   depth: number;
   expanded: Set<string>;
   onToggle: (path: string) => void;
   onFileClick: (path: string) => void;
+  onMention: (path: string) => void;
 }) {
   const isExpanded = expanded.has(node.path);
 
   return (
     <>
-      <button
-        type="button"
-        onClick={() =>
-          node.isDir ? onToggle(node.path) : onFileClick(node.path)
-        }
-        title={node.path}
-        className="flex w-full items-center gap-1 rounded-md px-2 py-1 text-left text-sm text-neutral-700 hover:bg-neutral-200/60 dark:text-neutral-300 dark:hover:bg-neutral-700/60 cursor-pointer"
-        style={{ paddingLeft: `${depth * 12 + 8}px` }}
-      >
-        {node.isDir ? (
-          <>
-            {isExpanded ? (
-              <ChevronDownIcon className="h-3 w-3 flex-shrink-0 text-neutral-400" />
-            ) : (
-              <ChevronRightIcon className="h-3 w-3 flex-shrink-0 text-neutral-400" />
-            )}
-            <FolderIcon className="h-4 w-4 flex-shrink-0 text-neutral-400" />
-          </>
-        ) : (
-          <DocumentIcon className="ml-4 h-4 w-4 flex-shrink-0 text-neutral-400" />
+      <div className="group relative flex items-center rounded-md hover:bg-neutral-200/60 dark:hover:bg-neutral-700/60">
+        <button
+          type="button"
+          onClick={(e) =>
+            node.isDir
+              ? onToggle(node.path)
+              : // modifier-click mentions the file instead of opening it
+                e.metaKey || e.ctrlKey
+                ? onMention(node.path)
+                : onFileClick(node.path)
+          }
+          title={node.path}
+          className="flex min-w-0 flex-1 items-center gap-1 px-2 py-1 text-left text-sm text-neutral-700 dark:text-neutral-300 cursor-pointer"
+          style={{ paddingLeft: `${depth * 12 + 8}px` }}
+        >
+          {node.isDir ? (
+            <>
+              {isExpanded ? (
+                <ChevronDownIcon className="h-3 w-3 flex-shrink-0 text-neutral-400" />
+              ) : (
+                <ChevronRightIcon className="h-3 w-3 flex-shrink-0 text-neutral-400" />
+              )}
+              <FolderIcon className="h-4 w-4 flex-shrink-0 text-neutral-400" />
+            </>
+          ) : (
+            <DocumentIcon className="ml-4 h-4 w-4 flex-shrink-0 text-neutral-400" />
+          )}
+          <span className="truncate">{node.name}</span>
+        </button>
+        {!node.isDir && (
+          <button
+            type="button"
+            onClick={() => onMention(node.path)}
+            title="Mention this file in the chat"
+            className="mr-1 flex-none rounded p-1 text-neutral-400 opacity-0 hover:bg-neutral-300/60 hover:text-neutral-600 focus:opacity-100 group-hover:opacity-100 dark:hover:bg-neutral-600/60 dark:hover:text-neutral-200 cursor-pointer"
+          >
+            <AtSymbolIcon className="h-3.5 w-3.5" />
+          </button>
         )}
-        <span className="truncate">{node.name}</span>
-      </button>
+      </div>
       {node.isDir &&
         isExpanded &&
         node.children.map((child) => (
@@ -106,6 +127,7 @@ function TreeEntry({
             expanded={expanded}
             onToggle={onToggle}
             onFileClick={onFileClick}
+            onMention={onMention}
           />
         ))}
     </>
@@ -117,6 +139,7 @@ export function ProjectPanel() {
   const { files, truncated, isLoading, refresh } = useProjectFiles();
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
   const [isRefreshing, setIsRefreshing] = useState(false);
+  const [previewPath, setPreviewPath] = useState<string | null>(null);
 
   const tree = useMemo(() => buildTree(files), [files]);
 
@@ -134,7 +157,10 @@ export function ProjectPanel() {
     });
   };
 
-  const handleFileClick = (path: string) => {
+  // Clicking a file opens the preview; mentioning it in the chat is an
+  // explicit action (the "@" button, or a modifier-click on the row)
+  const handleMention = (path: string) => {
+    setPreviewPath(null);
     window.dispatchEvent(
       new CustomEvent("project:mention-file", { detail: { path } }),
     );
@@ -191,7 +217,8 @@ export function ProjectPanel() {
                 depth={0}
                 expanded={expanded}
                 onToggle={handleToggle}
-                onFileClick={handleFileClick}
+                onFileClick={setPreviewPath}
+                onMention={handleMention}
               />
             ))}
             {truncated && (
@@ -202,6 +229,13 @@ export function ProjectPanel() {
           </>
         )}
       </div>
+      {previewPath && (
+        <FileViewer
+          path={previewPath}
+          onClose={() => setPreviewPath(null)}
+          onMention={handleMention}
+        />
+      )}
     </div>
   );
 }

--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -1,5 +1,8 @@
 import { Link } from "@tanstack/react-router";
 import { useSettings } from "@/hooks/useSettings";
+import { useProject } from "@/hooks/useProject";
+import { ProjectButton } from "@/components/ProjectButton";
+import { ProjectPanel } from "@/components/ProjectPanel";
 
 export function SidebarLayout({
   sidebar,
@@ -10,12 +13,13 @@ export function SidebarLayout({
   chatId?: string;
 }>) {
   const { settings, setSettings } = useSettings();
+  const { project } = useProject();
   const isWindows = navigator.platform.toLowerCase().includes("win");
 
   return (
     <div className={`flex transition-[width] duration-300 dark:bg-neutral-900`}>
       <div
-        className={`absolute flex mx-2 py-2 z-20 items-center transition-[left] duration-375 text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
+        className={`absolute flex mx-2 py-2 z-40 items-center transition-[left] duration-375 text-neutral-500 dark:text-neutral-400 ${settings.sidebarOpen ? (isWindows ? "left-2" : "left-[204px]") : isWindows ? "left-2" : "left-20"}`}
       >
         <button
           onClick={() => setSettings({ SidebarOpen: !settings.sidebarOpen })}
@@ -66,14 +70,26 @@ export function SidebarLayout({
         ></div>
         {settings.sidebarOpen && sidebar}
       </div>
+      {project && (
+        <div className="flex w-60 flex-none flex-col max-h-screen border-r border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-900">
+          <div
+            onDoubleClick={() => window.doubleClick && window.doubleClick()}
+            onMouseDown={() => window.drag && window.drag()}
+            className="flex-none h-13 w-full"
+          ></div>
+          <ProjectPanel />
+        </div>
+      )}
       <main
         className={`flex flex-1 flex-col min-w-0 transition-all duration-300`}
       >
         <div
-          className={`h-13 flex-none w-full z-10 flex items-center bg-white dark:bg-neutral-900 ${isWindows ? "xl:hidden" : "xl:fixed xl:bg-transparent xl:dark:bg-transparent"}`}
+          className={`h-13 flex-none w-full z-30 flex items-center justify-end px-4 bg-white dark:bg-neutral-900 ${isWindows ? "" : "xl:fixed xl:bg-transparent xl:dark:bg-transparent"}`}
           onDoubleClick={() => window.doubleClick && window.doubleClick()}
           onMouseDown={() => window.drag && window.drag()}
-        ></div>
+        >
+          <ProjectButton />
+        </div>
         {children}
       </main>
     </div>

--- a/app/ui/app/src/hooks/useChats.ts
+++ b/app/ui/app/src/hooks/useChats.ts
@@ -241,6 +241,7 @@ export const useSendMessage = (chatId: string) => {
       fileTools,
       forceUpdate,
       think,
+      fileRefs,
       onChatEvent,
     }: {
       message: string;
@@ -250,6 +251,7 @@ export const useSendMessage = (chatId: string) => {
       fileTools?: boolean;
       forceUpdate?: boolean;
       think?: boolean | string;
+      fileRefs?: string[];
       onChatEvent?: (event: ChatEventUnion) => void;
     }) => {
       // For existing chats, set streaming state and add optimistic user message
@@ -326,6 +328,7 @@ export const useSendMessage = (chatId: string) => {
         fileTools,
         forceUpdate,
         think,
+        fileRefs,
       );
       let currentChatId = chatId;
       let isCancelled = false;

--- a/app/ui/app/src/hooks/useProject.ts
+++ b/app/ui/app/src/hooks/useProject.ts
@@ -1,0 +1,119 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { useCallback, useMemo } from "react";
+import { getProject, openProject, closeProject, getProjectFiles } from "@/api";
+import { ProjectFile } from "@/gotypes";
+
+// Approximate context budget for @-mentioned files. Must stay in sync with
+// maxMentionTotalBytes in app/ui/project.go.
+export const MENTION_TOTAL_BYTES = 128 * 1024;
+
+export function useProject() {
+  const queryClient = useQueryClient();
+
+  const { data: project, isLoading } = useQuery({
+    queryKey: ["project"],
+    queryFn: getProject,
+  });
+
+  const invalidate = useCallback(() => {
+    queryClient.invalidateQueries({ queryKey: ["project"] });
+    queryClient.invalidateQueries({ queryKey: ["projectFiles"] });
+  }, [queryClient]);
+
+  const openMutation = useMutation({
+    mutationFn: openProject,
+    onSuccess: invalidate,
+  });
+
+  const closeMutation = useMutation({
+    mutationFn: closeProject,
+    onSuccess: invalidate,
+  });
+
+  // Opens the native folder picker and activates the selected folder
+  const openProjectDialog = useCallback(async () => {
+    const path = await window.webview?.selectWorkingDirectory();
+    if (!path) return null;
+    return openMutation.mutateAsync(path);
+  }, [openMutation]);
+
+  const openProjectPath = useCallback(
+    (path: string) => openMutation.mutateAsync(path),
+    [openMutation],
+  );
+
+  const close = useCallback(() => closeMutation.mutateAsync(), [closeMutation]);
+
+  const hasProject = !!project?.root;
+
+  return useMemo(
+    () => ({
+      project: hasProject ? project : null,
+      recentProjects: project?.recent ?? [],
+      isLoading,
+      openProjectDialog,
+      openProjectPath,
+      closeProject: close,
+      isOpening: openMutation.isPending,
+    }),
+    [
+      hasProject,
+      project,
+      isLoading,
+      openProjectDialog,
+      openProjectPath,
+      close,
+      openMutation.isPending,
+    ],
+  );
+}
+
+export function useProjectFiles() {
+  const { project } = useProject();
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["projectFiles", project?.root],
+    queryFn: () => getProjectFiles(),
+    enabled: !!project?.root,
+    staleTime: Infinity,
+  });
+
+  const refresh = useCallback(async () => {
+    if (!project?.root) return;
+    const refreshed = await getProjectFiles(true);
+    queryClient.setQueryData(["projectFiles", project.root], refreshed);
+  }, [project?.root, queryClient]);
+
+  const files: ProjectFile[] = useMemo(() => data?.files ?? [], [data?.files]);
+
+  // Set of non-directory paths for O(1) mention validation
+  const filePathSet = useMemo(() => {
+    const set = new Set<string>();
+    for (const f of files) {
+      if (!f.isDir) set.add(f.path);
+    }
+    return set;
+  }, [files]);
+
+  // Map of path -> size for context budget estimation
+  const fileSizes = useMemo(() => {
+    const map = new Map<string, number>();
+    for (const f of files) {
+      if (!f.isDir) map.set(f.path, f.size);
+    }
+    return map;
+  }, [files]);
+
+  return useMemo(
+    () => ({
+      files,
+      filePathSet,
+      fileSizes,
+      truncated: data?.truncated ?? false,
+      isLoading,
+      refresh,
+    }),
+    [files, filePathSet, fileSizes, data?.truncated, isLoading, refresh],
+  );
+}

--- a/app/ui/app/src/hooks/useProject.ts
+++ b/app/ui/app/src/hooks/useProject.ts
@@ -1,6 +1,12 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { useCallback, useMemo } from "react";
-import { getProject, openProject, closeProject, getProjectFiles } from "@/api";
+import {
+  getProject,
+  openProject,
+  closeProject,
+  getProjectFiles,
+  getProjectFile,
+} from "@/api";
 import { ProjectFile } from "@/gotypes";
 
 // Approximate context budget for @-mentioned files. Must stay in sync with
@@ -115,5 +121,30 @@ export function useProjectFiles() {
       refresh,
     }),
     [files, filePathSet, fileSizes, data?.truncated, isLoading, refresh],
+  );
+}
+
+// useProjectFileContent loads a single file of the active project for
+// previewing. Pass null to skip the request.
+export function useProjectFileContent(path: string | null) {
+  const { project } = useProject();
+
+  const { data, isLoading, error } = useQuery({
+    queryKey: ["projectFile", project?.root, path],
+    queryFn: () => getProjectFile(path!),
+    enabled: !!project?.root && !!path,
+    // files change on disk, so don't serve a stale preview on reopen
+    staleTime: 0,
+    gcTime: 0,
+    retry: false,
+  });
+
+  return useMemo(
+    () => ({
+      file: data ?? null,
+      isLoading,
+      error: error instanceof Error ? error.message : null,
+    }),
+    [data, isLoading, error],
   );
 }

--- a/app/ui/app/src/utils/fuzzyMatch.ts
+++ b/app/ui/app/src/utils/fuzzyMatch.ts
@@ -1,0 +1,53 @@
+// Lightweight fuzzy matching for project file paths.
+// Higher scores are better; -1 means no match.
+export function fuzzyScore(query: string, path: string): number {
+  if (!query) {
+    // With no query, prefer shallow, short paths
+    return 1000 - path.length - path.split("/").length * 10;
+  }
+
+  const q = query.toLowerCase();
+  const p = path.toLowerCase();
+  const basename = p.slice(p.lastIndexOf("/") + 1);
+
+  const basenameIdx = basename.indexOf(q);
+  if (basenameIdx !== -1) {
+    // Substring of the file name; earlier and tighter matches win
+    return 10000 - basenameIdx * 10 - path.length;
+  }
+
+  const pathIdx = p.indexOf(q);
+  if (pathIdx !== -1) {
+    return 5000 - pathIdx * 5 - path.length;
+  }
+
+  // Subsequence match over the full path
+  let pi = 0;
+  let first = -1;
+  let last = -1;
+  for (let qi = 0; qi < q.length; qi++) {
+    pi = p.indexOf(q[qi], pi);
+    if (pi === -1) return -1;
+    if (first === -1) first = pi;
+    last = pi;
+    pi++;
+  }
+  const spread = last - first;
+  return 1000 - spread * 2 - path.length;
+}
+
+export function fuzzyFilter(
+  query: string,
+  paths: string[],
+  limit: number,
+): string[] {
+  const scored: Array<{ path: string; score: number }> = [];
+  for (const path of paths) {
+    const score = fuzzyScore(query, path);
+    if (score >= 0) {
+      scored.push({ path, score });
+    }
+  }
+  scored.sort((a, b) => b.score - a.score || a.path.localeCompare(b.path));
+  return scored.slice(0, limit).map((s) => s.path);
+}

--- a/app/ui/project.go
+++ b/app/ui/project.go
@@ -1,0 +1,551 @@
+//go:build windows || darwin
+
+package ui
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"os"
+	"path"
+	"path/filepath"
+	"slices"
+	"sort"
+	"strings"
+
+	"github.com/ollama/ollama/app/store"
+	"github.com/ollama/ollama/app/ui/responses"
+)
+
+const (
+	// maxProjectFiles caps how many entries the project scanner returns
+	maxProjectFiles = 20000
+
+	// maxAgentsFileBytes caps how much of AGENTS.md is injected as context
+	maxAgentsFileBytes = 32 * 1024
+
+	// maxMentionFileBytes caps the content injected for a single @-mentioned file
+	maxMentionFileBytes = 64 * 1024
+
+	// maxMentionTotalBytes caps the combined content injected for all
+	// @-mentioned files in a single message (~32k tokens at ~4 bytes/token)
+	maxMentionTotalBytes = 128 * 1024
+
+	// maxRecentProjects caps the persisted recent projects list
+	maxRecentProjects = 8
+)
+
+// defaultIgnoredDirs are directory names skipped at any depth regardless of
+// .gitignore contents, since they are large and rarely useful as chat context
+var defaultIgnoredDirs = map[string]bool{
+	".git":         true,
+	"node_modules": true,
+	"build":        true,
+	"dist":         true,
+	"out":          true,
+	"target":       true,
+	"vendor":       true,
+	".next":        true,
+	".nuxt":        true,
+	".venv":        true,
+	"venv":         true,
+	"__pycache__":  true,
+	".cache":       true,
+	"coverage":     true,
+	"DerivedData":  true,
+	".gradle":      true,
+}
+
+type projectState struct {
+	Root      string
+	Files     []responses.ProjectFile
+	Truncated bool
+	AgentsMD  string
+	Skills    []responses.ProjectSkill
+}
+
+// activeProject returns the currently open project, lazily restoring the
+// last opened project from the store on first use. Returns nil when no
+// project is open.
+func (s *Server) activeProject() *projectState {
+	s.projectMu.Lock()
+	defer s.projectMu.Unlock()
+
+	if !s.projectLoaded {
+		s.projectLoaded = true
+		if s.Store != nil {
+			if dir, err := s.Store.ProjectDir(); err == nil && dir != "" {
+				if p, err := loadProject(dir); err == nil {
+					s.project = p
+				} else {
+					s.log().Warn("failed to restore last project", "dir", dir, "error", err)
+				}
+			}
+		}
+	}
+
+	return s.project
+}
+
+// loadProject scans root and builds the project state, including AGENTS.md
+// and .agents/skills metadata
+func loadProject(root string) (*projectState, error) {
+	root = filepath.Clean(root)
+	info, err := os.Stat(root)
+	if err != nil {
+		return nil, fmt.Errorf("stat project dir: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("%s is not a directory", root)
+	}
+
+	p := &projectState{Root: root}
+	p.Files, p.Truncated = scanProjectFiles(root)
+
+	if data, err := os.ReadFile(filepath.Join(root, "AGENTS.md")); err == nil {
+		if len(data) > maxAgentsFileBytes {
+			data = data[:maxAgentsFileBytes]
+		}
+		p.AgentsMD = string(data)
+	}
+
+	p.Skills = scanProjectSkills(root)
+
+	return p, nil
+}
+
+// Name returns the base name of the project folder
+func (p *projectState) Name() string {
+	return filepath.Base(p.Root)
+}
+
+// ignoreRule is a single parsed .gitignore pattern
+type ignoreRule struct {
+	segs     []string
+	negate   bool
+	dirOnly  bool
+	anchored bool
+	base     string // slash-separated dir (relative to root) containing the .gitignore
+}
+
+func parseGitignore(base string, data []byte) []ignoreRule {
+	var rules []ignoreRule
+	for line := range strings.SplitSeq(string(data), "\n") {
+		line = strings.TrimRight(line, "\r")
+		// unescape trailing spaces is not supported; plain trim is close enough
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		rule := ignoreRule{base: base}
+		if strings.HasPrefix(line, "!") {
+			rule.negate = true
+			line = line[1:]
+		}
+		line = strings.TrimPrefix(line, "\\")
+		if strings.HasSuffix(line, "/") {
+			rule.dirOnly = true
+			line = strings.TrimSuffix(line, "/")
+		}
+		if strings.HasPrefix(line, "/") {
+			rule.anchored = true
+			line = strings.TrimPrefix(line, "/")
+		} else if strings.Contains(line, "/") {
+			// patterns with a slash anywhere are anchored to the .gitignore dir
+			rule.anchored = true
+		}
+		if line == "" {
+			continue
+		}
+		rule.segs = strings.Split(line, "/")
+		rules = append(rules, rule)
+	}
+	return rules
+}
+
+// matches reports whether rel (slash-separated, relative to root) matches
+// the rule. rel must not be "."
+func (r ignoreRule) matches(rel string, isDir bool) bool {
+	if r.dirOnly && !isDir {
+		return false
+	}
+
+	// scope rel to the directory containing the .gitignore
+	if r.base != "" {
+		prefix := r.base + "/"
+		if !strings.HasPrefix(rel, prefix) {
+			return false
+		}
+		rel = strings.TrimPrefix(rel, prefix)
+	}
+
+	pathSegs := strings.Split(rel, "/")
+	if !r.anchored {
+		// unanchored single-segment patterns match the basename at any depth
+		ok, err := path.Match(r.segs[0], pathSegs[len(pathSegs)-1])
+		return err == nil && ok
+	}
+
+	return matchSegs(r.segs, pathSegs)
+}
+
+// matchSegs matches gitignore pattern segments (with ** support) against
+// path segments
+func matchSegs(patSegs, pathSegs []string) bool {
+	if len(patSegs) == 0 {
+		return len(pathSegs) == 0
+	}
+	if patSegs[0] == "**" {
+		for i := 0; i <= len(pathSegs); i++ {
+			if matchSegs(patSegs[1:], pathSegs[i:]) {
+				return true
+			}
+		}
+		return false
+	}
+	if len(pathSegs) == 0 {
+		return false
+	}
+	if ok, err := path.Match(patSegs[0], pathSegs[0]); err != nil || !ok {
+		return false
+	}
+	return matchSegs(patSegs[1:], pathSegs[1:])
+}
+
+func ignored(rules []ignoreRule, rel string, isDir bool) bool {
+	result := false
+	for _, r := range rules {
+		if r.matches(rel, isDir) {
+			result = !r.negate
+		}
+	}
+	return result
+}
+
+// scanProjectFiles walks root and returns a flat listing of files and
+// directories, honoring .gitignore files and skipping well-known heavy
+// directories. The returned bool reports whether the listing was truncated.
+func scanProjectFiles(root string) ([]responses.ProjectFile, bool) {
+	var files []responses.ProjectFile
+	var rules []ignoreRule
+	truncated := false
+
+	_ = filepath.WalkDir(root, func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // skip unreadable entries
+		}
+
+		rel, err := filepath.Rel(root, p)
+		if err != nil {
+			return nil //nolint:nilerr
+		}
+		rel = filepath.ToSlash(rel)
+
+		if rel == "." {
+			// load the root .gitignore before visiting children
+			if data, err := os.ReadFile(filepath.Join(p, ".gitignore")); err == nil {
+				rules = append(rules, parseGitignore("", data)...)
+			}
+			return nil
+		}
+
+		name := d.Name()
+
+		if d.IsDir() {
+			if defaultIgnoredDirs[name] || ignored(rules, rel, true) {
+				return fs.SkipDir
+			}
+			if data, err := os.ReadFile(filepath.Join(p, ".gitignore")); err == nil {
+				rules = append(rules, parseGitignore(rel, data)...)
+			}
+			files = append(files, responses.ProjectFile{Path: rel, IsDir: true})
+		} else {
+			if name == ".DS_Store" || d.Type()&fs.ModeSymlink != 0 || !d.Type().IsRegular() {
+				return nil
+			}
+			if ignored(rules, rel, false) {
+				return nil
+			}
+			var size int64
+			if info, err := d.Info(); err == nil {
+				size = info.Size()
+			}
+			files = append(files, responses.ProjectFile{Path: rel, Size: size})
+		}
+
+		if len(files) >= maxProjectFiles {
+			truncated = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+
+	sort.Slice(files, func(i, j int) bool { return files[i].Path < files[j].Path })
+	return files, truncated
+}
+
+// scanProjectSkills reads skill metadata from .agents/skills in the project
+// root. Both <skills>/<name>/SKILL.md and <skills>/<name>.md layouts are
+// supported.
+func scanProjectSkills(root string) []responses.ProjectSkill {
+	skillsDir := filepath.Join(root, ".agents", "skills")
+	entries, err := os.ReadDir(skillsDir)
+	if err != nil {
+		return nil
+	}
+
+	var skills []responses.ProjectSkill
+	for _, entry := range entries {
+		var skillFile, name string
+		if entry.IsDir() {
+			skillFile = filepath.Join(skillsDir, entry.Name(), "SKILL.md")
+			name = entry.Name()
+		} else if strings.HasSuffix(entry.Name(), ".md") {
+			skillFile = filepath.Join(skillsDir, entry.Name())
+			name = strings.TrimSuffix(entry.Name(), ".md")
+		} else {
+			continue
+		}
+
+		data, err := os.ReadFile(skillFile)
+		if err != nil {
+			continue
+		}
+
+		skill := responses.ProjectSkill{Name: name}
+		if fmName, fmDesc, ok := parseFrontmatter(string(data)); ok {
+			if fmName != "" {
+				skill.Name = fmName
+			}
+			skill.Description = fmDesc
+		}
+		skills = append(skills, skill)
+	}
+	return skills
+}
+
+// parseFrontmatter extracts name and description from a YAML frontmatter
+// block delimited by "---" lines
+func parseFrontmatter(content string) (name, description string, ok bool) {
+	lines := strings.Split(content, "\n")
+	if len(lines) == 0 || strings.TrimSpace(lines[0]) != "---" {
+		return "", "", false
+	}
+	for _, line := range lines[1:] {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "---" {
+			return name, description, true
+		}
+		if v, found := strings.CutPrefix(trimmed, "name:"); found {
+			name = strings.Trim(strings.TrimSpace(v), `"'`)
+		} else if v, found := strings.CutPrefix(trimmed, "description:"); found {
+			description = strings.Trim(strings.TrimSpace(v), `"'`)
+		}
+	}
+	return "", "", false
+}
+
+// systemPrompt builds the system message injected into chats while the
+// project is open
+func (p *projectState) systemPrompt() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "The user has the project folder %q open (full path: %s). File contents shared in messages come from this project.", p.Name(), p.Root)
+
+	if p.AgentsMD != "" {
+		b.WriteString("\n\nThe project provides the following instructions (AGENTS.md):\n\n")
+		b.WriteString(p.AgentsMD)
+	}
+
+	if len(p.Skills) > 0 {
+		b.WriteString("\n\nThe project defines the following skills in .agents/skills:\n")
+		for _, skill := range p.Skills {
+			if skill.Description != "" {
+				fmt.Fprintf(&b, "- %s: %s\n", skill.Name, skill.Description)
+			} else {
+				fmt.Fprintf(&b, "- %s\n", skill.Name)
+			}
+		}
+	}
+
+	return b.String()
+}
+
+// resolveFileRefs reads the contents of @-mentioned project files, skipping
+// paths outside the project root and filenames already present in skip.
+// Contents are truncated to per-file and total budgets.
+func (p *projectState) resolveFileRefs(refs []string, skip map[string]bool) []store.File {
+	var files []store.File
+	total := 0
+
+	for _, ref := range refs {
+		if skip[ref] {
+			continue
+		}
+		skip[ref] = true
+
+		rel := filepath.Clean(filepath.FromSlash(ref))
+		if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+			continue
+		}
+
+		full := filepath.Join(p.Root, rel)
+		info, err := os.Stat(full)
+		if err != nil || info.IsDir() {
+			continue
+		}
+
+		if total >= maxMentionTotalBytes {
+			break
+		}
+
+		data, err := os.ReadFile(full)
+		if err != nil {
+			continue
+		}
+
+		budget := min(maxMentionFileBytes, maxMentionTotalBytes-total)
+		if len(data) > budget {
+			data = append(data[:budget], []byte("\n... [truncated]")...)
+		}
+		total += len(data)
+
+		files = append(files, store.File{
+			Filename: filepath.ToSlash(rel),
+			Data:     data,
+		})
+	}
+
+	return files
+}
+
+func (s *Server) recentProjects() []string {
+	if s.Store == nil {
+		return nil
+	}
+	recents, err := s.Store.RecentProjects()
+	if err != nil {
+		s.log().Warn("failed to load recent projects", "error", err)
+		return nil
+	}
+	return recents
+}
+
+func (s *Server) addRecentProject(dir string) {
+	if s.Store == nil {
+		return
+	}
+	recents := s.recentProjects()
+	recents = slices.DeleteFunc(recents, func(r string) bool { return r == dir })
+	recents = append([]string{dir}, recents...)
+	if len(recents) > maxRecentProjects {
+		recents = recents[:maxRecentProjects]
+	}
+	if err := s.Store.SetRecentProjects(recents); err != nil {
+		s.log().Warn("failed to save recent projects", "error", err)
+	}
+}
+
+func (s *Server) projectResponse(p *projectState) responses.ProjectResponse {
+	resp := responses.ProjectResponse{Recent: s.recentProjects()}
+	if resp.Recent == nil {
+		resp.Recent = []string{}
+	}
+	if p != nil {
+		resp.Root = p.Root
+		resp.Name = p.Name()
+		resp.HasAgentsMd = p.AgentsMD != ""
+		resp.Skills = p.Skills
+	}
+	if resp.Skills == nil {
+		resp.Skills = []responses.ProjectSkill{}
+	}
+	return resp
+}
+
+func (s *Server) getProject(w http.ResponseWriter, r *http.Request) error {
+	p := s.activeProject()
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(s.projectResponse(p))
+}
+
+func (s *Server) openProject(w http.ResponseWriter, r *http.Request) error {
+	var req struct {
+		Path string `json:"path"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return fmt.Errorf("invalid request body: %w", err)
+	}
+	if req.Path == "" {
+		return fmt.Errorf("path is required")
+	}
+
+	p, err := loadProject(req.Path)
+	if err != nil {
+		return err
+	}
+
+	s.projectMu.Lock()
+	s.project = p
+	s.projectLoaded = true
+	s.projectMu.Unlock()
+
+	if s.Store != nil {
+		if err := s.Store.SetProjectDir(p.Root); err != nil {
+			s.log().Warn("failed to persist project dir", "error", err)
+		}
+		s.addRecentProject(p.Root)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(s.projectResponse(p))
+}
+
+func (s *Server) closeProject(w http.ResponseWriter, r *http.Request) error {
+	s.projectMu.Lock()
+	s.project = nil
+	s.projectLoaded = true
+	s.projectMu.Unlock()
+
+	if s.Store != nil {
+		if err := s.Store.SetProjectDir(""); err != nil {
+			s.log().Warn("failed to clear project dir", "error", err)
+		}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(s.projectResponse(nil))
+}
+
+func (s *Server) getProjectFiles(w http.ResponseWriter, r *http.Request) error {
+	p := s.activeProject()
+	if p == nil {
+		return fmt.Errorf("no project is open")
+	}
+
+	if r.URL.Query().Get("refresh") == "1" {
+		refreshed, err := loadProject(p.Root)
+		if err != nil {
+			return err
+		}
+		s.projectMu.Lock()
+		// only replace if the project didn't change while rescanning
+		if s.project != nil && s.project.Root == refreshed.Root {
+			s.project = refreshed
+			p = refreshed
+		}
+		s.projectMu.Unlock()
+	}
+
+	files := p.Files
+	if files == nil {
+		files = []responses.ProjectFile{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(responses.ProjectFilesResponse{
+		Files:     files,
+		Truncated: p.Truncated,
+	})
+}

--- a/app/ui/project.go
+++ b/app/ui/project.go
@@ -3,8 +3,11 @@
 package ui
 
 import (
+	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io"
 	"io/fs"
 	"net/http"
 	"os"
@@ -13,6 +16,7 @@ import (
 	"slices"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/ollama/ollama/app/store"
 	"github.com/ollama/ollama/app/ui/responses"
@@ -31,6 +35,13 @@ const (
 	// maxMentionTotalBytes caps the combined content injected for all
 	// @-mentioned files in a single message (~32k tokens at ~4 bytes/token)
 	maxMentionTotalBytes = 128 * 1024
+
+	// maxViewFileBytes caps how much of a file the viewer returns; longer
+	// files are truncated and flagged as such
+	maxViewFileBytes = 512 * 1024
+
+	// maxViewImageBytes caps images returned inline (base64) to the viewer
+	maxViewImageBytes = 8 * 1024 * 1024
 
 	// maxRecentProjects caps the persisted recent projects list
 	maxRecentProjects = 8
@@ -372,6 +383,17 @@ func (p *projectState) systemPrompt() string {
 	return b.String()
 }
 
+// resolvePath maps a project-relative reference to its slash-separated
+// relative form and absolute path on disk. It reports false for absolute
+// paths and for anything that would escape the project root.
+func (p *projectState) resolvePath(ref string) (rel, full string, ok bool) {
+	cleaned := filepath.Clean(filepath.FromSlash(ref))
+	if cleaned == "." || cleaned == ".." || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) || filepath.IsAbs(cleaned) {
+		return "", "", false
+	}
+	return filepath.ToSlash(cleaned), filepath.Join(p.Root, cleaned), true
+}
+
 // resolveFileRefs reads the contents of @-mentioned project files, skipping
 // paths outside the project root and filenames already present in skip.
 // Contents are truncated to per-file and total budgets.
@@ -385,12 +407,11 @@ func (p *projectState) resolveFileRefs(refs []string, skip map[string]bool) []st
 		}
 		skip[ref] = true
 
-		rel := filepath.Clean(filepath.FromSlash(ref))
-		if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		rel, full, ok := p.resolvePath(ref)
+		if !ok {
 			continue
 		}
 
-		full := filepath.Join(p.Root, rel)
 		info, err := os.Stat(full)
 		if err != nil || info.IsDir() {
 			continue
@@ -412,7 +433,7 @@ func (p *projectState) resolveFileRefs(refs []string, skip map[string]bool) []st
 		total += len(data)
 
 		files = append(files, store.File{
-			Filename: filepath.ToSlash(rel),
+			Filename: rel,
 			Data:     data,
 		})
 	}
@@ -548,4 +569,111 @@ func (s *Server) getProjectFiles(w http.ResponseWriter, r *http.Request) error {
 		Files:     files,
 		Truncated: p.Truncated,
 	})
+}
+
+// viewImageTypes maps image extensions the viewer renders inline to their
+// MIME type
+var viewImageTypes = map[string]string{
+	".png":  "image/png",
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+	".gif":  "image/gif",
+	".webp": "image/webp",
+	".bmp":  "image/bmp",
+	".svg":  "image/svg+xml",
+	".ico":  "image/x-icon",
+}
+
+// trimPartialRune drops the incomplete UTF-8 sequence a byte-size cut may
+// have left at the end of data
+func trimPartialRune(data []byte) []byte {
+	for range 3 {
+		if len(data) == 0 {
+			break
+		}
+		if r, size := utf8.DecodeLastRune(data); r != utf8.RuneError || size > 1 {
+			break
+		}
+		data = data[:len(data)-1]
+	}
+	return data
+}
+
+// isBinary reports whether data looks like something other than UTF-8 text
+func isBinary(data []byte) bool {
+	return bytes.IndexByte(data, 0) >= 0 || !utf8.Valid(trimPartialRune(data))
+}
+
+// getProjectFile returns the contents of a single file of the active project
+// so the UI can preview it. Text is returned as-is (truncated past
+// maxViewFileBytes), images as base64, and other binaries without content.
+func (s *Server) getProjectFile(w http.ResponseWriter, r *http.Request) error {
+	p := s.activeProject()
+	if p == nil {
+		return fmt.Errorf("no project is open")
+	}
+
+	ref := r.URL.Query().Get("path")
+	if ref == "" {
+		return fmt.Errorf("path is required")
+	}
+
+	rel, full, ok := p.resolvePath(ref)
+	if !ok {
+		return fmt.Errorf("invalid path %q", ref)
+	}
+
+	info, err := os.Stat(full)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", rel, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("%s is a directory", rel)
+	}
+
+	resp := responses.ProjectFileResponse{Path: rel, Size: info.Size()}
+
+	if mime, isImage := viewImageTypes[strings.ToLower(filepath.Ext(full))]; isImage {
+		resp.Binary = true
+		if info.Size() > maxViewImageBytes {
+			w.Header().Set("Content-Type", "application/json")
+			return json.NewEncoder(w).Encode(resp)
+		}
+		data, err := os.ReadFile(full)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", rel, err)
+		}
+		resp.MimeType = mime
+		resp.Content = base64.StdEncoding.EncodeToString(data)
+		w.Header().Set("Content-Type", "application/json")
+		return json.NewEncoder(w).Encode(resp)
+	}
+
+	f, err := os.Open(full)
+	if err != nil {
+		return fmt.Errorf("read %s: %w", rel, err)
+	}
+	defer f.Close()
+
+	// read one byte past the cap to tell a full file from a truncated one
+	data, err := io.ReadAll(io.LimitReader(f, maxViewFileBytes+1))
+	if err != nil {
+		return fmt.Errorf("read %s: %w", rel, err)
+	}
+	if len(data) > maxViewFileBytes {
+		data = data[:maxViewFileBytes]
+		resp.Truncated = true
+	}
+
+	if isBinary(data) {
+		resp.Binary = true
+	} else {
+		if resp.Truncated {
+			data = trimPartialRune(data)
+		}
+		resp.Content = string(data)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	return json.NewEncoder(w).Encode(resp)
 }

--- a/app/ui/project_test.go
+++ b/app/ui/project_test.go
@@ -4,8 +4,10 @@ package ui
 
 import (
 	"bytes"
+	"encoding/base64"
 	"encoding/json"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"slices"
@@ -233,6 +235,62 @@ func TestProjectSystemPrompt(t *testing.T) {
 	for _, want := range []string{"Always use tabs.", "deploy", "Deploys the app"} {
 		if !strings.Contains(prompt, want) {
 			t.Errorf("system prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
+func TestGetProjectFile(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "main.go", "package main\n")
+	writeFile(t, root, "big.txt", strings.Repeat("a", maxViewFileBytes+100))
+	writeFile(t, root, "bin.dat", "head\x00\x01binary")
+	writeFile(t, root, "img.png", "\x89PNG\r\n\x1a\n fake")
+
+	server := &Server{Restart: func() {}}
+	server.project = &projectState{Root: root}
+	server.projectLoaded = true
+
+	get := func(t *testing.T, path string) responses.ProjectFileResponse {
+		t.Helper()
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/v1/project/file?path="+url.QueryEscape(path), nil)
+		if err := server.getProjectFile(rr, req); err != nil {
+			t.Fatalf("getProjectFile(%q): %v", path, err)
+		}
+		var resp responses.ProjectFileResponse
+		if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+			t.Fatal(err)
+		}
+		return resp
+	}
+
+	if resp := get(t, "main.go"); resp.Content != "package main\n" || resp.Binary || resp.Truncated {
+		t.Errorf("unexpected response for main.go: %+v", resp)
+	}
+
+	resp := get(t, "big.txt")
+	if !resp.Truncated || len(resp.Content) != maxViewFileBytes {
+		t.Errorf("big.txt: truncated=%v len=%d, want truncated with %d bytes", resp.Truncated, len(resp.Content), maxViewFileBytes)
+	}
+
+	if resp := get(t, "bin.dat"); !resp.Binary || resp.Content != "" {
+		t.Errorf("unexpected response for bin.dat: %+v", resp)
+	}
+
+	resp = get(t, "img.png")
+	if resp.MimeType != "image/png" || !resp.Binary {
+		t.Errorf("unexpected response for img.png: %+v", resp)
+	}
+	if data, err := base64.StdEncoding.DecodeString(resp.Content); err != nil || !strings.HasPrefix(string(data), "\x89PNG") {
+		t.Errorf("img.png content not base64 png: %v", err)
+	}
+
+	// paths outside the project and directories are rejected
+	for _, bad := range []string{"../escape.txt", "/etc/passwd", "", "."} {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/api/v1/project/file?path="+url.QueryEscape(bad), nil)
+		if err := server.getProjectFile(rr, req); err == nil {
+			t.Errorf("expected error for path %q", bad)
 		}
 	}
 }

--- a/app/ui/project_test.go
+++ b/app/ui/project_test.go
@@ -1,0 +1,238 @@
+//go:build windows || darwin
+
+package ui
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/app/store"
+	"github.com/ollama/ollama/app/ui/responses"
+)
+
+func writeFile(t *testing.T, root, rel, content string) {
+	t.Helper()
+	full := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(full, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestScanProjectFiles(t *testing.T) {
+	root := t.TempDir()
+
+	writeFile(t, root, ".gitignore", "*.log\nsecret/\n/anchored.txt\n!keep.log\n")
+	writeFile(t, root, "main.go", "package main")
+	writeFile(t, root, "src/app.ts", "export {}")
+	writeFile(t, root, "src/.gitignore", "generated/\n")
+	writeFile(t, root, "src/generated/api.ts", "ignored")
+	writeFile(t, root, "debug.log", "ignored")
+	writeFile(t, root, "keep.log", "kept by negation")
+	writeFile(t, root, "secret/token.txt", "ignored")
+	writeFile(t, root, "anchored.txt", "ignored")
+	writeFile(t, root, "sub/anchored.txt", "not ignored: pattern is anchored")
+	writeFile(t, root, "node_modules/pkg/index.js", "ignored")
+	writeFile(t, root, ".git/config", "ignored")
+
+	files, truncated := scanProjectFiles(root)
+	if truncated {
+		t.Fatal("expected listing not to be truncated")
+	}
+
+	var paths []string
+	for _, f := range files {
+		if !f.IsDir {
+			paths = append(paths, f.Path)
+		}
+	}
+
+	want := []string{"keep.log", "main.go", "src/app.ts", "sub/anchored.txt"}
+	// .gitignore files themselves are listed too
+	for _, p := range paths {
+		if strings.HasSuffix(p, ".gitignore") {
+			continue
+		}
+		if !slices.Contains(want, p) {
+			t.Errorf("unexpected file in listing: %s", p)
+		}
+	}
+	for _, w := range want {
+		if !slices.Contains(paths, w) {
+			t.Errorf("missing file in listing: %s", w)
+		}
+	}
+}
+
+func TestResolveFileRefs(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "src/app.ts", "hello")
+	writeFile(t, root, "big.txt", strings.Repeat("x", maxMentionFileBytes+100))
+
+	p := &projectState{Root: root}
+
+	refs := p.resolveFileRefs([]string{
+		"src/app.ts",
+		"src/app.ts", // duplicate is skipped
+		"missing.txt",
+		"../outside.txt",
+		"/etc/passwd",
+		"big.txt",
+	}, map[string]bool{})
+
+	if len(refs) != 2 {
+		t.Fatalf("expected 2 resolved refs, got %d", len(refs))
+	}
+	if refs[0].Filename != "src/app.ts" || string(refs[0].Data) != "hello" {
+		t.Errorf("unexpected first ref: %+v", refs[0])
+	}
+	if refs[1].Filename != "big.txt" {
+		t.Fatalf("unexpected second ref: %s", refs[1].Filename)
+	}
+	if !strings.HasSuffix(string(refs[1].Data), "[truncated]") {
+		t.Error("expected oversized file to be truncated")
+	}
+
+	// already-attached filenames are skipped
+	refs = p.resolveFileRefs([]string{"src/app.ts"}, map[string]bool{"src/app.ts": true})
+	if len(refs) != 0 {
+		t.Errorf("expected already-attached ref to be skipped, got %d", len(refs))
+	}
+}
+
+func TestParseFrontmatter(t *testing.T) {
+	name, desc, ok := parseFrontmatter("---\nname: my-skill\ndescription: \"Does things\"\n---\nbody")
+	if !ok || name != "my-skill" || desc != "Does things" {
+		t.Errorf("got name=%q desc=%q ok=%v", name, desc, ok)
+	}
+
+	if _, _, ok := parseFrontmatter("no frontmatter here"); ok {
+		t.Error("expected no frontmatter")
+	}
+}
+
+func TestProjectEndpoints(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "main.go", "package main")
+	writeFile(t, root, "AGENTS.md", "Be nice.")
+
+	testStore := &store.Store{DBPath: filepath.Join(t.TempDir(), "db.sqlite")}
+	defer testStore.Close()
+
+	server := &Server{Store: testStore, Restart: func() {}}
+
+	// no project open initially
+	rr := httptest.NewRecorder()
+	if err := server.getProject(rr, httptest.NewRequest("GET", "/api/v1/project", nil)); err != nil {
+		t.Fatal(err)
+	}
+	var project responses.ProjectResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &project); err != nil {
+		t.Fatal(err)
+	}
+	if project.Root != "" {
+		t.Fatalf("expected no project, got %q", project.Root)
+	}
+
+	// open the project
+	body, _ := json.Marshal(map[string]string{"path": root})
+	rr = httptest.NewRecorder()
+	if err := server.openProject(rr, httptest.NewRequest("POST", "/api/v1/project/open", bytes.NewReader(body))); err != nil {
+		t.Fatal(err)
+	}
+	if err := json.Unmarshal(rr.Body.Bytes(), &project); err != nil {
+		t.Fatal(err)
+	}
+	if project.Root != root || !project.HasAgentsMd {
+		t.Fatalf("unexpected project response: %+v", project)
+	}
+	if !slices.Contains(project.Recent, root) {
+		t.Errorf("expected %q in recents, got %v", root, project.Recent)
+	}
+
+	// project dir persisted for reopening on restart
+	if dir, err := testStore.ProjectDir(); err != nil || dir != root {
+		t.Errorf("persisted project dir = %q, %v; want %q", dir, err, root)
+	}
+
+	// file listing includes the scanned file
+	rr = httptest.NewRecorder()
+	if err := server.getProjectFiles(rr, httptest.NewRequest("GET", "/api/v1/project/files", nil)); err != nil {
+		t.Fatal(err)
+	}
+	var files responses.ProjectFilesResponse
+	if err := json.Unmarshal(rr.Body.Bytes(), &files); err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, f := range files.Files {
+		if f.Path == "main.go" && !f.IsDir {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("main.go missing from listing: %+v", files.Files)
+	}
+
+	// refresh picks up new files
+	writeFile(t, root, "new.txt", "hi")
+	rr = httptest.NewRecorder()
+	if err := server.getProjectFiles(rr, httptest.NewRequest("GET", "/api/v1/project/files?refresh=1", nil)); err != nil {
+		t.Fatal(err)
+	}
+	files = responses.ProjectFilesResponse{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &files); err != nil {
+		t.Fatal(err)
+	}
+	found = false
+	for _, f := range files.Files {
+		if f.Path == "new.txt" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("new.txt missing after refresh")
+	}
+
+	// close the project
+	rr = httptest.NewRecorder()
+	if err := server.closeProject(rr, httptest.NewRequest("POST", "/api/v1/project/close", nil)); err != nil {
+		t.Fatal(err)
+	}
+	if p := server.activeProject(); p != nil {
+		t.Errorf("expected no active project after close, got %q", p.Root)
+	}
+	if dir, _ := testStore.ProjectDir(); dir != "" {
+		t.Errorf("expected cleared project dir, got %q", dir)
+	}
+	// recents survive closing
+	if recents, _ := testStore.RecentProjects(); !slices.Contains(recents, root) {
+		t.Errorf("expected %q to remain in recents, got %v", root, recents)
+	}
+}
+
+func TestProjectSystemPrompt(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, root, "AGENTS.md", "Always use tabs.")
+	writeFile(t, root, ".agents/skills/deploy/SKILL.md", "---\nname: deploy\ndescription: Deploys the app\n---\n")
+
+	p, err := loadProject(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	prompt := p.systemPrompt()
+	for _, want := range []string{"Always use tabs.", "deploy", "Deploys the app"} {
+		if !strings.Contains(prompt, want) {
+			t.Errorf("system prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}

--- a/app/ui/responses/types.go
+++ b/app/ui/responses/types.go
@@ -164,6 +164,18 @@ type ProjectResponse struct {
 	Recent      []string       `json:"recent"`
 }
 
+// ProjectFileResponse is the content of a single project file, as rendered
+// by the file viewer. Content holds text as-is, or base64 data when MimeType
+// is set (inline images); it is empty for binaries the UI cannot render.
+type ProjectFileResponse struct {
+	Path      string `json:"path"`
+	Size      int64  `json:"size"`
+	Content   string `json:"content"`
+	Truncated bool   `json:"truncated"`
+	Binary    bool   `json:"binary"`
+	MimeType  string `json:"mimeType"`
+}
+
 // ProjectFilesResponse is the cached file listing of the active project
 type ProjectFilesResponse struct {
 	Files     []ProjectFile `json:"files"`

--- a/app/ui/responses/types.go
+++ b/app/ui/responses/types.go
@@ -126,6 +126,10 @@ type ChatRequest struct {
 	FileTools   *bool        `json:"file_tools,omitempty"`
 	ForceUpdate bool         `json:"forceUpdate,omitempty"`
 	Think       any          `json:"think,omitempty"`
+
+	// FileRefs contains project-relative paths of files mentioned with "@"
+	// in the prompt. Their contents are injected into the model context.
+	FileRefs []string `json:"file_refs,omitempty"`
 }
 
 type Error struct {
@@ -135,6 +139,35 @@ type Error struct {
 type ModelUpstreamResponse struct {
 	Stale bool   `json:"stale"`
 	Error string `json:"error,omitempty"`
+}
+
+// ProjectFile is a single entry in the active project's file listing
+type ProjectFile struct {
+	Path  string `json:"path"`
+	Size  int64  `json:"size"`
+	IsDir bool   `json:"isDir"`
+}
+
+// ProjectSkill describes a skill found under .agents/skills in the project root
+type ProjectSkill struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// ProjectResponse describes the currently active project (empty Root means
+// no project is open)
+type ProjectResponse struct {
+	Root        string         `json:"root"`
+	Name        string         `json:"name"`
+	HasAgentsMd bool           `json:"hasAgentsMd"`
+	Skills      []ProjectSkill `json:"skills"`
+	Recent      []string       `json:"recent"`
+}
+
+// ProjectFilesResponse is the cached file listing of the active project
+type ProjectFilesResponse struct {
+	Files     []ProjectFile `json:"files"`
+	Truncated bool          `json:"truncated"`
 }
 
 // Serializable data for the browser state

--- a/app/ui/ui.go
+++ b/app/ui/ui.go
@@ -112,6 +112,14 @@ type Server struct {
 	// Updater for checking and downloading updates
 	Updater             *updater.Updater
 	UpdateAvailableFunc func()
+
+	// projectMu protects the active project state below
+	projectMu sync.Mutex
+	// project is the currently open project folder, if any
+	project *projectState
+	// projectLoaded is true once the last opened project has been restored
+	// from the store
+	projectLoaded bool
 }
 
 func (s *Server) log() *slog.Logger {
@@ -285,6 +293,11 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("DELETE /api/v1/chat/{id}", handle(s.deleteChat))
 	mux.Handle("POST /api/v1/create-chat", handle(s.createChat))
 	mux.Handle("PUT /api/v1/chat/{id}/rename", handle(s.renameChat))
+
+	mux.Handle("GET /api/v1/project", handle(s.getProject))
+	mux.Handle("POST /api/v1/project/open", handle(s.openProject))
+	mux.Handle("POST /api/v1/project/close", handle(s.closeProject))
+	mux.Handle("GET /api/v1/project/files", handle(s.getProjectFiles))
 
 	mux.Handle("GET /api/v1/inference-compute", handle(s.getInferenceCompute))
 	mux.Handle("POST /api/v1/model/upstream", handle(s.modelUpstream))
@@ -687,7 +700,7 @@ func (s *Server) chat(w http.ResponseWriter, r *http.Request) error {
 	// Only add user message if not forceUpdate
 	if !req.ForceUpdate {
 		var messageOptions *store.MessageOptions
-		if len(req.Attachments) > 0 {
+		if len(req.Attachments) > 0 || len(req.FileRefs) > 0 {
 			storeAttachments := make([]store.File, 0, len(req.Attachments))
 
 			for _, att := range req.Attachments {
@@ -715,6 +728,18 @@ func (s *Server) chat(w http.ResponseWriter, r *http.Request) error {
 						Filename: att.Filename,
 						Data:     data,
 					})
+				}
+			}
+
+			// Resolve @-mentioned project files into attachments so their
+			// contents reach the model and persist with the message
+			if len(req.FileRefs) > 0 {
+				if p := s.activeProject(); p != nil {
+					seen := make(map[string]bool, len(storeAttachments))
+					for _, att := range storeAttachments {
+						seen[att.Filename] = true
+					}
+					storeAttachments = append(storeAttachments, p.resolveFileRefs(req.FileRefs, seen)...)
 				}
 			}
 
@@ -1705,6 +1730,12 @@ func supportsBrowserTools(model string) bool {
 // buildChatRequest converts store.Chat to api.ChatRequest
 func (s *Server) buildChatRequest(chat *store.Chat, model string, think any, availableTools []map[string]any) (*api.ChatRequest, error) {
 	var msgs []api.Message
+
+	// When a project folder is open, provide its context (AGENTS.md and
+	// skills) as a system message
+	if p := s.activeProject(); p != nil {
+		msgs = append(msgs, api.Message{Role: "system", Content: p.systemPrompt()})
+	}
 	for _, m := range chat.Messages {
 		// Skip empty messages if present
 		if m.Content == "" && m.Thinking == "" && len(m.ToolCalls) == 0 && len(m.Attachments) == 0 {

--- a/app/ui/ui.go
+++ b/app/ui/ui.go
@@ -298,6 +298,7 @@ func (s *Server) Handler() http.Handler {
 	mux.Handle("POST /api/v1/project/open", handle(s.openProject))
 	mux.Handle("POST /api/v1/project/close", handle(s.closeProject))
 	mux.Handle("GET /api/v1/project/files", handle(s.getProjectFiles))
+	mux.Handle("GET /api/v1/project/file", handle(s.getProjectFile))
 
 	mux.Handle("GET /api/v1/inference-compute", handle(s.getInferenceCompute))
 	mux.Handle("POST /api/v1/model/upstream", handle(s.modelUpstream))


### PR DESCRIPTION
## What's this?

Stop copy-pasting. This PR turns the Ollama desktop app into a tool that actually knows the code you're talking about.

### 🗂️ Open folders as active projects (VSCode-style)
- **Open a folder** from a new pill in the header — instant file tree, no indexing hassle
- **Persistent state**: your last project reopens automatically; recent projects are one click away
- **Context-aware by default**: `AGENTS.md` and `.agents/skills/` are loaded into the system prompt, so the model already knows the rules of your repo
- Smart scanner respects `.gitignore` and skips heavy dirs (`node_modules`, `build`, `vendor`, …) with a `?refresh=1` cache bust

### 💬 `@`-mention files right in the chat
- Type `@` → **fuzzy autocomplete** of project files with keyboard navigation
- Mentioned files are **injected into the LLM context** automatically (with per-file and total token caps, so no prompt bloat)
- Clicking a file in the tree also drops it into the prompt

Free-floating chat mode is untouched — everything is opt-in per project.

## Why it's awesome
- No more "here's my code, please review" paste-jobs
- The model finally sees `AGENTS.md`, skills, and the exact files it should look at
- Works with the existing `selectWorkingDirectory()` native dialog — zero new native code

## What changed
- `app/ui/project.go` — project state, gitignore-aware scanner, AGENTS.md/skills loading, `file_refs` resolution with truncation
- `app/store` — SQLite schema v17: `project_dir` + `recent_projects`
- `app/ui/ui.go` + `responses/types.go` — new `/api/v1/project*` endpoints
- New React components: `ProjectButton`, `ProjectPanel`, `FileMentionMenu`, `useProject`, `fuzzyMatch`
- Tests: `project_test.go`

## Notes
- Builds only on `windows || darwin` (uses the existing webview directory dialog)