### PR TITLE
scripts: fall back to .tgz when zstd CLI is unavailable

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -126,18 +126,30 @@ if [ -n "$NEEDS" ]; then
     exit 1
 fi
 
-# Function to download and extract with fallback from zst to tgz
+# Current releases only publish .tar.zst archives; .tgz is served solely for
+# older releases predating that format (verified: every current
+# ollama-linux-*.tgz variant 404s, all zst equivalents 200). So zstd is not
+# optional for a Linux install today, and the check belongs here, before
+# anything is downloaded or any directory created - not inside
+# download_and_extract(), where the tool is only actually needed for the
+# .tar.zst branch and reporting it late leaves a misleading empty
+# /usr/local/lib/ollama behind.
+if ! available zstd; then
+    error "This version requires zstd for extraction. Please install zstd and try again:
+  - Debian/Ubuntu: sudo apt-get install zstd
+  - RHEL/CentOS/Fedora: sudo dnf install zstd
+  - Arch: sudo pacman -S zstd"
+fi
+
+# Function to download and extract, with a .tgz fallback for older releases
+# that predate .tar.zst.
 download_and_extract() {
     local url_base="$1"
     local dest_dir="$2"
     local filename="$3"
 
-    # Only take the .tar.zst path when we can actually extract it: check for
-    # the zstd tool first (cheap, local) before probing whether the archive
-    # exists (a network round trip). A system without zstd falls straight
-    # through to the .tgz archive below instead of erroring out - many
-    # distros (e.g. Ubuntu 26.04) no longer ship the zstd CLI by default.
-    if available zstd && curl --fail --silent --head --location "${url_base}/${filename}.tar.zst${VER_PARAM}" >/dev/null 2>&1; then
+    # Check if .tar.zst is available
+    if curl --fail --silent --head --location "${url_base}/${filename}.tar.zst${VER_PARAM}" >/dev/null 2>&1; then
         status "Downloading ${filename}.tar.zst"
         curl --fail --show-error --location --progress-bar \
             "${url_base}/${filename}.tar.zst${VER_PARAM}" | \
@@ -145,7 +157,7 @@ download_and_extract() {
         return 0
     fi
 
-    # Fall back to .tgz for older versions, or when zstd is unavailable.
+    # Fall back to .tgz for older versions
     status "Downloading ${filename}.tgz"
     curl --fail --show-error --location --progress-bar \
         "${url_base}/${filename}.tgz${VER_PARAM}" | \

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -132,16 +132,12 @@ download_and_extract() {
     local dest_dir="$2"
     local filename="$3"
 
-    # Check if .tar.zst is available
-    if curl --fail --silent --head --location "${url_base}/${filename}.tar.zst${VER_PARAM}" >/dev/null 2>&1; then
-        # zst file exists - check if we have zstd tool
-        if ! available zstd; then
-            error "This version requires zstd for extraction. Please install zstd and try again:
-  - Debian/Ubuntu: sudo apt-get install zstd
-  - RHEL/CentOS/Fedora: sudo dnf install zstd
-  - Arch: sudo pacman -S zstd"
-        fi
-
+    # Only take the .tar.zst path when we can actually extract it: check for
+    # the zstd tool first (cheap, local) before probing whether the archive
+    # exists (a network round trip). A system without zstd falls straight
+    # through to the .tgz archive below instead of erroring out - many
+    # distros (e.g. Ubuntu 26.04) no longer ship the zstd CLI by default.
+    if available zstd && curl --fail --silent --head --location "${url_base}/${filename}.tar.zst${VER_PARAM}" >/dev/null 2>&1; then
         status "Downloading ${filename}.tar.zst"
         curl --fail --show-error --location --progress-bar \
             "${url_base}/${filename}.tar.zst${VER_PARAM}" | \
@@ -149,7 +145,7 @@ download_and_extract() {
         return 0
     fi
 
-    # Fall back to .tgz for older versions
+    # Fall back to .tgz for older versions, or when zstd is unavailable.
     status "Downloading ${filename}.tgz"
     curl --fail --show-error --location --progress-bar \
         "${url_base}/${filename}.tgz${VER_PARAM}" | \


### PR DESCRIPTION
## What

`install.sh` errored out entirely when the `zstd` CLI was missing, even though it already has a `.tgz` fallback path a few lines below for older releases that predate `.tar.zst`. Some current distros no longer ship `zstd` by default (Ubuntu 26.04, the current LTS, is one), so a clean install on those systems aborted after creating an empty `/usr/local/lib/ollama`, with no `ollama` binary installed and no obvious indication that nothing actually got installed.

Fixes #17860, which has a full repro and root-cause writeup.

## Why this approach

The issue lists a few options; this is the smallest one, matching what the reporter flagged as the likely-smallest fix: check for `zstd` before probing whether `.tar.zst` exists, and fall through to `.tgz` when it's missing, reusing the fallback path that already exists for older releases. Checking `available zstd` first also means a system without it skips the network HEAD request entirely instead of making it and then failing anyway.

## Testing

- `sh -n scripts/install.sh` — syntax check passes.
- Extracted `download_and_extract()` in isolation and drove it with mocked `curl`/`zstd`/`tar` under all three cases:
  - `zstd` missing → skips the `.tar.zst` HEAD check, goes straight to `.tgz`, install proceeds.
  - `zstd` present, `.tar.zst` exists → unchanged: takes the zst path.
  - `zstd` present, `.tar.zst` doesn't exist (older release) → unchanged: falls back to `.tgz`.
- Didn't have a zstd-less Linux box handy to run the real installer end-to-end; the repo's own `test-install.yaml` CI runs `sh ./scripts/install.sh` on `ubuntu-latest`/`macos-latest`, which covers the unchanged happy path (those images ship `zstd`) but won't exercise the missing-zstd branch specifically, since that's exactly the CLI GitHub's runner images already have installed.
