### PR TITLE
llm: filter per-request llama-server logs unless debug is enabled

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -914,7 +914,9 @@ func NewLlamaServerRunner(
 	}
 
 	gpuLibs := ml.LibraryPaths(gpus)
-	status := NewStatusWriter(os.Stderr)
+	// The filter is the last hop before stderr so the parsers above it still
+	// see llama-server's full output.
+	status := NewStatusWriter(newRunnerLogFilter(os.Stderr))
 
 	// memWriter wraps the status writer and parses buffer size lines from llama-server logs
 	memWriter := &memoryParsingWriter{inner: status}

--- a/llm/log_filter.go
+++ b/llm/log_filter.go
@@ -1,0 +1,211 @@
+package llm
+
+import (
+	"bytes"
+	"io"
+	"log/slog"
+	"regexp"
+	"strings"
+
+	"github.com/ollama/ollama/envconfig"
+)
+
+// runnerLogFilter drops llama-server's routine per-request logging before it
+// reaches Ollama's own log output.
+//
+// llama-server runs at --log-verbosity 4 (TRACE) because the startup
+// memory/offload lines Ollama parses for scheduler accounting are emitted at
+// llama.cpp's INFO level, and the per-request chatter is split across both
+// INFO and TRACE. That means no single verbosity setting both keeps the lines
+// the scheduler needs and drops the noise, so the selection happens here
+// instead.
+//
+// This filter is deliberately the last writer in the chain
+// (memoryParsingWriter -> StatusWriter -> runnerLogFilter -> stderr): every
+// parser upstream still observes the unfiltered stream, so filtering cannot
+// affect memory accounting, offload detection, or captured error text.
+//
+// Suppression is an explicit list of known-routine messages rather than a
+// structural rule. Warnings and errors share the same "slot ... | task N |"
+// shape as the routine lines, and --no-log-prefix strips the level marker, so
+// matching on shape alone could swallow a diagnostic. With an explicit list an
+// unrecognized line always passes through: if a llama.cpp update renames a
+// message the noise returns, which is self-correcting, rather than a warning
+// going missing.
+type runnerLogFilter struct {
+	out io.Writer
+
+	// llama-server prints sampler parameters as a header line followed by an
+	// indented block. When the header is dropped its continuation lines, which
+	// carry no header of their own, are dropped with it.
+	inSamplerParams bool
+}
+
+func newRunnerLogFilter(out io.Writer) *runnerLogFilter {
+	return &runnerLogFilter{out: out}
+}
+
+// slotLineRegex matches llama-server's per-request slot logging, which is
+// formatted as "slot %12s: id %2d | task %d | <message>", and captures the
+// message. The task id is negative for slot bookkeeping that runs between
+// requests.
+var slotLineRegex = regexp.MustCompile(`^slot\s+\S+:\s+id\s+\d+\s+\|\s+task\s+-?\d+\s+\|\s*(.*)$`)
+
+// srvLineRegex matches llama-server's server-scope logging, formatted as
+// "srv  %12s: <message>", and captures the message.
+var srvLineRegex = regexp.MustCompile(`^srv\s+\S+:\s*(.*)$`)
+
+// routineRunnerMessages are llama-server messages emitted once or more per
+// request. Each entry is matched as a prefix of the message body, after the
+// "slot"/"srv" header is stripped and surrounding space is trimmed. The
+// strings are taken from the SLT_INF/SLT_TRC/SRV_TRC call sites in
+// llama.cpp's tools/server/server-context.cpp.
+var routineRunnerMessages = []string{
+	// Slot selection and task lifecycle.
+	"- checking sim =",
+	"- copying state to child",
+	"- skipping, is_processing =",
+	"- skipping, slot is empty",
+	"selected slot by LCP similarity",
+	"selected slot by LRU",
+	"selected slot by id",
+	"launching slots for parent task",
+	"processing task, is_child =",
+	"stop processing:",
+	"all slots are idle",
+
+	// Sampler setup.
+	"sampler chain:",
+	"sampler params:",
+	"init sampler, took",
+
+	// Prompt and KV cache bookkeeping.
+	"new prompt, n_ctx_slot =",
+	"prompt processing, n_tokens =",
+	"cached n_tokens =",
+	"clearing prompt with",
+	"checking checkpoint with",
+	"restored context checkpoint",
+	"erased invalidated context checkpoint",
+	"erasing context checkpoint too close",
+	"forcing full prompt re-processing",
+	"reusing chunk with size",
+	"encoding mtmd batch from idx =",
+	"saving idle slot to prompt cache",
+	"updating prompt cache",
+	"prompt cache update took",
+	"- saving prompt with length",
+
+	// Per-request timings and speculative-decoding stats.
+	"prompt eval time =",
+	"eval time =",
+	"total time =",
+	"graphs reused =",
+	"n_gen =",
+	"accepted",
+	"draft acceptance =",
+	"acc per pos =",
+}
+
+// suppressRunnerLine reports whether a llama-server log line is routine
+// per-request output that should be kept out of Ollama's log.
+func suppressRunnerLine(line string) bool {
+	var body string
+	switch match := slotLineRegex.FindStringSubmatch(line); {
+	case match != nil:
+		body = match[1]
+	default:
+		match = srvLineRegex.FindStringSubmatch(line)
+		if match == nil {
+			return false
+		}
+		body = match[1]
+	}
+
+	// Timing lines are padded for column alignment, so compare against the
+	// trimmed body.
+	body = strings.TrimSpace(body)
+	matched := false
+	for _, msg := range routineRunnerMessages {
+		if strings.HasPrefix(body, msg) {
+			matched = true
+			break
+		}
+	}
+	if !matched {
+		return false
+	}
+
+	// Never drop anything Ollama already recognizes as an error. This reuses
+	// the detection in status.go so error prefixes and out-of-memory messages
+	// survive regardless of which slot or task emitted them.
+	return statusErrorLine(line) == ""
+}
+
+// isSamplerParamsHeader reports whether a line introduces the indented sampler
+// parameter block.
+func isSamplerParamsHeader(line string) bool {
+	match := slotLineRegex.FindStringSubmatch(line)
+	if match == nil {
+		return false
+	}
+	return strings.HasPrefix(strings.TrimSpace(match[1]), "sampler params:")
+}
+
+// Write forwards b to the underlying writer with routine per-request lines
+// removed. Like StatusWriter, it assumes llama-server writes whole lines; a
+// line split across two calls is classified on the fragment it arrives in.
+func (w *runnerLogFilter) Write(b []byte) (int, error) {
+	if w.out == nil {
+		return len(b), nil
+	}
+
+	// OLLAMA_DEBUG asks for everything the runner emits.
+	if envconfig.LogLevel() <= slog.LevelDebug {
+		return w.out.Write(b)
+	}
+
+	var kept bytes.Buffer
+	lastIdx := bytes.Count(b, []byte{'\n'})
+	for i, raw := range bytes.Split(b, []byte{'\n'}) {
+		// The final element after a trailing newline is empty and carries no
+		// line of its own.
+		last := i == lastIdx
+		if last && len(raw) == 0 {
+			continue
+		}
+
+		line := strings.TrimRight(string(raw), " \t\r")
+
+		// Continuation lines of a dropped sampler parameter block are indented
+		// and have no header to match on.
+		if w.inSamplerParams {
+			if line == "" || strings.HasPrefix(line, " ") || strings.HasPrefix(line, "\t") {
+				continue
+			}
+			w.inSamplerParams = false
+		}
+
+		if suppressRunnerLine(line) {
+			if isSamplerParamsHeader(line) {
+				w.inSamplerParams = true
+			}
+			continue
+		}
+
+		kept.Write(raw)
+		if !last {
+			kept.WriteByte('\n')
+		}
+	}
+
+	if kept.Len() > 0 {
+		if _, err := w.out.Write(kept.Bytes()); err != nil {
+			return 0, err
+		}
+	}
+
+	// Report the full input as written so callers copying into this writer
+	// don't treat suppressed lines as a short write.
+	return len(b), nil
+}

