### PR TITLE
docs: fix broken aka.ms link (tooklit -> toolkit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ console.log(response.message.content);
 - [AI ST Completion](https://github.com/yaroslavyaroslav/OpenAI-sublime-text) - Sublime Text 4 AI assistant
 - [VT Code](https://github.com/vinhnx/vtcode) - Rust-based terminal coding agent with Tree-sitter
 - [QodeAssist](https://github.com/Palm1r/QodeAssist) - AI coding assistant for Qt Creator
-- [AI Toolkit for VS Code](https://aka.ms/ai-tooklit/ollama-docs) - Microsoft-official VS Code extension
+- [AI Toolkit for VS Code](https://aka.ms/ai-toolkit/ollama-docs) - Microsoft-official VS Code extension
 - [Open Interpreter](https://docs.openinterpreter.com/language-model-setup/local-models/ollama) - Natural language interface for computers
 
 ### Libraries & SDKs


### PR DESCRIPTION
## What

Fixed a typo in the README's "AI Toolkit for VS Code" integration link.

## Why

The link was pointing to https://aka.ms/ai-tooklit/ollama-docs (with "tooklit" typo), which does not resolve. The correct Microsoft alias is i-toolkit:

- https://aka.ms/ai-tooklit/ollama-docs → broken (redirect to error)
- https://aka.ms/ai-toolkit/ollama-docs → HTTP 200

## Change

i-tooklit → i-toolkit in the "AI Toolkit for VS Code" bullet.