### PR TITLE
mlxrunner: make prefix cache restore points survive cancelled and resumed prefills

### DIFF
--- a/x/mlxrunner/cache_trie.go
+++ b/x/mlxrunner/cache_trie.go
@@ -159,23 +159,17 @@ func findBestMatch(root *trieNode, tokens []trieKey) (path []*trieNode, matched 
 	return path, pos
 }
 
-// appendTokens either creates a new child node or extends the leaf in place,
-// returning the node that now holds the tokens.
-func (n *trieNode) appendTokens(root *trieNode, tokens []trieKey, endOffset int) *trieNode {
-	if n == root || len(n.children) > 0 || n.hasSnapshots() {
-		child := &trieNode{
-			tokens:    make([]trieKey, len(tokens)),
-			endOffset: endOffset,
-			parent:    n,
-			lastUsed:  n.lastUsed,
-		}
-		copy(child.tokens, tokens)
-		n.children = append(n.children, child)
-		return child
+// appendChild creates a child node holding the tokens.
+func (n *trieNode) appendChild(tokens []trieKey, endOffset int) *trieNode {
+	child := &trieNode{
+		tokens:    make([]trieKey, len(tokens)),
+		endOffset: endOffset,
+		parent:    n,
+		lastUsed:  n.lastUsed,
 	}
-	n.tokens = append(n.tokens, tokens...)
-	n.endOffset = endOffset
-	return n
+	copy(child.tokens, tokens)
+	n.children = append(n.children, child)
+	return child
 }
 
 // removeNode removes a leaf node from the trie.

--- a/x/mlxrunner/cache_trie_test.go
+++ b/x/mlxrunner/cache_trie_test.go
@@ -170,7 +170,7 @@ func TestFindSplitAppendSequence(t *testing.T) {
 	matchedInEdge := matched - lastNode.startOffset()
 	split := splitNode(lastNode, matchedInEdge, nil, nil)
 
-	split.appendTokens(root, []trieKey{6, 7}, 5)
+	split.appendChild([]trieKey{6, 7}, 5)
 
 	if len(root.children) != 1 {
 		t.Fatalf("root should have 1 child, got %d", len(root.children))
@@ -200,7 +200,7 @@ func TestFindSplitAppendSequence(t *testing.T) {
 func TestRepeatedBranching(t *testing.T) {
 	root := &trieNode{lastUsed: time.Now()}
 
-	root.appendTokens(root, []trieKey{1, 2, 3, 4, 5}, 5)
+	root.appendChild([]trieKey{1, 2, 3, 4, 5}, 5)
 
 	_, matchedB := findBestMatch(root, []trieKey{1, 2, 3, 6, 7})
 	if matchedB != 3 {
@@ -208,14 +208,14 @@ func TestRepeatedBranching(t *testing.T) {
 	}
 	nodeA := root.children[0]
 	split1 := splitNode(nodeA, 3, nil, nil)
-	split1.appendTokens(root, []trieKey{6, 7}, 5)
+	split1.appendChild([]trieKey{6, 7}, 5)
 
 	_, matchedC := findBestMatch(root, []trieKey{1, 2, 8, 9})
 	if matchedC != 2 {
 		t.Fatalf("C: expected 2 matched, got %d", matchedC)
 	}
 	split2 := splitNode(split1, 2, nil, nil)
-	split2.appendTokens(root, []trieKey{8, 9}, 4)
+	split2.appendChild([]trieKey{8, 9}, 4)
 
 	_, mA := findBestMatch(root, []trieKey{1, 2, 3, 4, 5})
 	if mA != 5 {

--- a/x/mlxrunner/pipeline.go
+++ b/x/mlxrunner/pipeline.go
@@ -169,6 +169,10 @@ func (r *Runner) prefill(ctx context.Context, session *cacheSession, spec *specu
 	media.release(position)
 	for total-processed > 1 {
 		if err := ctx.Err(); err != nil {
+			// Settle the drafter with the next prompt token so the caches
+			// rest level with the recorded keys and a retry resumes exactly
+			// where this prefill stopped.
+			spec.settle(mlx.FromValues(tokens[processed:processed+1], 1))
 			return nil, 0, 0, err
 		}
 

--- a/x/mlxrunner/prefix_cache.go
+++ b/x/mlxrunner/prefix_cache.go
@@ -5,10 +5,9 @@
 //
 // Key properties:
 //   - Only one path through the trie is "active" (backed by live MLX arrays)
-//     at a time. Switching paths pages out the frontier node and pages in the
-//     new path.
-//   - Snapshots are only captured at the frontier (end) of the active path.
-//     Intermediate node snapshots come from split prefill.
+//     at a time. Switching paths pages in the new path from its snapshots.
+//   - Every node carries its snapshots from creation: prefill captures for
+//     prompt segments, a page-out at close for generated ones.
 //   - All cache layers must stay at the same token offset.
 //   - Sibling edges must not share a common token prefix (compressed trie
 //     invariant).
@@ -177,7 +176,7 @@ func (s *cacheSession) storedKeys() []trieKey {
 }
 
 // switchToPath transitions from the current active path to a new path,
-// paging out diverging segments and paging in the new path.
+// rewinding the caches and paging in the new path's snapshots.
 func (c *prefixCache) switchToPath(newPath []*trieNode, matched int) {
 	defer c.enforceEvictionPolicy()
 
@@ -195,33 +194,7 @@ func (c *prefixCache) switchToPath(newPath []*trieNode, matched int) {
 		ancestorOffset = c.activePath[commonLen-1].endOffset
 	}
 
-	var pageOutCount, pageInCount int
-
-	// Page out the leaf of the old path. Only the leaf's live cache
-	// state is correct — intermediate nodes already have snapshots
-	// captured during their creation (splitNode + prefill). Snapshotting
-	// non-leaf nodes here would produce wrong results for non-rewindable
-	// caches (e.g. RecurrentCache) whose state reflects the leaf, not
-	// the intermediate boundary.
-	leaf := len(c.activePath) - 1
-	leafDiverges := leaf >= commonLen
-	leafNeedsRewind := matched < c.activePath[leaf].endOffset
-	if leafDiverges || leafNeedsRewind {
-		node := c.activePath[leaf]
-		if !hasAllSnapshots(node, c.caches) {
-			fromOffset := node.startOffset()
-			snaps := make([]cache.Snapshot, len(c.caches))
-			for j, kv := range c.caches {
-				if kv == nil {
-					continue
-				}
-				snaps[j] = kv.Snapshot(fromOffset)
-			}
-			node.setSnapshots(snaps, &c.pagedOutBytes)
-			pageOutCount++
-			logutil.Trace(fmt.Sprintf("page out: [%d, %d)", fromOffset, node.endOffset))
-		}
-	}
+	var pageInCount int
 
 	// Rewind each cache to the target offset or free it. When matched
 	// falls within the ancestor's range (same-path case), we rewind
@@ -294,8 +267,8 @@ pageIn:
 		c.activePath[len(c.activePath)-1].lastUsed = time.Now()
 	}
 
-	if pageOutCount > 0 || pageInCount > 0 {
-		slog.Debug("switching cache path", "page_out", pageOutCount, "page_in", pageInCount)
+	if pageInCount > 0 {
+		slog.Debug("switching cache path", "page_in", pageInCount)
 	}
 }
 
@@ -510,6 +483,24 @@ func (c *prefixCache) advancePath(frontier *trieNode, tokens []trieKey, endOffse
 	return dest
 }
 
+// pageOut captures a fresh node's state from the live caches, which rest
+// exactly at its end. Nodes reached by traversal already carry snapshots.
+func (c *prefixCache) pageOut(node *trieNode) {
+	if node.hasSnapshots() {
+		return
+	}
+	snaps := make([]cache.Snapshot, len(c.caches))
+	for i, kv := range c.caches {
+		if kv == nil {
+			continue
+		}
+		snaps[i] = kv.Snapshot(node.startOffset())
+	}
+	node.setSnapshots(snaps, &c.pagedOutBytes)
+	logutil.Trace(fmt.Sprintf("page out: [%d, %d)", node.startOffset(), node.endOffset))
+	c.enforceEvictionPolicy()
+}
+
 // freeAll releases all cache layers.
 func (c *prefixCache) freeAll() {
 	for _, kv := range c.caches {
@@ -569,12 +560,13 @@ func (s *cacheSession) close() {
 		panic(fmt.Sprintf("cache: offset %d exceeds %d stored keys", offset, len(stored)))
 	}
 
-	// Advance the trie frontier with any newly generated tokens.
+	// Advance the trie frontier with any newly generated tokens and page
+	// the new segment out.
 	if len(c.activePath) > 0 {
 		frontier := c.activePath[len(c.activePath)-1]
 		if offset > frontier.endOffset {
 			newTokens := stored[frontier.endOffset:offset]
-			c.advancePath(frontier, newTokens, offset)
+			c.pageOut(c.advancePath(frontier, newTokens, offset))
 		}
 		c.activePath[len(c.activePath)-1].lastUsed = time.Now()
 	}

--- a/x/mlxrunner/prefix_cache.go
+++ b/x/mlxrunner/prefix_cache.go
@@ -63,7 +63,7 @@ type cacheSession struct {
 
 	// pendingSnapshots lists offsets where snapshots should be captured
 	// during prefill, sorted by offset. Entries are scheduled on the caches
-	// before prefill and drained or discarded after.
+	// before prefill and drained when the captures are attached.
 	pendingSnapshots []pendingSnapshot
 }
 
@@ -326,29 +326,6 @@ func (s *cacheSession) schedulePrefillSnapshots(offsets []int) {
 	}
 }
 
-// discardPrefillSnapshots drains and closes the snapshots scheduled by
-// schedulePrefillSnapshots without attaching them to the trie, releasing their
-// pinned/lazy state. It is a no-op once attachPrefillSnapshots has drained the
-// schedule, so close can call it unconditionally to clean up an abandoned
-// prefill.
-func (s *cacheSession) discardPrefillSnapshots() {
-	if len(s.pendingSnapshots) == 0 {
-		return
-	}
-	s.pendingSnapshots = nil
-
-	for _, kv := range s.cache.caches {
-		if kv == nil {
-			continue
-		}
-		for _, snap := range kv.TakeSnapshots() {
-			if snap != nil {
-				snap.Close()
-			}
-		}
-	}
-}
-
 // attachPrefillSnapshots collects the snapshots captured during prefill and
 // attaches them to the trie, materializing a node at each requested offset.
 // Pending offsets are ascending and were scheduled in the same order, so the
@@ -538,13 +515,10 @@ func (c *prefixCache) minCacheOffset() int {
 
 // close saves the token state if the forward pass ran.
 func (s *cacheSession) close() {
-	// Release any prefill snapshots the session scheduled but never attached to
-	// the trie. A successful prefill drains them in attachPrefillSnapshots (so
-	// this is a no-op then); an abandoned one (e.g. cancellation between
-	// schedule and attach) leaves them in the caches, where the next request's
-	// PrepareSnapshots would overwrite the schedule without closing them,
-	// leaking the pinned/lazy snapshots and their VRAM.
-	s.discardPrefillSnapshots()
+	// A cancelled prefill never reaches the success-path attach; attaching
+	// here keeps its crossed captures for the retry and drains the schedule
+	// PrepareSnapshots would otherwise overwrite, leaking them.
+	s.attachPrefillSnapshots()
 
 	offset := s.cache.minCacheOffset()
 	if offset <= 0 {

--- a/x/mlxrunner/prefix_cache.go
+++ b/x/mlxrunner/prefix_cache.go
@@ -441,9 +441,31 @@ func (s *cacheSession) attachPrefillSnapshots() {
 // whose offset the live cache has already advanced past: the snapshots come
 // from the capture scheduled earlier, not from the cache's current state. The
 // node takes ownership of the snapshots (TakeSnapshots already transferred it).
+// Each capture is clipped to the node's edge, and a layer that already has a
+// snapshot keeps it.
 func (s *cacheSession) attachCapturedSnapshots(node *trieNode, snaps []cache.Snapshot) {
 	c := s.cache
-	node.setSnapshots(snaps, &c.pagedOutBytes)
+	next := make([]cache.Snapshot, len(c.caches))
+	copy(next, node.snapshots)
+	for i, kv := range c.caches {
+		if kv == nil || i >= len(snaps) || snaps[i] == nil {
+			continue
+		}
+		if next[i] != nil {
+			snaps[i].Close()
+			continue
+		}
+		head, tail := kv.Split(snaps[i], node.startOffset())
+		if head != nil {
+			head.Close()
+		}
+		next[i] = tail
+	}
+	for i, old := range node.swapSnapshots(next, &c.pagedOutBytes) {
+		if old != nil && old != next[i] {
+			old.Close()
+		}
+	}
 	node.lastUsed = time.Now()
 	slog.Debug("created snapshot", "offset", node.endOffset)
 	c.enforceEvictionPolicy()

--- a/x/mlxrunner/prefix_cache.go
+++ b/x/mlxrunner/prefix_cache.go
@@ -7,7 +7,9 @@
 //   - Only one path through the trie is "active" (backed by live MLX arrays)
 //     at a time. Switching paths pages in the new path from its snapshots.
 //   - Every node carries its snapshots from creation: prefill captures for
-//     prompt segments, a page-out at close for generated ones.
+//     prompt segments, a page-out at close for generated ones. Sliceable
+//     (KV) layers always span exactly the node's edge; whole-state layers
+//     (recurrent, rotating) keep entries only at node ends.
 //   - All cache layers must stay at the same token offset.
 //   - Sibling edges must not share a common token prefix (compressed trie
 //     invariant).
@@ -406,7 +408,9 @@ func (s *cacheSession) attachPrefillSnapshots() {
 			frontier.user = true
 		}
 		s.attachCapturedSnapshots(frontier, rows[i])
+		c.compactPath()
 	}
+	c.enforceEvictionPolicy()
 }
 
 // attachCapturedSnapshots stores pre-captured snapshots on a trie node. Unlike
@@ -441,12 +445,11 @@ func (s *cacheSession) attachCapturedSnapshots(node *trieNode, snaps []cache.Sna
 	}
 	node.lastUsed = time.Now()
 	slog.Debug("created snapshot", "offset", node.endOffset)
-	c.enforceEvictionPolicy()
 }
 
 // advancePath advances the active path from the current frontier by matching
 // tokens against existing trie children, splitting partial matches, and
-// appending any remaining tokens as new nodes. Returns the new frontier.
+// appending any remaining tokens as a new child node. Returns the new frontier.
 func (c *prefixCache) advancePath(frontier *trieNode, tokens []trieKey, endOffset int) *trieNode {
 	// Check if existing children already cover some or all of tokens.
 	// tokens may span multiple trie nodes when extending a previous run's
@@ -469,18 +472,26 @@ func (c *prefixCache) advancePath(frontier *trieNode, tokens []trieKey, endOffse
 	dest := matchPath[len(matchPath)-1]
 
 	if len(remaining) > 0 {
-		// Drop non-user snapshots so appendTokens can extend in-place
-		// rather than creating a new child node.
-		if len(dest.children) == 0 && !dest.user {
-			dest.setSnapshots(nil, &c.pagedOutBytes)
-		}
-		newDest := dest.appendTokens(c.root, remaining, endOffset)
-		if newDest != dest {
-			c.activePath = append(c.activePath, newDest)
-		}
-		dest = newDest
+		dest = dest.appendChild(remaining, endOffset)
+		c.activePath = append(c.activePath, dest)
 	}
 	return dest
+}
+
+// compactPath absorbs the active path's last node into its parent when the
+// parent is a non-user node with no other children, keeping consecutive
+// non-user segments compressed into one node.
+func (c *prefixCache) compactPath() {
+	n := len(c.activePath)
+	if n < 2 {
+		return
+	}
+	parent := c.activePath[n-2]
+	if parent == c.root || parent.user || len(parent.children) != 1 {
+		return
+	}
+	mergeWithChild(parent, c.caches, &c.pagedOutBytes)
+	c.activePath = c.activePath[:n-1]
 }
 
 // pageOut captures a fresh node's state from the live caches, which rest
@@ -561,12 +572,14 @@ func (s *cacheSession) close() {
 	}
 
 	// Advance the trie frontier with any newly generated tokens and page
-	// the new segment out.
+	// the new segment out. Merging after the page-out combines covered
+	// snapshots.
 	if len(c.activePath) > 0 {
 		frontier := c.activePath[len(c.activePath)-1]
 		if offset > frontier.endOffset {
 			newTokens := stored[frontier.endOffset:offset]
 			c.pageOut(c.advancePath(frontier, newTokens, offset))
+			c.compactPath()
 		}
 		c.activePath[len(c.activePath)-1].lastUsed = time.Now()
 	}

--- a/x/mlxrunner/prefix_cache_scenario_test.go
+++ b/x/mlxrunner/prefix_cache_scenario_test.go
@@ -1,0 +1,267 @@
+package mlxrunner
+
+import (
+	"bytes"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/x/mlxrunner/cache"
+)
+
+// Scenario tests drive prefixCache through multi-request timelines on the
+// production cache layout of a hybrid model with MTP speculation: interleaved
+// recurrent (GDN) and rewindable (attention KV) target layers plus a draft KV
+// cache with one token of look-ahead. They verify the cache lifecycle
+// invariants: a request extending the active conversation resumes exactly, a
+// request diverging below the frontier restores to within the capture cadence
+// of its match, and every stored snapshot spans exactly its node's edge.
+
+// The capture cadence of the scenario prompts: a snapshot every interval
+// tokens plus one preThinking tokens before each prompt's end.
+const (
+	interval    = 8
+	preThinking = 4
+)
+
+// restoreBound is how far a restore may trail its match. Captures land every
+// interval tokens and preThinking tokens before a prompt's end, shifted back
+// by the draft look-ahead, and the tokens generated or dropped since the last
+// prompt have no user capture of their own.
+func (e *hybridEnv) restoreBound(prevGen, dropped int) int {
+	return interval + preThinking + e.pc.draftLookahead + prevGen + dropped
+}
+
+// captureWarns redirects slog to a buffer for the duration of the test and
+// returns a func that reports captured output.
+func captureWarns(t *testing.T) func() string {
+	t.Helper()
+	var buf bytes.Buffer
+	old := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelDebug})))
+	t.Cleanup(func() { slog.SetDefault(old) })
+	return func() string { return buf.String() }
+}
+
+// hybridEnv mirrors the production layout for a hybrid model with MTP:
+// interleaved recurrent (GDN) and rewindable (attention KV) target layers,
+// then the draft KV cache last, with draftLookahead=1.
+type hybridEnv struct {
+	pc    *prefixCache
+	draft *fakeRewindableCache
+}
+
+func newHybridEnv() *hybridEnv {
+	tr := &snapshotTracker{}
+	targets := []cache.Cache{
+		&fakeRecurrentCache{tracker: tr},
+		&fakeRewindableCache{tracker: tr},
+		&fakeRecurrentCache{tracker: tr},
+		&fakeRewindableCache{tracker: tr},
+	}
+	draft := &fakeRewindableCache{tracker: tr}
+	pc := &prefixCache{caches: append(targets, draft)}
+	pc.draftLookahead = 1
+	return &hybridEnv{pc: pc, draft: draft}
+}
+
+// kvLayers returns the cache indices whose snapshots are position-sliceable.
+func (e *hybridEnv) kvLayers() []int {
+	var layers []int
+	for i, c := range e.pc.caches {
+		if _, ok := c.(*fakeRewindableCache); ok {
+			layers = append(layers, i)
+		}
+	}
+	return layers
+}
+
+// tokenStream hands out distinct tokens so prompts never collide by accident.
+type tokenStream struct{ next int32 }
+
+func (ts *tokenStream) fresh(n int) []int32 {
+	out := make([]int32, n)
+	for i := range out {
+		ts.next++
+		out[i] = ts.next
+	}
+	return out
+}
+
+// periodic returns the scenario capture schedule for a prompt: every interval
+// tokens, plus one preThinking tokens before the end.
+func periodic(promptLen int) []int {
+	var offs []int
+	for o := interval; o < promptLen; o += interval {
+		offs = append(offs, o)
+	}
+	if end := promptLen - preThinking; end > 0 {
+		offs = append(offs, end)
+	}
+	return offs
+}
+
+// parseBeginLine extracts the counters from a begin log line. ok is false for
+// any other line.
+func parseBeginLine(line string) (total, matched, cached, left int, ok bool) {
+	if !strings.Contains(line, "cache hit") && !strings.Contains(line, "cache miss") {
+		return 0, 0, 0, 0, false
+	}
+	for _, f := range strings.Fields(line) {
+		fmt.Sscanf(f, "total=%d", &total)
+		fmt.Sscanf(f, "matched=%d", &matched)
+		fmt.Sscanf(f, "cached=%d", &cached)
+		fmt.Sscanf(f, "left=%d", &left)
+	}
+	return total, matched, cached, left, true
+}
+
+// beginLog scans the captured log for begin lines, one call per request.
+type beginLog struct {
+	t    *testing.T
+	logs func() string
+	mark int
+}
+
+// next returns the counters of the begin line logged since the previous call.
+func (b *beginLog) next() (total, matched, cached, left int) {
+	b.t.Helper()
+	out := b.logs()
+	seg := out[b.mark:]
+	b.mark = len(out)
+	for _, l := range strings.Split(seg, "\n") {
+		if total, matched, cached, left, ok := parseBeginLine(l); ok {
+			return total, matched, cached, left
+		}
+	}
+	b.t.Fatalf("no begin line in:\n%s", seg)
+	return 0, 0, 0, 0
+}
+
+// runRequest mirrors the production pipeline for a successful request:
+// begin -> schedule periodic snapshots -> prefill all but the last prompt
+// token -> attach -> decode generated tokens (all caches level, last token
+// unforwarded) -> close.
+func (e *hybridEnv) runRequest(t *testing.T, inputs, generated []int32) *cacheSession {
+	t.Helper()
+	pc := e.pc
+	session := pc.begin(inputs, nil)
+
+	session.schedulePrefillSnapshots(periodic(len(inputs)))
+	base := pc.minCacheOffset()
+	seed := len(inputs) - 1
+	if base < seed {
+		feedAll(pc.caches, inputs[base:seed])
+	}
+	session.attachPrefillSnapshots()
+
+	if len(generated) > 0 {
+		session.outputs = generated
+		feedAll(pc.caches, inputs[seed:])
+		feedAll(pc.caches, generated[:len(generated)-1])
+	}
+	session.close()
+	return session
+}
+
+// checkSnapshotCoverage asserts the snapshot invariant over the trie: every
+// node carries a snapshot for each position-sliceable (KV) layer, spanning
+// exactly its edge.
+func checkSnapshotCoverage(t *testing.T, pc *prefixCache, kvLayers []int) {
+	t.Helper()
+	walkNodes(pc.root, func(n *trieNode) bool {
+		if n.endOffset == n.startOffset() { // root has an empty edge
+			return true
+		}
+		for _, layer := range kvLayers {
+			var snap *fakeSnapshot
+			if layer < len(n.snapshots) && n.snapshots[layer] != nil {
+				snap = n.snapshots[layer].(*fakeSnapshot)
+			}
+			if snap == nil {
+				t.Errorf("node [%d,%d) layer %d has no snapshot", n.startOffset(), n.endOffset, layer)
+				continue
+			}
+			if snap.from != n.startOffset() || snap.to != n.endOffset {
+				t.Errorf("node [%d,%d) layer %d snapshot [%d,%d) does not span the edge", n.startOffset(), n.endOffset, layer, snap.from, snap.to)
+			}
+		}
+		return true
+	})
+}
+
+// TestScenarioConversationTurns advances a conversation turn by turn. A turn
+// keeping the whole previous response extends the frontier and must resume
+// exactly; a turn dropping part of it diverges below the frontier and must
+// restore to within the capture cadence of its match; and a switch to an
+// unrelated session must not cost the conversation more than that same bound
+// when the next turn returns to it.
+func TestScenarioConversationTurns(t *testing.T) {
+	logs := captureWarns(t)
+	e := newHybridEnv()
+	ts := &tokenStream{}
+	begins := &beginLog{t: t, logs: logs}
+
+	type turn struct {
+		keepGen int // previous generation kept in the prompt (-1 = all)
+		newTail int
+		genLen  int
+		away    bool // an unrelated session runs before this turn
+	}
+	turns := []turn{
+		{keepGen: 3, newTail: 9, genLen: 6},
+		{keepGen: -1, newTail: 4, genLen: 5},
+		{keepGen: 4, newTail: 6, genLen: 7},
+		{keepGen: -1, newTail: 5, genLen: 6},
+		{keepGen: 5, newTail: 8, genLen: 8},
+		{keepGen: 4, newTail: 7, genLen: 6, away: true},
+		{keepGen: -1, newTail: 6, genLen: 7},
+		{keepGen: 3, newTail: 8, genLen: 6},
+		{keepGen: -1, newTail: 5, genLen: 5},
+		{keepGen: 4, newTail: 9, genLen: 6},
+	}
+
+	prompt := ts.fresh(50)
+	gen := ts.fresh(6)
+	e.runRequest(t, prompt, gen)
+	begins.next()
+	stream := prompt // committed conversation, minus the latest response
+	lastGen := gen   // latest response
+
+	for i, tn := range turns {
+		if tn.away {
+			e.runRequest(t, ts.fresh(24), ts.fresh(4))
+			begins.next()
+		}
+
+		dropped := 0
+		var p []int32
+		if tn.keepGen < 0 {
+			p = slices.Concat(stream, lastGen, ts.fresh(tn.newTail))
+		} else {
+			dropped = len(lastGen) - tn.keepGen
+			p = slices.Concat(stream, slices.Clone(lastGen[:tn.keepGen]), ts.fresh(tn.newTail))
+		}
+		bound := e.restoreBound(len(lastGen), dropped)
+		g := ts.fresh(tn.genLen)
+		e.runRequest(t, p, g)
+
+		_, matched, cached, _ := begins.next()
+		if dropped == 0 && !tn.away && cached != matched {
+			t.Errorf("turn %d: extension resumed cached=%d != matched=%d", i, cached, matched)
+		}
+		if cached < matched-bound {
+			t.Errorf("turn %d: cached=%d fell more than %d below matched=%d", i, cached, bound, matched)
+		}
+
+		stream = p
+		lastGen = g
+	}
+
+	if out := logs(); strings.Contains(out, "failed to restore cache") {
+		t.Errorf("freeAll warn fired:\n%s", out)
+	}
+	checkSnapshotCoverage(t, e.pc, e.kvLayers())
+}

--- a/x/mlxrunner/prefix_cache_scenario_test.go
+++ b/x/mlxrunner/prefix_cache_scenario_test.go
@@ -265,3 +265,126 @@ func TestScenarioConversationTurns(t *testing.T) {
 	}
 	checkSnapshotCoverage(t, e.pc, e.kvLayers())
 }
+
+// runCancelledPrefill mirrors a prefill cancelled by a client timeout at
+// (roughly) cancelAt prompt tokens: begin, schedule, feed whole chunks until
+// cancelAt with the drafter's pairs lagging one token, settle the drafter with
+// the next prompt token, then close, which attaches the crossed captures.
+func (e *hybridEnv) runCancelledPrefill(t *testing.T, inputs []int32, chunk, cancelAt int) {
+	t.Helper()
+	pc := e.pc
+	session := pc.begin(inputs, nil)
+	session.schedulePrefillSnapshots(periodic(len(inputs)))
+
+	pos := pc.minCacheOffset()
+	for pos < cancelAt && pos < len(inputs)-1 {
+		n := min(chunk, len(inputs)-1-pos)
+		for _, c := range pc.caches {
+			if c == cache.Cache(e.draft) {
+				continue
+			}
+			if fc, ok := c.(feedableCache); ok {
+				fc.feed(inputs[pos : pos+n])
+			}
+		}
+		if d := e.draft.Offset(); d < pos+n-1 {
+			e.draft.feed(inputs[d : pos+n-1])
+		}
+		pos += n
+	}
+
+	if d := e.draft.Offset(); d < pos {
+		e.draft.feed(inputs[d:pos])
+	}
+	session.close()
+}
+
+// TestScenarioCancelledPrefills covers the cancellation invariants: a retry
+// of a cancelled prefill resumes exactly where the previous attempt stopped,
+// and the captures the cancelled attempt crossed become restore points.
+func TestScenarioCancelledPrefills(t *testing.T) {
+	logs := captureWarns(t)
+	e := newHybridEnv()
+	ts := &tokenStream{}
+	begins := &beginLog{t: t, logs: logs}
+
+	prompt := ts.fresh(47)
+
+	// Cancelled after two chunks of 9. The prefill crossed the captures
+	// scheduled at interval and 2*interval — key offsets 7 and 15 after the
+	// draft look-ahead shift — and close attached them.
+	e.runCancelledPrefill(t, prompt, 9, 2*9)
+	begins.next()
+
+	// A session diverging inside the cancelled span restores to the deepest
+	// crossed capture: 17 keys match, and the entry at 15 is the closest
+	// restore point below.
+	probe := slices.Concat(slices.Clone(prompt[:18]), ts.fresh(10))
+	pr := e.pc.begin(probe, nil)
+	if _, m, c, _ := begins.next(); m != 17 || c != 15 {
+		t.Errorf("probe into cancelled span: matched=%d cached=%d, want 17/15", m, c)
+	}
+	pr.close()
+
+	// The retry resumes exactly at the 18 tokens the first attempt recorded,
+	// and is cancelled again two chunks deeper.
+	e.runCancelledPrefill(t, prompt, 9, 2*9+2*9)
+	if _, m, c, _ := begins.next(); m != 18 || c != 18 {
+		t.Errorf("first retry: matched=%d cached=%d, want 18/18", m, c)
+	}
+
+	// The final retry resumes at 36 and completes.
+	e.runRequest(t, prompt, ts.fresh(6))
+	if _, m, c, _ := begins.next(); m != 36 || c != 36 {
+		t.Errorf("second retry: matched=%d cached=%d, want 36/36", m, c)
+	}
+
+	if out := logs(); strings.Contains(out, "failed to restore cache") {
+		t.Errorf("freeAll warn fired:\n%s", out)
+	}
+	checkSnapshotCoverage(t, e.pc, e.kvLayers())
+}
+
+// TestScenarioDivergentCancels interleaves cancelled prefills that diverge
+// from a conversation mid-history with completed requests, growing branch
+// points above and below the conversation's capture offsets, then re-requests
+// the full conversation, which must restore to within the capture cadence.
+func TestScenarioDivergentCancels(t *testing.T) {
+	logs := captureWarns(t)
+	e := newHybridEnv()
+	ts := &tokenStream{}
+	begins := &beginLog{t: t, logs: logs}
+
+	prompt := ts.fresh(24)
+	gen := ts.fresh(8)
+	e.runRequest(t, prompt, gen)
+	stream := slices.Concat(prompt, gen)
+	begins.next()
+
+	// A cancelled prefill diverging between the second and third captures.
+	e.runCancelledPrefill(t, slices.Concat(slices.Clone(stream[:2*interval+2]), ts.fresh(20)), 5, 12)
+	begins.next()
+
+	// A completed turn extends the conversation.
+	p2 := slices.Concat(stream, ts.fresh(10))
+	g2 := ts.fresh(4)
+	e.runRequest(t, p2, g2)
+	stream = slices.Concat(p2, g2)
+	begins.next()
+
+	// A cancelled prefill diverging below the first capture.
+	e.runCancelledPrefill(t, slices.Concat(slices.Clone(stream[:interval-2]), ts.fresh(16)), 5, 14)
+	begins.next()
+
+	// Re-requesting the full conversation restores to within the cadence of
+	// the last completed turn.
+	e.runRequest(t, slices.Concat(stream, ts.fresh(12)), ts.fresh(5))
+	if _, m, c, _ := begins.next(); c < m-e.restoreBound(len(g2), 0) {
+		t.Errorf("re-request: cached=%d fell more than %d below matched=%d", c, e.restoreBound(len(g2), 0), m)
+	}
+
+	if out := logs(); strings.Contains(out, "failed to restore cache") {
+		t.Errorf("freeAll warn fired:\n%s", out)
+	}
+	checkSnapshotCoverage(t, e.pc, e.kvLayers())
+}

--- a/x/mlxrunner/prefix_cache_test.go
+++ b/x/mlxrunner/prefix_cache_test.go
@@ -56,12 +56,18 @@ func (p *fakePending) take() []cache.Snapshot {
 func (p *fakePending) feedCapturing(start int, tokens []int32, capture func(from, reached int) cache.Snapshot, advance func([]int32)) {
 	end := start + len(tokens)
 	captureAt := func(reached int) {
+		fired := false
 		for i, o := range p.offsets {
 			if p.captured[i] == nil && o == reached {
 				p.captured[i] = capture(p.base, reached)
+				fired = true
 			}
 		}
-		p.base = reached
+		// The base advances only when a capture fires, mirroring
+		// pendingSnapshots.captureReached.
+		if fired {
+			p.base = reached
+		}
 	}
 
 	if len(p.offsets) == 0 {
@@ -1005,12 +1011,13 @@ func TestSnapshotBeyondPrefillSkipped(t *testing.T) {
 	})
 }
 
-// TestPrefillSnapshotsDiscardedOnCancel mirrors a prefill canceled after the
-// caches captured interior snapshots but before attachPrefillSnapshots ran. The
-// abandoned captures must be released when the session closes; otherwise the
-// next request's PrepareSnapshots overwrites the schedule without closing them,
-// leaking the snapshots (caught by checkSnapshotLeaks in the env cleanup).
-func TestPrefillSnapshotsDiscardedOnCancel(t *testing.T) {
+// TestPrefillSnapshotsKeptOnCancel mirrors a prefill canceled after the caches
+// captured interior snapshots but before the success-path attach ran. Closing
+// the session attaches the crossed captures so a retry can resume from them,
+// and drains the capture schedule; otherwise the next request's
+// PrepareSnapshots would overwrite it without closing the captures, leaking
+// them (caught by checkSnapshotLeaks in the env cleanup).
+func TestPrefillSnapshotsKeptOnCancel(t *testing.T) {
 	forEachEnv(t, func(t *testing.T, env *testEnv) {
 		pc := env.pc
 		inputs := []int32{1, 2, 3, 4, 5}
@@ -1018,12 +1025,17 @@ func TestPrefillSnapshotsDiscardedOnCancel(t *testing.T) {
 		session := pc.begin(inputs, nil)
 		session.schedulePrefillSnapshots([]int{3})
 		// Cross offset 3 so the caches capture it, then close the session as a
-		// canceled prefill would, before the captures are attached to the trie.
+		// canceled prefill would, before the success-path attach.
 		feedAll(pc.caches, inputs[pc.minCacheOffset():3])
 		session.close()
 
+		// The crossed capture becomes a restore point for the retry.
+		if at := 3 - pc.draftLookahead; !nodeExistsAtOffset(pc.root, at) {
+			t.Errorf("no trie node at capture point %d after cancel", at)
+		}
+
 		// A second request re-prepares snapshots on the same caches: if the
-		// discarded ones were not closed, prepare() orphans them here.
+		// pending ones were not drained, prepare() orphans them here.
 		simulateRequest(t, pc, inputs, nil, 5)
 
 		checkTrieInvariants(t, pc.root)

--- a/x/mlxrunner/prefix_cache_test.go
+++ b/x/mlxrunner/prefix_cache_test.go
@@ -1022,15 +1022,6 @@ func TestPrefillSnapshotsDiscardedOnCancel(t *testing.T) {
 		feedAll(pc.caches, inputs[pc.minCacheOffset():3])
 		session.close()
 
-		// close advances the trie over the committed tokens, but the abandoned
-		// captures must not be attached as snapshots to any node.
-		walkNodes(pc.root, func(n *trieNode) bool {
-			if n != pc.root && n.hasSnapshots() {
-				t.Errorf("abandoned capture attached as snapshot at offset %d", n.endOffset)
-			}
-			return true
-		})
-
 		// A second request re-prepares snapshots on the same caches: if the
 		// discarded ones were not closed, prepare() orphans them here.
 		simulateRequest(t, pc, inputs, nil, 5)


### PR DESCRIPTION
Agent clients routinely cancel long prefills — their timeouts are shorter
than the minutes a 40k-token prompt takes. On the MLX engine a cancelled
request threw away everything it had computed, so retries restarted from
zero and never outran the timeout, presenting as the model hanging forever.
Worse, a prefill that resumed partway into cached history recorded restore
points that didn't cover what they claimed; on models with recurrent layers
hitting one freed all cache state, and a request matching 46k tokens of a
47k-token prompt reprocessed from zero.

The fix makes restore points trustworthy by construction: every trie node
carries snapshots spanning exactly its edge from the moment it exists.
Generated tokens are paged out when close records them, prompt segments
carry exactly their prefill captures, trie growth never disturbs stored
snapshots, and a cancelled prefill keeps every restore point it crossed so
retries resume where it stopped.

Fixes #17839
