### PR TITLE
server: return 204 for OPTIONS on loopback/private hosts

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -1819,6 +1819,11 @@ func allowedHostsMiddleware(addr net.Addr) gin.HandlerFunc {
 
 		if addr, err := netip.ParseAddr(host); err == nil {
 			if addr.IsLoopback() || addr.IsPrivate() || addr.IsUnspecified() || isLocalIP(addr) {
+				if c.Request.Method == http.MethodOptions {
+					c.AbortWithStatus(http.StatusNoContent)
+					return
+				}
+
 				c.Next()
 				return
 			}


### PR DESCRIPTION
Fixes #17887

## Problem

Browser CORS preflight `OPTIONS` requests to `/api/generate` on hosts reachable via loopback/private/LAN addresses return `405 Method Not Allowed` with `Allow: POST` and no CORS headers, breaking `fetch()` from web pages served from the same machine/LAN.

## Root cause

The agent UI refactor (82f905cd) dropped the `OPTIONS` → `204 No Content` early return from the loopback/private/unspecified/local-IP branch of `allowedHostsMiddleware` (previously added in 781585d9). That branch now falls through with `c.Next()`, and gin's `HandleMethodNotAllowed` answers `405`.

The `allowedHost(host)` branch below it still returns `204` for OPTIONS, so behavior is inconsistent depending on whether the host resolves to an IP literal.

## Fix

Restore the early `204 No Content` return for `OPTIONS` requests in the loopback/private/unspecified/local-IP branch, matching both the `allowedHost` branch and the pre-refactor behavior.
