### PR TITLE
README: add MindMap Chat to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ console.log(response.message.content);
 - [Serene Pub](https://github.com/doolijb/serene-pub) - AI roleplaying app
 - [Mayan EDMS](https://gitlab.com/mayan-edms/mayan-edms) - Document management with Ollama workflows
 - [TagSpaces](https://www.tagspaces.org) - File management with [AI tagging](https://docs.tagspaces.org/ai/)
+- [MindMap Chat](https://mindmapchat.app/) - Visual knowledge map where every node is an AI you can talk to
 
 ### Observability & Monitoring
 


### PR DESCRIPTION
MindMap Chat is a cross-platform desktop and mobile app that turns study material into a visual knowledge map where every node is its own AI chat context.

It works with Ollama out of the box — it detects a local or LAN Ollama instance, and installs and starts Ollama for the user on Windows, macOS and Linux where the OS allows it. Adding it under Productivity & Apps.