### PR TITLE
format: use the rounded hour count for the years label

### DIFF
--- a/format/time.go
+++ b/format/time.go
@@ -43,7 +43,9 @@ func humanDuration(d time.Duration) string {
 		return fmt.Sprintf("%d months", hours/24/30)
 	}
 
-	return fmt.Sprintf("%d years", int(d.Hours())/24/365)
+	// hours, not int(d.Hours()): the switch above picked this branch from the
+	// rounded count, and the two disagree in the last half hour of a year.
+	return fmt.Sprintf("%d years", hours/24/365)
 }
 
 func HumanTime(t time.Time, zeroValue string) string {

--- a/format/time_test.go
+++ b/format/time_test.go
@@ -43,3 +43,24 @@ func TestHumanTime(t *testing.T) {
 		assertEqual(t, HumanTimeLower(v, ""), "forever")
 	})
 }
+
+func TestHumanDurationYearBoundary(t *testing.T) {
+	// The switch reads the rounded hour count, so the years label has to divide
+	// the same one. It used to divide the truncated count instead, and in the
+	// last half hour before a year boundary the two disagree: the label went
+	// backwards, "24 months" for a shorter age and "1 years" for a longer one,
+	// before jumping to "2 years".
+	for _, tc := range []struct {
+		d    time.Duration
+		want string
+	}{
+		{17519*time.Hour + 20*time.Minute, "24 months"},
+		{17519*time.Hour + 30*time.Minute, "2 years"},
+		{17519*time.Hour + 59*time.Minute, "2 years"},
+		{17520 * time.Hour, "2 years"},
+		{26279*time.Hour + 40*time.Minute, "3 years"},
+		{26280 * time.Hour, "3 years"},
+	} {
+		assertEqual(t, humanDuration(tc.d), tc.want)
+	}
+}


### PR DESCRIPTION
`humanDuration` computes `hours := int(math.Round(d.Hours()))` and every branch
guard and every branch body reads that rounded value, except the last line,
which recomputes from the truncated `int(d.Hours())`.

For `d.Hours()` in `[N*8760 - 0.5, N*8760)` the rounded value crosses the
`hours < 24*365*2` guard into the years branch while the truncated one is still
a year short, so the label an extra half hour of age produces is *smaller*:

```
17519h20m ago -> "24 months ago"
17519h30m ago -> "1 years ago"     <- one year short, and lower than the line above
17519h59m ago -> "1 years ago"
17520h00m ago -> "2 years ago"
```

The years branch is only reachable once rounded hours is at least 17520, so
`hours/24/365` can never be 1: "1 years" is a string the function is not built
to be able to emit, which is what makes it a clear signature rather than a
rounding preference. The same one-year undercount recurs at every later year
boundary (nearly 3 years prints "2 years", nearly 4 prints "3 years", and so
on).

This shows up in the `MODIFIED` column of `ollama list` and the `UNTIL` column
of `ollama ps`, both of which go through `format.HumanTime`.

No design call is needed here: the switch already decided the unit from the
rounded count, so the body has to divide the same one.

## Blast radius

Comparing the old and new expressions minute by minute from 0 to 8 years, they
differ on 210 minutes total: exactly the seven 30-minute windows before each
year boundary, and nowhere else. Branch reachability is unchanged, since the
guard was already reading `hours`.

## Tests

`format/time_test.go` gains `TestHumanDurationYearBoundary`, a table over the
first two boundaries with the neighbouring values as controls. Against the
unmodified `format/time.go` three of its six cases fail:

```
$ go test ./format/ -run TestHumanDurationYearBoundary
--- FAIL: TestHumanDurationYearBoundary (0.00s)
    time_test.go:10: Assert failed, expected 2 years, got 1 years
    time_test.go:10: Assert failed, expected 2 years, got 1 years
    time_test.go:10: Assert failed, expected 3 years, got 2 years
```

With the change, `go test ./format/` passes, including the existing
`TestHumanTime` cases, and `gofmt -l` and `go vet ./format/` are clean.
It tests `humanDuration` directly rather than `HumanTime` so the boundary is
exact and does not depend on `time.Since`.
