### PR TITLE
fix(install): Support different DNF versions

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -328,8 +328,13 @@ install_cuda_driver_yum() {
             fi
             ;;
         dnf)
+            DNF_VERSION=$(dnf --version | grep -E -o -m 1 "dnf[4-5]")
+            if [ "$DNF_VERSION" = "dnf5" ]; then
+                ADD_REPO_DNF_FMT="addrepo"
+            else
+                ADD_REPO_DNF_FMT="--add-repo"
             if curl -I --silent --fail --location "https://developer.download.nvidia.com/compute/cuda/repos/$1$2/$(uname -m | sed -e 's/aarch64/sbsa/')/cuda-$1$2.repo" >/dev/null ; then
-                $SUDO $PACKAGE_MANAGER config-manager --add-repo https://developer.download.nvidia.com/compute/cuda/repos/$1$2/$(uname -m | sed -e 's/aarch64/sbsa/')/cuda-$1$2.repo
+                $SUDO $PACKAGE_MANAGER config-manager ${ADD_REPO_DNF_FMT} https://developer.download.nvidia.com/compute/cuda/repos/$1$2/$(uname -m | sed -e 's/aarch64/sbsa/')/cuda-$1$2.repo
             else
                 error $CUDA_REPO_ERR_MSG
             fi


### PR DESCRIPTION
I was trying to install Ollama on a Fedora 43 machine and came across errors adding the NVIDIA repo. For dnf5 systems, the expression should actually be `config-manager addrepo xxx`.[^1]
While dnf5 is now the new defacto version, some systems may still use dnf4, which uses the old format.

This commit makes the branch statement slightly more flexible, supporting installations on dnf5-based systems.

Piggybacks significantly on #8691 (don't know why it was closed) but takes a simpler approach to make that syntax flexible for the installation script to work.

Fixes #7869

- [^1]: https://dnf5.readthedocs.io/en/latest/dnf5_plugins/config-manager.8.html