### PR TITLE
renderers/qwen: tolerate transcripts without a plain user query

### DIFF
--- a/model/renderers/qwen35.go
+++ b/model/renderers/qwen35.go
@@ -177,22 +177,6 @@ func (r *Qwen35Renderer) validateMessages(messages []api.Message) error {
 		return fmt.Errorf("system message cannot contain images")
 	}
 
-	foundUserQuery := false
-	for _, message := range messages {
-		if message.Role != "user" {
-			continue
-		}
-		content, _ := r.renderContent(message, 0)
-		content = strings.TrimSpace(content)
-		if !(strings.HasPrefix(content, "<tool_response>") && strings.HasSuffix(content, "</tool_response>")) {
-			foundUserQuery = true
-			break
-		}
-	}
-	if !foundUserQuery {
-		return fmt.Errorf("no user query found in messages")
-	}
-
 	return nil
 }
 
@@ -275,6 +259,10 @@ func (r *Qwen35Renderer) Render(messages []api.Message, tools []api.Tool, think 
 				lastQueryIndex = i
 			}
 		}
+	}
+
+	if r.variant == qwen35Renderer38 && multiStepTool {
+		slog.Warn("no user query found in messages", "renderer", "qwen3.8")
 	}
 
 	imageOffset := 0

--- a/model/renderers/qwen38_test.go
+++ b/model/renderers/qwen38_test.go
@@ -282,6 +282,47 @@ Montréal
 			matchesTemplate: true,
 		},
 		{
+			// Truncation can drop the original user query from a long tool
+			// loop, leaving only tool responses. The reference template raises
+			// on this shape, so it is not template-checked.
+			name: "tool loop without a plain user query",
+			messages: []api.Message{
+				{
+					Role:     "assistant",
+					Thinking: "Need current data.",
+					Content:  "I'll check.",
+					ToolCalls: []api.ToolCall{{Function: api.ToolCallFunction{
+						Name:      "get_weather",
+						Arguments: weatherArgs,
+					}}},
+				},
+				{Role: "tool", Content: `{"temp": 18}`},
+			},
+			tools: weather,
+			think: think(true),
+			want: toolHeader + `<|im_start|>assistant
+<think>
+Need current data.
+</think>
+
+I'll check.
+
+<tool_call>
+<function=get_weather>
+<parameter=city>
+Montréal
+</parameter>
+</function>
+</tool_call><|im_end|>
+<|im_start|>user
+<tool_response>
+{"temp": 18}
+</tool_response><|im_end|>
+<|im_start|>assistant
+<think>
+`,
+		},
+		{
 			name: "image content",
 			messages: []api.Message{{
 				Role:    "user",
@@ -359,11 +400,6 @@ func TestQwen38RendererRejectsInvalidTranscripts(t *testing.T) {
 		wantErr  string
 	}{
 		{name: "empty", wantErr: "no messages provided"},
-		{
-			name:     "no user query",
-			messages: []api.Message{{Role: "system", Content: "Hello"}},
-			wantErr:  "no user query found in messages",
-		},
 		{
 			name: "system image",
 			messages: []api.Message{


### PR DESCRIPTION
Fixes #17778
Fixes #17812

## Problem

`qwen3.8` returns HTTP 500 `no user query found in messages` during multi-turn tool calling. Two reports: an agentic tool loop through `/api/chat` (#17778), and Ollama Desktop's web search (#17812).

`validateMessages` required at least one `user` message whose content is not wholly a `<tool_response>` block. A long tool loop can leave none. `chatPrompt` drops messages from the front when the transcript exceeds the context window, and a large tool response can push the original query out. The renderer then rejected the request instead of rendering it.

rick-github diagnosed this in #17778.

## Change

Drop the check and log a warning instead. This matches #17757, which removed the sibling `system message must be at the beginning` guard from the same function. Both guards mirror `raise_exception` calls in the reference template (`qwen38_chat_template.jinja` lines 100 and 106).

The other validations are unchanged: empty message list, and images on a leading system message.

## Tests

- Removed the `no user query` case from `TestQwen38RendererRejectsInvalidTranscripts`.
- Added `tool loop without a plain user query` to `TestQwen38RendererMatchesReferenceFlows`: an assistant tool call followed by a tool response, with no plain user message. To check that it reproduces the bug instead of pinning current behavior, I reverted `qwen35.go` on its own and re-ran it. It fails with `no user query found in messages`, the error both issues report.

The new case leaves `matchesTemplate` at its zero value, because the reference template raises on this shape. A comment above the case says so.

## Verification

I ran these locally, and they pass:
- `go build ./model/renderers/...`
- `go vet ./model/renderers/...`
- `go test ./model/... -count=1`
- `gofmt -l model/renderers` (no output)

I could not run `go build ./...`, `go vet ./server/...` or `go test ./server/...`. They already fail on a clean checkout on my machine, because `app/dist` needs an npm build and `x/mlxrunner/mlx` needs a native MLX build. Neither is related to this change.

I did not add an integration case. This shape is defined by a message that is missing, so I cannot create it by adding a message to an existing fixture, and both user turns in `runOllamaToolRoute` are load-bearing for that test's assertions. The new renderer test covers the behavior instead.
