### PR TITLE
server: don't wedge chat and generate on a mid-stream parser error

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -651,7 +651,12 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		// TODO (jmorganca): avoid building the response twice both here and below
 		var sb strings.Builder
 		defer close(ch)
-		if err := r.Completion(c.Request.Context(), llm.CompletionRequest{
+
+		ctx, cancel := context.WithCancel(c.Request.Context())
+		defer cancel()
+		var parserErr error
+
+		if err := r.Completion(ctx, llm.CompletionRequest{
 			Prompt:          prompt,
 			Media:           media,
 			Format:          req.Format,
@@ -680,7 +685,8 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 			if builtinParser != nil {
 				content, thinking, toolCalls, err := builtinParser.Add(cr.Content, cr.Done)
 				if err != nil {
-					ch <- gin.H{"error": err.Error()}
+					parserErr = err
+					cancel()
 					return
 				}
 				res.Response = content
@@ -726,13 +732,18 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 
 			ch <- res
 		}); err != nil {
-			s.sched.expireRunnersForRuntimeOOM(m, err)
-			var serr api.StatusError
-			if errors.As(err, &serr) {
-				ch <- gin.H{"error": serr.ErrorMessage, "status": serr.StatusCode}
-			} else {
-				ch <- gin.H{"error": err.Error()}
+			if parserErr == nil {
+				s.sched.expireRunnersForRuntimeOOM(m, err)
+				var serr api.StatusError
+				if errors.As(err, &serr) {
+					ch <- gin.H{"error": serr.ErrorMessage, "status": serr.StatusCode}
+				} else {
+					ch <- gin.H{"error": err.Error()}
+				}
 			}
+		}
+		if parserErr != nil {
+			ch <- gin.H{"error": parserErr.Error()}
 		}
 	}()
 
@@ -2758,6 +2769,8 @@ func (s *Server) ChatHandler(c *gin.Context) {
 			// sets up new context given parent context per request
 			ctx, cancel := context.WithCancel(c.Request.Context())
 
+			var parserErr error
+
 			err := r.Completion(ctx, llm.CompletionRequest{
 				Prompt:          prompt,
 				Media:           media,
@@ -2796,7 +2809,8 @@ func (s *Server) ChatHandler(c *gin.Context) {
 
 					content, thinking, toolCalls, err := builtinParser.Add(r.Content, r.Done)
 					if err != nil {
-						ch <- gin.H{"error": err.Error()}
+						parserErr = err
+						cancel()
 						return
 					}
 
@@ -2875,6 +2889,10 @@ func (s *Server) ChatHandler(c *gin.Context) {
 
 				ch <- res
 			})
+			if parserErr != nil {
+				ch <- gin.H{"error": parserErr.Error()}
+				return
+			}
 			if err != nil {
 				if structuredOutputsState == structuredOutputsState_ReadyToApply && strings.Contains(err.Error(), "context canceled") && c.Request.Context().Err() == nil {
 					// only ignores error if it's a context cancellation due to setting structured outputs

--- a/server/routes_parse_error_test.go
+++ b/server/routes_parse_error_test.go
@@ -1,0 +1,140 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/fs/ggml"
+	"github.com/ollama/ollama/llm"
+)
+
+// malformedToolCall closes <parameter> with </function>, which the qwen3.5
+// parser rejects.
+const malformedToolCall = "<think>\nthinking\n</think>\n\n<tool_call>\n<function=write_file>\n<parameter=path>\nprobe.txt\n</function>\n</tool_call>"
+
+func TestChatParseErrorMidStreamDoesNotWedge(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	secondChunkReturned := make(chan struct{})
+
+	mock := mockRunner{
+		CompletionFn: func(ctx context.Context, r llm.CompletionRequest, fn func(llm.CompletionResponse)) error {
+			fn(llm.CompletionResponse{Content: malformedToolCall})
+			// The chunk after the failed parse is the one that wedges.
+			fn(llm.CompletionResponse{Content: "trailing"})
+			close(secondChunkReturned)
+			fn(llm.CompletionResponse{Done: true, DoneReason: llm.DoneReasonStop})
+			return nil
+		},
+	}
+
+	s := newServerWithMockRunner(t, &mock)
+	createParserModel(t, s, "parse-wedge", "qwen3.5")
+
+	stream := false
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		w := createRequest(t, s.ChatHandler, api.ChatRequest{
+			Model:    "parse-wedge",
+			Messages: []api.Message{{Role: "user", Content: "hello"}},
+			Stream:   &stream,
+		})
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("expected 500 from parse failure, got %d: %s", w.Code, w.Body.String())
+		}
+	}()
+
+	select {
+	case <-secondChunkReturned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("completion callback blocked after a parse error")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("chat handler did not return after a parse error")
+	}
+}
+
+func TestGenerateParseErrorMidStreamDoesNotWedge(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	secondChunkReturned := make(chan struct{})
+
+	mock := mockRunner{
+		CompletionFn: func(ctx context.Context, r llm.CompletionRequest, fn func(llm.CompletionResponse)) error {
+			fn(llm.CompletionResponse{Content: malformedToolCall})
+			fn(llm.CompletionResponse{Content: "trailing"})
+			close(secondChunkReturned)
+			fn(llm.CompletionResponse{Done: true, DoneReason: llm.DoneReasonStop})
+			return nil
+		},
+	}
+
+	s := newServerWithMockRunner(t, &mock)
+	createParserModel(t, s, "parse-wedge-gen", "qwen3.5")
+
+	stream := false
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		w := createRequest(t, s.GenerateHandler, api.GenerateRequest{
+			Model:  "parse-wedge-gen",
+			Prompt: "hello",
+			Stream: &stream,
+		})
+		if w.Code != http.StatusInternalServerError {
+			t.Errorf("expected 500 from parse failure, got %d: %s", w.Code, w.Body.String())
+		}
+	}()
+
+	select {
+	case <-secondChunkReturned:
+	case <-time.After(5 * time.Second):
+		t.Fatal("completion callback blocked after a parse error")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("generate handler did not return after a parse error")
+	}
+}
+
+func createParserModel(t *testing.T, s *Server, name, parser string) {
+	t.Helper()
+
+	kv := ggml.KV{
+		"general.architecture":          "llama",
+		"llama.block_count":             uint32(1),
+		"llama.context_length":          uint32(8192),
+		"llama.embedding_length":        uint32(4096),
+		"llama.attention.head_count":    uint32(32),
+		"llama.attention.head_count_kv": uint32(8),
+		"tokenizer.ggml.tokens":         []string{""},
+		"tokenizer.ggml.scores":         []float32{0},
+		"tokenizer.ggml.token_type":     []int32{0},
+	}
+	_, digest := createBinFile(t, kv, []*ggml.Tensor{
+		{Name: "token_embd.weight", Shape: []uint64{1}, WriterTo: bytes.NewReader(make([]byte, 4))},
+	})
+
+	stream := false
+	w := createRequest(t, s.CreateHandler, api.CreateRequest{
+		Model:  name,
+		Files:  map[string]string{"file.gguf": digest},
+		Parser: parser,
+		Stream: &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("creating model: %d: %s", w.Code, w.Body.String())
+	}
+}


### PR DESCRIPTION
When a builtin parser rejects model output, the completion callback wrote the error to an unbuffered channel and returned. The callback cannot stop generation -- it has no error return -- so the next chunk re-entered the callback, hit the same parse error and blocked writing to a channel the consumer had already stopped reading after emitting its 500. The completion never returned, the goroutine leaked and the runner request was never released, so retrying the same prompt hung with no log output until the client gave up.

Record the parse error, cancel the completion, and report it once the completion has returned. Parse failures landing on the final chunk were already terminal, which is why non-thinking requests and the direct qwen3-coder parser path failed cleanly and only thinking mode wedged.

ChatHandler and GenerateHandler share the defect: both run the same parser in the same shape of callback behind a consumer that stops reading at the first error. GenerateHandler had no cancel func at all, so one is added there.

Fixes #17825