### PR TITLE
readme: add otaku to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,7 @@ console.log(response.message.content);
 - [LLM-X](https://github.com/mrdjohnson/llm-x) - Progressive web app for LLMs
 - [cmdh](https://github.com/pgibler/cmdh) - Natural language to shell commands
 - [VT](https://github.com/vinhnx/vt.ai) - Minimal multimodal AI chat app
+- [otaku](https://github.com/enclavum/otaku) - Roleplay terminal client
 
 ### Productivity & Apps
 

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ console.log(response.message.content);
 - [LLM-X](https://github.com/mrdjohnson/llm-x) - Progressive web app for LLMs
 - [cmdh](https://github.com/pgibler/cmdh) - Natural language to shell commands
 - [VT](https://github.com/vinhnx/vt.ai) - Minimal multimodal AI chat app
-- [otaku](https://github.com/enclavum/otaku) - Roleplay terminal client
+- [otaku](https://github.com/enclavum/otaku) - LLM frontend for roleplay
 
 ### Productivity & Apps
 


### PR DESCRIPTION
Adds otaku, a roleplay terminal client that talks to Ollama, under Terminal & CLI