### PR TITLE
Fix typo in runner README

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -2,7 +2,7 @@
 
 > Note: this is a work in progress
 
-A minimial runner for loading a model and running inference via a http web server.
+A minimal runner for loading a model and running inference via a http web server.
 
 ```shell
 ./runner -model <model binary>


### PR DESCRIPTION
Fixes a typo in the runner README: \minimial\ -> \minimal\.