### PR TITLE
mlx: add DFlash2 support

### DIFF
--- a/x/create/create.go
+++ b/x/create/create.go
@@ -498,6 +498,7 @@ var tensorImportTransformRegistry = map[string]tensorImportTransformFactory{
 	"NemotronH_Nano_VL_V2":                  newNemotronHImportTransform,
 	"NemotronH_Nano_Omni_Reasoning_V3":      newNemotronHImportTransform,
 	"NemotronHForCausalLM":                  newNemotronHImportTransform,
+	"DFlash2DraftModel":                     newDFlash2ImportTransform,
 }
 
 func newTensorImportTransform(inv Inventory) (quantizePolicy, error) {

--- a/x/create/dflash2.go
+++ b/x/create/dflash2.go
@@ -1,0 +1,24 @@
+package create
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+type dflash2ImportTransform struct{ defaultQuantPolicy }
+
+func newDFlash2ImportTransform(json.RawMessage) (quantizePolicy, error) {
+	return dflash2ImportTransform{}, nil
+}
+
+func (dflash2ImportTransform) quantizationType(name string, shape []int32, requested string) string {
+	if strings.HasSuffix(name, "candidate_selector.predecessor_codebook") ||
+		strings.HasSuffix(name, "candidate_selector.successor_codebook") {
+		requested = normalizeQuantType(requested)
+		if len(shape) == 2 && isAligned(shape, requested) {
+			return requested
+		}
+		return ""
+	}
+	return defaultQuantPolicy{}.quantizationType(name, shape, requested)
+}

--- a/x/create/dflash2_test.go
+++ b/x/create/dflash2_test.go
@@ -1,0 +1,18 @@
+package create
+
+import "testing"
+
+func TestDFlash2CodebookQuantization(t *testing.T) {
+	policy := dflash2ImportTransform{}
+	for _, name := range []string{
+		"candidate_selector.predecessor_codebook",
+		"candidate_selector.successor_codebook",
+	} {
+		if got := policy.quantizationType(name, []int32{248320, 256}, "int4"); got != "int4" {
+			t.Errorf("quantizationType(%q) = %q, want int4", name, got)
+		}
+	}
+	if got := policy.quantizationType("candidate_selector.hidden_projection.weight", []int32{256, 5120}, "int4"); got != "int4" {
+		t.Errorf("hidden projection quantization = %q, want int4", got)
+	}
+}

--- a/x/mlxrunner/dflash.go
+++ b/x/mlxrunner/dflash.go
@@ -6,6 +6,7 @@ import (
 	"github.com/ollama/ollama/x/mlxrunner/batch"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 	"github.com/ollama/ollama/x/mlxrunner/model/base"
+	sampler "github.com/ollama/ollama/x/mlxrunner/sample"
 )
 
 // dflashPendingFlushTokens bounds the pinned feature rows between flushes.
@@ -175,11 +176,58 @@ func (d *dflashDraftSession) propose(current *mlx.Array, maxTokens int) *draftCa
 	// Row i predicts the token at its own position, so the anchor row is
 	// unused. Rows 1..n are sampled from one batched distribution; penalties
 	// see only the committed history, not the other rows of the block.
-	logits := spec.draft.Unembed(hidden.Slice(mlx.Slice(), mlx.Slice(1, n+1), mlx.Slice()))
+	predicted := hidden.Slice(mlx.Slice(), mlx.Slice(1, n+1), mlx.Slice())
+	if pathDraft, ok := spec.draft.(base.PathBlockDraft); ok {
+		return d.samplePath(pathDraft, predicted, current)
+	}
+	logits := spec.draft.Unembed(predicted)
 	dist := r.Sampler.Distribution(pipelineSlot, logits, nil)
 	tokens := r.Sampler.SampleDistribution(pipelineSlot, dist)
 	return &draftCandidates{
 		tokens: tokens.ExpandDims(0),
 		dist:   dist,
+	}
+}
+
+func (d *dflashDraftSession) samplePath(draft base.PathBlockDraft, hidden, anchor *mlx.Array) *draftCandidates {
+	r := d.drafter.spec.r
+	ids, scores := draft.CandidateLattice(hidden, anchor)
+	n, k := ids.Dim(1), ids.Dim(2)
+	temperature := r.Sampler.Temperature(pipelineSlot)
+
+	tokens := make([]*mlx.Array, 0, n)
+	dists := make([]sampler.Distribution, 0, n)
+	var previous *mlx.Array
+	for position := range n {
+		candidateIDs := ids.Slice(mlx.Slice(), mlx.Slice(position, position+1), mlx.Slice()).Squeeze(1)
+		positionScores := scores.Slice(mlx.Slice(), mlx.Slice(position, position+1), mlx.Slice(), mlx.Slice()).Squeeze(1)
+		var row *mlx.Array
+		if position == 0 {
+			row = positionScores.Slice(mlx.Slice(), mlx.Slice(0, 1), mlx.Slice()).Squeeze(1)
+		} else {
+			index := mlx.Tile(previous.Reshape(1, 1, 1), []int32{1, 1, int32(k)})
+			row = positionScores.TakeAlongAxis(index, 1).Squeeze(1)
+		}
+
+		if temperature <= 0 {
+			previous = row.Argmax(-1, false).AsType(mlx.DTypeInt32)
+			token := candidateIDs.TakeAlongAxis(previous.ExpandDims(-1), -1).Squeeze(-1)
+			tokens = append(tokens, token)
+			dists = append(dists, sampler.Distribution{
+				IDs:   token.ExpandDims(-1),
+				Probs: mlx.AddScalar(mlx.MulScalar(token.AsType(mlx.DTypeFloat32).ExpandDims(-1), 0), 1),
+			})
+			continue
+		}
+
+		probs := mlx.SoftmaxAxis(mlx.DivScalar(row.AsType(mlx.DTypeFloat32), temperature), -1, true)
+		previous = r.Sampler.SampleDistribution(pipelineSlot, sampler.Distribution{Probs: probs})
+		tokens = append(tokens, candidateIDs.TakeAlongAxis(previous.ExpandDims(-1), -1).Squeeze(-1))
+		dists = append(dists, sampler.Distribution{IDs: candidateIDs, Probs: probs})
+	}
+
+	return &draftCandidates{
+		tokens: mlx.Stack(tokens, 1),
+		dist:   sampler.ConcatenateDistributions(dists),
 	}
 }

--- a/x/mlxrunner/dflash_test.go
+++ b/x/mlxrunner/dflash_test.go
@@ -111,6 +111,36 @@ func draftTokensOf(caches []cache.Cache) []int32 {
 	return caches[1].(*fakeRewindableCache).tokens
 }
 
