### PR TITLE
docs: clarify update check data collection in FAQ

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -160,6 +160,8 @@ docker run -d -e HTTPS_PROXY=https://my.proxy.example.com -p 11434:11434 ollama-
 
 Ollama runs locally. We don't see your prompts or data when you run locally. When using cloud-hosted models, we process your prompts and responses to provide the service but do not store or log that content and never train on it. We collect basic account info and limited usage metadata to provide the service that does not include prompt or response content. We don't sell your data. You can delete your account anytime.
 
+When checking for updates, Ollama sends a device identifier and basic system information (OS, architecture) to our servers. This helps us track update distribution and diagnose issues. No prompts, model data, or conversation history is included in these requests.
+
 ## How do I disable Ollama Cloud features?
 
 Ollama can run in local only mode by disabling Ollama's cloud features. By turning off Ollama's cloud features, you will lose the ability to use Ollama's cloud models and web search. 


### PR DESCRIPTION
Add clarification about what data is sent during update checks to improve transparency. Users now know that a device identifier and basic system information (OS, architecture) are sent, but no prompts, model data, or conversation history.

Fixes #17155