### PR TITLE
CLAUDE.md: import AGENTS.md directly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,3 @@
 # CLAUDE.md
 
-See `AGENTS.md` for the shared agent instructions for this repository.
+@AGENTS.md


### PR DESCRIPTION
## Summary

Replace the natural-language reference to `AGENTS.md` in `CLAUDE.md` with Claude Code's supported file import syntax:

```diff
-See `AGENTS.md` for the shared agent instructions for this repository.
+@AGENTS.md
```

This keeps `AGENTS.md` as the canonical shared instruction file while making Claude Code load those instructions through its native project-memory mechanism.

## Problem

Claude Code reads `CLAUDE.md` as project instructions, but it does not automatically treat `AGENTS.md` as project memory.

The current `CLAUDE.md` tells the model in prose to see `AGENTS.md`. That relies on the model interpreting the sentence and reading the file during the session.

Claude Code supports importing files from `CLAUDE.md` with `@path/to/file`. Anthropic's documentation specifically recommends this pattern when a repository already uses `AGENTS.md` for other coding agents:

https://code.claude.com/docs/en/memory#agentsmd

Using `@AGENTS.md` makes the relationship explicit and causes the shared instructions to be expanded into Claude Code's project context when the project instructions are loaded.

## Why this is useful

- preserves `AGENTS.md` as the single source of truth for shared coding-agent guidance
- avoids duplicating instructions between `AGENTS.md` and `CLAUDE.md`
- uses Claude Code's documented import mechanism instead of natural-language indirection
- makes the intended relationship between the two files explicit to both contributors and tooling

## Behavior

Before:

```text
Claude Code
  -> loads CLAUDE.md
  -> reads a prose instruction to see AGENTS.md
  -> may read AGENTS.md as part of normal agent execution
```

After:

```text
Claude Code
  -> loads CLAUDE.md
  -> resolves @AGENTS.md
  -> loads the shared instructions into project context
```

This does not change Ollama runtime behavior, build behavior, APIs, or dependencies. It only changes how Claude Code consumes the repository's existing shared agent instructions.

## Testing

No runtime tests were run because this is a one-line project-instruction/documentation change with no executable Ollama code changes.

The branch was compared against `main` and contains exactly one modified file (`CLAUDE.md`), with one insertion and one deletion.

## Contribution scope

This is a small root-level documentation/project-instruction correction, so it falls under the small documentation updates described in `CONTRIBUTING.md` and does not require a prior proposal issue.