### PR TITLE
docs: fix typo in runner README

### DIFF
--- a/runner/README.md
+++ b/runner/README.md
@@ -2,7 +2,7 @@
 
 > Note: this is a work in progress
 
-A minimial runner for loading a model and running inference via a http web server.
+A minimal runner for loading a model and running inference via a http web server.
 
 ```shell
 ./runner -model <model binary>


### PR DESCRIPTION
`minimial` -> `minimal` in `runner/README.md`.

One word, docs only

AI usage disclosure: I used Claude to run a spell check over the repository's markdown. I checked it myself & I am responsible for it