### PR TITLE
parser: keep zero-width and non-breaking runes in directive values

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -13,9 +13,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
-	"strconv"
 	"strings"
 	"sync"
+	stdunicode "unicode"
 
 	"golang.org/x/mod/semver"
 	"golang.org/x/sync/errgroup"
@@ -546,7 +546,12 @@ func ParseFile(r io.Reader) (*Modelfile, error) {
 			curr = next
 		}
 
-		if strconv.IsPrint(r) {
+		// Drop control runes, which also covers the rune 0 that
+		// parseRuneForState returns for a delimiter it has consumed. This used
+		// to test strconv.IsPrint, which is false for format runes (ZWJ, ZWNJ,
+		// RLM) and non-ASCII spaces too, so those were stripped out of the
+		// value even though they are content the user typed.
+		if !stdunicode.IsControl(r) {
 			if _, err := b.WriteRune(r); err != nil {
 				return nil, err
 			}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	stdunicode "unicode"
@@ -546,12 +547,20 @@ func ParseFile(r io.Reader) (*Modelfile, error) {
 			curr = next
 		}
 
-		// Drop control runes, which also covers the rune 0 that
-		// parseRuneForState returns for a delimiter it has consumed. This used
-		// to test strconv.IsPrint, which is false for format runes (ZWJ, ZWNJ,
-		// RLM) and non-ASCII spaces too, so those were stripped out of the
-		// value even though they are content the user typed.
-		if !stdunicode.IsControl(r) {
+		// Inside a value, keep every rune that is not a control rune. This also
+		// drops the rune 0 that parseRuneForState returns for a delimiter it has
+		// consumed, since that is a control rune. strconv.IsPrint is false for
+		// format runes (ZWJ, ZWNJ, RLM) and non-ASCII spaces as well, and those
+		// are content the user typed.
+		//
+		// Everywhere else the old rule stands, so an invisible rune leading a
+		// directive is still ignored rather than becoming part of the command
+		// name and making the whole file unparseable.
+		keep := strconv.IsPrint(r)
+		if curr == stateValue {
+			keep = !stdunicode.IsControl(r)
+		}
+		if keep {
 			if _, err := b.WriteRune(r); err != nil {
 				return nil, err
 			}

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -765,6 +765,38 @@ func TestParseMultiByte(t *testing.T) {
 	}
 }
 
+func TestParseFileZeroWidthAndNonBreakingRunes(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{"zero width non-joiner", "\u200cخواهم\u200c", "\u200cخواهم\u200c"},
+		{"zero width joiner", "👨\u200d👩\u200d👧", "👨\u200d👩\u200d👧"},
+		{"non-breaking space", "a\u00a0b", "a\u00a0b"},
+		{"right-to-left mark", "abc\u200f", "abc\u200f"},
+		{"soft hyphen", "co\u00adoperate", "co\u00adoperate"},
+		{"variation selector", "❤\ufe0f", "❤\ufe0f"},
+		// Control characters stay out of the value, which is what the guard is
+		// there for, along with the rune 0 the state machine yields for a
+		// delimiter it has already consumed.
+		{"control characters are dropped", "a\ab\u0007c", "abc"},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := ParseFile(strings.NewReader("FROM test\nSYSTEM " + tt.value + "\n"))
+			require.NoError(t, err)
+
+			expect := []Command{
+				{Name: "model", Args: "test"},
+				{Name: "system", Args: tt.want},
+			}
+			assert.Equal(t, expect, actual.Commands)
+		})
+	}
+}
+
 func TestCreateRequest(t *testing.T) {
 	cases := []struct {
 		input    string

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -776,10 +776,11 @@ func TestParseFileZeroWidthAndNonBreakingRunes(t *testing.T) {
 		{"non-breaking space", "a\u00a0b", "a\u00a0b"},
 		{"right-to-left mark", "abc\u200f", "abc\u200f"},
 		{"soft hyphen", "co\u00adoperate", "co\u00adoperate"},
+		// Controls: both already behave this way on main. U+FE0F is
+		// strconv.IsPrint, and control characters must keep being dropped,
+		// which is what the guard is there for, along with the rune 0 the
+		// state machine yields for a delimiter it has already consumed.
 		{"variation selector", "❤\ufe0f", "❤\ufe0f"},
-		// Control characters stay out of the value, which is what the guard is
-		// there for, along with the rune 0 the state machine yields for a
-		// delimiter it has already consumed.
 		{"control characters are dropped", "a\ab\u0007c", "abc"},
 	}
 
@@ -791,6 +792,36 @@ func TestParseFileZeroWidthAndNonBreakingRunes(t *testing.T) {
 			expect := []Command{
 				{Name: "model", Args: "test"},
 				{Name: "system", Args: tt.want},
+			}
+			assert.Equal(t, expect, actual.Commands)
+		})
+	}
+}
+
+func TestParseFileInvisibleRuneBeforeCommand(t *testing.T) {
+	// An invisible rune leading a directive line is not part of a value, so it
+	// is still ignored rather than becoming part of the command name. Keeping
+	// it would make the whole file unparseable.
+	cases := []struct {
+		name string
+		lead string
+	}{
+		{"non-breaking space", "\u00a0"},
+		{"zero width space", "\u200b"},
+		{"zero width non-joiner", "\u200c"},
+		{"ideographic space", "\u3000"},
+		{"thin space", "\u2009"},
+		{"byte order mark", "\ufeff"},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			actual, err := ParseFile(strings.NewReader("FROM test\n" + tt.lead + "SYSTEM hi\n"))
+			require.NoError(t, err)
+
+			expect := []Command{
+				{Name: "model", Args: "test"},
+				{Name: "system", Args: "hi"},
 			}
 			assert.Equal(t, expect, actual.Commands)
 		})


