### PR TITLE
app/ui: keep settings the client did not send

### DIFF
--- a/app/ui/app/src/api.ts
+++ b/app/ui/app/src/api.ts
@@ -270,7 +270,9 @@ export async function getSettings(): Promise<{
   };
 }
 
-export async function updateSettings(settings: Settings): Promise<{
+// Accepts a subset of the settings; fields that are left out keep their
+// current value on the server.
+export async function updateSettings(settings: Partial<Settings>): Promise<{
   settings: Settings;
 }> {
   const response = await fetch(`${API_BASE}/api/v1/settings`, {

--- a/app/ui/app/src/hooks/useSettings.ts
+++ b/app/ui/app/src/hooks/useSettings.ts
@@ -57,19 +57,35 @@ export function useSettings() {
     [settingsData?.settings],
   );
 
-  // Single function to update most settings
+  const { mutateAsync } = updateSettingsMutation;
+
+  // Single function to update most settings.
+  //
+  // Only the fields that actually change are sent, and the comparison is made
+  // against the cache rather than a render-time copy of the settings. Sending
+  // the whole object from a copy that has gone stale reverts fields another
+  // view just saved; that view then re-applies them, reverting these in turn,
+  // and the two keep writing to /api/v1/settings for the life of the process.
+  // Dropping writes that change nothing keeps effects that re-assert a setting
+  // from issuing a request every time the settings are refetched.
   const setSettings = useCallback(
     async (updates: SettingsUpdate) => {
-      if (!settingsData?.settings) return;
+      const current = queryClient.getQueryData<{ settings: Settings }>([
+        "settings",
+      ])?.settings;
+      if (!current) return;
 
-      const updatedSettings = new Settings({
-        ...settingsData.settings,
-        ...updates,
-      });
+      const changed = Object.fromEntries(
+        Object.entries(updates).filter(
+          ([key, value]) => value !== current[key as keyof Settings],
+        ),
+      ) as SettingsUpdate;
 
-      await updateSettingsMutation.mutateAsync(updatedSettings);
+      if (Object.keys(changed).length === 0) return;
+
+      await mutateAsync(changed);
     },
-    [settingsData?.settings, updateSettingsMutation],
+    [queryClient, mutateAsync],
   );
 
   return useMemo(

--- a/app/ui/ui.go
+++ b/app/ui/ui.go
@@ -1464,7 +1464,12 @@ func (s *Server) settings(w http.ResponseWriter, r *http.Request) error {
 		return fmt.Errorf("failed to load settings: %w", err)
 	}
 
-	var settings store.Settings
+	// Decode over a copy of the stored settings so that fields the client
+	// leaves out keep their current values. Clients send only the fields they
+	// are changing; decoding into a zero value resets everything else, so two
+	// views saving different settings would each undo the other's change and
+	// then re-apply their own, looping until the app is killed.
+	settings := old
 	if err := json.NewDecoder(r.Body).Decode(&settings); err != nil {
 		return fmt.Errorf("invalid request body: %w", err)
 	}

--- a/app/ui/ui_test.go
+++ b/app/ui/ui_test.go
@@ -840,3 +840,116 @@ func TestSettingsToggleAutoUpdateOn_NoPendingUpdate_TriggersCheck(t *testing.T) 
 		t.Fatal("UpdateAvailableFunc should not be called when there is no pending update")
 	}
 }
+
+// postSettings sends a raw JSON body to the settings handler and returns the
+// settings as they were stored afterwards.
+func postSettings(t *testing.T, server *Server, body string) store.Settings {
+	t.Helper()
+
+	req := httptest.NewRequest("POST", "/api/v1/settings", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+
+	if err := server.settings(rr, req); err != nil {
+		t.Fatalf("settings(%s) error = %v", body, err)
+	}
+	if rr.Code != http.StatusOK {
+		t.Fatalf("settings(%s) status = %d, want %d", body, rr.Code, http.StatusOK)
+	}
+
+	saved, err := server.Store.Settings()
+	if err != nil {
+		t.Fatalf("Settings() error = %v", err)
+	}
+	return saved
+}
+
+func seededSettings() store.Settings {
+	return store.Settings{
+		Expose:            true,
+		Browser:           true,
+		Survey:            true,
+		Models:            "/custom/models",
+		Agent:             true,
+		Tools:             true,
+		WorkingDir:        "/workspace",
+		ContextLength:     8192,
+		TurboEnabled:      true,
+		WebSearchEnabled:  true,
+		ThinkEnabled:      true,
+		ThinkLevel:        "high",
+		SelectedModel:     "gemma3:4b",
+		SidebarOpen:       true,
+		LastHomeView:      "launch",
+		AutoUpdateEnabled: true,
+	}
+}
+
+func newSeededServer(t *testing.T, restart func()) *Server {
+	t.Helper()
+
+	testStore := &store.Store{
+		DBPath: filepath.Join(t.TempDir(), "db.sqlite"),
+	}
+	t.Cleanup(func() { testStore.Close() })
+
+	if err := testStore.SetSettings(seededSettings()); err != nil {
+		t.Fatalf("SetSettings() error = %v", err)
+	}
+
+	return &Server{
+		Store:   testStore,
+		Restart: restart,
+	}
+}
+
+func TestHandlePostApiSettingsPreservesOmittedFields(t *testing.T) {
+	server := newSeededServer(t, func() {})
+
+	got := postSettings(t, server, `{"LastHomeView":"chat"}`)
+
+	want := seededSettings()
+	want.LastHomeView = "chat"
+	if got != want {
+		t.Errorf("settings after partial update:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+func TestHandlePostApiSettingsPartialUpdatesDoNotClobberEachOther(t *testing.T) {
+	// Several views save different settings independently. Each request only
+	// carries the field it changed, so no request may undo another's change --
+	// otherwise each view re-applies its own value on the next read and the app
+	// writes to /api/v1/settings for the rest of the session.
+	server := newSeededServer(t, func() {})
+
+	postSettings(t, server, `{"LastHomeView":"chat"}`)
+	postSettings(t, server, `{"SelectedModel":"llama3.2"}`)
+	got := postSettings(t, server, `{"SidebarOpen":false}`)
+
+	want := seededSettings()
+	want.LastHomeView = "chat"
+	want.SelectedModel = "llama3.2"
+	want.SidebarOpen = false
+	if got != want {
+		t.Errorf("settings after independent updates:\n got %+v\nwant %+v", got, want)
+	}
+}
+
+func TestHandlePostApiSettingsRestartsOnlyForServerSettings(t *testing.T) {
+	// Restarting tears down the running ollama server, so an update that leaves
+	// Expose, Models and ContextLength alone must not trigger one.
+	restarts := 0
+	server := newSeededServer(t, func() { restarts++ })
+
+	postSettings(t, server, `{"SelectedModel":"llama3.2"}`)
+	postSettings(t, server, `{"SidebarOpen":false}`)
+	postSettings(t, server, `{"LastHomeView":"chat"}`)
+	if restarts != 0 {
+		t.Errorf("Restart called %d times for updates unrelated to the server, want 0", restarts)
+	}
+
+	postSettings(t, server, `{"ContextLength":16384}`)
+	if restarts != 1 {
+		t.Errorf("Restart called %d times after changing the context length, want 1", restarts)
+	}
+}


### PR DESCRIPTION
Fixes #17876

## The problem

`POST /api/v1/settings` decodes the request body into a zero-valued
`store.Settings`, so any field the client leaves out is written back as its
zero value. To work around that, the UI sends the *entire* settings object on
every write.

`useSettings()` builds that object inside a `useCallback` memoized on
`[settingsData?.settings, updateSettingsMutation]`, and the hook is called
independently by `Chat`, `ChatForm`, `ModelPicker`, `SidebarLayout`,
`LaunchCommands`, `useSelectedModel` and the `/c/$chatId` route. Each caller
therefore holds its own copy of the settings.

That is enough for two views to deadlock against each other:

1. View A saves `{...its copy, LastHomeView: "chat"}`.
2. View B, still holding the copy from before A's write, saves
   `{...its copy, SelectedModel: "..."}` — which resets `LastHomeView`.
3. Every write calls `invalidateQueries(["settings"])`, so a `GET` follows,
   `settingsData` gets a new identity, `setSettings` gets a new identity, and
   every effect listing `setSettings` in its dependency array re-runs.
4. A sees `LastHomeView` reverted and writes again, reverting B's field. B
   re-runs and writes again.

Neither side ever converges, and because each round trip re-arms the effects,
the two keep writing for the life of the process — the sustained
`POST → GET → POST` traffic at ~1000 req/s in the report.

## The fix

**Server** (`app/ui/ui.go`) — decode over the stored settings instead of a zero
value, so fields the client omits keep their current values. Two writers
sending disjoint fields can no longer overwrite each other.

**Client** (`app/ui/app/src/hooks/useSettings.ts`) — `setSettings` now:

- sends only the fields whose value actually differs, so writes from different
  views no longer overlap;
- compares against the query cache at call time rather than a render-time copy,
  so a stale copy cannot revert a setting another view just saved;
- returns without a request when nothing would change, so an effect that
  re-asserts a setting stops issuing a request on every refetch;
- no longer depends on `settingsData`, so it keeps a stable identity and stops
  re-triggering every effect that lists it as a dependency.

## Tests

Three tests in `app/ui/ui_test.go`, all of which fail without the server change:

- `TestHandlePostApiSettingsPreservesOmittedFields` — a `{"LastHomeView":"chat"}`
  body leaves the other fifteen fields alone. Before: every one is wiped.
- `TestHandlePostApiSettingsPartialUpdatesDoNotClobberEachOther` — three
  independent single-field updates all survive. Before: each undoes the last,
  which is the loop.
- `TestHandlePostApiSettingsRestartsOnlyForServerSettings` — updates that do not
  touch `Expose`, `Models` or `ContextLength` do not restart the ollama server;
  changing the context length still does. Before the fix, an update that omits
  `Models` reads as a change to it and restarts the server on every write.

`go test ./app/ui/... ./app/store/...`, `npx vitest run`, `npx tsc -b`,
`npx eslint` and `npm run build` all pass.

## Note on behaviour

"Reset to defaults" in Settings sends only the seven fields it lists, so with
merge semantics it now resets exactly those and leaves the selected model,
sidebar state and home view alone. That matches what the button offers on that
page; previously it silently cleared them too.
