### PR TITLE
launch: fill cloud model metadata gaps from show on config writes

### DIFF
--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -780,7 +780,7 @@ func (c *launcherClient) launchEditorIntegration(ctx context.Context, name strin
 	var launchModels []LaunchModel
 	liveConfigMatches := slices.Equal(editor.Models(), models)
 	if needsConfigure || req.ModelOverride != "" || !savedMatchesModels(saved, models) || !liveConfigMatches {
-		launchModels = c.modelInventory().Resolve(ctx, models)
+		launchModels = c.resolveConfigModels(ctx, models)
 		if err := prepareEditorIntegration(name, editor, launchModels); err != nil {
 			return err
 		}
@@ -817,7 +817,7 @@ func (c *launcherClient) launchManagedSingleIntegration(ctx context.Context, nam
 		if err != nil {
 			return err
 		}
-		if err := prepareManagedSingleIntegration(name, managed, target, c.modelInventory().Resolve(ctx, configureModels)); err != nil {
+		if err := prepareManagedSingleIntegration(name, managed, target, c.resolveConfigModels(ctx, configureModels)); err != nil {
 			return err
 		}
 		if refresher, ok := managed.(ManagedRuntimeRefresher); ok {
@@ -1456,6 +1456,15 @@ func hasLocalModel(inventory []LaunchModel, name string) bool {
 
 func (c *launcherClient) resolveRunModels(ctx context.Context, models []string) []LaunchModel {
 	return c.modelInventory().Resolve(ctx, models)
+}
+
+// resolveConfigModels additionally enriches names the local model list could
+// not describe via Show. Run paths use resolveRunModels to avoid probing
+// saved models that are intentionally not validated.
+func (c *launcherClient) resolveConfigModels(ctx context.Context, models []string) []LaunchModel {
+	inventory := c.modelInventory()
+	resolved := inventory.Resolve(ctx, models)
+	return inventory.enrichUnresolvedFromShow(ctx, resolved)
 }
 
 func runIntegration(runner Runner, modelName string, models []LaunchModel, args []string) error {

--- a/cmd/launch/model_inventory.go
+++ b/cmd/launch/model_inventory.go
@@ -5,6 +5,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/ollama/ollama/api"
 	modelpkg "github.com/ollama/ollama/types/model"
@@ -44,6 +45,9 @@ func (m LaunchModel) WithCloudLimits() LaunchModel {
 	}
 	return m
 }
+
+// modelShowTimeout bounds Show metadata probes. Var so tests can shorten it.
+var modelShowTimeout = 5 * time.Second
 
 type modelInventory struct {
 	client *api.Client
@@ -114,6 +118,63 @@ func (i *modelInventory) Resolve(ctx context.Context, names []string) []LaunchMo
 		}
 	}
 	return resolved
+}
+
+// enrichUnresolvedFromShow fills gaps in entries the local model list could
+// not describe (typically unpulled ":cloud" models) via Show. Best-effort:
+// failures keep the fallback zero values.
+func (i *modelInventory) enrichUnresolvedFromShow(ctx context.Context, resolved []LaunchModel) []LaunchModel {
+	if i == nil || i.client == nil {
+		return resolved
+	}
+
+	i.mu.Lock()
+	loaded, loadErr := i.loaded, i.err
+	models := cloneLaunchModels(i.models)
+	i.mu.Unlock()
+
+	if !loaded || loadErr != nil {
+		return resolved
+	}
+
+	for j := range resolved {
+		if _, found := findLaunchModel(models, resolved[j].Name); !found {
+			resolved[j] = i.enrichFromShow(ctx, resolved[j])
+		}
+	}
+	return resolved
+}
+
+// enrichFromShow fills gaps in m from Show, preserving metadata already
+// resolved from the model list or cloud limit maps.
+func (i *modelInventory) enrichFromShow(ctx context.Context, m LaunchModel) LaunchModel {
+	ctx, cancel := context.WithTimeout(ctx, modelShowTimeout)
+	defer cancel()
+
+	resp, err := i.client.Show(ctx, &api.ShowRequest{Model: m.Name})
+	if err != nil {
+		return m
+	}
+
+	if len(m.Capabilities) == 0 {
+		m.Capabilities = append([]modelpkg.Capability(nil), resp.Capabilities...)
+		m.ToolCapable = m.HasCapability(modelpkg.CapabilityTools)
+	}
+
+	if m.ContextLength <= 0 {
+		if resp.Details.ContextLength > 0 {
+			m.ContextLength = resp.Details.ContextLength
+		} else if n, ok := modelInfoContextLength(resp.ModelInfo); ok {
+			// parser shared with the Kimi CLI integration (kimi.go)
+			m.ContextLength = n
+		}
+		if m.ContextLength > 0 {
+			// Mirror List-derived models for integrations reading Details.
+			m.Details.ContextLength = m.ContextLength
+		}
+	}
+
+	return m
 }
 
 func resolveLaunchModels(names []string, models []LaunchModel) ([]LaunchModel, bool) {

--- a/cmd/launch/model_inventory_test.go
+++ b/cmd/launch/model_inventory_test.go
@@ -78,3 +78,97 @@ func TestModelInventoryResolveDoesNotRefreshCloudMiss(t *testing.T) {
 		t.Fatalf("cloud limits not applied: %#v", got[0])
 	}
 }
+
+func TestModelInventoryEnrichUnresolvedFromShow(t *testing.T) {
+	showCalls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			fmt.Fprint(w, `{"models":[]}`)
+		case "/api/show":
+			showCalls++
+			fmt.Fprint(w, `{"capabilities":["thinking","tools"],"model_info":{"kimi-k3.context_length":1048576,"kimi-k3.embedding_length":7168},"details":{"family":"kimi-k3"}}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	u, _ := url.Parse(srv.URL)
+	inventory := newModelInventory(api.NewClient(u, srv.Client()))
+
+	resolved := inventory.Resolve(context.Background(), []string{"kimi-k3:cloud"})
+	got := inventory.enrichUnresolvedFromShow(context.Background(), resolved)
+	if len(got) != 1 {
+		t.Fatalf("enrichUnresolvedFromShow returned %d models, want 1", len(got))
+	}
+	if showCalls != 1 {
+		t.Fatalf("Show calls = %d, want 1", showCalls)
+	}
+	if got[0].ContextLength != 1_048_576 {
+		t.Fatalf("ContextLength = %d, want 1048576", got[0].ContextLength)
+	}
+	if got[0].Details.ContextLength != 1_048_576 {
+		t.Fatalf("Details.ContextLength = %d, want 1048576", got[0].Details.ContextLength)
+	}
+	if !got[0].HasCapability(modelpkg.CapabilityThinking) || !got[0].ToolCapable {
+		t.Fatalf("capabilities = %v toolCapable=%v, want thinking and tools from Show", got[0].Capabilities, got[0].ToolCapable)
+	}
+	if !got[0].Remote {
+		t.Fatal("Remote = false, want cloud fallback to stay remote")
+	}
+}
+
+func TestModelInventoryEnrichKeepsFallbackWhenShowFails(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/api/tags" {
+			fmt.Fprint(w, `{"models":[]}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	u, _ := url.Parse(srv.URL)
+	inventory := newModelInventory(api.NewClient(u, srv.Client()))
+
+	resolved := inventory.Resolve(context.Background(), []string{"newcloud:cloud"})
+	got := inventory.enrichUnresolvedFromShow(context.Background(), resolved)
+	if len(got) != 1 {
+		t.Fatalf("enrichUnresolvedFromShow returned %d models, want 1", len(got))
+	}
+	if got[0].ContextLength != 0 || len(got[0].Capabilities) != 0 {
+		t.Fatalf("fallback metadata = %#v, want zero values when Show is unavailable", got[0])
+	}
+	if !got[0].Remote {
+		t.Fatal("Remote = false, want fallback marked remote")
+	}
+}
+
+func TestModelInventoryEnrichSkipsShowForListedModels(t *testing.T) {
+	showCalls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			fmt.Fprint(w, `{"models":[{"name":"local:latest","details":{"context_length":32768},"capabilities":["completion"]}]}`)
+		case "/api/show":
+			showCalls++
+			fmt.Fprint(w, `{}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	u, _ := url.Parse(srv.URL)
+	inventory := newModelInventory(api.NewClient(u, srv.Client()))
+
+	resolved := inventory.Resolve(context.Background(), []string{"local"})
+	got := inventory.enrichUnresolvedFromShow(context.Background(), resolved)
+	if len(got) != 1 || got[0].ContextLength != 32_768 {
+		t.Fatalf("resolved = %#v, want local model metadata from the list", got)
+	}
+	if showCalls != 0 {
+		t.Fatalf("Show calls = %d, want 0 for models resolved from the list", showCalls)
+	}
+}

--- a/cmd/launch/pi.go
+++ b/cmd/launch/pi.go
@@ -588,12 +588,10 @@ func (p *Pi) Edit(models []LaunchModel) error {
 				if !isPiOllamaModel(modelObj) {
 					newModels = append(newModels, m)
 				} else if selectedSet[id] {
-					// Rebuild stale managed cloud entries so createConfig refreshes
-					// the whole entry instead of patching it in place.
-					if !hasContextWindow(modelObj) {
-						if _, ok := lookupCloudModelLimit(id); ok {
-							continue
-						}
+					// Rebuild stale managed entries missing contextWindow when the
+					// freshly resolved models can now supply it.
+					if !hasContextWindow(modelObj) && freshContextAvailable(models, id) {
+						continue
 					}
 					newModels = append(newModels, m)
 					selectedSet[id] = false
@@ -672,6 +670,14 @@ func isPiOllamaModel(cfg map[string]any) bool {
 		return true
 	}
 	return false
+}
+
+// freshContextAvailable reports whether the models being written by Edit
+// contain id with context metadata.
+func freshContextAvailable(models []LaunchModel, id string) bool {
+	return slices.IndexFunc(models, func(m LaunchModel) bool {
+		return m.Name == id && m.ContextLength > 0
+	}) >= 0
 }
 
 func hasContextWindow(cfg map[string]any) bool {

--- a/cmd/launch/pi_test.go
+++ b/cmd/launch/pi_test.go
@@ -1080,6 +1080,55 @@ func TestPiEdit(t *testing.T) {
 		}
 	})
 
+	t.Run("rebuilds stale managed entry from resolved model metadata", func(t *testing.T) {
+		cleanup()
+		os.MkdirAll(configDir, 0o755)
+
+		// kimi-k3:cloud is not covered by the cloud limit maps; the resolved
+		// LaunchModel (enriched from Show metadata) is the only source of its
+		// context window.
+		existingConfig := `{
+			"providers": {
+				"ollama": {
+					"baseUrl": "http://localhost:11434/v1",
+					"api": "openai-completions",
+					"apiKey": "ollama",
+					"models": [
+						{"id": "kimi-k3:cloud", "_launch": true}
+					]
+				}
+			}
+		}`
+		if err := os.WriteFile(configPath, []byte(existingConfig), 0o644); err != nil {
+			t.Fatal(err)
+		}
+
+		models := []LaunchModel{{
+			Name:          "kimi-k3:cloud",
+			Remote:        true,
+			ContextLength: 1_048_576,
+			Capabilities:  []model.Capability{model.CapabilityThinking},
+		}}
+		if err := pi.Edit(models); err != nil {
+			t.Fatalf("Edit() error = %v", err)
+		}
+
+		cfg := readConfig()
+		providers := cfg["providers"].(map[string]any)
+		ollama := providers["ollama"].(map[string]any)
+		modelsArray := ollama["models"].([]any)
+		if len(modelsArray) != 1 {
+			t.Fatalf("Expected 1 model after update, got %d", len(modelsArray))
+		}
+		modelEntry := modelsArray[0].(map[string]any)
+		if modelEntry["contextWindow"] != float64(1_048_576) {
+			t.Errorf("contextWindow = %v, want 1048576", modelEntry["contextWindow"])
+		}
+		if modelEntry["reasoning"] != true {
+			t.Errorf("reasoning = %v, want true", modelEntry["reasoning"])
+		}
+	})
+
 	t.Run("replaces old models with new ones", func(t *testing.T) {
 		cleanup()
 		os.MkdirAll(configDir, 0o755)


### PR DESCRIPTION
Cloud models without a local manifest aren't in the model list, and ones also missing from the static limit tables and recommendations feed (e.g. newly released or usage-billed models like kimi-k3:cloud) resolved to zero metadata, so pi entries were written without contextWindow/reasoning and pi fell back to its 128k context default.

Config writes now enrich unresolved names with one best-effort, 5s-bounded show probe that fails open to the old fallback behavior; run paths are unchanged and never probe unvalidated saved models. Pi also rebuilds stale _launch entries missing contextWindow whenever the resolved models can supply one, so affected configs heal on the next launch.

Before:
<img width="392" height="35" alt="image" src="https://github.com/user-attachments/assets/e23ae7d1-1a20-4862-a40f-be8b792b3be1" />

After:
<img width="379" height="63" alt="image" src="https://github.com/user-attachments/assets/e352be27-ede1-4b8c-b752-992cab704495" />
