### PR TITLE
progress: track only visible rendered lines

### DIFF
--- a/progress/progress.go
+++ b/progress/progress.go
@@ -138,7 +138,7 @@ func (p *Progress) renderLocked() {
 		}
 	}
 
-	p.pos = len(p.states)
+	p.pos = maxHeight
 }
 
 func (p *Progress) start() {

--- a/progress/progress_test.go
+++ b/progress/progress_test.go
@@ -1,11 +1,45 @@
 package progress
 
 import (
+	"bufio"
 	"bytes"
+	"os"
 	"runtime"
+	"strings"
 	"testing"
 	"time"
+
+	"golang.org/x/term"
 )
+
+type testState string
+
+func (s testState) String() string { return string(s) }
+
+func TestStopAndClearOnlyClearsVisibleLines(t *testing.T) {
+	_, termHeight, err := term.GetSize(int(os.Stderr.Fd()))
+	if err != nil {
+		termHeight = defaultTermHeight
+	}
+
+	var buf bytes.Buffer
+	p := &Progress{
+		w:    bufio.NewWriter(&buf),
+		done: make(chan struct{}),
+	}
+	for range termHeight + 1 {
+		p.states = append(p.states, testState("working"))
+	}
+
+	if !p.StopAndClear() {
+		t.Fatal("first stop should report true")
+	}
+
+	const clearLine = "\033[2K\033[1G"
+	if got := strings.Count(buf.String(), clearLine); got != termHeight {
+		t.Fatalf("cleared %d lines, want %d visible lines", got, termHeight)
+	}
+}
 
 // TestStopIsIdempotent pins the contract cmd relies on: a second Stop (e.g. a
 // deferred StopAndClear after an explicit one) reports false so callers don't


### PR DESCRIPTION
When progress has more states than the terminal height, the renderer only
draws the last `maxHeight` states but records all states as rendered. The next
frame therefore moves the cursor above the progress region, and
`StopAndClear` can erase terminal history that Ollama did not draw.

Record `maxHeight` as the rendered line count. The regression test creates one
more state than the terminal can display and verifies that only visible lines
are cleared.

Validated with:

- `go test ./progress ./cmd -count=1`
- `go test -race ./progress -count=1`
- `go vet ./progress ./cmd`
- all Go packages except the two desktop UI packages that require generated
  `app/dist` assets
- a full local CMake build of the Go binary and llama.cpp runtime
