### PR TITLE
cmd: fall back to current model when save parent is unavailable

### DIFF
--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -1793,6 +1794,164 @@ func TestNewCreateRequest(t *testing.T) {
 			actual := NewCreateRequest(tt.from, tt.opts)
 			if !cmp.Equal(actual, tt.expected) {
 				t.Errorf("expected output %#v, got %#v", tt.expected, actual)
+			}
+		})
+	}
+}
+
+func TestNewSaveCreateRequest(t *testing.T) {
+	tests := []struct {
+		name       string
+		opts       runOptions
+		showStatus int
+		showError  string
+		wantReq    *api.CreateRequest
+		wantErr    string
+		wantShow   []string
+	}{
+		{
+			name: "parent model not found falls back to current model",
+			opts: runOptions{
+				Model:       "local-model",
+				ParentModel: "remote-parent",
+				Options: map[string]any{
+					"draft_num_predict": 2,
+				},
+			},
+			showStatus: http.StatusNotFound,
+			showError:  "model 'remote-parent' not found",
+			wantReq: &api.CreateRequest{
+				Model: "saved-model",
+				From:  "local-model",
+				Parameters: map[string]any{
+					"draft_num_predict": 2,
+				},
+			},
+			wantShow: []string{"remote-parent"},
+		},
+		{
+			name: "parent model exists locally",
+			opts: runOptions{
+				Model:       "local-model",
+				ParentModel: "local-parent",
+			},
+			showStatus: http.StatusOK,
+			wantReq: &api.CreateRequest{
+				Model: "saved-model",
+				From:  "local-parent",
+			},
+			wantShow: []string{"local-parent"},
+		},
+		{
+			name: "parent model show non-404 returns error",
+			opts: runOptions{
+				Model:       "local-model",
+				ParentModel: "local-parent",
+			},
+			showStatus: http.StatusInternalServerError,
+			showError:  "server exploded",
+			wantErr:    "server exploded",
+			wantShow:   []string{"local-parent"},
+		},
+		{
+			name: "parent model not found drops loaded messages",
+			opts: runOptions{
+				Model:          "local-model",
+				ParentModel:    "remote-parent",
+				LoadedMessages: []api.Message{{Role: "assistant", Content: "loaded"}},
+				Messages:       []api.Message{{Role: "user", Content: "new"}},
+			},
+			showStatus: http.StatusNotFound,
+			showError:  "model 'remote-parent' not found",
+			wantReq: &api.CreateRequest{
+				Model:    "saved-model",
+				From:     "local-model",
+				Messages: []api.Message{{Role: "user", Content: "new"}},
+			},
+			wantShow: []string{"remote-parent"},
+		},
+		{
+			name: "empty parent model uses current model without show",
+			opts: runOptions{
+				Model: "local-model",
+			},
+			wantReq: &api.CreateRequest{
+				Model: "saved-model",
+				From:  "local-model",
+			},
+		},
+		{
+			name: "explicit cloud model preserves source without parent show",
+			opts: runOptions{
+				Model:       "qwen3.5:cloud",
+				ParentModel: "qwen3.5",
+			},
+			wantReq: &api.CreateRequest{
+				Model: "saved-model",
+				From:  "qwen3.5:cloud",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var showReqs []api.ShowRequest
+			mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/api/show" || r.Method != http.MethodPost {
+					http.NotFound(w, r)
+					return
+				}
+
+				var req api.ShowRequest
+				if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+					http.Error(w, err.Error(), http.StatusBadRequest)
+					return
+				}
+				showReqs = append(showReqs, req)
+
+				if tt.showStatus == 0 {
+					w.WriteHeader(http.StatusInternalServerError)
+					_ = json.NewEncoder(w).Encode(map[string]string{"error": "unexpected show request"})
+					return
+				}
+
+				w.WriteHeader(tt.showStatus)
+				if tt.showStatus == http.StatusOK {
+					_ = json.NewEncoder(w).Encode(api.ShowResponse{})
+				} else {
+					_ = json.NewEncoder(w).Encode(map[string]string{"error": tt.showError})
+				}
+			}))
+			t.Cleanup(mockServer.Close)
+
+			u, err := url.Parse(mockServer.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			req, err := newSaveCreateRequest(t.Context(), api.NewClient(u, mockServer.Client()), "saved-model", tt.opts)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("error = %v, want %q", err, tt.wantErr)
+				}
+				if req != nil {
+					t.Fatalf("request = %#v, want nil", req)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				if diff := cmp.Diff(tt.wantReq, req); diff != "" {
+					t.Fatalf("create request mismatch (-want +got):\n%s", diff)
+				}
+			}
+
+			var gotShow []string
+			for _, req := range showReqs {
+				gotShow = append(gotShow, req.Model)
+			}
+			if diff := cmp.Diff(tt.wantShow, gotShow); diff != "" {
+				t.Fatalf("show requests mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/cmd/interactive.go
+++ b/cmd/interactive.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"cmp"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -264,7 +265,11 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 				return err
 			}
 
-			req := NewCreateRequest(args[1], opts)
+			req, err := newSaveCreateRequest(cmd.Context(), client, args[1], opts)
+			if err != nil {
+				return err
+			}
+
 			fn := func(resp api.ProgressResponse) error { return nil }
 			err = client.Create(cmd.Context(), req, fn)
 			if err != nil {
@@ -543,6 +548,27 @@ func generateInteractive(cmd *cobra.Command, opts runOptions) error {
 			sb.Reset()
 		}
 	}
+}
+
+func newSaveCreateRequest(ctx context.Context, client *api.Client, name string, opts runOptions) (*api.CreateRequest, error) {
+	req := NewCreateRequest(name, opts)
+	if req.From != opts.ParentModel || req.From == "" || req.From == opts.Model || modelref.HasExplicitCloudSource(req.From) {
+		return req, nil
+	}
+
+	if _, err := client.Show(ctx, &api.ShowRequest{Model: req.From}); err != nil {
+		var statusErr api.StatusError
+		if errors.As(err, &statusErr) && statusErr.StatusCode == http.StatusNotFound {
+			opts = opts.Copy()
+			opts.ParentModel = ""
+			opts.LoadedMessages = nil
+			return NewCreateRequest(name, opts), nil
+		}
+
+		return nil, err
+	}
+
+	return req, nil
 }
 
 func NewCreateRequest(name string, opts runOptions) *api.CreateRequest {


### PR DESCRIPTION
## Problem

`/save` prefers the model's `ParentModel` so saved sessions remain based on
the original parent model.

Some locally available models have a syntactically valid `ParentModel` that
is not available locally. In that case `/save` sends the missing parent as
`From` to `/api/create`, which attempts to resolve it through the registry
and can fail with:

`pull model manifest: file does not exist`

This is the behavior reported in #17735.

## Fix

Before using `ParentModel` for `/save`, check whether it is available locally.

- If the parent exists locally, preserve the existing parent-model behavior.
- If the parent returns 404, fall back to the currently loaded model.
- Propagate non-404 errors rather than silently changing the save source.
- Preserve explicit cloud-model behavior.
- When falling back to the current model, omit `LoadedMessages` because they
  are already inherited by that model and would otherwise be duplicated.

## Tests

Added coverage for:

- locally unavailable parent
- locally available parent
- non-404 errors
- no parent
- loaded-message fallback behavior
- explicit cloud-model behavior

Fixes #17735