### PR TITLE
llm: strip stray LLAMA_API_KEY from llama-server subprocess env

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -445,6 +445,20 @@ func startLlamaServer(launch llamaServerLaunchConfig, out io.Writer) (cmd *exec.
 func SetupLlamaServerCommandEnv(cmd *exec.Cmd, exe string, gpuLibs []string, extraEnvs map[string]string) {
 	cmd.Env = os.Environ()
 
+	// Ollama's llama-server subprocess is always a private, localhost-only
+	// child process — Ollama itself never sends an Authorization header to
+	// it (see tokenize/detokenize/completion calls in this file). If the
+	// host environment happens to carry a stray LLAMA_API_KEY (e.g. left
+	// over from an unrelated llama.cpp install), llama-server picks it up
+	// and starts requiring bearer-token auth on every request, so Ollama's
+	// own unauthenticated internal calls fail with 401 "Invalid API Key".
+	// Drop it unconditionally so a variable meant for some other tool can't
+	// leak in and break the subprocess Ollama itself manages.
+	cmd.Env = slices.DeleteFunc(cmd.Env, func(kv string) bool {
+		key, _, ok := strings.Cut(kv, "=")
+		return ok && strings.EqualFold(key, "LLAMA_API_KEY")
+	})
+
 	envUpdates := make(map[string]string, len(extraEnvs)+2)
 	for k, v := range extraEnvs {
 		envUpdates[k] = v

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -1363,6 +1363,32 @@ func TestSetupLlamaServerCommandEnv(t *testing.T) {
 	}
 }
 
+func TestSetupLlamaServerCommandEnvStripsLlamaAPIKey(t *testing.T) {
+	exeDir := t.TempDir()
+	exe := filepath.Join(exeDir, "llama-server")
+	if err := os.WriteFile(exe, nil, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// A stray LLAMA_API_KEY in the parent environment (e.g. left over from
+	// an unrelated llama.cpp install) must not reach the llama-server
+	// subprocess: Ollama's own internal calls to it never send an
+	// Authorization header, so llama-server would reject them with 401 if
+	// it picked up an API key and started requiring auth.
+	t.Setenv("LLAMA_API_KEY", "stray-value-from-another-tool")
+	t.Setenv("llama_api_key", "should-also-be-stripped-case-insensitively")
+
+	cmd := exec.Command("echo")
+	SetupLlamaServerCommandEnv(cmd, exe, nil, nil)
+
+	for _, kv := range cmd.Env {
+		key, _, ok := strings.Cut(kv, "=")
+		if ok && strings.EqualFold(key, "LLAMA_API_KEY") {
+			t.Fatalf("cmd.Env contains %q, want LLAMA_API_KEY stripped", kv)
+		}
+	}
+}
+
 func TestFilteredEnvLogValue(t *testing.T) {
 	attrs := filteredEnv([]string{
 		"OLLAMA_DEBUG=1",


### PR DESCRIPTION
## Summary

Fixes #17822.

`SetupLlamaServerCommandEnv` passes the entire parent environment through to the `llama-server` subprocess via `os.Environ()`. If the host happens to have a stray `LLAMA_API_KEY` set (e.g. left over from an unrelated llama.cpp install, as reported in the issue), llama-server inherits it and starts requiring bearer-token auth on every request.

The problem is that Ollama's own internal calls to its `llama-server` child (tokenize, detokenize, completion) never send an `Authorization` header — this subprocess is always a private, localhost-only process that Ollama itself manages, not something meant to be independently auth-gated. So once llama-server picks up a stray API key, Ollama's own requests to it start failing with 401, surfacing to users as:

```
tokenize error: {"error":{"message":"Invalid API Key","type":"authentication_error","code":401}}
```

This drops `LLAMA_API_KEY` (case-insensitively) from the subprocess environment unconditionally, so a variable set for some unrelated tool can't leak in and break the llama-server instance Ollama manages.

## Test plan

- [x] Added `TestSetupLlamaServerCommandEnvStripsLlamaAPIKey`, verified it fails without the fix and passes with it
- [x] `go test ./llm/...` — all pass
- [x] `go vet ./llm/...` — clean
- [x] `gofmt -l` on changed files — clean