### PR TITLE
gemma4: accept '=' separator in tool call arguments

### DIFF
--- a/model/parsers/gemma4.go
+++ b/model/parsers/gemma4.go
@@ -472,7 +472,7 @@ func quoteGemma4BareKeys(s string) string {
 		sb.WriteString(s[spaceStart:i])
 
 		keyEnd := gemma4BareKeyEnd(s, i)
-		if keyEnd > i && keyEnd < len(s) && s[keyEnd] == ':' {
+		if keyEnd > i && keyEnd < len(s) && (s[keyEnd] == ':' || s[keyEnd] == '=') {
 			sb.WriteByte('"')
 			sb.WriteString(s[i:keyEnd])
 			sb.WriteByte('"')
@@ -617,7 +617,7 @@ func repairGemma4SingleQuotedValues(s string) string {
 			}
 		}
 
-		if s[i] != ':' {
+		if s[i] != ':' && s[i] != '=' {
 			sb.WriteByte(s[i])
 			i++
 			continue

--- a/model/parsers/gemma4_test.go
+++ b/model/parsers/gemma4_test.go
@@ -857,6 +857,26 @@ func TestGemma4ArgsToJSON(t *testing.T) {
 			expected: `{"name":"test","count":5,"active":true,"tags":["a"]}`,
 		},
 		{
+			name:     "equals_separator_bare_key",
+			input:    `{save_as=<|"|>report.docx<|"|>}`,
+			expected: `{"save_as":"report.docx"}`,
+		},
+		{
+			name:     "equals_separator_multiple_bare_keys",
+			input:    `{save_as=<|"|>report.docx<|"|>,format=<|"|>docx<|"|>}`,
+			expected: `{"save_as":"report.docx","format":"docx"}`,
+		},
+		{
+			name:     "mixed_separators",
+			input:    `{save_as=<|"|>report.docx<|"|>,format:<|"|>docx<|"|>}`,
+			expected: `{"save_as":"report.docx","format":"docx"}`,
+		},
+		{
+			name: "equals_separator_nested_object",
+			input: `{config={enabled=true,name=<|"|>test<|"|>}}`,
+			expected: `{"config":{"enabled":true,"name":"test"}}`,
+		},
+		{
 			name:     "null_value",
 			input:    `{value:null}`,
 			expected: `{"value":null}`,
@@ -1045,6 +1065,16 @@ func TestRepairGemma4SingleQuotedValues(t *testing.T) {
 			name:     "converts_single_quoted_value",
 			input:    `{pattern:':\s*\w+'}`,
 			expected: `{pattern:<|"|>:\s*\w+<|"|>}`,
+		},
+		{
+			name:     "converts_single_quoted_value_with_equals_separator",
+			input:    `{save_as='report.docx'}`,
+			expected: `{save_as=<|"|>report.docx<|"|>}`,
+		},
+		{
+			name:     "converts_middle_single_quoted_value_with_equals_separator",
+			input:    `{save_as='a',format:'docx',path='b'}`,
+			expected: `{save_as=<|"|>a<|"|>,format:<|"|>docx<|"|>,path=<|"|>b<|"|>}`,
 		},
 		{
 			name:     "converts_middle_single_quoted_value",


### PR DESCRIPTION
Fixes #17882

gemma4 models sometimes emit tool-call arguments as `save_as='report.docx'` instead of the canonical `save_as:<|"|>report.docx<|"|>`. When they do, parsing fails and the API returns `tool_calls: []` with empty `content`.

Root cause: `quoteGemma4BareKeys` (model/parsers/gemma4.go) only recognized a bare key when followed by `:`, and `repairGemma4SingleQuotedValues` was also anchored on `:`, so both recovery paths missed the `=` case and `json.Unmarshal` failed.

Changes:
- `quoteGemma4BareKeys` now quotes a bare key followed by either `:` or `=`, normalizing to `:` in the output.
- `repairGemma4SingleQuotedValues` now converts single-quoted values following either separator into the gemma string-delimited form, so `save_as='report.docx'` repairs to `save_as:<|"|>report.docx<|"|>` and then parses as `{"save_as": "report.docx"}`.

Both paths accept `=` anywhere `:` was accepted. Existing `:`-separated parsing is unchanged.

Tests added to `TestGemma4ArgsToJSON` (equals separator, multiple keys, mixed separators, nested object) and `TestRepairGemma4SingleQuotedValues` (equals-separated single-quoted values).
