### PR TITLE
docs: clarify that eval_count includes thinking tokens

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -101,7 +101,8 @@ The final response in the stream also includes additional data about the generat
 - `load_duration`: time spent in nanoseconds loading the model
 - `prompt_eval_count`: number of tokens in the prompt
 - `prompt_eval_duration`: time spent in nanoseconds evaluating the prompt
-- `eval_count`: number of tokens in the response
+- `eval_count`: number of tokens the model generated, including any `thinking`
+  tokens as well as the `response` content
 - `eval_duration`: time in nanoseconds spent generating the response
 - `context`: an encoding of the conversation used in this response, this can be sent in the next request to keep a conversational memory
 - `response`: empty if the response was streamed, if not streamed, this will contain the full response


### PR DESCRIPTION
`docs/api.md` documents `eval_count` as **"number of tokens in the response"**, which naturally reads as the `response` field. It is the runner's raw decode count, so with `think: true` it also covers everything emitted into `thinking` — usually the larger share.

### Why it can't be response-only

The count is copied from the runner *before* the thinking/content split happens:

- **`/api/generate`** — `EvalCount: cr.EvalCount` (`server/routes.go:679`) is set in the same struct literal whose `cr.Content` only reaches `builtinParser.Add(...)` at `:686` and `thinkingState.AddContent(...)` at `:697`. The split is textual and runs afterwards, writing `res.Response` / `res.Thinking`.
- **`/api/chat`** — same shape at `:2775` and `:2983`.

Nothing downstream recomputes the value from parsed content.

### Why it's worth a line

`eval_count / eval_duration` is documented immediately below as the token rate, and that is correct either way. But `eval_count` read on its own is easy to take as the answer length, and for a thinking model it usually isn't — a short answer behind a long reasoning block reports a large `eval_count`, which makes any "tokens per answer" comparison across models with different reasoning behaviour misleading.

Docs only; one bullet, no behaviour change.