### PR TITLE
docs: fix broken .md/.mdx links

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 ### Getting Started
 * [Quickstart](https://docs.ollama.com/quickstart)
-* [Examples](./examples.md)
+* [Examples](./examples)
 * [Importing models](https://docs.ollama.com/import)
 * [MacOS Documentation](https://docs.ollama.com/macos)
 * [Linux Documentation](https://docs.ollama.com/linux)
@@ -14,10 +14,10 @@
 * [API Reference](https://docs.ollama.com/api)
 * [Modelfile Reference](https://docs.ollama.com/modelfile)
 * [OpenAI Compatibility](https://docs.ollama.com/api/openai-compatibility)
-* [Anthropic Compatibility](./api/anthropic-compatibility.mdx)
+* [Anthropic Compatibility](./api/anthropic-compatibility)
 
 ### Resources
 
 * [Troubleshooting Guide](https://docs.ollama.com/troubleshooting)
 * [FAQ](https://docs.ollama.com/faq)
-* [Development guide](./development.md)
+* [Development guide](./development)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,14 +1,14 @@
 # Examples
 
-This directory contains different examples of using Ollama/
+This directory contains different examples of using Ollama.
 
 ## Python examples
-Ollama Python examples at [ollama-python/examples](https://github/com/ollama/ollama-python/tree/main/examples)
+Ollama Python examples at [ollama-python/examples](https://github.com/ollama/ollama-python/tree/main/examples)
 
 
 ## JavaScript examples
-Ollama JavaScript examples at [ollama-js/examples](https://github/com/ollama/ollama-js/tree/main/examples)
+Ollama JavaScript examples at [ollama-js/examples](https://github.com/ollama/ollama-js/tree/main/examples)
 
 
 ## OpenAI compatibility examples
-Ollama OpenAI compatibility examples at [ollama/examples/openai](//api/openai-compatibility/mdx)
+Ollama OpenAI compatibility examples at [ollama/examples/openai](./api/openai-compatibility)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,14 +1,14 @@
 # Examples
 
-This directory contains different examples of using Ollama.
+This directory contains different examples of using Ollama/
 
 ## Python examples
-Ollama Python examples at [ollama-python/examples](https://github.com/ollama/ollama-python/tree/main/examples)
+Ollama Python examples at [ollama-python/examples](https://github/com/ollama/ollama-python/tree/main/examples)
 
 
 ## JavaScript examples
-Ollama JavaScript examples at [ollama-js/examples](https://github.com/ollama/ollama-js/tree/main/examples)
+Ollama JavaScript examples at [ollama-js/examples](https://github/com/ollama/ollama-js/tree/main/examples)
 
 
 ## OpenAI compatibility examples
-Ollama OpenAI compatibility examples at [ollama/examples/openai](./api/openai-compatibility.mdx)
+Ollama OpenAI compatibility examples at [ollama/examples/openai](//api/openai-compatibility/mdx)

--- a/docs/gpu.mdx
+++ b/docs/gpu.mdx
@@ -3,52 +3,52 @@ title: Hardware support
 ---
 
 ## Nvidia
-Ollama supports Nvidia GPUs with compute capability 5/0+ and driver version 550 and newer/
-Nvidia GPUs with compute capability 5/0 through 6/2 require driver version 570 or newer/
+Ollama supports Nvidia GPUs with compute capability 5.0+ and driver version 550 and newer.
+Nvidia GPUs with compute capability 5.0 through 6.2 require driver version 570 or newer.
 
 Check your compute compatibility to see if your card is supported:
-[https://developer/nvidia/com/cuda-gpus](https://developer/nvidia/com/cuda-gpus)
+[https://developer.nvidia.com/cuda-gpus](https://developer.nvidia.com/cuda-gpus)
 
 | Compute Capability | Family              | Cards                                                                                                                          |
 | ------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| 12/1               | NVIDIA              | `GB10 (DGX Spark)`                                                                                                             |
-| 12/0               | GeForce RTX 50xx    | `RTX 5060` `RTX 5060 Ti` `RTX 5070` `RTX 5070 Ti` `RTX 5080` `RTX 5090`                                                        |
+| 12.1               | NVIDIA              | `GB10 (DGX Spark)`                                                                                                             |
+| 12.0               | GeForce RTX 50xx    | `RTX 5060` `RTX 5060 Ti` `RTX 5070` `RTX 5070 Ti` `RTX 5080` `RTX 5090`                                                        |
 |                    | NVIDIA Professional | `RTX PRO 4000 Blackwell` `RTX PRO 4500 Blackwell` `RTX PRO 5000 Blackwell` `RTX PRO 6000 Blackwell`                            |
-| 9/0                | NVIDIA              | `H200` `H100`                                                                                                                  |
-| 8/9                | GeForce RTX 40xx    | `RTX 4090` `RTX 4080 SUPER` `RTX 4080` `RTX 4070 Ti SUPER` `RTX 4070 Ti` `RTX 4070 SUPER` `RTX 4070` `RTX 4060 Ti` `RTX 4060`  |
+| 9.0                | NVIDIA              | `H200` `H100`                                                                                                                  |
+| 8.9                | GeForce RTX 40xx    | `RTX 4090` `RTX 4080 SUPER` `RTX 4080` `RTX 4070 Ti SUPER` `RTX 4070 Ti` `RTX 4070 SUPER` `RTX 4070` `RTX 4060 Ti` `RTX 4060`  |
 |                    | NVIDIA Professional | `L4` `L40` `RTX 6000`                                                                                                          |
-| 8/6                | GeForce RTX 30xx    | `RTX 3090 Ti` `RTX 3090` `RTX 3080 Ti` `RTX 3080` `RTX 3070 Ti` `RTX 3070` `RTX 3060 Ti` `RTX 3060` `RTX 3050 Ti` `RTX 3050`   |
+| 8.6                | GeForce RTX 30xx    | `RTX 3090 Ti` `RTX 3090` `RTX 3080 Ti` `RTX 3080` `RTX 3070 Ti` `RTX 3070` `RTX 3060 Ti` `RTX 3060` `RTX 3050 Ti` `RTX 3050`   |
 |                    | NVIDIA Professional | `A40` `RTX A6000` `RTX A5000` `RTX A4000` `RTX A3000` `RTX A2000` `A10` `A16` `A2`                                             |
-| 8/0                | NVIDIA              | `A100` `A30`                                                                                                                   |
-| 7/5                | GeForce GTX/RTX     | `GTX 1650 Ti` `TITAN RTX` `RTX 2080 Ti` `RTX 2080` `RTX 2070` `RTX 2060`                                                       |
+| 8.0                | NVIDIA              | `A100` `A30`                                                                                                                   |
+| 7.5                | GeForce GTX/RTX     | `GTX 1650 Ti` `TITAN RTX` `RTX 2080 Ti` `RTX 2080` `RTX 2070` `RTX 2060`                                                       |
 |                    | NVIDIA Professional | `T4` `RTX 5000` `RTX 4000` `RTX 3000` `T2000` `T1200` `T1000` `T600` `T500`                                                    |
 |                    | Quadro              | `RTX 8000` `RTX 6000` `RTX 5000` `RTX 4000`                                                                                    |
-| 7/0                | NVIDIA              | `TITAN V` `V100` `Quadro GV100`                                                                                                |
-| 6/1                | NVIDIA TITAN        | `TITAN Xp` `TITAN X`                                                                                                           |
+| 7.0                | NVIDIA              | `TITAN V` `V100` `Quadro GV100`                                                                                                |
+| 6.1                | NVIDIA TITAN        | `TITAN Xp` `TITAN X`                                                                                                           |
 |                    | GeForce GTX         | `GTX 1080 Ti` `GTX 1080` `GTX 1070 Ti` `GTX 1070` `GTX 1060` `GTX 1050 Ti` `GTX 1050`                                          |
 |                    | Quadro              | `P6000` `P5200` `P4200` `P3200` `P5000` `P4000` `P3000` `P2200` `P2000` `P1000` `P620` `P600` `P500` `P520`                    |
 |                    | Tesla               | `P40` `P4`                                                                                                                     |
-| 6/0                | NVIDIA              | `Tesla P100` `Quadro GP100`                                                                                                    |
-| 5/2                | GeForce GTX         | `GTX TITAN X` `GTX 980 Ti` `GTX 980` `GTX 970` `GTX 960` `GTX 950`                                                             |
+| 6.0                | NVIDIA              | `Tesla P100` `Quadro GP100`                                                                                                    |
+| 5.2                | GeForce GTX         | `GTX TITAN X` `GTX 980 Ti` `GTX 980` `GTX 970` `GTX 960` `GTX 950`                                                             |
 |                    | Quadro              | `M6000 24GB` `M6000` `M5000` `M5500M` `M4000` `M2200` `M2000` `M620`                                                           |
 |                    | Tesla               | `M60` `M40`                                                                                                                    |
-| 5/0                | GeForce GTX         | `GTX 750 Ti` `GTX 750` `NVS 810`                                                                                               |
+| 5.0                | GeForce GTX         | `GTX 750 Ti` `GTX 750` `NVS 810`                                                                                               |
 |                    | Quadro              | `K2200` `K1200` `K620` `M1200` `M520` `M5000M` `M4000M` `M3000M` `M2000M` `M1000M` `K620M` `M600M` `M500M`                     |
 
-For building locally to support older GPUs, see [development](//development/md)/
+For building locally to support older GPUs, see [development](./development).
 
 ### GPU Selection
 
 If you have multiple NVIDIA GPUs in your system and want to limit Ollama to use
-a subset, you can set `CUDA_VISIBLE_DEVICES` to a comma separated list of GPUs/
-Numeric IDs may be used, however ordering may vary, so UUIDs are more reliable/
+a subset, you can set `CUDA_VISIBLE_DEVICES` to a comma separated list of GPUs.
+Numeric IDs may be used, however ordering may vary, so UUIDs are more reliable.
 You can discover the UUID of your GPUs by running `nvidia-smi -L` If you want to
-ignore the GPUs and force CPU usage, use an invalid GPU ID (e/g/, "-1")
+ignore the GPUs and force CPU usage, use an invalid GPU ID (e.g., "-1")
 
 ### Linux Suspend Resume
 
 On linux, after a suspend/resume cycle, sometimes Ollama will fail to discover
-your NVIDIA GPU, and fallback to running on the CPU/ You can workaround this
+your NVIDIA GPU, and fallback to running on the CPU. You can workaround this
 driver bug by reloading the NVIDIA UVM driver with `sudo rmmod nvidia_uvm &&
 sudo modprobe nvidia_uvm`
 
@@ -57,14 +57,14 @@ sudo modprobe nvidia_uvm`
 Ollama supports the following AMD GPUs via the ROCm library:
 
 > **NOTE:**
-> Additional AMD GPU support is provided by the Vulkan Library - see below/
+> Additional AMD GPU support is provided by the Vulkan Library - see below.
 
 
 ### Linux Support
 
-Ollama requires the AMD ROCm v7 driver on Linux/ You can install or upgrade
+Ollama requires the AMD ROCm v7 driver on Linux. You can install or upgrade
 using the `amdgpu-install` utility from
-[AMD's ROCm documentation](https://rocm/docs/amd/com/projects/install-on-linux/en/latest/)/
+[AMD's ROCm documentation](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/).
 
 | Family         | Cards and accelerators                                                                                                                                         |
 | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -76,7 +76,7 @@ using the `amdgpu-install` utility from
 
 ### Windows Support
 
-Ollama requires an AMD ROCm v7 / HIP7-capable driver stack on Windows/
+Ollama requires an AMD ROCm v7 / HIP7-capable driver stack on Windows.
 
 | Family         | Cards and accelerators                                                                                               |
 | -------------- | -------------------------------------------------------------------------------------------------------------------- |
@@ -85,21 +85,21 @@ Ollama requires an AMD ROCm v7 / HIP7-capable driver stack on Windows/
 
 ### Overrides on Linux
 
-Ollama leverages the AMD ROCm library, which does not support all AMD GPUs/ In
+Ollama leverages the AMD ROCm library, which does not support all AMD GPUs. In
 some cases you can force the system to try to use a similar LLVM target that is
-close/ For example The Radeon RX 5400 is `gfx1034` (also known as 10/3/4)
-however, ROCm does not currently support this target/ The closest support is
-`gfx1030`/ You can use the environment variable `HSA_OVERRIDE_GFX_VERSION` with
-`x/y/z` syntax/ So for example, to force the system to run on the RX 5400, you
-would set `HSA_OVERRIDE_GFX_VERSION="10/3/0"` as an environment variable for the
-server/ If you have an unsupported AMD GPU you can experiment using the list of
-supported types below/
+close. For example The Radeon RX 5400 is `gfx1034` (also known as 10.3.4)
+however, ROCm does not currently support this target. The closest support is
+`gfx1030`. You can use the environment variable `HSA_OVERRIDE_GFX_VERSION` with
+`x.y.z` syntax. So for example, to force the system to run on the RX 5400, you
+would set `HSA_OVERRIDE_GFX_VERSION="10.3.0"` as an environment variable for the
+server. If you have an unsupported AMD GPU you can experiment using the list of
+supported types below.
 
 If you have multiple GPUs with different GFX versions, append the numeric device
-number to the environment variable to set them individually/ For example,
-`HSA_OVERRIDE_GFX_VERSION_0=10/3/0` and `HSA_OVERRIDE_GFX_VERSION_1=11/0/0`
+number to the environment variable to set them individually. For example,
+`HSA_OVERRIDE_GFX_VERSION_0=10.3.0` and `HSA_OVERRIDE_GFX_VERSION_1=11.0.0`
 
-At this time, the known supported GPU types on linux are the following LLVM Targets/
+At this time, the known supported GPU types on linux are the following LLVM Targets.
 This table shows some example GPUs that map to these LLVM targets:
 | **LLVM Target** | **An Example GPU** |
 |-----------------|---------------------|
@@ -116,47 +116,47 @@ This table shows some example GPUs that map to these LLVM targets:
 | gfx1200 | Radeon RX 9070 |
 | gfx1201 | Radeon RX 9070 XT |
 
-Reach out on [Discord](https://discord/gg/ollama) or file an
-[issue](https://github/com/ollama/ollama/issues) for additional help/
+Reach out on [Discord](https://discord.gg/ollama) or file an
+[issue](https://github.com/ollama/ollama/issues) for additional help.
 
 ### GPU Selection
 
 If you have multiple AMD GPUs in your system and want to limit Ollama to use a
-subset, you can set `ROCR_VISIBLE_DEVICES` to a comma separated list of GPUs/
-You can see the list of devices with `rocminfo`/ If you want to ignore the GPUs
-and force CPU usage, use an invalid GPU ID (e/g/, "-1")/ When available, use the
-`Uuid` to uniquely identify the device instead of numeric value/
+subset, you can set `ROCR_VISIBLE_DEVICES` to a comma separated list of GPUs.
+You can see the list of devices with `rocminfo`. If you want to ignore the GPUs
+and force CPU usage, use an invalid GPU ID (e.g., "-1"). When available, use the
+`Uuid` to uniquely identify the device instead of numeric value.
 
 ### Container Permission
 
 In some Linux distributions, SELinux can prevent containers from
-accessing the AMD GPU devices/ On the host system you can run
-`sudo setsebool container_use_devices=1` to allow containers to use devices/
+accessing the AMD GPU devices. On the host system you can run
+`sudo setsebool container_use_devices=1` to allow containers to use devices.
 
 ## Metal (Apple GPUs)
 
-Ollama supports GPU acceleration on Apple devices via the Metal API/
+Ollama supports GPU acceleration on Apple devices via the Metal API.
 
 
 ## Vulkan GPU Support
 
 Additional GPU support on Windows and Linux is provided via
-[Vulkan](https://www/vulkan/org/)/ Vulkan is enabled by default when the
-backend is installed/ On Windows most GPU vendors drivers come
-bundled with Vulkan support and require no additional setup steps/ Most Linux
+[Vulkan](https://www.vulkan.org/). Vulkan is enabled by default when the
+backend is installed. On Windows most GPU vendors drivers come
+bundled with Vulkan support and require no additional setup steps. Most Linux
 distributions require installing additional components, and you may have
 multiple options for Vulkan drivers between Mesa and GPU Vendor specific packages
 
-- Linux Intel GPU Instructions - https://dgpu-docs/intel/com/driver/client/overview/html
-- Linux AMD GPU Instructions - https://amdgpu-install/readthedocs/io/en/latest/install-script/html#specifying-a-vulkan-implementation
+- Linux Intel GPU Instructions - https://dgpu-docs.intel.com/driver/client/overview.html
+- Linux AMD GPU Instructions - https://amdgpu-install.readthedocs.io/en/latest/install-script.html#specifying-a-vulkan-implementation
 
-For AMD GPUs on some Linux distributions, you may need to add the `ollama` user to the `render` group/
+For AMD GPUs on some Linux distributions, you may need to add the `ollama` user to the `render` group.
 
 The Ollama scheduler leverages available VRAM data reported by the GPU libraries to
-make optimal scheduling decisions/  Vulkan requires additional capabilities or
-running as root to expose this available VRAM data/  If neither root access or this
+make optimal scheduling decisions.  Vulkan requires additional capabilities or
+running as root to expose this available VRAM data.  If neither root access or this
 capability are granted, Ollama will use approximate sizes of the models
-to make best effort scheduling decisions/
+to make best effort scheduling decisions.
 
 ```bash
 sudo setcap cap_perfmon+ep /usr/local/bin/ollama
@@ -166,11 +166,11 @@ sudo setcap cap_perfmon+ep /usr/local/bin/ollama
 
 To select specific Vulkan GPU(s), you can set the environment variable
 `GGML_VK_VISIBLE_DEVICES` to one or more numeric IDs on the Ollama server as
-described in the [FAQ](faq#how-do-i-configure-ollama-server)/ If you
+described in the [FAQ](faq#how-do-i-configure-ollama-server). If you
 encounter any problems with Vulkan based GPUs, you can disable all Vulkan GPUs
-by setting `OLLAMA_VULKAN=0` or `GGML_VK_VISIBLE_DEVICES=-1`/
+by setting `OLLAMA_VULKAN=0` or `GGML_VK_VISIBLE_DEVICES=-1`.
 
 On mixed iGPU/dGPU systems where the Vulkan iGPU is unstable, keep Vulkan
-enabled and set `GGML_VK_VISIBLE_DEVICES` to the discrete GPU index/ For
+enabled and set `GGML_VK_VISIBLE_DEVICES` to the discrete GPU index. For
 example, use `GGML_VK_VISIBLE_DEVICES=1` when `Vulkan1` is the discrete
-GPU/
+GPU.

--- a/docs/gpu.mdx
+++ b/docs/gpu.mdx
@@ -3,52 +3,52 @@ title: Hardware support
 ---
 
 ## Nvidia
-Ollama supports Nvidia GPUs with compute capability 5.0+ and driver version 550 and newer.
-Nvidia GPUs with compute capability 5.0 through 6.2 require driver version 570 or newer.
+Ollama supports Nvidia GPUs with compute capability 5/0+ and driver version 550 and newer/
+Nvidia GPUs with compute capability 5/0 through 6/2 require driver version 570 or newer/
 
 Check your compute compatibility to see if your card is supported:
-[https://developer.nvidia.com/cuda-gpus](https://developer.nvidia.com/cuda-gpus)
+[https://developer/nvidia/com/cuda-gpus](https://developer/nvidia/com/cuda-gpus)
 
 | Compute Capability | Family              | Cards                                                                                                                          |
 | ------------------ | ------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| 12.1               | NVIDIA              | `GB10 (DGX Spark)`                                                                                                             |
-| 12.0               | GeForce RTX 50xx    | `RTX 5060` `RTX 5060 Ti` `RTX 5070` `RTX 5070 Ti` `RTX 5080` `RTX 5090`                                                        |
+| 12/1               | NVIDIA              | `GB10 (DGX Spark)`                                                                                                             |
+| 12/0               | GeForce RTX 50xx    | `RTX 5060` `RTX 5060 Ti` `RTX 5070` `RTX 5070 Ti` `RTX 5080` `RTX 5090`                                                        |
 |                    | NVIDIA Professional | `RTX PRO 4000 Blackwell` `RTX PRO 4500 Blackwell` `RTX PRO 5000 Blackwell` `RTX PRO 6000 Blackwell`                            |
-| 9.0                | NVIDIA              | `H200` `H100`                                                                                                                  |
-| 8.9                | GeForce RTX 40xx    | `RTX 4090` `RTX 4080 SUPER` `RTX 4080` `RTX 4070 Ti SUPER` `RTX 4070 Ti` `RTX 4070 SUPER` `RTX 4070` `RTX 4060 Ti` `RTX 4060`  |
+| 9/0                | NVIDIA              | `H200` `H100`                                                                                                                  |
+| 8/9                | GeForce RTX 40xx    | `RTX 4090` `RTX 4080 SUPER` `RTX 4080` `RTX 4070 Ti SUPER` `RTX 4070 Ti` `RTX 4070 SUPER` `RTX 4070` `RTX 4060 Ti` `RTX 4060`  |
 |                    | NVIDIA Professional | `L4` `L40` `RTX 6000`                                                                                                          |
-| 8.6                | GeForce RTX 30xx    | `RTX 3090 Ti` `RTX 3090` `RTX 3080 Ti` `RTX 3080` `RTX 3070 Ti` `RTX 3070` `RTX 3060 Ti` `RTX 3060` `RTX 3050 Ti` `RTX 3050`   |
+| 8/6                | GeForce RTX 30xx    | `RTX 3090 Ti` `RTX 3090` `RTX 3080 Ti` `RTX 3080` `RTX 3070 Ti` `RTX 3070` `RTX 3060 Ti` `RTX 3060` `RTX 3050 Ti` `RTX 3050`   |
 |                    | NVIDIA Professional | `A40` `RTX A6000` `RTX A5000` `RTX A4000` `RTX A3000` `RTX A2000` `A10` `A16` `A2`                                             |
-| 8.0                | NVIDIA              | `A100` `A30`                                                                                                                   |
-| 7.5                | GeForce GTX/RTX     | `GTX 1650 Ti` `TITAN RTX` `RTX 2080 Ti` `RTX 2080` `RTX 2070` `RTX 2060`                                                       |
+| 8/0                | NVIDIA              | `A100` `A30`                                                                                                                   |
+| 7/5                | GeForce GTX/RTX     | `GTX 1650 Ti` `TITAN RTX` `RTX 2080 Ti` `RTX 2080` `RTX 2070` `RTX 2060`                                                       |
 |                    | NVIDIA Professional | `T4` `RTX 5000` `RTX 4000` `RTX 3000` `T2000` `T1200` `T1000` `T600` `T500`                                                    |
 |                    | Quadro              | `RTX 8000` `RTX 6000` `RTX 5000` `RTX 4000`                                                                                    |
-| 7.0                | NVIDIA              | `TITAN V` `V100` `Quadro GV100`                                                                                                |
-| 6.1                | NVIDIA TITAN        | `TITAN Xp` `TITAN X`                                                                                                           |
+| 7/0                | NVIDIA              | `TITAN V` `V100` `Quadro GV100`                                                                                                |
+| 6/1                | NVIDIA TITAN        | `TITAN Xp` `TITAN X`                                                                                                           |
 |                    | GeForce GTX         | `GTX 1080 Ti` `GTX 1080` `GTX 1070 Ti` `GTX 1070` `GTX 1060` `GTX 1050 Ti` `GTX 1050`                                          |
 |                    | Quadro              | `P6000` `P5200` `P4200` `P3200` `P5000` `P4000` `P3000` `P2200` `P2000` `P1000` `P620` `P600` `P500` `P520`                    |
 |                    | Tesla               | `P40` `P4`                                                                                                                     |
-| 6.0                | NVIDIA              | `Tesla P100` `Quadro GP100`                                                                                                    |
-| 5.2                | GeForce GTX         | `GTX TITAN X` `GTX 980 Ti` `GTX 980` `GTX 970` `GTX 960` `GTX 950`                                                             |
+| 6/0                | NVIDIA              | `Tesla P100` `Quadro GP100`                                                                                                    |
+| 5/2                | GeForce GTX         | `GTX TITAN X` `GTX 980 Ti` `GTX 980` `GTX 970` `GTX 960` `GTX 950`                                                             |
 |                    | Quadro              | `M6000 24GB` `M6000` `M5000` `M5500M` `M4000` `M2200` `M2000` `M620`                                                           |
 |                    | Tesla               | `M60` `M40`                                                                                                                    |
-| 5.0                | GeForce GTX         | `GTX 750 Ti` `GTX 750` `NVS 810`                                                                                               |
+| 5/0                | GeForce GTX         | `GTX 750 Ti` `GTX 750` `NVS 810`                                                                                               |
 |                    | Quadro              | `K2200` `K1200` `K620` `M1200` `M520` `M5000M` `M4000M` `M3000M` `M2000M` `M1000M` `K620M` `M600M` `M500M`                     |
 
-For building locally to support older GPUs, see [development](./development.md).
+For building locally to support older GPUs, see [development](//development/md)/
 
 ### GPU Selection
 
 If you have multiple NVIDIA GPUs in your system and want to limit Ollama to use
-a subset, you can set `CUDA_VISIBLE_DEVICES` to a comma separated list of GPUs.
-Numeric IDs may be used, however ordering may vary, so UUIDs are more reliable.
+a subset, you can set `CUDA_VISIBLE_DEVICES` to a comma separated list of GPUs/
+Numeric IDs may be used, however ordering may vary, so UUIDs are more reliable/
 You can discover the UUID of your GPUs by running `nvidia-smi -L` If you want to
-ignore the GPUs and force CPU usage, use an invalid GPU ID (e.g., "-1")
+ignore the GPUs and force CPU usage, use an invalid GPU ID (e/g/, "-1")
 
 ### Linux Suspend Resume
 
 On linux, after a suspend/resume cycle, sometimes Ollama will fail to discover
-your NVIDIA GPU, and fallback to running on the CPU. You can workaround this
+your NVIDIA GPU, and fallback to running on the CPU/ You can workaround this
 driver bug by reloading the NVIDIA UVM driver with `sudo rmmod nvidia_uvm &&
 sudo modprobe nvidia_uvm`
 
@@ -57,14 +57,14 @@ sudo modprobe nvidia_uvm`
 Ollama supports the following AMD GPUs via the ROCm library:
 
 > **NOTE:**
-> Additional AMD GPU support is provided by the Vulkan Library - see below.
+> Additional AMD GPU support is provided by the Vulkan Library - see below/
 
 
 ### Linux Support
 
-Ollama requires the AMD ROCm v7 driver on Linux. You can install or upgrade
+Ollama requires the AMD ROCm v7 driver on Linux/ You can install or upgrade
 using the `amdgpu-install` utility from
-[AMD's ROCm documentation](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/).
+[AMD's ROCm documentation](https://rocm/docs/amd/com/projects/install-on-linux/en/latest/)/
 
 | Family         | Cards and accelerators                                                                                                                                         |
 | -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -76,7 +76,7 @@ using the `amdgpu-install` utility from
 
 ### Windows Support
 
-Ollama requires an AMD ROCm v7 / HIP7-capable driver stack on Windows.
+Ollama requires an AMD ROCm v7 / HIP7-capable driver stack on Windows/
 
 | Family         | Cards and accelerators                                                                                               |
 | -------------- | -------------------------------------------------------------------------------------------------------------------- |
@@ -85,21 +85,21 @@ Ollama requires an AMD ROCm v7 / HIP7-capable driver stack on Windows.
 
 ### Overrides on Linux
 
-Ollama leverages the AMD ROCm library, which does not support all AMD GPUs. In
+Ollama leverages the AMD ROCm library, which does not support all AMD GPUs/ In
 some cases you can force the system to try to use a similar LLVM target that is
-close. For example The Radeon RX 5400 is `gfx1034` (also known as 10.3.4)
-however, ROCm does not currently support this target. The closest support is
-`gfx1030`. You can use the environment variable `HSA_OVERRIDE_GFX_VERSION` with
-`x.y.z` syntax. So for example, to force the system to run on the RX 5400, you
-would set `HSA_OVERRIDE_GFX_VERSION="10.3.0"` as an environment variable for the
-server. If you have an unsupported AMD GPU you can experiment using the list of
-supported types below.
+close/ For example The Radeon RX 5400 is `gfx1034` (also known as 10/3/4)
+however, ROCm does not currently support this target/ The closest support is
+`gfx1030`/ You can use the environment variable `HSA_OVERRIDE_GFX_VERSION` with
+`x/y/z` syntax/ So for example, to force the system to run on the RX 5400, you
+would set `HSA_OVERRIDE_GFX_VERSION="10/3/0"` as an environment variable for the
+server/ If you have an unsupported AMD GPU you can experiment using the list of
+supported types below/
 
 If you have multiple GPUs with different GFX versions, append the numeric device
-number to the environment variable to set them individually. For example,
-`HSA_OVERRIDE_GFX_VERSION_0=10.3.0` and `HSA_OVERRIDE_GFX_VERSION_1=11.0.0`
+number to the environment variable to set them individually/ For example,
+`HSA_OVERRIDE_GFX_VERSION_0=10/3/0` and `HSA_OVERRIDE_GFX_VERSION_1=11/0/0`
 
-At this time, the known supported GPU types on linux are the following LLVM Targets.
+At this time, the known supported GPU types on linux are the following LLVM Targets/
 This table shows some example GPUs that map to these LLVM targets:
 | **LLVM Target** | **An Example GPU** |
 |-----------------|---------------------|
@@ -116,47 +116,47 @@ This table shows some example GPUs that map to these LLVM targets:
 | gfx1200 | Radeon RX 9070 |
 | gfx1201 | Radeon RX 9070 XT |
 
-Reach out on [Discord](https://discord.gg/ollama) or file an
-[issue](https://github.com/ollama/ollama/issues) for additional help.
+Reach out on [Discord](https://discord/gg/ollama) or file an
+[issue](https://github/com/ollama/ollama/issues) for additional help/
 
 ### GPU Selection
 
 If you have multiple AMD GPUs in your system and want to limit Ollama to use a
-subset, you can set `ROCR_VISIBLE_DEVICES` to a comma separated list of GPUs.
-You can see the list of devices with `rocminfo`. If you want to ignore the GPUs
-and force CPU usage, use an invalid GPU ID (e.g., "-1"). When available, use the
-`Uuid` to uniquely identify the device instead of numeric value.
+subset, you can set `ROCR_VISIBLE_DEVICES` to a comma separated list of GPUs/
+You can see the list of devices with `rocminfo`/ If you want to ignore the GPUs
+and force CPU usage, use an invalid GPU ID (e/g/, "-1")/ When available, use the
+`Uuid` to uniquely identify the device instead of numeric value/
 
 ### Container Permission
 
 In some Linux distributions, SELinux can prevent containers from
-accessing the AMD GPU devices. On the host system you can run
-`sudo setsebool container_use_devices=1` to allow containers to use devices.
+accessing the AMD GPU devices/ On the host system you can run
+`sudo setsebool container_use_devices=1` to allow containers to use devices/
 
 ## Metal (Apple GPUs)
 
-Ollama supports GPU acceleration on Apple devices via the Metal API.
+Ollama supports GPU acceleration on Apple devices via the Metal API/
 
 
 ## Vulkan GPU Support
 
 Additional GPU support on Windows and Linux is provided via
-[Vulkan](https://www.vulkan.org/). Vulkan is enabled by default when the
-backend is installed. On Windows most GPU vendors drivers come
-bundled with Vulkan support and require no additional setup steps. Most Linux
+[Vulkan](https://www/vulkan/org/)/ Vulkan is enabled by default when the
+backend is installed/ On Windows most GPU vendors drivers come
+bundled with Vulkan support and require no additional setup steps/ Most Linux
 distributions require installing additional components, and you may have
 multiple options for Vulkan drivers between Mesa and GPU Vendor specific packages
 
-- Linux Intel GPU Instructions - https://dgpu-docs.intel.com/driver/client/overview.html
-- Linux AMD GPU Instructions - https://amdgpu-install.readthedocs.io/en/latest/install-script.html#specifying-a-vulkan-implementation
+- Linux Intel GPU Instructions - https://dgpu-docs/intel/com/driver/client/overview/html
+- Linux AMD GPU Instructions - https://amdgpu-install/readthedocs/io/en/latest/install-script/html#specifying-a-vulkan-implementation
 
-For AMD GPUs on some Linux distributions, you may need to add the `ollama` user to the `render` group.
+For AMD GPUs on some Linux distributions, you may need to add the `ollama` user to the `render` group/
 
 The Ollama scheduler leverages available VRAM data reported by the GPU libraries to
-make optimal scheduling decisions.  Vulkan requires additional capabilities or
-running as root to expose this available VRAM data.  If neither root access or this
+make optimal scheduling decisions/  Vulkan requires additional capabilities or
+running as root to expose this available VRAM data/  If neither root access or this
 capability are granted, Ollama will use approximate sizes of the models
-to make best effort scheduling decisions.
+to make best effort scheduling decisions/
 
 ```bash
 sudo setcap cap_perfmon+ep /usr/local/bin/ollama
@@ -166,11 +166,11 @@ sudo setcap cap_perfmon+ep /usr/local/bin/ollama
 
 To select specific Vulkan GPU(s), you can set the environment variable
 `GGML_VK_VISIBLE_DEVICES` to one or more numeric IDs on the Ollama server as
-described in the [FAQ](faq#how-do-i-configure-ollama-server). If you
+described in the [FAQ](faq#how-do-i-configure-ollama-server)/ If you
 encounter any problems with Vulkan based GPUs, you can disable all Vulkan GPUs
-by setting `OLLAMA_VULKAN=0` or `GGML_VK_VISIBLE_DEVICES=-1`.
+by setting `OLLAMA_VULKAN=0` or `GGML_VK_VISIBLE_DEVICES=-1`/
 
 On mixed iGPU/dGPU systems where the Vulkan iGPU is unstable, keep Vulkan
-enabled and set `GGML_VK_VISIBLE_DEVICES` to the discrete GPU index. For
+enabled and set `GGML_VK_VISIBLE_DEVICES` to the discrete GPU index/ For
 example, use `GGML_VK_VISIBLE_DEVICES=1` when `Vulkan1` is the discrete
-GPU.
+GPU/


### PR DESCRIPTION
## What

Fixes 5 broken internal links in the docs that use the .md / .mdx file extension. Ollama's docs are built with Mintlify, which routes pages without these extensions, so links like ./examples.md resolve to a 404 instead of ./examples.

## Changes

- docs/README.md
  - ./examples.md → ./examples
  - ./api/anthropic-compatibility.mdx → ./api/anthropic-compatibility
  - ./development.md → ./development
- docs/gpu.mdx
  - ./development.md → ./development
- docs/examples.md
  - ./api/openai-compatibility.mdx → ./api/openai-compatibility

Each target route returns HTTP 200 without the extension.

## Note

This intentionally leaves out the docs/faq.mdx and docs/api.md .mdx links that are already being addressed in other open PRs.