### PR TITLE
openai: reject non-string chat stop sequences

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -648,6 +648,8 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 		for _, s := range stop {
 			if str, ok := s.(string); ok {
 				stops = append(stops, str)
+			} else {
+				return nil, fmt.Errorf("invalid type for 'stop' field: %T", s)
 			}
 		}
 		options["stop"] = stops

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -177,6 +177,21 @@ func TestFromCompleteRequest_Basic(t *testing.T) {
 	}
 }
 
+func TestFromChatRequest_InvalidStopArrayElement(t *testing.T) {
+	req := ChatCompletionRequest{
+		Model: "test-model",
+		Messages: []Message{
+			{Role: "user", Content: "Hello"},
+		},
+		Stop: []any{"valid", 42},
+	}
+
+	_, err := FromChatRequest(req)
+	if err == nil {
+		t.Fatal("expected error for non-string stop sequence, got nil")
+	}
+}
+
 func TestToUsage(t *testing.T) {
 	resp := api.ChatResponse{
 		Metrics: api.Metrics{


### PR DESCRIPTION
## Summary

`FromChatRequest` previously ignored non-string values in an OpenAI-compatible chat `stop` array, silently changing the requested stop sequences. Return a validation error instead, matching the completions path, and add regression coverage.

## Verification

- `go test ./openai -count=1`
- `go test -race ./openai -count=1`