+func TestDFlashRequestDraftLimit(t *testing.T) {
+	r := &Runner{}
+	draft := &fakeBlockDraft{blockSize: 8, maskToken: 6}
+	s := newSpeculation(r, draft, nil, nil)
+	s.depth.scheduled = 7
+
+	for _, tt := range []struct {
+		name    string
+		request int
+		enabled bool
+		want    int
+	}{
+		{name: "disabled", request: 0, enabled: false, want: 0},
+		{name: "request cap", request: 2, enabled: true, want: 2},
+		{name: "model cap", request: 99, enabled: true, want: 7},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			req := Request{CompletionRequest: CompletionRequest{Options: api.Options{Runner: api.Runner{DraftNumPredict: tt.request}}}}
+			session := s.open(req, nil)
+			defer session.close()
+			if session.enabled != tt.enabled {
+				t.Fatalf("enabled = %v, want %v", session.enabled, tt.enabled)
+			}
+			if session.maxDraft != tt.want || session.limit != tt.want {
+				t.Fatalf("maxDraft/limit = %d/%d, want %d/%d", session.maxDraft, session.limit, tt.want, tt.want)
+			}
+		})
+	}
+}
+
 func TestDFlashCommittedBuffersPastFlushCap(t *testing.T) {
 	skipIfNoMLX(t)
 	_, draft, session, caches := newBlockTestSession(t, nil, 4)
@@ -284,7 +314,7 @@ func TestDecodeBlockDraft(t *testing.T) {
 	req := Request{
 		Responses:         ch,
 		Tokens:            []int32{1},
-		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		CompletionRequest: CompletionRequest{Options: api.Options{Runner: api.Runner{DraftNumPredict: 4}, NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
 	spec := r.spec.open(req, nil)

--- a/x/mlxrunner/model/base/base.go
+++ b/x/mlxrunner/model/base/base.go
@@ -63,6 +63,14 @@ type BlockDraft interface {
 	BlockParams() (blockSize int, maskToken int32)
 }
 
+// PathBlockDraft augments a block draft with a path selector. CandidateLattice
+// returns token ids [B,L,K] and transition scores [B,L,K,K]; at position zero
+// every predecessor row represents the supplied anchor.
+type PathBlockDraft interface {
+	BlockDraft
+	CandidateLattice(hidden, anchor *mlx.Array) (ids, scores *mlx.Array)
+}
+
 // SelfDraft is implemented by models whose draft head ships inline with the
 // target weights; it returns the head, or nil when the checkpoint shipped none.
 type SelfDraft interface {

--- a/x/mlxrunner/mtp_test.go
+++ b/x/mlxrunner/mtp_test.go
@@ -403,7 +403,7 @@ func TestRunMTPDecodeGreedy(t *testing.T) {
 	req := Request{
 		Responses:         ch,
 		Tokens:            []int32{0},
-		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		CompletionRequest: CompletionRequest{Options: api.Options{Runner: api.Runner{DraftNumPredict: 4}, NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
 	d := testDecoder(r, req, caches, []int32{1}, position)
@@ -464,7 +464,7 @@ func TestRunMTPDecodeSampled(t *testing.T) {
 	req := Request{
 		Responses:         ch,
 		Tokens:            []int32{0},
-		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		CompletionRequest: CompletionRequest{Options: api.Options{Runner: api.Runner{DraftNumPredict: 4}, NumPredict: 20}},
 		SamplerOpts:       sampler.Options{Temperature: 1, Seed: 42, UseSeed: true},
 	}
 	spec := r.spec.open(req, nil)
@@ -508,7 +508,7 @@ func TestRunMTPDecodeWarmDrafter(t *testing.T) {
 	req := Request{
 		Responses:         ch,
 		Tokens:            []int32{0},
-		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		CompletionRequest: CompletionRequest{Options: api.Options{Runner: api.Runner{DraftNumPredict: 4}, NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
 	spec := r.spec.open(req, nil)
@@ -569,7 +569,7 @@ func TestRunMTPDecodeEOSCutLeavesPositionsUnjudged(t *testing.T) {
 	req := Request{
 		Responses:         ch,
 		Tokens:            []int32{0},
-		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		CompletionRequest: CompletionRequest{Options: api.Options{Runner: api.Runner{DraftNumPredict: 4}, NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
 	spec := r.spec.open(req, nil)
@@ -625,7 +625,7 @@ func TestDecodePlain(t *testing.T) {
 	req := Request{
 		Responses:         ch,
 		Tokens:            []int32{0},
-		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		CompletionRequest: CompletionRequest{Options: api.Options{Runner: api.Runner{DraftNumPredict: 4}, NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
 	d := testDecoder(r, req, caches, []int32{1}, position)
@@ -683,7 +683,7 @@ func TestDecodeCancelledMidStream(t *testing.T) {
 	req := Request{
 		Responses:         ch,
 		Tokens:            []int32{1},
-		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		CompletionRequest: CompletionRequest{Options: api.Options{Runner: api.Runner{DraftNumPredict: 4}, NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
 	d := testDecoder(r, req, caches, []int32{1}, position)
@@ -726,7 +726,7 @@ func TestLayoutRidesEveryForward(t *testing.T) {
 	req := Request{
 		Responses:         ch,
 		Tokens:            []int32{0},
-		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		CompletionRequest: CompletionRequest{Options: api.Options{Runner: api.Runner{DraftNumPredict: 4}, NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
 	spec := r.spec.open(req, []any{"layout"})
@@ -802,7 +802,7 @@ func TestDecodeKVDraft(t *testing.T) {
 	req := Request{
 		Responses:         ch,
 		Tokens:            []int32{1},
-		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		CompletionRequest: CompletionRequest{Options: api.Options{Runner: api.Runner{DraftNumPredict: 4}, NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
 	spec := r.spec.open(req, nil)
@@ -887,7 +887,7 @@ func TestDecodeKVDraftRejectionRebuildsFromTarget(t *testing.T) {
 	req := Request{
 		Responses:         ch,
 		Tokens:            []int32{1},
-		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		CompletionRequest: CompletionRequest{Options: api.Options{Runner: api.Runner{DraftNumPredict: 4}, NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
 	spec := r.spec.open(req, nil)
@@ -957,7 +957,7 @@ func TestDecodeMaintainsDraftCacheWithoutDrafting(t *testing.T) {
 	req := Request{
 		Responses:         ch,
 		Tokens:            []int32{1},
-		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		CompletionRequest: CompletionRequest{Options: api.Options{Runner: api.Runner{DraftNumPredict: 4}, NumPredict: 20}},
 		SamplerOpts:       opts,
 	}
 	spec := r.spec.open(req, nil)
@@ -1015,7 +1015,7 @@ func TestSettleLevelsDraftCacheWithPrefill(t *testing.T) {
 	r.cache.caches = caches
 	r.spec = newSpeculation(r, draft, caches[:1], caches[1:])
 	req := Request{
-		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		CompletionRequest: CompletionRequest{Options: api.Options{Runner: api.Runner{DraftNumPredict: 4}, NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
 	spec := r.spec.open(req, nil)
@@ -1097,7 +1097,7 @@ func TestCommittedRunBatchesPastFlushCap(t *testing.T) {
 	r.cache.caches = caches
 	r.spec = newSpeculation(r, draft, caches[:1], caches[1:])
 	req := Request{
-		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		CompletionRequest: CompletionRequest{Options: api.Options{Runner: api.Runner{DraftNumPredict: 4}, NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
 	spec := r.spec.open(req, nil)
@@ -1139,7 +1139,7 @@ func TestRestoredPrefixRewritesBoundaryPair(t *testing.T) {
 	req := Request{
 		Responses:         ch,
 		Tokens:            []int32{1},
-		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		CompletionRequest: CompletionRequest{Options: api.Options{Runner: api.Runner{DraftNumPredict: 4}, NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
 	spec := r.spec.open(req, nil)
@@ -1193,7 +1193,7 @@ func TestDecodeParkedDraftResume(t *testing.T) {
 	r.spec = newSpeculation(r, draft, caches[:1], caches[1:])
 	req := Request{
 		Tokens:            []int32{1},
-		CompletionRequest: CompletionRequest{Options: api.Options{NumPredict: 20}},
+		CompletionRequest: CompletionRequest{Options: api.Options{Runner: api.Runner{DraftNumPredict: 4}, NumPredict: 20}},
 		SamplerOpts:       sampler.Options{},
 	}
 	spec := r.spec.open(req, nil)

--- a/x/mlxrunner/sample/sample.go
+++ b/x/mlxrunner/sample/sample.go
@@ -119,10 +119,17 @@ func (d Distribution) ResidualAgainst(draft Distribution) Distribution {
 		return Distribution{IDs: d.IDs, Probs: normalizeProbs(mlx.Maximum(diff, mlx.FromValue(float32(0))))}
 	}
 	if draft.IDs != nil {
-		panic("sample.Distribution.ResidualAgainst: dense target with sparse draft is unsupported")
+		diff := d.Probs.ScatterAddAxis(draft.IDs, draft.Probs.Negative(), -1)
+		return Distribution{Probs: normalizeProbs(mlx.Maximum(diff, mlx.FromValue(float32(0))))}
 	}
 	diff := d.Probs.Subtract(draft.Probs)
 	return Distribution{Probs: normalizeProbs(mlx.Maximum(diff, mlx.FromValue(float32(0))))}
+}
+
+// Temperature returns the registered slot's sampling temperature without
+// mutating its history or RNG state.
+func (s *Sampler) Temperature(seqID int) float32 {
+	return s.mustSlot("Temperature", seqID).opts.Temperature
 }
 
 // LogProbs returns dense log-probabilities, scattering sparse distributions

--- a/x/mlxrunner/sample/sample_test.go
+++ b/x/mlxrunner/sample/sample_test.go
@@ -212,6 +212,25 @@ func TestDistributionResidualUsesTargetSupport(t *testing.T) {
 	}
 }
 
+func TestDenseResidualSubtractsSparseDraft(t *testing.T) {
+	skipIfNoMLX(t)
+
+	target := Distribution{Probs: mlx.FromValues([]float32{0.2, 0.5, 0.3}, 1, 3)}
+	draft := Distribution{
+		IDs:   mlx.NewArrayInt32([]int32{0, 2}, []int32{1, 2}),
+		Probs: mlx.FromValues([]float32{0.1, 0.9}, 1, 2),
+	}
+	residual := target.ResidualAgainst(draft)
+	mlx.Eval(residual.Probs)
+
+	want := []float32{1.0 / 6.0, 5.0 / 6.0, 0}
+	for i, got := range residual.Probs.Floats() {
+		if math.Abs(float64(got-want[i])) > 1e-5 {
+			t.Fatalf("residual[%d] = %g, want %g", i, got, want[i])
+		}
+	}
+}
+
 func TestSeededSamplingIsReproducible(t *testing.T) {
 	skipIfNoMLX(t)
 

--- a/x/mlxrunner/speculate.go
+++ b/x/mlxrunner/speculate.go
@@ -92,12 +92,13 @@ func newSpeculation(r *Runner, draft base.DraftModel, targets, draftKV []cache.C
 // it owns the drafter and runs the validate rounds. A nil session is a plain
 // decode.
 type speculationSession struct {
-	spec    *speculation
-	drafter draftSession
-	enabled bool  // whether this request drafts; false parks (maintain-only)
-	limit   int   // current draft length
-	layout  []any // the request's per-row layout state, stamped on every target forward
-	stats   specStats
+	spec     *speculation
+	drafter  draftSession
+	enabled  bool  // whether this request drafts; false parks (maintain-only)
+	maxDraft int   // request's maximum draft length, held to the drafter's limit
+	limit    int   // current draft length
+	layout   []any // the request's per-row layout state, stamped on every target forward
+	stats    specStats
 
 	// Cost sampling: each round's wall time (start to next start, spanning the
 	// next emit's sync) is attributed to its draft depth only when the depth
@@ -115,14 +116,19 @@ func (s *speculation) open(request Request, layout []any) *speculationSession {
 	}
 	d := s.drafter.open(layout)
 
-	// Logprobs are not yet supported, so a logprobs request keeps a speculationSession
-	// only to maintain a draft cache in lockstep (permanently parked).
-	opts := request.SamplerOpts
-	enabled := !opts.Logprobs && opts.TopLogprobs == 0
+	maxDraft := request.Options.DraftNumPredict
+	if limit := s.drafter.draftLimit(); limit > 0 {
+		maxDraft = min(maxDraft, limit)
+	}
 
-	spec := &speculationSession{spec: s, drafter: d, layout: layout, enabled: enabled, prevDrafts: -1, roundDrafts: -1}
+	// A disabled or logprobs request keeps a speculationSession only to maintain
+	// the draft cache in lockstep (permanently parked).
+	opts := request.SamplerOpts
+	enabled := maxDraft > 0 && !opts.Logprobs && opts.TopLogprobs == 0
+
+	spec := &speculationSession{spec: s, drafter: d, layout: layout, enabled: enabled, maxDraft: maxDraft, prevDrafts: -1, roundDrafts: -1}
 	if enabled {
-		spec.limit = s.depth.scheduled
+		spec.limit = min(s.depth.scheduled, maxDraft)
 	}
 	return spec
 }
@@ -155,7 +161,7 @@ func (s *speculationSession) endRound(drafted, accepted, observed int) {
 		if observed > 0 {
 			s.spec.depth.acc.observe(observed, accepted)
 		}
-		s.limit = s.spec.depth.next()
+		s.limit = s.spec.depth.next(s.maxDraft)
 	}
 }
 

--- a/x/mlxrunner/speculate_depth.go
+++ b/x/mlxrunner/speculate_depth.go
@@ -56,11 +56,15 @@ func newDepthController() *depthController {
 func (c *depthController) frontier() int { return c.acc.frontier() }
 
 // limit is the deepest depth the search considers: one past the frontier, held
-// to what the drafter can produce.
-func (c *depthController) limit() int {
+// to what the drafter and this request can produce. maxDepth 0 means no
+// request-specific bound.
+func (c *depthController) limit(maxDepth int) int {
 	limit := c.frontier() + 1
 	if c.drafterLimit > 0 {
 		limit = min(limit, c.drafterLimit)
+	}
+	if maxDepth > 0 {
+		limit = min(limit, maxDepth)
 	}
 	return limit
 }
@@ -71,9 +75,9 @@ func (c *depthController) limit() int {
 // doubles toward its cap while probes change nothing and resets on any selection
 // change, giving the new selection a full interval to settle. The chosen depth is
 // recorded in c.scheduled for the next request's open to consume.
-func (c *depthController) next() (depth int) {
+func (c *depthController) next(maxDepth int) (depth int) {
 	defer func() { c.scheduled = depth }()
-	sel := c.selected()
+	sel := c.selected(maxDepth)
 	if sel != c.lastSelected {
 		c.probeInterval = depthProbeInterval
 		c.probeSince = 0
@@ -86,7 +90,7 @@ func (c *depthController) next() (depth int) {
 	c.probeSince++
 	if c.probeSince >= c.probeInterval {
 		c.probeSince = 0
-		if probe := min(sel+1, c.limit()); probe != sel {
+		if probe := min(sel+1, c.limit(maxDepth)); probe != sel {
 			c.probed = true
 			return probe
 		}
@@ -97,7 +101,7 @@ func (c *depthController) next() (depth int) {
 	// at has no clean sample; draft the shallowest such depth to dwell there. Without
 	// this the controller stays at the one depth it can sit at without a transition
 	// (depth 0) and never learns that drafting pays on a deep-optimum model.
-	if seed := c.costSeedDepth(); seed >= 0 {
+	if seed := c.costSeedDepth(maxDepth); seed >= 0 {
 		return seed
 	}
 	return sel
@@ -106,8 +110,8 @@ func (c *depthController) next() (depth int) {
 // costSeedDepth is the shallowest depth within the search limit with no clean
 // cost sample, or -1 if all are sampled; the bound keeps cost-seeding from
 // outrunning the acceptance frontier or the drafter.
-func (c *depthController) costSeedDepth() int {
-	limit := c.limit()
+func (c *depthController) costSeedDepth(maxDepth int) int {
+	limit := c.limit(maxDepth)
 	for n := 0; n <= limit; n++ {
 		if !c.cost.sampled(n) {
 			return n
@@ -120,11 +124,11 @@ func (c *depthController) costSeedDepth() int {
 // argmax within the search limit. The frontier bound keeps the inherited optimistic
 // rate from making ever-deeper depths look best; the depth-0 floor lets it stop
 // speculating. Returns 0 until the cost model can compare depths.
-func (c *depthController) selected() int {
+func (c *depthController) selected(maxDepth int) int {
 	if !c.cost.ready() {
 		return 0
 	}
-	limit := c.limit()
+	limit := c.limit(maxDepth)
 	best, bestEV := 0, c.acc.expectedCommitted(0)/c.cost.cost(0)
 	for n := 1; n <= limit; n++ {
 		if ev := c.acc.expectedCommitted(n) / c.cost.cost(n); ev > bestEV {

--- a/x/mlxrunner/speculate_depth_test.go
+++ b/x/mlxrunner/speculate_depth_test.go
@@ -14,7 +14,7 @@ import (
 // leading run of positions whose draws succeed.
 func driveDepthController(c *depthController, n int, fwdMS func(width int) float64, draw func(pos, step int) bool) int {
 	for step := range n {
-		d := c.next()
+		d := c.next(0)
 		c.cost.observe(d, time.Duration(fwdMS(d+1)*float64(time.Millisecond)))
 		accepted := 0
 		for i := 1; i <= d; i++ {
@@ -26,7 +26,7 @@ func driveDepthController(c *depthController, n int, fwdMS func(width int) float
 		}
 		c.acc.observe(d, accepted)
 	}
-	return c.selected()
+	return c.selected(0)
 }
 
 // deterministicDraw turns a per-position acceptance rate into a reproducible,
@@ -115,7 +115,7 @@ func TestDepthControllerExploresBeforeCostReady(t *testing.T) {
 	// from the shallowest end — never jumping deep. The first draft is 0 (depth-0,
 	// plain-decode cost); once that depth is recorded the next is 1. Those are the two
 	// depths the controller first compares at.
-	first := c.next()
+	first := c.next(0)
 	if cost.ready() {
 		t.Fatal("cost model should not be ready before any observation")
 	}
@@ -123,7 +123,7 @@ func TestDepthControllerExploresBeforeCostReady(t *testing.T) {
 		t.Errorf("first warmup draft = %d, want 0 (depth-0 cost first, never deep)", first)
 	}
 	cost.observe(first, 24*time.Millisecond)
-	second := c.next()
+	second := c.next(0)
 	if second != 1 {
 		t.Errorf("second warmup draft = %d, want 1 (depth-1 cost next)", second)
 	}
@@ -147,7 +147,7 @@ func TestDepthControllerClimbsOutwardWithinFrontier(t *testing.T) {
 	always := func(int) float64 { return 1.0 }
 	draw := deterministicDraw(always)
 	for step := range 400 {
-		d := c.next()
+		d := c.next(0)
 		if d > c.frontier()+1 {
 			t.Fatalf("step %d drafted depth %d, want <= frontier+1 = %d", step, d, c.frontier()+1)
 		}
@@ -161,6 +161,22 @@ func TestDepthControllerClimbsOutwardWithinFrontier(t *testing.T) {
 			}
 		}
 		c.acc.observe(d, accepted)
+	}
+}
+
+func TestDepthControllerStaysWithinRequestLimit(t *testing.T) {
+	c := newDepthController()
+	c.drafterLimit = 7
+	for step := range 600 {
+		d := c.next(2)
+		if d > 2 {
+			t.Fatalf("step %d drafted depth %d, want <= request limit 2", step, d)
+		}
+		c.cost.observe(d, time.Duration(bandwidthBoundCost(d+1)*float64(time.Millisecond)))
+		c.acc.observe(d, d)
+	}
+	if got := c.selected(2); got > 2 {
+		t.Fatalf("selected depth %d, want <= request limit 2", got)
 	}
 }
 
@@ -201,7 +217,7 @@ func TestDepthControllerStaysParkedThroughHostStall(t *testing.T) {
 	// parked baseline remains credible and the controller does not start
 	// drafting against a phantom plain-decode cost.
 	cost.observe(0, 49*time.Millisecond)
-	if selected := c.selected(); selected != 0 {
+	if selected := c.selected(0); selected != 0 {
 		t.Errorf("a single stall-inflated depth-0 sample un-parked the controller: selected %d with cost(0)=%.1fms", selected, cost.cost(0))
 	}
 }
@@ -211,7 +227,7 @@ func TestDepthControllerStaysParkedThroughHostStall(t *testing.T) {
 func driveCountingProbes(c *depthController, n int, fwdMS func(width int) float64, draw func(pos, step int) bool) int {
 	probes := 0
 	for step := range n {
-		d := c.next()
+		d := c.next(0)
 		if d > 0 {
 			probes++
 		}
@@ -238,8 +254,8 @@ func TestDepthControllerProbeBackoff(t *testing.T) {
 	steep := func(width int) float64 { return 16.0 + 15.0*float64(width-1) }
 	mediocre := deterministicDraw(func(int) float64 { return 0.6 })
 	driveDepthController(c, 600, steep, mediocre)
-	if c.selected() != 0 {
-		t.Fatalf("expected the controller to park at depth 0, got %d", c.selected())
+	if c.selected(0) != 0 {
+		t.Fatalf("expected the controller to park at depth 0, got %d", c.selected(0))
 	}
 	probes := driveCountingProbes(c, 4096, steep, mediocre)
 	if c.probeInterval != depthProbeIntervalMax {
@@ -283,7 +299,7 @@ func TestDepthControllerTracksAcceptanceDrift(t *testing.T) {
 	}
 	deepFavoring := func(int) float64 { return 0.95 } // deep readily accepted
 	driveDepthController(c, 400, bandwidthBoundCost, deterministicDraw(shallowFavoring))
-	shallow := c.selected()
+	shallow := c.selected(0)
 	if shallow > 4 {
 		t.Fatalf("expected shallow selection while deep acceptance is poor, got %d", shallow)
 	}
@@ -291,7 +307,7 @@ func TestDepthControllerTracksAcceptanceDrift(t *testing.T) {
 	// recovery runs at backed-off probe spacing until the first selection
 	// change snaps it back — the drive must span several backed-off intervals.
 	driveDepthController(c, 4096, bandwidthBoundCost, deterministicDraw(deepFavoring))
-	deep := c.selected()
+	deep := c.selected(0)
 	if deep <= shallow {
 		t.Errorf("expected selection to deepen after acceptance rose (was %d, now %d)", shallow, deep)
 	}

--- a/x/mlxrunner/speculate_stats.go
+++ b/x/mlxrunner/speculate_stats.go
@@ -74,7 +74,7 @@ func (s *speculationSession) logStats() {
 	for n := 1; n <= frontier; n++ {
 		rates = append(rates, fmt.Sprintf("%d:%.2f", n, d.acc.acceptance(n)))
 	}
-	limit := d.limit()
+	limit := d.limit(s.maxDraft)
 	tps := make([]string, 0, limit+1)
 	if d.cost.ready() {
 		for n := 0; n <= limit; n++ {

--- a/x/models/dflash/dflash.go
+++ b/x/models/dflash/dflash.go
@@ -18,13 +18,16 @@ import (
 
 func init() {
 	base.RegisterDraft("DFlashDraftModel", func(root *model.Root, target base.Model) (base.DraftModel, error) {
-		return newModel(root, target, false)
+		return newModel(root, target, false, false)
 	})
 	base.RegisterDraft("DFlashLagunaForCausalLM", func(root *model.Root, target base.Model) (base.DraftModel, error) {
-		return newModel(root, target, true)
+		return newModel(root, target, true, false)
 	})
 	base.RegisterDraft("MuseGlimmerAssistantModel", func(root *model.Root, target base.Model) (base.DraftModel, error) {
-		return newModel(root, target, false)
+		return newModel(root, target, false, false)
+	})
+	base.RegisterDraft("DFlash2DraftModel", func(root *model.Root, target base.Model) (base.DraftModel, error) {
+		return newModel(root, target, false, true)
 	})
 }
 
@@ -47,6 +50,14 @@ type Config struct {
 	VocabSize      int32
 	TargetLayerIDs []int
 
+	InputEmbeddingScale float32
+	OutputMultiplier    float32
+	FinalLogitSoftcap   float32
+	ConvKernelSize      int32
+	ConvGroupSize       int32
+	SelectorRank        int32
+	SelectorTopK        int
+
 	// RopeInterleaved selects the draft's rotary pairing convention:
 	// true pairs adjacent dims (torch view_as_complex over pairs, the glimmer
 	// publisher convention); false pairs split halves (HF rotate_half, the
@@ -57,6 +68,8 @@ type Config struct {
 	// Causal, when set, overrides every layer's attention direction;
 	// otherwise only sliding layers run causal.
 	Causal *bool
+
+	DFlash2 bool
 }
 
 // draftTarget is what dflash requires of its target beyond base.Model.
@@ -97,6 +110,7 @@ type Model struct {
 	target draftTarget
 
 	tensorPrefix string
+	Selector     *CandidateSelector
 
 	QuantGroupSize int
 	QuantBits      int
@@ -105,12 +119,14 @@ type Model struct {
 }
 
 type Layer struct {
-	InputNorm    *nn.RMSNorm
-	PostAttnNorm *nn.RMSNorm
-	Attention    *Attention
-	MLP          *MLP
-	IsSliding    bool
-	IsCausal     bool
+	InputNorm     *nn.RMSNorm
+	PostAttnNorm  *nn.RMSNorm
+	Attention     *Attention
+	MLP           *MLP
+	AttentionConv *GroupedDynamicConv
+	MLPConv       *GroupedDynamicConv
+	IsSliding     bool
+	IsCausal      bool
 }
 
 // Attention holds a q projection and a fused k|v projection: split
@@ -148,12 +164,20 @@ func parseConfig(data []byte) (*Config, error) {
 		} `json:"rope_parameters"`
 		BlockSize    int `json:"block_size"`
 		DFlashConfig struct {
-			BlockSize       int    `json:"block_size"`
-			MaskTokenID     *int32 `json:"mask_token_id"`
-			TargetLayerIDs  []int  `json:"target_layer_ids"`
-			NumTargetLayers int    `json:"num_target_layers"`
-			Causal          *bool  `json:"causal"`
+			BlockSize             int     `json:"block_size"`
+			MaskTokenID           *int32  `json:"mask_token_id"`
+			TargetLayerIDs        []int   `json:"target_layer_ids"`
+			NumTargetLayers       int     `json:"num_target_layers"`
+			Causal                *bool   `json:"causal"`
+			InputEmbeddingScale   float32 `json:"input_embedding_scale"`
+			OutputMultiplier      float32 `json:"output_multiplier"`
+			FinalLogitSoftcapping float32 `json:"final_logit_softcapping"`
+			ConvKernelSize        int32   `json:"conv_kernel_size"`
+			ConvGroupSize         int32   `json:"conv_group_size"`
+			SelectorRank          int32   `json:"selector_rank"`
+			SelectorTopK          int     `json:"selector_top_k"`
 		} `json:"dflash_config"`
+		IsCausal        *bool    `json:"is_causal"`
 		NumTargetLayers int      `json:"num_target_layers"`
 		VocabSize       int32    `json:"vocab_size"`
 		LayerTypes      []string `json:"layer_types"`
@@ -165,19 +189,35 @@ func parseConfig(data []byte) (*Config, error) {
 	}
 
 	cfg := &Config{
-		HiddenSize:        raw.HiddenSize,
-		NumHiddenLayers:   raw.NumHiddenLayers,
-		NumAttentionHeads: raw.NumAttentionHeads,
-		NumKeyValueHeads:  raw.NumKeyValueHeads,
-		HeadDim:           raw.HeadDim,
-		RMSNormEps:        raw.RMSNormEps,
-		RopeTheta:         raw.RopeTheta,
-		SlidingWindow:     raw.SlidingWindow,
-		LayerTypes:        raw.LayerTypes,
-		BlockSize:         raw.DFlashConfig.BlockSize,
-		VocabSize:         raw.VocabSize,
-		TargetLayerIDs:    raw.DFlashConfig.TargetLayerIDs,
-		Causal:            raw.DFlashConfig.Causal,
+		HiddenSize:          raw.HiddenSize,
+		NumHiddenLayers:     raw.NumHiddenLayers,
+		NumAttentionHeads:   raw.NumAttentionHeads,
+		NumKeyValueHeads:    raw.NumKeyValueHeads,
+		HeadDim:             raw.HeadDim,
+		RMSNormEps:          raw.RMSNormEps,
+		RopeTheta:           raw.RopeTheta,
+		SlidingWindow:       raw.SlidingWindow,
+		LayerTypes:          raw.LayerTypes,
+		BlockSize:           raw.DFlashConfig.BlockSize,
+		VocabSize:           raw.VocabSize,
+		TargetLayerIDs:      raw.DFlashConfig.TargetLayerIDs,
+		Causal:              raw.DFlashConfig.Causal,
+		InputEmbeddingScale: raw.DFlashConfig.InputEmbeddingScale,
+		OutputMultiplier:    raw.DFlashConfig.OutputMultiplier,
+		FinalLogitSoftcap:   raw.DFlashConfig.FinalLogitSoftcapping,
+		ConvKernelSize:      raw.DFlashConfig.ConvKernelSize,
+		ConvGroupSize:       raw.DFlashConfig.ConvGroupSize,
+		SelectorRank:        raw.DFlashConfig.SelectorRank,
+		SelectorTopK:        raw.DFlashConfig.SelectorTopK,
+	}
+	if cfg.Causal == nil {
+		cfg.Causal = raw.IsCausal
+	}
+	if cfg.InputEmbeddingScale == 0 {
+		cfg.InputEmbeddingScale = 1
+	}
+	if cfg.OutputMultiplier == 0 {
+		cfg.OutputMultiplier = 1
 	}
 	if raw.RopeInterleaved != nil {
 		cfg.RopeInterleaved = *raw.RopeInterleaved
@@ -232,7 +272,7 @@ func parseConfig(data []byte) (*Config, error) {
 	return cfg, nil
 }
 
-func newModel(root *model.Root, targetModel base.Model, ctxLayerNorm bool) (base.DraftModel, error) {
+func newModel(root *model.Root, targetModel base.Model, ctxLayerNorm, dflash2 bool) (base.DraftModel, error) {
 	if root == nil || root.Draft == nil {
 		return nil, fmt.Errorf("draft metadata missing")
 	}
@@ -248,6 +288,15 @@ func newModel(root *model.Root, targetModel base.Model, ctxLayerNorm bool) (base
 	cfg, err := parseConfig(configData)
 	if err != nil {
 		return nil, err
+	}
+	cfg.DFlash2 = dflash2
+	if dflash2 {
+		if cfg.ConvKernelSize <= 0 || cfg.ConvGroupSize <= 0 || cfg.HiddenSize%cfg.ConvGroupSize != 0 {
+			return nil, fmt.Errorf("invalid dflash2 convolution config")
+		}
+		if cfg.SelectorRank <= 0 || cfg.SelectorTopK <= 0 {
+			return nil, fmt.Errorf("invalid dflash2 selector config")
+		}
 	}
 
 	target, ok := targetModel.(draftTarget)
@@ -303,6 +352,9 @@ func newModel(root *model.Root, targetModel base.Model, ctxLayerNorm bool) (base
 			m.QuantGroupSize = gs
 		}
 	}
+	if dflash2 {
+		return &Model2{Model: m}, nil
+	}
 	return m, nil
 }
 
@@ -346,6 +398,10 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 			MLP: &MLP{
 				DownProj: linears.Make(layerPrefix + ".mlp.down_proj"),
 			},
+		}
+		if m.DFlash2 {
+			layer.AttentionConv = loadDynamicConv(linears, tensors, layerPrefix+".attention_conv", m.Config)
+			layer.MLPConv = loadDynamicConv(linears, tensors, layerPrefix+".mlp_conv", m.Config)
 		}
 		a := layer.Attention
 		qDim := m.NumAttentionHeads * m.HeadDim
@@ -402,7 +458,16 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 		if layer.InputNorm == nil || layer.PostAttnNorm == nil {
 			return fmt.Errorf("dflash layer %d: missing norm weights", i)
 		}
+		if m.DFlash2 && (layer.AttentionConv == nil || layer.MLPConv == nil) {
+			return fmt.Errorf("dflash2 layer %d: missing convolution weights", i)
+		}
 		m.Layers[i] = layer
+	}
+	if m.DFlash2 {
+		m.Selector = loadCandidateSelector(linears, tensors, prefix, m)
+		if m.Selector == nil {
+			return fmt.Errorf("missing dflash2 candidate selector weights")
+		}
 	}
 	return nil
 }
@@ -577,6 +642,9 @@ func (m *Model) Forward(b *batch.Batch, _, draftCaches []cache.Cache) (hidden, a
 		dims := b.InputIDs.Dims()
 		B, L = int32(dims[0]), int32(dims[1])
 		h = m.target.TokenEmbeddings(b.InputIDs)
+		if m.InputEmbeddingScale != 1 {
+			h = mlx.MulScalar(h, m.InputEmbeddingScale)
+		}
 		blockStart := b.SeqOffsets[0] + nCtx
 		bb = &batch.Batch{InputIDs: b.InputIDs, SeqOffsets: []int32{blockStart}, SeqQueryLens: b.SeqQueryLens}
 		blockPositions = mlx.FromValues([]int32{blockStart}, 1)
@@ -608,8 +676,27 @@ func (m *Model) Forward(b *batch.Batch, _, draftCaches []cache.Cache) (hidden, a
 }
 
 func (l *Layer) Forward(x, ctxK, ctxV *mlx.Array, c cache.Cache, bb *batch.Batch, positions *mlx.Array, mask nn.AttentionMask, B, L int32, cfg *Config) *mlx.Array {
-	h := mlx.Add(x, l.Attention.Forward(l.InputNorm.Forward(x, cfg.RMSNormEps), ctxK, ctxV, c, bb, positions, mask, B, L, cfg))
-	return mlx.Add(h, l.MLP.Forward(l.PostAttnNorm.Forward(h, cfg.RMSNormEps)))
+	attnIn := l.InputNorm.Forward(x, cfg.RMSNormEps)
+	var attnKernel *mlx.Array
+	if l.AttentionConv != nil {
+		attnIn, attnKernel = l.AttentionConv.Prepare(attnIn)
+	}
+	attnOut := l.Attention.Forward(attnIn, ctxK, ctxV, c, bb, positions, mask, B, L, cfg)
+	if l.AttentionConv != nil {
+		attnOut = l.AttentionConv.Finish(attnOut, attnKernel)
+	}
+	h := mlx.Add(x, attnOut)
+
+	mlpIn := l.PostAttnNorm.Forward(h, cfg.RMSNormEps)
+	var mlpKernel *mlx.Array
+	if l.MLPConv != nil {
+		mlpIn, mlpKernel = l.MLPConv.Prepare(mlpIn)
+	}
+	mlpOut := l.MLP.Forward(mlpIn)
+	if l.MLPConv != nil {
+		mlpOut = l.MLPConv.Finish(mlpOut, mlpKernel)
+	}
+	return mlx.Add(h, mlpOut)
 }
 
 // contextKV projects feature rows into the layer's context K/V.

--- a/x/models/dflash/dflash2.go
+++ b/x/models/dflash/dflash2.go
@@ -1,0 +1,137 @@
+package dflash
+
+import (
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
+	"github.com/ollama/ollama/x/models/nn"
+)
+
+// Model2 is the path-selecting DFlash2 variant. Embedding Model keeps the
+// existing DFlash implementation and runtime interface unchanged.
+type Model2 struct{ *Model }
+
+var _ base.PathBlockDraft = (*Model2)(nil)
+
+type GroupedDynamicConv struct {
+	BaseKernel       *mlx.Array
+	KernelProjection nn.LinearLayer
+	KernelSize       int32
+	GroupSize        int32
+}
+
+func loadDynamicConv(linears model.LinearFactory, tensors map[string]*mlx.Array, prefix string, cfg *Config) *GroupedDynamicConv {
+	baseKernel := tensors[prefix+".base_kernel"]
+	projection := linears.Make(prefix + ".kernel_projection")
+	if baseKernel == nil || projection == nil {
+		return nil
+	}
+	return &GroupedDynamicConv{
+		BaseKernel:       baseKernel,
+		KernelProjection: projection,
+		KernelSize:       cfg.ConvKernelSize,
+		GroupSize:        cfg.ConvGroupSize,
+	}
+}
+
+func (c *GroupedDynamicConv) Prepare(hidden *mlx.Array) (*mlx.Array, *mlx.Array) {
+	B, L, H := hidden.Dim(0), hidden.Dim(1), hidden.Dim(2)
+	groups := H / int(c.GroupSize)
+	dynamic := c.KernelProjection.Forward(hidden).Reshape(B, L, 2, int(c.KernelSize), groups)
+	first := dynamic.Slice(mlx.Slice(), mlx.Slice(), mlx.Slice(0, 1), mlx.Slice(), mlx.Slice()).Squeeze(2)
+	second := dynamic.Slice(mlx.Slice(), mlx.Slice(), mlx.Slice(1, 2), mlx.Slice(), mlx.Slice()).Squeeze(2)
+	base := c.BaseKernel
+	return c.convolve(hidden, first, base.Slice(mlx.Slice(0, 1), mlx.Slice(), mlx.Slice()).Squeeze(0)), second
+}
+
+func (c *GroupedDynamicConv) Finish(hidden, dynamic *mlx.Array) *mlx.Array {
+	base := c.BaseKernel.Slice(mlx.Slice(1, 2), mlx.Slice(), mlx.Slice()).Squeeze(0)
+	return c.convolve(hidden, dynamic, base)
+}
+
+func (c *GroupedDynamicConv) convolve(hidden, dynamic, base *mlx.Array) *mlx.Array {
+	B, L, H := hidden.Dim(0), hidden.Dim(1), hidden.Dim(2)
+	groups, groupSize := H/int(c.GroupSize), int(c.GroupSize)
+	blocks := hidden.Reshape(B, L, groups, groupSize)
+	out := mlx.Zeros(hidden.DType(), B, L, groups, groupSize)
+	for offset := range int(c.KernelSize) {
+		values := blocks
+		if offset > 0 {
+			zeros := mlx.Zeros(hidden.DType(), B, offset, groups, groupSize)
+			values = zeros.Concatenate(1, blocks.Slice(mlx.Slice(), mlx.Slice(0, L-offset), mlx.Slice(), mlx.Slice()))
+		}
+		baseAt := base.Slice(mlx.Slice(offset, offset+1), mlx.Slice()).Reshape(1, 1, groups, groupSize)
+		dynamicAt := dynamic.Slice(mlx.Slice(), mlx.Slice(), mlx.Slice(offset, offset+1), mlx.Slice()).Squeeze(2).ExpandDims(-1)
+		out = out.Add(baseAt.Add(dynamicAt).Multiply(values))
+	}
+	return out.Reshape(B, L, H)
+}
+
+type CandidateSelector struct {
+	Predecessor      nn.EmbeddingLayer
+	Successor        nn.EmbeddingLayer
+	HiddenProjection nn.LinearLayer
+	TopK             int
+}
+
+func loadCandidateSelector(linears model.LinearFactory, tensors map[string]*mlx.Array, prefix string, m *Model) *CandidateSelector {
+	pred := loadCodebook(tensors, prefix+"candidate_selector.predecessor_codebook", m)
+	succ := loadCodebook(tensors, prefix+"candidate_selector.successor_codebook", m)
+	projection := linears.Make(prefix + "candidate_selector.hidden_projection")
+	if pred == nil || succ == nil || projection == nil {
+		return nil
+	}
+	return &CandidateSelector{
+		Predecessor:      pred,
+		Successor:        succ,
+		HiddenProjection: projection,
+		TopK:             m.SelectorTopK,
+	}
+}
+
+func loadCodebook(tensors map[string]*mlx.Array, path string, m *Model) nn.EmbeddingLayer {
+	w := tensors[path]
+	if w == nil {
+		return nil
+	}
+	if scales := tensors[path+"_scale"]; scales != nil {
+		groupSize, bits, mode := model.ResolveLinearQuantParams(
+			m.QuantGroupSize, m.QuantBits, m.QuantMode, m.TensorQuant,
+			path, w, scales,
+		)
+		return &nn.QuantizedEmbedding{
+			Weight: w, Scales: scales, QBiases: tensors[path+"_qbias"],
+			GroupSize: groupSize, Bits: bits, Mode: mode,
+		}
+	}
+	return nn.NewEmbedding(w)
+}
+
+// CandidateLattice constructs the K-way token candidates and all KxK
+// transition scores. The runtime samples one predecessor-conditioned row per
+// position and retains that exact sparse distribution for rejection sampling.
+func (m *Model2) CandidateLattice(hidden, anchor *mlx.Array) (ids, scores *mlx.Array) {
+	logits := m.Unembed(hidden)
+	k := m.Selector.TopK
+	ids = logits.Negative().ArgpartitionAxis(k-1, -1).Slice(mlx.Slice(), mlx.Slice(), mlx.Slice(0, k)).AsType(mlx.DTypeInt32)
+	unary := logits.TakeAlongAxis(ids, -1).AsType(mlx.DTypeFloat32)
+	if m.OutputMultiplier != 1 {
+		unary = mlx.MulScalar(unary, m.OutputMultiplier)
+	}
+	if m.FinalLogitSoftcap > 0 {
+		cap := mlx.FromValue(m.FinalLogitSoftcap).AsType(unary.DType())
+		unary = mlx.LogitSoftcap(unary, cap)
+	}
+
+	B, L := hidden.Dim(0), hidden.Dim(1)
+	projected := m.Selector.HiddenProjection.Forward(hidden)
+	predecessorIDs := mlx.Tile(anchor.Reshape(B, 1, 1), []int32{1, 1, int32(k)})
+	if L > 1 {
+		predecessorIDs = predecessorIDs.Concatenate(1, ids.Slice(mlx.Slice(), mlx.Slice(0, L-1), mlx.Slice()))
+	}
+	predecessors := m.Selector.Predecessor.Forward(predecessorIDs)
+	successors := m.Selector.Successor.Forward(ids)
+	edges := predecessors.Multiply(projected.ExpandDims(2)).ExpandDims(3).
+		Multiply(successors.ExpandDims(2)).SumAxis(-1, false)
+	return ids, edges.Add(unary.ExpandDims(2))
+}

--- a/x/models/dflash/dflash_test.go
+++ b/x/models/dflash/dflash_test.go
@@ -1,0 +1,127 @@
+package dflash
+
+import (
+	"math"
+	"testing"
+
+	"github.com/ollama/ollama/x/internal/mlxtest"
+	"github.com/ollama/ollama/x/mlxrunner/batch"
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/models/nn"
+	"github.com/ollama/ollama/x/tokenizer"
+)
+
+func TestParseDFlash2Config(t *testing.T) {
+	cfg, err := parseConfig([]byte(`{
+		"hidden_size": 5120,
+		"num_hidden_layers": 5,
+		"num_attention_heads": 40,
+		"num_key_value_heads": 8,
+		"head_dim": 128,
+		"rms_norm_eps": 1e-6,
+		"vocab_size": 248320,
+		"sliding_window": 2048,
+		"layer_types": ["sliding_attention", "sliding_attention", "sliding_attention", "sliding_attention", "sliding_attention"],
+		"is_causal": false,
+		"dflash_config": {
+			"block_size": 8,
+			"mask_token_id": 248070,
+			"target_layer_ids": [5, 19, 33, 47, 61],
+			"conv_kernel_size": 2,
+			"conv_group_size": 16,
+			"selector_rank": 256,
+			"selector_top_k": 16
+		}
+	}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Causal == nil || *cfg.Causal {
+		t.Fatalf("Causal = %v, want false", cfg.Causal)
+	}
+	if cfg.BlockSize != 8 || cfg.ConvKernelSize != 2 || cfg.ConvGroupSize != 16 {
+		t.Fatalf("block/conv config = %d/%d/%d", cfg.BlockSize, cfg.ConvKernelSize, cfg.ConvGroupSize)
+	}
+	if cfg.SelectorRank != 256 || cfg.SelectorTopK != 16 {
+		t.Fatalf("selector config = %d/%d", cfg.SelectorRank, cfg.SelectorTopK)
+	}
+	if cfg.InputEmbeddingScale != 1 || cfg.OutputMultiplier != 1 {
+		t.Fatalf("default scales = %g/%g, want 1/1", cfg.InputEmbeddingScale, cfg.OutputMultiplier)
+	}
+}
+
+func TestGroupedDynamicConvIsBlockLocalAndCausal(t *testing.T) {
+	mlxtest.Setup(t)
+	c := &GroupedDynamicConv{KernelSize: 2, GroupSize: 2}
+	hidden := mlx.FromValues([]float32{1, 2, 3, 4, 5, 6}, 1, 3, 2)
+	dynamic := mlx.Zeros(mlx.DTypeFloat32, 1, 3, 2, 1)
+	base := mlx.FromValues([]float32{1, 1, 10, 10}, 2, 2)
+	out := c.convolve(hidden, dynamic, base)
+	mlx.Eval(out)
+	want := []float32{1, 2, 13, 24, 35, 46}
+	for i, got := range out.Floats() {
+		if math.Abs(float64(got-want[i])) > 1e-5 {
+			t.Fatalf("output[%d] = %g, want %g", i, got, want[i])
+		}
+	}
+}
+
+type selectorTarget struct{ logits *mlx.Array }
+
+func (t *selectorTarget) LoadWeights(map[string]*mlx.Array) error { return nil }
+func (t *selectorTarget) NewCaches() []cache.Cache                { return nil }
+func (t *selectorTarget) Forward(*batch.Batch, []cache.Cache) (*mlx.Array, *mlx.Array) {
+	return nil, nil
+}
+func (t *selectorTarget) Unembed(*mlx.Array) *mlx.Array         { return t.logits }
+func (t *selectorTarget) RawLogits(*mlx.Array) *mlx.Array       { return t.logits }
+func (t *selectorTarget) TokenEmbeddings(*mlx.Array) *mlx.Array { return nil }
+func (t *selectorTarget) SetAuxHiddenLayers([]int)              {}
+func (t *selectorTarget) NumLayers() int                        { return 1 }
+func (t *selectorTarget) Tokenizer() *tokenizer.Tokenizer       { return nil }
+func (t *selectorTarget) MaxContextLength() int                 { return 128 }
+
+func TestCandidateLatticeUsesPredecessorEdges(t *testing.T) {
+	mlxtest.Setup(t)
+	target := &selectorTarget{logits: mlx.FromValues([]float32{
+		0, 0, 5, 4,
+		5, 4, 0, 0,
+	}, 1, 2, 4)}
+	m := &Model2{Model: &Model{
+		Config: &Config{OutputMultiplier: 1},
+		target: target,
+		Selector: &CandidateSelector{
+			Predecessor:      nn.NewEmbedding(mlx.FromValues([]float32{1, 2, 3, 4}, 4, 1)),
+			Successor:        nn.NewEmbedding(mlx.FromValues([]float32{-2, -1, 1, 2}, 4, 1)),
+			HiddenProjection: nn.NewLinear(mlx.FromValues([]float32{1, 0, 0, 0}, 1, 4), nil),
+			TopK:             2,
+		},
+	}}
+	hidden := mlx.FromValues([]float32{
+		1, 0, 0, 0,
+		1, 0, 0, 0,
+	}, 1, 2, 4)
+	ids, scores := m.CandidateLattice(hidden, mlx.FromValues([]int32{1}, 1))
+	mlx.Eval(ids, scores)
+
+	candidates := ids.Ints()
+	lattice := scores.Floats()
+	k := 2
+	previous := 0
+	want := []int{3, 1}
+	for position := range 2 {
+		best := 0
+		for candidate := 1; candidate < k; candidate++ {
+			base := ((position*k + previous) * k)
+			if lattice[base+candidate] > lattice[base+best] {
+				best = candidate
+			}
+		}
+		got := candidates[position*k+best]
+		if got != want[position] {
+			t.Fatalf("path[%d] = %d, want %d (ids=%v scores=%v)", position, got, want[position], candidates, lattice)
+		}
+		previous = best
+	}
+}

--- a/x/models/qwen3_5/qwen3_5.go
+++ b/x/models/qwen3_5/qwen3_5.go
@@ -832,8 +832,7 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 
 	shouldShiftNormWeights := false
 	for name, t := range tensors {
-		if strings.Contains(name, "mtp.") ||
-			(strings.Contains(name, ".linear_attn.conv1d.weight") && t != nil && t.NumDims() == 3 && t.Dim(2) != 1) {
+		if strings.Contains(name, ".linear_attn.conv1d.weight") && t != nil && t.NumDims() == 3 && t.Dim(2) != 1 {
 			shouldShiftNormWeights = true
 			break
 		}
@@ -887,7 +886,7 @@ func (m *Model) LoadWeights(tensors map[string]*mlx.Array) error {
 	// num_nextn_predict_layers while a package ships without them. mtp.* names
 	// carry no container prefix.
 	if fc, _ := tensorByBase(tensors, "mtp.fc"); fc != nil {
-		if err := m.loadMTPHead(linears, tensors, useQuantizedExperts, shouldShiftNormWeights); err != nil {
+		if err := m.loadMTPHead(linears, tensors, useQuantizedExperts, true); err != nil {
 			return err
 		}
 	}

--- a/x/models/qwen3_5/qwen3_5.go
+++ b/x/models/qwen3_5/qwen3_5.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math"
+	"slices"
 	"strings"
 
 	"github.com/ollama/ollama/x/mlxrunner/batch"
@@ -108,7 +109,8 @@ type Model struct {
 	tok *tokenizer.Tokenizer
 	*Config
 
-	weightPrefix string
+	weightPrefix    string
+	auxHiddenLayers []int
 }
 
 // MTPHead is the multi-token-prediction draft head; it writes one KV cache
@@ -1236,19 +1238,36 @@ func (m *Model) Forward(b *batch.Batch, caches []cache.Cache) (hidden, auxHidden
 		mropeCos, mropeSin = mropeCosSin(m.Config, mp, L)
 	}
 
+	var features []*mlx.Array
 	for i, layer := range m.Layers {
 		var c cache.Cache
 		if caches != nil && i < len(caches) {
 			c = caches[i]
 		}
 		h = layer.Forward(h, b, c, positions, B, L, m.Config, mropeCos, mropeSin)
+		if slices.Contains(m.auxHiddenLayers, i) {
+			features = append(features, h)
+		}
 	}
 	out := m.Norm.Forward(h, m.RMSNormEps)
+	if features != nil {
+		return out, mlx.Concatenate(features, -1)
+	}
 	return out, out
 }
 
 func (m *Model) Unembed(x *mlx.Array) *mlx.Array {
 	return m.LMHead.Forward(x)
+}
+
+func (m *Model) SetAuxHiddenLayers(layers []int) { m.auxHiddenLayers = layers }
+
+func (m *Model) TokenEmbeddings(ids *mlx.Array) *mlx.Array {
+	return m.EmbedTokens.Forward(ids)
+}
+
+func (m *Model) RawLogits(hidden *mlx.Array) *mlx.Array {
+	return m.LMHead.Forward(hidden)
 }
 
 // mtpDraft is the model viewed as its own draft: the same struct, carrying


### PR DESCRIPTION
## Summary

- add native MLX loading and inference for `DFlash2DraftModel` checkpoints
- implement the dynamic short convolution and parallel path selector with canonical predecessor/successor codebooks
- preserve config-driven causal/sliding-window attention and bounded rotating draft KV caches
- support sparse DFlash2 proposal distributions with exact rejection sampling for sampled decoding
- import and quantize selector codebooks, and expose configured Qwen target hidden layers to the draft model
- respect `draft_num_predict` and the checkpoint block limit in the adaptive speculative-depth controller

## Testing

- `gofmt` and `git diff --check`
- `go test ./x/create ./x/mlxrunner ./x/mlxrunner/sample ./x/models/dflash ./x/models/qwen3_5`
- full CMake build on macOS arm64, including the Go binary, llama.cpp payload, MLX, MLX-C, and Metal library
- `go test ./...`: all runnable packages passed; the two app UI packages require the generated `app/dist` assets that are absent from a source-only checkout
- end-to-end Qwen3.8-27B greedy comparison using the same target artifact: 8/8 final answers matched between target-only and DFlash2; 5/8 generations were byte-identical, with the remaining differences limited to equivalent reasoning wording from the batched verification numerical path

## Performance

Apple M5 Pro, 64 GB, single stream, eight fixed GSM8K prompts repeated three times, temperature 1.0, top-p 0.95, top-k 20, high reasoning, and 1024 maximum new tokens.

- Target: [`mlx-community/Qwen3.8-27B-4bit`](https://huggingface.co/mlx-community/Qwen3.8-27B-4bit), 4-bit affine quantization with group size 64
- DFlash2 draft: [`incoai/Qwen3.8-27B-DFlash2`](https://huggingface.co/incoai/Qwen3.8-27B-DFlash2), imported with 4-bit affine quantization and group size 64
- MTP: the target checkpoint's built-in MTP layer

`Adaptive max draft` is the controller's ceiling, not a fixed draft depth.

| Method | Adaptive max draft | Decode throughput | Speedup vs. AR |
|---|---:|---:|---:|
| Autoregressive | 0 | 16.86 tok/s | 1.00x |
| MTP | 3 | 30.03 tok/s | 1.78x |
| MTP | 4 | 35.19 tok/s | 2.09x |
| MTP | 5 | 35.35 tok/s | 2.10x |
| MTP | 6 | 35.67 tok/s | 2.12x |
| MTP | 7 | 37.59 tok/s | 2.23x |
| DFlash2 | 3 | 41.25 tok/s | 2.45x |
| DFlash2 | 4 | 43.67 tok/s | 2.59x |
| DFlash2 | 5 | 43.69 tok/s | 2.59x |
| DFlash2 | 6 | 40.08 tok/s | 2.38x |
| DFlash2 | 7 | 43.66 tok/s | 2.59x |

DFlash2 was 16.2% faster than the best MTP configuration in this sweep. Thermal state remained nominal throughout the benchmark.
