### PR TITLE
llm: fix llama-server memory accounting for multi-model loads

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -2715,9 +2715,15 @@ type memoryParsingWriter struct {
 	inner   io.Writer
 	runner  *llamaServerRunner
 	buffers map[memoryBufferKey]memoryBuffer
+
+	// currentModel attributes buffer lines to the model being loaded: a
+	// subprocess can load a target, a speculative draft, and a projector,
+	// whose buffer lines are otherwise indistinguishable.
+	currentModel string
 }
 
 type memoryBufferKey struct {
+	model     string // owning model: target, draft, projector
 	component string
 	backend   string
 	kind      string
@@ -2726,6 +2732,22 @@ type memoryBufferKey struct {
 type memoryBuffer struct {
 	bytes uint64
 }
+
+// Model attribution for buffers parsed from the subprocess stream.
+const (
+	memoryModelTarget    = "target"
+	memoryModelDraft     = "draft"
+	memoryModelProjector = "projector"
+
+	// memoryBackendProjector marks the projector's estimate, which names
+	// no device; aggregation assigns it to the busiest one.
+	memoryBackendProjector = "(projector)"
+)
+
+// mmprojMemoryRegex matches the projector's worst-case memory estimate:
+//
+//	srv  load_model: [mtmd] estimated worst-case memory usage of mmproj is 1700.98 MiB (took 36.34 ms)
+var mmprojMemoryRegex = regexp.MustCompile(`estimated worst-case memory usage of mmproj is ([\d.]+)\s*MiB`)
 
 // deviceFreeRegex matches per-device free VRAM reported at model load time:
 //
@@ -2779,52 +2801,116 @@ func (w *memoryParsingWriter) Write(b []byte) (int, error) {
 			w.runner.memoryMu.Lock()
 			defer w.runner.memoryMu.Unlock()
 
-			if match := deviceFreeRegex.FindSubmatch(b); match != nil {
-				devName := string(match[1])
-				if mib, err := strconv.ParseUint(string(match[2]), 10, 64); err == nil {
-					w.runner.systemFreeAtLoad[devName] = mib * 1024 * 1024
-				}
-			}
-			for _, match := range offloadedLayersRegex.FindAllSubmatch(b, -1) {
-				loaded, loadedErr := strconv.ParseUint(string(match[1]), 10, 64)
-				total, totalErr := strconv.ParseUint(string(match[2]), 10, 64)
-				if loadedErr == nil && totalErr == nil {
-					w.runner.gpuLayers = loaded
-					w.runner.totalLayers = total
-				}
-			}
-			for _, match := range fitOverflowingLayersRegex.FindAllSubmatch(b, -1) {
-				overflowing, err := strconv.ParseUint(string(match[1]), 10, 64)
-				if err == nil && overflowing > 0 {
-					w.runner.gpuLayerOverflow += int(overflowing)
-				}
-			}
-			for _, match := range bufferSizeRegex.FindAllSubmatch(b, -1) {
-				backendName := string(match[2])
-				if mib, err := strconv.ParseFloat(string(match[4]), 64); err == nil {
-					if w.buffers == nil {
-						w.buffers = make(map[memoryBufferKey]memoryBuffer)
-					}
-					w.buffers[memoryBufferKey{
-						component: string(match[1]),
-						backend:   backendName,
-						kind:      string(match[3]),
-					}] = memoryBuffer{bytes: uint64(mib * 1024 * 1024)}
-					w.updateRunnerMemoryLocked()
-				}
+			// Line at a time: attribution markers must apply in stream
+			// order relative to surrounding buffer lines.
+			for line := range bytes.SplitSeq(b, []byte("\n")) {
+				w.parseLineLocked(line)
 			}
 		}()
 	}
 	return w.inner.Write(b)
 }
 
+// parseLineLocked parses a single llama-server log line for memory tracking.
+// Caller holds runner.memoryMu.
+func (w *memoryParsingWriter) parseLineLocked(line []byte) {
+	if bytes.Contains(line, []byte("loading draft model")) {
+		w.currentModel = memoryModelDraft
+		return
+	}
+	if bytes.Contains(line, []byte("loading model tensors")) {
+		// A new tensor-load pass supersedes the current model's previous
+		// buffers (e.g. a fit probe); other models' buffers are kept.
+		for key := range w.buffers {
+			if key.model == w.model() {
+				delete(w.buffers, key)
+			}
+		}
+		w.updateRunnerMemoryLocked()
+		return
+	}
+
+	if match := deviceFreeRegex.FindSubmatch(line); match != nil {
+		devName := string(match[1])
+		if mib, err := strconv.ParseUint(string(match[2]), 10, 64); err == nil {
+			w.runner.systemFreeAtLoad[devName] = mib * 1024 * 1024
+		}
+	}
+	if match := offloadedLayersRegex.FindSubmatch(line); match != nil {
+		// Only the target's counts drive offload status; the draft
+		// prints its own (e.g. "offloaded 6/6").
+		if w.model() == memoryModelTarget {
+			loaded, loadedErr := strconv.ParseUint(string(match[1]), 10, 64)
+			total, totalErr := strconv.ParseUint(string(match[2]), 10, 64)
+			if loadedErr == nil && totalErr == nil {
+				w.runner.gpuLayers = loaded
+				w.runner.totalLayers = total
+			}
+		}
+	}
+	if match := fitOverflowingLayersRegex.FindSubmatch(line); match != nil {
+		overflowing, err := strconv.ParseUint(string(match[1]), 10, 64)
+		if err == nil && overflowing > 0 {
+			w.runner.gpuLayerOverflow += int(overflowing)
+		}
+	}
+	if match := mmprojMemoryRegex.FindSubmatch(line); match != nil {
+		if mib, err := strconv.ParseFloat(string(match[1]), 64); err == nil {
+			w.setBufferLocked(memoryBufferKey{
+				model:     memoryModelProjector,
+				component: "mtmd",
+				backend:   memoryBackendProjector,
+				kind:      "model",
+			}, uint64(mib*1024*1024), false)
+		}
+	}
+	if match := bufferSizeRegex.FindSubmatch(line); match != nil {
+		if mib, err := strconv.ParseFloat(string(match[4]), 64); err == nil {
+			// Accumulate: one pass can allocate several same-key buffers
+			// (hybrid attention prints one KV line per cache pool).
+			w.setBufferLocked(memoryBufferKey{
+				model:     w.model(),
+				component: string(match[1]),
+				backend:   string(match[2]),
+				kind:      string(match[3]),
+			}, uint64(mib*1024*1024), true)
+		}
+	}
+}
+
+// model returns the model currently being loaded in the subprocess stream.
+func (w *memoryParsingWriter) model() string {
+	if w.currentModel == "" {
+		return memoryModelTarget
+	}
+	return w.currentModel
+}
+
+func (w *memoryParsingWriter) setBufferLocked(key memoryBufferKey, bytes uint64, accumulate bool) {
+	if w.buffers == nil {
+		w.buffers = make(map[memoryBufferKey]memoryBuffer)
+	}
+	if accumulate {
+		bytes += w.buffers[key].bytes
+	}
+	w.buffers[key] = memoryBuffer{bytes: bytes}
+	w.updateRunnerMemoryLocked()
+}
+
 func (w *memoryParsingWriter) updateRunnerMemoryLocked() {
-	var total, gpu, modelFileBacked, cpuMappedModel uint64
+	var total, gpu, modelFileBacked, cpuMappedModel, projector uint64
 	byDevice := make(map[string]uint64)
 
 	for key, buffer := range w.buffers {
 		total += buffer.bytes
-		if key.kind == "model" {
+		if key.backend == memoryBackendProjector {
+			projector += buffer.bytes
+			continue
+		}
+		// The mmap-overlap trim in MemorySize compares against the
+		// target's file, so only target buffers participate; the draft's
+		// small mmap double-count is accepted.
+		if key.kind == "model" && key.model == memoryModelTarget {
 			onGPU := isGPUBuffer(key.backend)
 			mmapBacked := strings.HasSuffix(key.backend, "_Mapped")
 			// Device copies and mmap views mirror the on-disk weights, so their
@@ -2841,6 +2927,21 @@ func (w *memoryParsingWriter) updateRunnerMemoryLocked() {
 		if isGPUBuffer(key.backend) {
 			gpu += buffer.bytes
 			byDevice[deviceName(key.backend)] += buffer.bytes
+		}
+	}
+
+	if projector > 0 {
+		// Count the projector estimate as GPU usage on the busiest device
+		// so the scheduler reserves for it.
+		gpu += projector
+		var busiest string
+		for dev, used := range byDevice {
+			if busiest == "" || used > byDevice[busiest] {
+				busiest = dev
+			}
+		}
+		if busiest != "" {
+			byDevice[busiest] += projector
 		}
 	}
 

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -2940,10 +2940,12 @@ func TestMemoryParsingWriter(t *testing.T) {
 		{
 			name: "fit probe buffers are replaced by final load",
 			lines: []string{
+				"load_tensors: loading model tensors, this can take a while... (load_mode = mmap)\n",
 				"load_tensors:        CUDA0 model buffer size =  1000.00 MiB\n",
 				"llama_kv_cache:      CUDA0 KV buffer size =  2000.00 MiB\n",
 				"sched_reserve:      CUDA0 compute buffer size =   300.00 MiB\n",
 				"sched_reserve:  CUDA_Host compute buffer size =   400.00 MiB\n",
+				"load_tensors: loading model tensors, this can take a while... (load_mode = mmap)\n",
 				"load_tensors:        CUDA0 model buffer size =  1100.00 MiB\n",
 				"llama_kv_cache:      CUDA0 KV buffer size =  2200.00 MiB\n",
 				"sched_reserve:      CUDA0 compute buffer size =   330.00 MiB\n",
@@ -2957,6 +2959,7 @@ func TestMemoryParsingWriter(t *testing.T) {
 		{
 			name: "rc21 fit probe accounting",
 			lines: []string{
+				"load_tensors: loading model tensors, this can take a while... (load_mode = mmap)\n",
 				"load_tensors:          CPU model buffer size =     0.00 MiB\n",
 				"load_tensors:        CUDA0 model buffer size =     0.00 MiB\n",
 				"load_tensors:        CUDA1 model buffer size =     0.00 MiB\n",
@@ -2968,9 +2971,11 @@ func TestMemoryParsingWriter(t *testing.T) {
 				"sched_reserve:      CUDA0 compute buffer size =  9952.25 MiB\n",
 				"sched_reserve:      CUDA1 compute buffer size =  6436.28 MiB\n",
 				"sched_reserve:  CUDA_Host compute buffer size =  8272.31 MiB\n",
+				"load_tensors: loading model tensors, this can take a while... (load_mode = mmap)\n",
 				"load_tensors:          CPU model buffer size =   682.03 MiB\n",
 				"load_tensors:        CUDA0 model buffer size =  8171.01 MiB\n",
 				"load_tensors:        CUDA1 model buffer size =  6618.25 MiB\n",
+				"llama_context:  CUDA_Host  output buffer size =     0.95 MiB\n",
 				"llama_kv_cache:      CUDA0 KV buffer size =  9216.00 MiB\n",
 				"llama_kv_cache:      CUDA1 KV buffer size =  7168.00 MiB\n",
 				"llama_memory_recurrent:      CUDA0 RS buffer size =    90.40 MiB\n",
@@ -2983,6 +2988,53 @@ func TestMemoryParsingWriter(t *testing.T) {
 			},
 			wantGPU:   47799.52,
 			wantTotal: 56779.74,
+		},
+		{
+			// Hybrid attention prints one same-key KV line per cache
+			// pool; both are live allocations and must sum.
+			name: "hybrid attention KV pools accumulate",
+			lines: []string{
+				"load_tensors: loading model tensors, this can take a while... (load_mode = mmap)\n",
+				"load_tensors:  MTL0_Mapped model buffer size = 15967.91 MiB\n",
+				"llama_kv_cache:       MTL0 KV buffer size =  1664.00 MiB\n",
+				"llama_kv_cache:       MTL0 KV buffer size =   156.00 MiB\n",
+			},
+			wantGPU:   15967.91 + 1664 + 156,
+			wantTotal: 15967.91 + 1664 + 156,
+		},
+		{
+			// Distilled from a muse-glimmer q8_0+DFlash load: draft
+			// buffers add to the target's, not replace them.
+			name: "speculative draft buffers add to the target's",
+			lines: []string{
+				"load_tensors: loading model tensors, this can take a while... (load_mode = mmap)\n",
+				"load_tensors:   CPU_Mapped model buffer size =  1362.69 MiB\n",
+				"load_tensors:  MTL0_Mapped model buffer size = 28228.61 MiB\n",
+				"llama_context:        CPU  output buffer size =     0.77 MiB\n",
+				"llama_kv_cache:       MTL0 KV buffer size =  1664.00 MiB\n",
+				"llama_kv_cache:       MTL0 KV buffer size =   156.00 MiB\n",
+				"sched_reserve:       MTL0 compute buffer size =  1100.07 MiB\n",
+				"sched_reserve:        CPU compute buffer size =   632.08 MiB\n",
+				"common_speculative_init_result: loading draft model '/blobs/sha256-draft'\n",
+				"load_tensors: loading model tensors, this can take a while... (load_mode = mmap)\n",
+				"load_tensors:  MTL0_Mapped model buffer size =  1543.17 MiB\n",
+				"llama_kv_cache:       MTL0 KV buffer size =    52.00 MiB\n",
+				"sched_reserve:       MTL0 compute buffer size =   200.00 MiB\n",
+			},
+			wantGPU:   28228.61 + 1664 + 156 + 1100.07 + 1543.17 + 52 + 200,
+			wantTotal: 28228.61 + 1664 + 156 + 1100.07 + 1543.17 + 52 + 200 + 1362.69 + 0.77 + 632.08,
+		},
+		{
+			// The projector estimate names no device; counted on the
+			// busiest one.
+			name: "projector estimate counted on busiest device",
+			lines: []string{
+				"load_tensors: loading model tensors, this can take a while... (load_mode = mmap)\n",
+				"load_tensors:        CUDA0 model buffer size = 15246.49 MiB\n",
+				"srv    load_model: [mtmd] estimated worst-case memory usage of mmproj is 1700.98 MiB (took 36.34 ms)\n",
+			},
+			wantGPU:   15246.49 + 1700.98,
+			wantTotal: 15246.49 + 1700.98,
 		},
 	}
 
@@ -3218,6 +3270,18 @@ func TestMemoryParsingWriterMemorySizeFullOffload(t *testing.T) {
 				"llm_load_tensors: offloaded 33/33 layers to GPU\n",
 			},
 			wantProcessTotal: 80,
+			wantProcessVRAM:  80,
+		},
+		{
+			// The draft's own layer counts must not overwrite the
+			// target's partial-offload status.
+			name: "draft offload counts do not overwrite the target's",
+			lines: []string{
+				"llm_load_tensors: offloaded 40/53 layers to GPU\n",
+				"common_speculative_init_result: loading draft model '/blobs/x'\n",
+				"load_tensors: offloaded 6/6 layers to GPU\n",
+			},
+			wantProcessTotal: 100,
 			wantProcessVRAM:  80,
 		},
 		{


### PR DESCRIPTION
Buffer lines were deduped by component/backend/kind assuming one model per subprocess, so a speculative draft's lines replaced the target's — a 30B dflash model reported ~2.3GB in `ollama ps` and in the scheduler's VRAM accounting. The same replacement dropped one of a hybrid-attention model's two KV pools, let the draft overwrite the target's offload status, and never counted the projector.

Attribute buffer lines to the model currently loading, accumulate same-key buffers within a tensor-load pass (resetting on the next pass to preserve fit-probe replacement), take layer counts from the target only, and count the projector's estimate against the busiest device.

Fixes #17251

Before:
```
NAME                   ID              SIZE     PROCESSOR    CONTEXT    UNTIL
muse-glimmer:latest    87113cf62a3e    18 GB    100% GPU     131072     4 minutes from now
```
After:
```
NAME                   ID              SIZE     PROCESSOR    CONTEXT    UNTIL
muse-glimmer:latest    de878ce33ad8    21 GB    100% GPU     131072     4 minutes from now
```