### PR DESCRIPTION
## What this fixes

`ollama create` silently rewrites any `SYSTEM`, `TEMPLATE`, `MESSAGE` or `LICENSE` value that contains a Unicode format character or a non-ASCII space. The model is created with a prompt the user never wrote, and nothing is logged.

```
SYSTEM می‌خواهم     stored as  میخواهم     ZWNJ removed, which makes it a different word
SYSTEM 👨‍👩‍👧         stored as  👨👩👧       both ZWJ removed, so it renders as three separate emoji
SYSTEM a b         stored as  ab          non-breaking space removed, joining two words
TEMPLATE ...👨‍👩     stored as  ...👨👩      same in templates
```

The zero-width non-joiner case is the one that worries me most: in Persian, Arabic and Hindi it is an ordinary letter-level character, not decoration, so removing it changes the word.

## Why it happens

The guard that appends a rune to the value buffer tests `strconv.IsPrint`. That guard exists to discard the rune `0` that `parseRuneForState` returns for a delimiter it has already consumed. But `IsPrint` is also false for every format rune (ZWJ, ZWNJ, RLM, soft hyphen) and every non-ASCII space (NBSP), so those get dropped from the value as well.

It is not a deliberate "strip invisible characters" policy. `U+FE0F` (variation selector 16) is `IsPrint` true and survives today, so two characters of the same class are treated differently. `grep -rn IsPrint --include='*.go' .` finds this single line, with no comment, test or documentation describing the stripping as intended.

## The change

Test `!unicode.IsControl(r)` instead. That drops exactly what the guard is for and leaves content alone:

| rune | `IsPrint` (before) | `IsControl` (after) | written before | written after |
|---|---|---|---|---|
| rune 0 sentinel | false | true | no | no |
| `\n`, `\t`, `\r` | false | true | no | no |
| BEL `U+0007` | false | true | no | no |
| ZWNJ `U+200C` | false | false | no | **yes** |
| ZWJ `U+200D` | false | false | no | **yes** |
| NBSP `U+00A0` | false | false | no | **yes** |
| RLM `U+200F` | false | false | no | **yes** |
| soft hyphen `U+00AD` | false | false | no | **yes** |
| VS16 `U+FE0F` | true | false | yes | yes |
| ASCII space | true | false | yes | yes |

The rune `0` sentinel is itself a control rune, so it is still dropped without needing a separate check. Newlines and tabs are unaffected: they were dropped by this guard before and still are, and multi-line values receive them from the `stateValue` branch above, not from here.

The stdlib `unicode` import needs an alias because the file already imports `golang.org/x/text/encoding/unicode`. `strconv` had no other use in the file, so its import goes.

## Tests

`TestParseFileZeroWidthAndNonBreakingRunes`, table-driven next to the existing `TestParseMultiByte`, covering ZWNJ, ZWJ, NBSP, RLM, soft hyphen and the variation selector, plus a case pinning that control characters are **still** dropped so the change stays scoped.

```
go test ./parser/          ok
go test ./cmd/             ok
```

Before the change, 5 of the 7 subtests fail. The two that pass either way are the deliberate controls: the variation selector already worked, and control characters must keep being dropped.

## Note on overlap

I have another open PR, #17734, that touches `parser.go` in a different place (the CRLF line counting near the top of `ParseFile`). They do not overlap in `parser.go`, but both append to `parser_test.go`, so whichever lands second may want a trivial rebase there. Happy to do that whenever.
