### PR TITLE
envconfig: normalize OLLAMA_HOST scheme

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -24,6 +24,7 @@ func Host() *url.URL {
 
 	s := strings.TrimSpace(Var("OLLAMA_HOST"))
 	scheme, hostport, ok := strings.Cut(s, "://")
+	scheme = strings.ToLower(scheme)
 	switch {
 	case !ok:
 		scheme, hostport = "http", s

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -36,8 +36,10 @@ func TestHost(t *testing.T) {
 		"extra single quotes": {"'1.2.3.4'", "http://1.2.3.4:11434"},
 		"http":                {"http://1.2.3.4", "http://1.2.3.4:80"},
 		"http port":           {"http://1.2.3.4:4321", "http://1.2.3.4:4321"},
+		"uppercase http":      {"HTTP://1.2.3.4", "http://1.2.3.4:80"},
 		"https":               {"https://1.2.3.4", "https://1.2.3.4:443"},
 		"https port":          {"https://1.2.3.4:4321", "https://1.2.3.4:4321"},
+		"mixed case https":    {"HtTpS://1.2.3.4", "https://1.2.3.4:443"},
 		"proxy path":          {"https://example.com/ollama", "https://example.com:443/ollama"},
 		"ollama.com":          {"ollama.com", "https://ollama.com:443"},
 	}


### PR DESCRIPTION
## Summary

Normalize the URL scheme parsed from `OLLAMA_HOST` to lowercase. URI schemes are case-insensitive, but mixed-case values currently miss the HTTP/HTTPS branches, retain a non-canonical scheme, and receive port `11434` instead of the expected `80` or `443`.

The behavior tests cover uppercase HTTP and mixed-case HTTPS inputs. Explicit ports and existing lowercase inputs are unchanged.

## Tests

- `go test ./envconfig -count=1`
- `go test -race ./envconfig -count=1`
- `gofmt` and `git diff --check`

OpenAI Codex assisted with identifying the edge case and preparing the focused test cases; the behavior and test results were verified locally.
