### PR TITLE
launch: accept Claude context window suffix

### DIFF
--- a/cmd/launch/claude.go
+++ b/cmd/launch/claude.go
@@ -17,6 +17,13 @@ type Claude struct{}
 
 func (c *Claude) String() string { return "Claude Code" }
 
+func (c *Claude) readinessModel(model string) string {
+	if base, ok := strings.CutSuffix(model, "[1m]"); ok && base != "" {
+		return base
+	}
+	return model
+}
+
 func (c *Claude) args(model string, extra []string) []string {
 	var args []string
 	if model != "" {

--- a/cmd/launch/claude_test.go
+++ b/cmd/launch/claude_test.go
@@ -26,6 +26,32 @@ func TestClaudeIntegration(t *testing.T) {
 	})
 }
 
+func TestClaudeReadinessModel(t *testing.T) {
+	c := &Claude{}
+
+	tests := []struct {
+		name  string
+		model string
+		want  string
+	}{
+		{name: "cloud model", model: "deepseek-v4-flash:0731-cloud[1m]", want: "deepseek-v4-flash:0731-cloud"},
+		{name: "local model", model: "gemma4[1m]", want: "gemma4"},
+		{name: "ordinary model", model: "gemma4", want: "gemma4"},
+		{name: "empty base", model: "[1m]", want: "[1m]"},
+		{name: "different suffix", model: "gemma4[200k]", want: "gemma4[200k]"},
+		{name: "case differs", model: "gemma4[1M]", want: "gemma4[1M]"},
+		{name: "suffix is not terminal", model: "gemma4[1m]-custom", want: "gemma4[1m]-custom"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := c.readinessModel(tt.model); got != tt.want {
+				t.Errorf("readinessModel(%q) = %q, want %q", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestClaudeFindPath(t *testing.T) {
 	c := &Claude{}
 
@@ -318,6 +344,7 @@ func TestClaudeArgs(t *testing.T) {
 		want  []string
 	}{
 		{"with model", "llama3.2", nil, []string{"--model", "llama3.2"}},
+		{"preserves context suffix", "gemma4[1m]", nil, []string{"--model", "gemma4[1m]"}},
 		{"empty model", "", nil, nil},
 		{"with model and verbose", "llama3.2", []string{"--verbose"}, []string{"--model", "llama3.2", "--verbose"}},
 		{"empty model with help", "", []string{"--help"}, []string{"--help"}},

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -145,6 +145,17 @@ type Runner interface {
 	String() string
 }
 
+type readinessModelResolver interface {
+	readinessModel(model string) string
+}
+
+func modelForReadiness(runner Runner, model string) string {
+	if resolver, ok := runner.(readinessModelResolver); ok {
+		return resolver.readinessModel(model)
+	}
+	return model
+}
+
 // Editor can edit config files for integrations that support model configuration.
 type Editor interface {
 	Paths() []string
@@ -969,7 +980,7 @@ func (c *launcherClient) resolveSingleIntegrationTarget(ctx context.Context, nam
 		usable := skipReadiness && target != ""
 		if !skipReadiness {
 			var err error
-			usable, err = c.savedModelUsable(ctx, target)
+			usable, err = c.savedModelUsable(ctx, modelForReadiness(runner, target))
 			if err != nil {
 				return "", false, err
 			}
@@ -986,7 +997,8 @@ func (c *launcherClient) resolveSingleIntegrationTarget(ctx context.Context, nam
 		}
 		target = selected
 	} else if !skipReadiness {
-		if err := c.ensureModelsReadyFor(ctx, []string{target}, runner.String(), name); err != nil {
+		readinessModel := modelForReadiness(runner, target)
+		if err := c.ensureModelsReadyFor(ctx, []string{readinessModel}, runner.String(), name); err != nil {
 			if !errors.Is(err, errDeprecatedLaunchModelDeclined) {
 				return "", false, err
 			}

--- a/cmd/launch/launch_test.go
+++ b/cmd/launch/launch_test.go
@@ -3615,6 +3615,121 @@ func TestLaunchIntegration_ClaudeModelOverrideSkipsSelector(t *testing.T) {
 	}
 }
 
+func TestLaunchIntegration_ClaudeContextSuffixUsesBaseModelForReadiness(t *testing.T) {
+	tmpDir := t.TempDir()
+	setLaunchTestHome(t, tmpDir)
+	withLauncherHooks(t)
+	withInteractiveSession(t, false)
+
+	binDir := t.TempDir()
+	writeFakeBinary(t, binDir, "claude")
+	t.Setenv("PATH", binDir)
+
+	DefaultConfirmPrompt = func(string, ConfirmOptions) (bool, error) {
+		return false, nil
+	}
+
+	var shownModel string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/show" {
+			http.NotFound(w, r)
+			return
+		}
+
+		var req apiShowRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Fatalf("failed to decode show request: %v", err)
+		}
+		shownModel = req.Model
+		if req.Model != "deepseek-v4-flash:0731-cloud" {
+			w.WriteHeader(http.StatusBadRequest)
+			fmt.Fprint(w, `{"error":"invalid model name"}`)
+			return
+		}
+		fmt.Fprint(w, `{"model":"deepseek-v4-flash:0731-cloud","remote_model":"deepseek-v4-flash:0731"}`)
+	}))
+	defer srv.Close()
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	const model = "deepseek-v4-flash:0731-cloud[1m]"
+	if err := LaunchIntegration(context.Background(), IntegrationLaunchRequest{
+		Name:          "claude",
+		ModelOverride: model,
+		ConfigureOnly: true,
+	}); err != nil {
+		t.Fatalf("LaunchIntegration returned error: %v", err)
+	}
+	if shownModel != "deepseek-v4-flash:0731-cloud" {
+		t.Fatalf("readiness model = %q, want deepseek-v4-flash:0731-cloud", shownModel)
+	}
+
+	saved, err := config.LoadIntegration("claude")
+	if err != nil {
+		t.Fatalf("failed to reload saved config: %v", err)
+	}
+	if saved.Models[0] != model {
+		t.Fatalf("saved model = %q, want %q", saved.Models[0], model)
+	}
+}
+
+func TestLaunchIntegration_ClaudeSavedContextSuffixUsesBaseModelForReadiness(t *testing.T) {
+	tmpDir := t.TempDir()
+	setLaunchTestHome(t, tmpDir)
+	withLauncherHooks(t)
+	withInteractiveSession(t, false)
+
+	const model = "gemma4[1m]"
+	if err := config.SaveIntegration("claude", []string{model}); err != nil {
+		t.Fatalf("failed to seed saved config: %v", err)
+	}
+
+	DefaultConfirmPrompt = func(string, ConfirmOptions) (bool, error) {
+		return false, nil
+	}
+
+	var shownModel string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/tags":
+			fmt.Fprint(w, `{"models":[{"name":"gemma4"}]}`)
+		case "/api/show":
+			var req apiShowRequest
+			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+				t.Fatalf("failed to decode show request: %v", err)
+			}
+			shownModel = req.Model
+			if req.Model != "gemma4" {
+				w.WriteHeader(http.StatusBadRequest)
+				fmt.Fprint(w, `{"error":"invalid model name"}`)
+				return
+			}
+			fmt.Fprint(w, `{"model":"gemma4"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+	t.Setenv("OLLAMA_HOST", srv.URL)
+
+	if err := LaunchIntegration(context.Background(), IntegrationLaunchRequest{
+		Name:          "claude",
+		ConfigureOnly: true,
+	}); err != nil {
+		t.Fatalf("LaunchIntegration returned error: %v", err)
+	}
+	if shownModel != "gemma4" {
+		t.Fatalf("readiness model = %q, want gemma4", shownModel)
+	}
+
+	saved, err := config.LoadIntegration("claude")
+	if err != nil {
+		t.Fatalf("failed to reload saved config: %v", err)
+	}
+	if saved.Models[0] != model {
+		t.Fatalf("saved model = %q, want %q", saved.Models[0], model)
+	}
+}
+
 func TestLaunchIntegration_ClaudeModelOverrideDeprecatedDeclineOpensPicker(t *testing.T) {
 	tmpDir := t.TempDir()
 	setLaunchTestHome(t, tmpDir)


### PR DESCRIPTION
Fixes #17584

## Summary

Claude Code's terminal `[1m]` model suffix selects its one-million-token context window, but the suffix is not part of the underlying Ollama model name. The launcher's readiness path passed the full selector to `/api/show`, so Ollama rejected it as an invalid model name before Claude could start.

## Fix

- remove only a non-empty, terminal, lowercase `[1m]` suffix for Claude readiness checks
- preserve the original selector in saved configuration and in `claude --model`
- leave ordinary model names, other suffixes, non-terminal suffixes, and every other launcher unchanged

The resolver is an unexported, optional launcher seam, so the behavior change is confined to Claude. Compared with the author-closed #17623, this keeps the API internal and adds explicit edge-case and preservation coverage.

## Tests

The regression test failed on unmodified `main` with `invalid model name` after the mock `/api/show` endpoint received the suffixed selector.

Passing after the fix:

- `go test ./cmd/launch -run "^TestClaude(ReadinessModel|Args)$|^TestLaunchIntegration_Claude(ContextSuffix|SavedContextSuffix)UsesBaseModelForReadiness$" -count=1`
- `go test -race ./cmd/launch -run "^TestClaude(ReadinessModel|Args)$|^TestLaunchIntegration_Claude(ContextSuffix|SavedContextSuffix)UsesBaseModelForReadiness$" -count=1`
- `go test ./cmd/launch -count=1`
- `go vet ./cmd/launch`
- `npm ci && npm run build` in `app/ui/app`
- `go test -count=1 ./app/ui ./app/cmd/app`
- `git diff --check`

The full Windows `go test -count=1 -benchtime=1x ./...` run passed the changed `cmd/launch` package and the rest of the suite except two unrelated one-second timing tests under parallel load. Both failing tests pass immediately in isolation:

- `go test -count=1 ./app/server -run '^TestGetInferenceInfo$'`
- `go test -count=1 ./server -run '^TestDownloadChunkReturnsWhenTransferCompletes$'`

No model download, Ollama server, external API, or paid service is required by the new tests.