### PR TITLE
lint fixes

### DIFF
--- a/app/cmd/app/app.go
+++ b/app/cmd/app/app.go
@@ -407,7 +407,7 @@ func startHiddenTasks() {
 				return
 			}
 
-			if err := updater.DoUpgradeAtStartup(); err != nil {
+			if err := updater.DoUpgradeAtStartup(); err != nil { //nolint:staticcheck,nolintlint // DoUpgradeAtStartup may always return non-nil on Windows
 				slog.Info("unable to perform upgrade at startup", "error", err)
 				// Make sure the restart to upgrade menu shows so we can attempt an interactive upgrade to get authorization
 				UpdateAvailable("")

--- a/app/cmd/app/app_darwin.go
+++ b/app/cmd/app/app_darwin.go
@@ -119,7 +119,7 @@ func maybeMoveAndRestart() appMove {
 	}
 
 	// Ask to move to applications directory
-	status := (appMove)(C.askToMoveToApplications())
+	status := appMove(C.askToMoveToApplications())
 	if status == MoveCompleted {
 		// Double check
 		if _, err := os.Stat(updater.SystemWidePath); err != nil {

--- a/app/cmd/app/app_windows.go
+++ b/app/cmd/app/app_windows.go
@@ -130,7 +130,7 @@ func (app *appCallbacks) DoUpdate() {
 
 	app.shutdown()
 
-	if err := updater.DoUpgrade(true); err != nil {
+	if err := updater.DoUpgrade(true); err != nil { //nolint:staticcheck,nolintlint // DoUpgrade may always return non-nil on Windows
 		slog.Warn(fmt.Sprintf("upgrade attempt failed: %s", err))
 	}
 }

--- a/app/dialog/dlgs_windows.go
+++ b/app/dialog/dlgs_windows.go
@@ -143,13 +143,13 @@ func utf16ptr(utf16 []uint16) *uint16 {
 
 func utf16slice(ptr *uint16) []uint16 { //nolint:unused
 	hdr := reflect.SliceHeader{Data: uintptr(unsafe.Pointer(ptr)), Len: 1, Cap: 1}
-	slice := *((*[]uint16)(unsafe.Pointer(&hdr))) //nolint:govet
+	slice := *(*[]uint16)(unsafe.Pointer(&hdr)) //nolint:govet
 	i := 0
 	for slice[len(slice)-1] != 0 {
 		i++
 	}
 	hdr.Len = i
-	slice = *((*[]uint16)(unsafe.Pointer(&hdr))) //nolint:govet
+	slice = *(*[]uint16)(unsafe.Pointer(&hdr)) //nolint:govet
 	return slice
 }
 

--- a/app/updater/updater_darwin.go
+++ b/app/updater/updater_darwin.go
@@ -434,7 +434,7 @@ func IsUpdatePending() bool {
 func chownWithAuthorization(user string) bool {
 	u := C.CString(user)
 	defer C.free(unsafe.Pointer(u))
-	return (bool)(C.chownWithAuthorization(u))
+	return bool(C.chownWithAuthorization(u))
 }
 
 func verifyExtractedBundle(path string) error {

--- a/app/updater/updater_windows.go
+++ b/app/updater/updater_windows.go
@@ -78,7 +78,7 @@ func init() {
 func loadOSVersion() {
 	UserAgentOS = "Windows"
 	verInfo := OSVERSIONINFOEXW{}
-	verInfo.dwOSVersionInfoSize = (uint32)(unsafe.Sizeof(verInfo))
+	verInfo.dwOSVersionInfoSize = uint32(unsafe.Sizeof(verInfo))
 	ntdll, err := windows.LoadDLL("ntdll.dll")
 	if err != nil {
 		slog.Warn("unable to find ntdll", "error", err)
@@ -394,13 +394,13 @@ func IsProcRunning(procName string) []uint32 {
 		defer windows.CloseHandle(hProcess)
 		var module windows.Handle
 		var cbNeeded uint32
-		cb := (uint32)(unsafe.Sizeof(module))
+		cb := uint32(unsafe.Sizeof(module))
 		if err := windows.EnumProcessModules(hProcess, &module, cb, &cbNeeded); err != nil {
 			continue
 		}
 		var sz uint32 = 1024 * 8
 		moduleName := make([]uint16, sz)
-		cb = uint32(len(moduleName)) * (uint32)(unsafe.Sizeof(uint16(0)))
+		cb = uint32(len(moduleName)) * uint32(unsafe.Sizeof(uint16(0)))
 		if err := windows.GetModuleBaseName(hProcess, module, &moduleName[0], cb); err != nil && err != syscall.ERROR_INSUFFICIENT_BUFFER {
 			continue
 		}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2085,7 +2085,7 @@ func checkServerHeartbeat(cmd *cobra.Command, _ []string) error {
 		if !(strings.Contains(err.Error(), " refused") || strings.Contains(err.Error(), "could not connect")) {
 			return err
 		}
-		if err := startApp(cmd.Context(), client); err != nil {
+		if err := startApp(cmd.Context(), client); err != nil { //nolint:staticcheck,nolintlint // startApp always returns non-nil on Linux (start_default.go) but can return nil on macOS/Windows
 			return err
 		}
 	}

--- a/cmd/start_windows.go
+++ b/cmd/start_windows.go
@@ -93,13 +93,13 @@ func isProcRunning(procName string) []uint32 {
 		defer windows.CloseHandle(hProcess)
 		var module windows.Handle
 		var cbNeeded uint32
-		cb := (uint32)(unsafe.Sizeof(module))
+		cb := uint32(unsafe.Sizeof(module))
 		if err := windows.EnumProcessModules(hProcess, &module, cb, &cbNeeded); err != nil {
 			continue
 		}
 		var sz uint32 = 1024 * 8
 		moduleName := make([]uint16, sz)
-		cb = uint32(len(moduleName)) * (uint32)(unsafe.Sizeof(uint16(0)))
+		cb = uint32(len(moduleName)) * uint32(unsafe.Sizeof(uint16(0)))
 		if err := windows.GetModuleBaseName(hProcess, module, &moduleName[0], cb); err != nil && err != syscall.ERROR_INSUFFICIENT_BUFFER {
 			continue
 		}

--- a/convert/convert_qwen3next.go
+++ b/convert/convert_qwen3next.go
@@ -1437,17 +1437,19 @@ func (q *qwen3NextModel) splitQKVZTensor(t Tensor) (*ggml.Tensor, *ggml.Tensor, 
 	qkvName := strings.Replace(t.Name(), "ssm_in", "attn_qkv", 1)
 	gateName := strings.Replace(t.Name(), "ssm_in", "attn_gate", 1)
 
-	return &ggml.Tensor{
-			Name:     qkvName,
-			Kind:     t.Kind(),
-			Shape:    []uint64{uint64(spec.qkvOut), uint64(spec.hidden)},
-			WriterTo: qkvTensor,
-		}, &ggml.Tensor{
-			Name:     gateName,
-			Kind:     t.Kind(),
-			Shape:    []uint64{uint64(spec.gateOut), uint64(spec.hidden)},
-			WriterTo: gateTensor,
-		}, true
+	qkv := &ggml.Tensor{
+		Name:     qkvName,
+		Kind:     t.Kind(),
+		Shape:    []uint64{uint64(spec.qkvOut), uint64(spec.hidden)},
+		WriterTo: qkvTensor,
+	}
+	gate := &ggml.Tensor{
+		Name:     gateName,
+		Kind:     t.Kind(),
+		Shape:    []uint64{uint64(spec.gateOut), uint64(spec.hidden)},
+		WriterTo: gateTensor,
+	}
+	return qkv, gate, true
 }
 
 func (q *qwen3NextModel) repackQKVZ(spec qkvzSplitSpec, extractGate bool) Repacker {

--- a/discover/native_probe.go
+++ b/discover/native_probe.go
@@ -110,15 +110,15 @@ func RunNativeProbeCommand(ctx context.Context, libDirs []string, out io.Writer)
 		libDirs = []string{ml.LibOllamaPath}
 	}
 
-	devices, err := runNativeProbe(ctx, libDirs)
-	if err != nil {
+	devices, err := runNativeProbe(ctx, libDirs) //nolint:staticcheck,nolintlint // runNativeProbe always returns non-nil on macOS (stub) but can return nil on Linux with cgo
+	if err != nil {                              //nolint:staticcheck,nolintlint
 		return err
 	}
 
 	return json.NewEncoder(out).Encode(nativeProbeResult{Devices: devices})
 }
 
-func runNativeProbe(ctx context.Context, libDirs []string) ([]nativeProbeDevice, error) {
+func runNativeProbe(ctx context.Context, libDirs []string) ([]nativeProbeDevice, error) { //nolint:staticcheck,nolintlint
 	return runPlatformNativeProbe(ctx, libDirs)
 }
 

--- a/readline/buffer.go
+++ b/readline/buffer.go
@@ -294,7 +294,7 @@ func (b *Buffer) drawRemaining() {
 
 	// render the other lines
 	if remLength > currLineSpace {
-		remaining := (remainingText[len(currLine):])
+		remaining := remainingText[len(currLine):]
 		var totalLines int
 		var displayLength int
 		var lineLength int = currLineSpace

--- a/server/download.go
+++ b/server/download.go
@@ -475,7 +475,7 @@ type downloadOpts struct {
 // downloadBlob downloads a blob from the registry and stores it in the blobs directory
 func downloadBlob(ctx context.Context, opts downloadOpts) (cacheHit bool, _ error) {
 	if opts.digest == "" {
-		return false, fmt.Errorf(("%s: %s"), opts.n.DisplayNamespaceModel(), "digest is empty")
+		return false, fmt.Errorf("%s: %s", opts.n.DisplayNamespaceModel(), "digest is empty")
 	}
 
 	fp, err := manifest.BlobsPath(opts.digest)

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -2148,6 +2148,7 @@ func (s *mockLlm) Close() error {
 	s.closeCalled = true
 	return s.closeResp
 }
+
 func (s *mockLlm) MemorySize() (uint64, uint64)                       { return s.totalSize, s.vramSize }
 func (s *mockLlm) VRAMByGPU(id ml.DeviceID) uint64                    { return s.vramByGPU[id] }
 func (s *mockLlm) Pid() int                                           { return -1 }

--- a/template/template.go
+++ b/template/template.go
@@ -602,11 +602,11 @@ func deleteNode(n parse.Node, fn func(parse.Node) bool) parse.Node {
 			t.Nodes = nodes
 			return t
 		case *parse.IfNode:
-			t.BranchNode = *(walk(&t.BranchNode).(*parse.BranchNode))
+			t.BranchNode = *walk(&t.BranchNode).(*parse.BranchNode)
 		case *parse.WithNode:
-			t.BranchNode = *(walk(&t.BranchNode).(*parse.BranchNode))
+			t.BranchNode = *walk(&t.BranchNode).(*parse.BranchNode)
 		case *parse.RangeNode:
-			t.BranchNode = *(walk(&t.BranchNode).(*parse.BranchNode))
+			t.BranchNode = *walk(&t.BranchNode).(*parse.BranchNode)
 		case *parse.BranchNode:
 			t.List = walk(t.List).(*parse.ListNode)
 			if t.ElseList != nil {

--- a/x/create/writer.go
+++ b/x/create/writer.go
@@ -67,8 +67,8 @@ func writeBlob(spec BlobSpec, src *sourceFiles, store BlobStore) (LayerInfo, err
 	// take the MLX path.
 	var r io.Reader
 	if needsMLX {
-		blobData, err := quantizeBlob(items)
-		if err != nil {
+		blobData, err := quantizeBlob(items) //nolint:staticcheck,nolintlint // quantizeBlob can return nil via runOnMLXThread; staticcheck SA4023 false positive on closure-capture pattern
+		if err != nil {                      //nolint:staticcheck,nolintlint
 			return LayerInfo{}, fmt.Errorf("quantize blob %s: %w", spec.Name, err)
 		}
 		r = bytes.NewReader(blobData)


### PR DESCRIPTION
Our current CI configuration doesn't pin to a specific golangci-lint so this gets us back to a fully clean tree with the latest version.