--- a/llm/log_filter_test.go
+++ b/llm/log_filter_test.go
@@ -1,0 +1,261 @@
+package llm
+
+import (
+	"bytes"
+	"io"
+	"maps"
+	"strings"
+	"testing"
+)
+
+// runnerLogSample is the llama-server output reported in ollama/ollama#16897,
+// interleaved with the startup lines Ollama parses for scheduler accounting.
+const runnerLogSample = `using device CUDA0 (NVIDIA GeForce RTX 4060 Ti) (0000:01:00.0) - 15221 MiB free
+load_tensors: offloaded 33/33 layers to GPU
+load_tensors: CUDA0 model buffer size =   852.89 MiB
+load_tensors: CPU_Mapped model buffer size =   308.23 MiB
+llama_context: CUDA0 KV buffer size =  1920.00 MiB
+llama_context: CUDA0 compute buffer size =   378.04 MiB
+slot get_availabl: id  4 | task -1 | selected slot by LCP similarity, sim_best = 1.000 (> 0.100 thold), f_keep = 0.651
+slot launch_slot_: id  4 | task -1 | sampler chain: logits -> penalties -> dist
+slot launch_slot_: id  4 | task -1 | sampler params:
+	repeat_last_n = 64, repeat_penalty = 1.100, frequency_penalty = 0.000
+	top_k = 40, top_p = 1.000, min_p = 0.000, temp = 0.000
+slot launch_slot_: id  4 | task 3794 | processing task, is_child = 0
+slot process_sing: id  0 | task -1 | saving idle slot to prompt cache
+slot update_slots: id  4 | task 3794 | new prompt, n_ctx_slot = 28160, n_keep = 4, task.n_tokens = 69
+slot update_slots: id  4 | task 3794 | restored context checkpoint (pos_min = 0, pos_max = 64, n_tokens = 65)
+slot update_slots: id  4 | task 3794 | cached n_tokens = 64, memory_seq_rm [64, end)
+slot init_sampler: id  4 | task 3794 | init sampler, took 0.04 ms, tokens: text = 69, total = 69
+slot print_timing: id  4 | task 3794 | prompt eval time =      23.60 ms /     5 tokens
+slot print_timing: id  4 | task 3794 |        eval time =     217.72 ms /    38 tokens
+slot print_timing: id  4 | task 3794 |       total time =     241.33 ms /    43 tokens
+slot print_timing: id  4 | task 3794 |    graphs reused =       3750
+slot      release: id  4 | task 3794 | stop processing: n_tokens = 106, truncated = 0
+srv  update_slots: all slots are idle
+`
+
+func filterLog(t *testing.T, in string) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	w := newRunnerLogFilter(&buf)
+	n, err := w.Write([]byte(in))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != len(in) {
+		t.Fatalf("Write reported %d bytes, want %d", n, len(in))
+	}
+	return buf.String()
+}
+
+func TestRunnerLogFilterDropsPerRequestLines(t *testing.T) {
+	got := filterLog(t, runnerLogSample)
+
+	for _, noise := range []string{
+		"selected slot by LCP similarity",
+		"sampler chain:",
+		"sampler params:",
+		"repeat_last_n = 64",
+		"top_k = 40",
+		"processing task, is_child",
+		"saving idle slot to prompt cache",
+		"new prompt, n_ctx_slot",
+		"restored context checkpoint",
+		"cached n_tokens",
+		"init sampler, took",
+		"prompt eval time",
+		"eval time",
+		"total time",
+		"graphs reused",
+		"stop processing",
+		"all slots are idle",
+	} {
+		if strings.Contains(got, noise) {
+			t.Errorf("kept per-request line containing %q\n%s", noise, got)
+		}
+	}
+}
+
+// The scheduler parses these lines out of llama-server's output, so the filter
+// must never remove them.
+func TestRunnerLogFilterKeepsSchedulerLines(t *testing.T) {
+	got := filterLog(t, runnerLogSample)
+
+	for _, want := range []string{
+		"using device CUDA0 (NVIDIA GeForce RTX 4060 Ti) (0000:01:00.0) - 15221 MiB free",
+		"load_tensors: offloaded 33/33 layers to GPU",
+		"load_tensors: CUDA0 model buffer size =   852.89 MiB",
+		"load_tensors: CPU_Mapped model buffer size =   308.23 MiB",
+		"llama_context: CUDA0 KV buffer size =  1920.00 MiB",
+		"llama_context: CUDA0 compute buffer size =   378.04 MiB",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("dropped scheduler line %q\n%s", want, got)
+		}
+	}
+}
+
+func TestRunnerLogFilterKeepsLines(t *testing.T) {
+	tests := []struct {
+		name string
+		log  string
+	}{
+		{
+			name: "error wearing a slot header",
+			log:  "slot update_slots: id  4 | task 12 | error: failed to decode batch\n",
+		},
+		{
+			name: "out of memory wearing a slot header",
+			log:  "slot update_slots: id  4 | task 12 | CUDA error: out of memory\n",
+		},
+		{
+			name: "unrecognized slot message",
+			log:  "slot update_slots: id  4 | task 12 | something new upstream added\n",
+		},
+		{
+			name: "slot warning",
+			log:  "slot update_slots: id  0 | task 5 | slot context shift is disabled\n",
+		},
+		{
+			name: "server startup",
+			log:  "srv          init: initializing, n_slots = 4, n_ctx_slot = 28160\n",
+		},
+		{
+			name: "model load",
+			log:  "srv    load_model: loading model 'qwen3.5:4b'\n",
+		},
+		{
+			name: "assertion",
+			log:  "GGML_ASSERT(buffer) failed\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := filterLog(t, tt.log); got != tt.log {
+				t.Errorf("got %q, want %q", got, tt.log)
+			}
+		})
+	}
+}
+
+func TestRunnerLogFilterDebugKeepsEverything(t *testing.T) {
+	t.Setenv("OLLAMA_DEBUG", "1")
+
+	if got := filterLog(t, runnerLogSample); got != runnerLogSample {
+		t.Errorf("OLLAMA_DEBUG=1 should pass everything through, got:\n%s", got)
+	}
+}
+
+func TestRunnerLogFilterSamplerParamsBlockEndsAtNextHeader(t *testing.T) {
+	const log = `slot launch_slot_: id  4 | task -1 | sampler params:
+	top_k = 40, top_p = 1.000
+llama_context: CUDA0 KV buffer size =  1920.00 MiB
+`
+	got := filterLog(t, log)
+	want := "llama_context: CUDA0 KV buffer size =  1920.00 MiB\n"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// llama-server may emit several lines in one write, and the indented sampler
+// block can arrive in a later call than its header.
+func TestRunnerLogFilterAcrossWrites(t *testing.T) {
+	var buf bytes.Buffer
+	w := newRunnerLogFilter(&buf)
+
+	for _, chunk := range []string{
+		"slot launch_slot_: id  4 | task -1 | sampler params: \n",
+		"\ttop_k = 40, top_p = 1.000\n\tmirostat = 0\n",
+		"load_tensors: offloaded 33/33 layers to GPU\n",
+	} {
+		if _, err := w.Write([]byte(chunk)); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	want := "load_tensors: offloaded 33/33 layers to GPU\n"
+	if got := buf.String(); got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestRunnerLogFilterPreservesPartialLine(t *testing.T) {
+	const log = "load_tensors: offloaded 33/33 layers to GPU"
+	if got := filterLog(t, log); got != log {
+		t.Errorf("got %q, want %q", got, log)
+	}
+}
+
+// The filter sits at the end of the writer chain, so replaying a log through
+// the real chain must parse exactly the same memory values as parsing it with
+// the filter absent.
+func TestRunnerLogFilterDoesNotAffectMemoryAccounting(t *testing.T) {
+	parse := func(out io.Writer) *llamaServerRunner {
+		t.Helper()
+
+		runner := &llamaServerRunner{
+			vramByDevice:     make(map[string]uint64),
+			systemFreeAtLoad: make(map[string]uint64),
+		}
+		w := &memoryParsingWriter{inner: NewStatusWriter(out), runner: runner}
+		if _, err := w.Write([]byte(runnerLogSample)); err != nil {
+			t.Fatal(err)
+		}
+		return runner
+	}
+
+	unfiltered := parse(io.Discard)
+
+	var buf bytes.Buffer
+	filtered := parse(newRunnerLogFilter(&buf))
+
+	if filtered.memTotal != unfiltered.memTotal {
+		t.Errorf("memTotal = %d, want %d", filtered.memTotal, unfiltered.memTotal)
+	}
+	if filtered.memGPU != unfiltered.memGPU {
+		t.Errorf("memGPU = %d, want %d", filtered.memGPU, unfiltered.memGPU)
+	}
+	if filtered.gpuLayers != unfiltered.gpuLayers || filtered.totalLayers != unfiltered.totalLayers {
+		t.Errorf("layers = %d/%d, want %d/%d",
+			filtered.gpuLayers, filtered.totalLayers, unfiltered.gpuLayers, unfiltered.totalLayers)
+	}
+	if !maps.Equal(filtered.vramByDevice, unfiltered.vramByDevice) {
+		t.Errorf("vramByDevice = %v, want %v", filtered.vramByDevice, unfiltered.vramByDevice)
+	}
+	if !maps.Equal(filtered.systemFreeAtLoad, unfiltered.systemFreeAtLoad) {
+		t.Errorf("systemFreeAtLoad = %v, want %v", filtered.systemFreeAtLoad, unfiltered.systemFreeAtLoad)
+	}
+
+	// Guard against the sample silently stopping to exercise the parser.
+	if unfiltered.memTotal == 0 || unfiltered.gpuLayers == 0 || len(unfiltered.vramByDevice) == 0 {
+		t.Fatal("sample log did not exercise the memory parser")
+	}
+	if strings.Contains(buf.String(), "all slots are idle") {
+		t.Error("filter did not run in the chain")
+	}
+}
+
+// The memory parser and error capture run upstream of the filter, so they must
+// still observe suppressed lines.
+func TestStatusWriterSeesSuppressedLines(t *testing.T) {
+	var buf bytes.Buffer
+	status := NewStatusWriter(newRunnerLogFilter(&buf))
+
+	const log = "slot update_slots: id  4 | task 12 | cached n_tokens = 64, memory_seq_rm [64, end)\n" +
+		"slot update_slots: id  4 | task 12 | CUDA error: out of memory\n"
+
+	if _, err := status.Write([]byte(log)); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := status.LastError(); !strings.Contains(got, "CUDA error: out of memory") {
+		t.Errorf("error not captured, got %q", got)
+	}
+	if got := buf.String(); strings.Contains(got, "cached n_tokens") {
+		t.Errorf("routine line reached output: %q", got)
+	}
+}


### PR DESCRIPTION
This PR was written in part with the assistance of generative AI.

Fixes #16897.

`llama-server` is spawned with `--log-verbosity 4` and its stdout/stderr is piped straight into Ollama's stderr, so every request contributes ~20 lines of slot bookkeeping. Two reporters confirmed the impact: journald flooding on Linux, and on macOS a log file that reached **387 MB** growing ~20 MB/day, of which **~95% was this output** — for a workload that only calls `/v1/embeddings`.

### Why the verbosity can't just be lowered

This was tried in #16899 and correctly rejected, because the startup memory/offload lines the scheduler parses are emitted at llama.cpp's INFO level. I checked the call sites at the pinned `LLAMA_CPP_VERSION` (`b10488`) to find out what a lower threshold would actually cost.

From `common/log.h`: `ERROR 1, WARN 2, INFO 3, TRACE 4, DEBUG 5`, emitted when `verbosity <= thold`.

The per-request noise turns out to be **split across two levels** (`tools/server/server-context.cpp`):

| Message | Macro | Level |
|---|---|---|
| `new prompt, n_ctx_slot = …` | `SLT_TRC` | 4 |
| `sampler chain:` / `sampler params:` | `SLT_TRC` | 4 |
| `saving idle slot to prompt cache` | `SLT_TRC` | 4 |
| `init sampler, took …` | `SLT_TRC` | 4 |
| `restored context checkpoint …` | `SLT_TRC` | 4 |
| `cached n_tokens = …` | `SLT_TRC` | 4 |
| `all slots are idle` | `SRV_TRC` | 4 |
| `selected slot by LCP similarity …` | **`SLT_INF`** | **3** |
| `processing task, is_child = …` | **`SLT_INF`** | **3** |
| `stop processing: …` | **`SLT_INF`** | **3** |
| `prompt eval time` / `eval time` / `total time` / `graphs reused` | **`SLT_INF`** | **3** |

So **no single `--log-verbosity` value works**: `3` leaves all the `SLT_INF` per-request lines behind, and `2` silences the INFO-level memory/offload lines the scheduler depends on. `appendLlamaServerLogArgs` is left at 4, unchanged.

### Approach

Filtering happens in the Ollama server, as suggested on the issue, as the **last** writer before stderr:

```
llama-server ─► memoryParsingWriter ─► StatusWriter ─► runnerLogFilter ─► stderr
                (parses mem/offload)   (captures errors)
```

Both existing parsers sit above the filter and still observe the **complete, unmodified** stream. Memory accounting, offload detection, OOM/Metal retry, and `StatusWriter.LastError()` are therefore unaffected by construction — the change only alters what gets written out.

Suppression is an explicit list of known-routine messages rather than a structural rule. `SLT_WRN`/`SLT_ERR` share the identical `slot … | task N |` shape and `--no-log-prefix` strips the level marker, so matching on shape alone could swallow a diagnostic. With an explicit list, an unrecognized line always passes through: if an upstream bump renames a message the noise returns, which is visible and self-correcting, rather than a warning going missing. Lines that `statusErrorLine` already recognizes are never dropped, and `OLLAMA_DEBUG` disables the filter entirely.

### Tests

`llm/log_filter_test.go` replays the log sample from the issue:

- per-request lines are dropped, including the indented `sampler params` continuation block (23 → 6 lines on the sample)
- the parsed lines survive: `using device CUDA0 … MiB free`, `offloaded 33/33 layers to GPU`, `… model buffer size = … MiB`, KV and compute buffers
- errors and warnings survive, including ones wearing a `slot … | task N |` header, and unrecognized slot messages pass through
- `OLLAMA_DEBUG=1` passes everything through
- **`TestRunnerLogFilterDoesNotAffectMemoryAccounting`** replays a log through the real `memoryParsingWriter → StatusWriter → filter` chain and asserts `memTotal`, `memGPU`, layer counts, `vramByDevice` and `systemFreeAtLoad` are identical to parsing with the filter absent — a direct regression test for what #16899 broke

`go test ./llm/`, `go vet`, `gofmt` and `golangci-lint run llm/...` are clean.

I do not have a machine that can run the built runner end to end, so this is verified offline against the real writer chain rather than against a live model; happy to adjust the suppression list if you'd rather it start narrower.

