### PR TITLE
qwen3coder: tolerate a dropped closing tag, and stop rewriting parameter values

### DIFF
--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -422,8 +422,12 @@ func parseTypedToolValue(raw string, paramType api.PropertyType) any {
 }
 
 var (
-	qwenTagRegex    = regexp.MustCompile(`<(\w+)=([^>]+)>`)
-	qwenXMLTagRegex = regexp.MustCompile(`</?(?:function|parameter)(?:\s+name="[^"]*")?>`)
+	// Only `function` and `parameter` are tags in this format, opening with a
+	// value and closing bare. Matching any `<word=value>` rewrote text that
+	// merely looked like a tag, and parameter values are full of it:
+	// `if (a<b=c>d)` came out as `if (a<b name="c">d)`, silently, in the command
+	// a tool was about to run.
+	qwenTagRegex = regexp.MustCompile(`</?(function|parameter)(=[^>]*)?>`)
 
 	qwenFunctionOpenRegex  = regexp.MustCompile(`<function\b[^>]*>`)
 	qwenParameterOpenRegex = regexp.MustCompile(`<parameter\b[^>]*>`)
@@ -501,30 +505,48 @@ func repairToolCallXML(xmlString string) (string, bool) {
 
 // transformToXML transforms a raw qwen tool call with xml-like tags into valid
 // xml so that it can be parsed by any xml parser
+//
+// Only `<function…>` and `<parameter…>` are markup here. Rewriting every
+// `<word=value>` in the block reached into parameter values, which are character
+// data and are allowed to look like markup: `if (a<b=c>d)` arrived at the tool
+// as `if (a<b name="c">d)`, a changed command with nothing said about it.
+//
+// A `<parameter=…>` inside an open parameter is left structural on purpose. It
+// is ambiguous -- either the model forgot `</parameter>` or the value mentions a
+// tag -- and the first is what models actually do under long context, so reading
+// it as a new parameter recovers the call instead of swallowing it into the
+// previous value.
 func transformToXML(raw string) string {
-	// take the form `<tag=abc>` and transform it to `<tag name="abc">`, taking
-	// care to properly escape the string that becomes the attribute value
-	transformed := qwenTagRegex.ReplaceAllStringFunc(raw, func(match string) string {
-		groups := qwenTagRegex.FindStringSubmatch(match)
-		tag := groups[1]
-		var escapedValue strings.Builder
-		_ = xml.EscapeText(&escapedValue, []byte(groups[2])) // error is always nil for strings.Builder
-		return fmt.Sprintf(`<%s name="%s">`, tag, escapedValue.String())
-	})
-
-	// Walk the resulting string, escaping any character data that sits between the
-	// xml tags we just emitted
 	var out strings.Builder
+
 	lastIdx := 0
-	for _, loc := range qwenXMLTagRegex.FindAllStringIndex(transformed, -1) {
-		if loc[0] > lastIdx {
-			escapeTextNode(&out, transformed[lastIdx:loc[0]])
+	for _, loc := range qwenTagRegex.FindAllStringSubmatchIndex(raw, -1) {
+		match := raw[loc[0]:loc[1]]
+		closing := strings.HasPrefix(match, "</")
+		name := raw[loc[2]:loc[3]]
+
+		// An opening tag without a value (`<function>`) is not this format and
+		// never was, so it stays character data.
+		if !closing && loc[4] < 0 {
+			continue
 		}
-		out.WriteString(transformed[loc[0]:loc[1]])
+
+		if loc[0] > lastIdx {
+			escapeTextNode(&out, raw[lastIdx:loc[0]])
+		}
+		if closing {
+			out.WriteString(match)
+		} else {
+			// `<tag=abc>` becomes `<tag name="abc">`, escaping the string that
+			// becomes the attribute value.
+			var escapedValue strings.Builder
+			_ = xml.EscapeText(&escapedValue, []byte(raw[loc[4]+1:loc[5]])) // error is always nil for strings.Builder
+			fmt.Fprintf(&out, `<%s name="%s">`, name, escapedValue.String())
+		}
 		lastIdx = loc[1]
 	}
-	if lastIdx < len(transformed) {
-		escapeTextNode(&out, transformed[lastIdx:])
+	if lastIdx < len(raw) {
+		escapeTextNode(&out, raw[lastIdx:])
 	}
 
 	return out.String()

--- a/model/parsers/qwen3coder.go
+++ b/model/parsers/qwen3coder.go
@@ -68,8 +68,19 @@ func (p *Qwen3CoderParser) Add(s string, done bool) (content string, thinking st
 		case qwenEventRawToolCall:
 			toolCall, err := parseToolCall(event, p.tools)
 			if err != nil {
-				slog.Warn("qwen tool call parsing failed", "error", err)
-				return "", "", nil, err
+				// Returning the error here fails the request, and the caller has
+				// nothing to fail towards: a turn can already have run commands
+				// before the malformed call arrived, so there is no safe automatic
+				// retry, and the user is left pressing Retry by hand
+				// (mann1x/cline#54). The block is the model's own output, so hand it
+				// back as content -- the model then sees what it emitted and can
+				// correct itself on the next turn, which is what the manual retry
+				// was achieving anyway.
+				slog.Warn("qwen tool call parsing failed; returning it as content", "error", err)
+				sb.WriteString(toolOpenTag)
+				sb.WriteString(event.raw)
+				sb.WriteString(toolCloseTag)
+				continue
 			}
 			toolCall.Function.Index = p.callIndex
 			p.callIndex++
@@ -234,7 +245,16 @@ func parseToolCall(raw qwenEventRawToolCall, tools []api.Tool) (api.ToolCall, er
 	var functionCall XMLFunctionCall
 	err := xml.Unmarshal([]byte(xmlString), &functionCall)
 	if err != nil {
-		return api.ToolCall{}, err
+		repaired, ok := repairToolCallXML(xmlString)
+		if !ok {
+			return api.ToolCall{}, err
+		}
+		if repairErr := xml.Unmarshal([]byte(repaired), &functionCall); repairErr != nil {
+			// Report what the model actually produced, not what the repair made
+			// of it -- the first error is the one that describes the defect.
+			return api.ToolCall{}, err
+		}
+		slog.Warn("qwen tool call was missing closing tags; recovered", "error", err)
 	}
 
 	toolCall.Function = api.ToolCallFunction{
@@ -404,7 +424,80 @@ func parseTypedToolValue(raw string, paramType api.PropertyType) any {
 var (
 	qwenTagRegex    = regexp.MustCompile(`<(\w+)=([^>]+)>`)
 	qwenXMLTagRegex = regexp.MustCompile(`</?(?:function|parameter)(?:\s+name="[^"]*")?>`)
+
+	qwenFunctionOpenRegex  = regexp.MustCompile(`<function\b[^>]*>`)
+	qwenParameterOpenRegex = regexp.MustCompile(`<parameter\b[^>]*>`)
 )
+
+// repairToolCallXML closes tags the model left open, so that a dropped closing
+// tag costs a warning rather than the whole request.
+//
+// Under long context the model stops emitting `</parameter>`. Measured on a
+// single agent session (2026-08-21), the same model produced both shapes: a
+// value running into the next tag ("element <parameter> closed by </function>")
+// and a block that closes nothing at all ("unexpected EOF"). Either one fails
+// `Unmarshal`, and the error travels all the way out as a failed request.
+//
+// The repair is possible because parameters do not nest: a value ends where the
+// next tag begins whether or not the model said so. Doing it as a textual
+// repair and re-parsing keeps escaping and attribute decoding in the one place
+// that already does them, rather than growing a second half-parser here.
+//
+// Reports false when there is nothing to repair towards -- without a
+// `<function>` header there is no name, and a call with no name cannot be
+// dispatched to a tool.
+func repairToolCallXML(xmlString string) (string, bool) {
+	header := qwenFunctionOpenRegex.FindStringIndex(xmlString)
+	if header == nil {
+		return "", false
+	}
+
+	var repaired strings.Builder
+	repaired.WriteString(xmlString[:header[1]])
+
+	body := xmlString[header[1]:]
+	opens := qwenParameterOpenRegex.FindAllStringIndex(body, -1)
+	cursor := 0
+	for i, open := range opens {
+		// Anything between the previous parameter and this one is text the model
+		// put outside a parameter; it is not ours to interpret, so it is copied
+		// through untouched.
+		repaired.WriteString(body[cursor:open[1]])
+
+		// The value ends at the first of: its own closing tag, the next
+		// parameter's opening tag, the function's closing tag, or the end of the
+		// block. Only the first of those is the model closing the tag itself.
+		end := len(body)
+		if i+1 < len(opens) {
+			end = opens[i+1][0]
+		}
+		value := body[open[1]:end]
+		for _, terminator := range []string{"</parameter>", "</function>"} {
+			if idx := strings.Index(value, terminator); idx >= 0 {
+				value = value[:idx]
+				end = open[1] + idx
+				// The model's own `</parameter>` is consumed here and re-emitted
+				// below, so that a closed and an unclosed parameter leave the
+				// cursor in the same place; `</function>` is left for the tail.
+				if terminator == "</parameter>" {
+					end += len(terminator)
+				}
+				break
+			}
+		}
+		repaired.WriteString(value)
+		repaired.WriteString("</parameter>")
+		cursor = end
+	}
+
+	rest := body[cursor:]
+	repaired.WriteString(rest)
+	if !strings.Contains(rest, "</function>") {
+		repaired.WriteString("</function>")
+	}
+
+	return repaired.String(), true
+}
 
 // transformToXML transforms a raw qwen tool call with xml-like tags into valid
 // xml so that it can be parsed by any xml parser

--- a/model/parsers/qwen3coder_test.go
+++ b/model/parsers/qwen3coder_test.go
@@ -558,6 +558,39 @@ Hello! 你好! 🌟 مرحبا
 	}
 }
 
+// A parameter's value is character data, not markup. Rewriting `<tag=value>`
+// everywhere in the block reached into values that only looked like tags, and
+// changed them without saying so -- the first case here is a shell command that
+// would have run altered.
+func TestQwenToolCallValuesAreNotRewritten(t *testing.T) {
+	cases := []struct {
+		name  string
+		value string
+	}{
+		{
+			name:  "comparison followed by an assignment",
+			value: `node -e "if (a<b=c>d) console.log(1)"`,
+		},
+		{
+			name:  "text that looks like a tag",
+			value: "const el = <div=foo>;",
+		},
+	}
+
+	for _, tc := range cases {
+		raw := "<function=editor>\n<parameter=new_text>\n" + tc.value + "\n</parameter>\n</function>"
+		gotToolCall, err := parseToolCall(qwenEventRawToolCall{raw: raw}, []api.Tool{})
+		if err != nil {
+			t.Errorf("%s: %v", tc.name, err)
+			continue
+		}
+		got, _ := gotToolCall.Function.Arguments.Get("new_text")
+		if got != tc.value {
+			t.Errorf("%s: got %q, want %q", tc.name, got, tc.value)
+		}
+	}
+}
+
 // A model under long context stops emitting closing tags. All three shapes here
 // were taken from one agent session (2026-08-21), which produced both
 // `element <parameter> closed by </function>` and `unexpected EOF` from the same

--- a/model/parsers/qwen3coder_test.go
+++ b/model/parsers/qwen3coder_test.go
@@ -558,6 +558,96 @@ Hello! 你好! 🌟 مرحبا
 	}
 }
 
+// A model under long context stops emitting closing tags. All three shapes here
+// were taken from one agent session (2026-08-21), which produced both
+// `element <parameter> closed by </function>` and `unexpected EOF` from the same
+// model; the third is the same defect between two parameters. None of them is
+// ambiguous, because parameters do not nest.
+func TestQwenToolCallRecoversMissingClosingTags(t *testing.T) {
+	cases := []struct {
+		name         string
+		rawToolCall  string
+		wantToolCall api.ToolCall
+	}{
+		{
+			name: "parameter not closed before the next parameter",
+			rawToolCall: `<function=editor>
+<parameter=path>
+manic_miner.html
+<parameter=old_text>
+this.sX()
+</parameter>
+</function>`,
+			wantToolCall: api.ToolCall{
+				Function: api.ToolCallFunction{
+					Name: "editor",
+					Arguments: testArgs(map[string]any{
+						"path":     "manic_miner.html",
+						"old_text": "this.sX()",
+					}),
+				},
+			},
+		},
+		{
+			name: "parameter closed by the function's closing tag",
+			rawToolCall: `<function=editor>
+<parameter=path>
+manic_miner.html
+</function>`,
+			wantToolCall: api.ToolCall{
+				Function: api.ToolCallFunction{
+					Name:      "editor",
+					Arguments: testArgs(map[string]any{"path": "manic_miner.html"}),
+				},
+			},
+		},
+		{
+			name: "nothing closed at all",
+			rawToolCall: `<function=editor>
+<parameter=path>
+manic_miner.html`,
+			wantToolCall: api.ToolCall{
+				Function: api.ToolCallFunction{
+					Name:      "editor",
+					Arguments: testArgs(map[string]any{"path": "manic_miner.html"}),
+				},
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		gotToolCall, err := parseToolCall(qwenEventRawToolCall{raw: tc.rawToolCall}, []api.Tool{})
+		if err != nil {
+			t.Errorf("%s: %v", tc.name, err)
+			continue
+		}
+		if !toolCallEqual(gotToolCall, tc.wantToolCall) {
+			t.Errorf("%s: got tool call %#v, want %#v", tc.name, gotToolCall, tc.wantToolCall)
+		}
+	}
+}
+
+// Without a `<function>` header there is no name to dispatch, so the call cannot
+// be recovered -- but failing the request is worse than saying nothing, because
+// the turn may already have run commands and there is no safe automatic retry
+// (mann1x/cline#54). The block goes back as content instead.
+func TestQwenUnrecoverableToolCallBecomesContent(t *testing.T) {
+	parser := Qwen3CoderParser{}
+	parser.Init(nil, nil, nil)
+
+	raw := "\n<parameter=command>\nls\n</parameter>\n</function>\n"
+	content, _, calls, err := parser.Add(toolOpenTag+raw+toolCloseTag, true)
+	if err != nil {
+		t.Fatalf("expected the malformed call to be tolerated, got error: %v", err)
+	}
+	if len(calls) != 0 {
+		t.Errorf("expected no tool calls, got %d", len(calls))
+	}
+	if want := toolOpenTag + raw + toolCloseTag; content != want {
+		t.Errorf("got content %q, want %q", content, want)
+	}
+}
+
 func TestTrailingWhitespaceLenUnicode(t *testing.T) {
 	cases := []struct {
 		name  string


### PR DESCRIPTION
Two defects in the Qwen3-Coder tool-call parser, both found while running long agentic sessions against local qwen3.5/3.6 models. `Qwen35Parser` delegates its tool calls to this parser, so every model using either parser is affected.

## 1. A dropped closing tag fails the whole request

Under long context the model stops emitting `</parameter>`. `parseToolCall` hands the `xml.Unmarshal` error back through `Add`, which fails the stream, which fails the request.

One agent session on 2026-08-21 produced both shapes from the same model, and the second ended a run that had been going for 9841 seconds across 369 iterations:

```
WARN source=qwen3coder.go:71 msg="qwen tool call parsing failed"
     error="XML syntax error on line 21: element <parameter> closed by </function>"
WARN source=qwen3coder.go:71 msg="qwen tool call parsing failed"
     error="XML syntax error on line 21: unexpected EOF"
```

Parameters do not nest, so a value ends where the next tag begins whether or not the model marked it. `repairToolCallXML` closes the tags textually and re-parses, which keeps escaping and attribute decoding in the one place that already does them rather than growing a second half-parser. Strict parsing stays the primary path; the repair only runs after it fails.

| what the model emitted | before | after |
| --- | --- | --- |
| `<parameter>` not closed before the next `<parameter>` | `element <parameter> closed by </function>` | both parameters recovered |
| `<parameter>` closed by `</function>` | `element <parameter> closed by </function>` | parameter recovered |
| nothing closed at all | `unexpected EOF` | parameter recovered |

When there is genuinely nothing to recover — no `<function>` header, so no name to dispatch — the block now goes back as content instead of failing. A turn can already have executed tool calls before the malformed one arrives, so there is no safe automatic retry; handing the model its own output back lets it correct itself on the next turn, which is what a user pressing "retry" achieves by hand today.

## 2. A parameter's value is rewritten as if it were markup

`transformToXML` rewrote every `<word=value>` in the block, including character data inside a parameter. Measured against the parser before this change:

```
sent: node -e "if (a<b=c>d) console.log(1)"
got:  node -e "if (a<b name="c">d) console.log(1)"
```

The command a tool was about to run came out altered, with nothing logged. Any value carrying a comparison next to an assignment, or JSX-shaped text, is exposed.

Only `function` and `parameter` are tags in this format, so the walk now matches only those, rewriting openings and escaping everything else. A `<parameter=…>` found inside an open parameter is deliberately still treated as structural: that case is ambiguous, and a model forgetting `</parameter>` is what actually happens in the wild, so reading it as a new parameter recovers the call instead of swallowing it into the previous value.

## Tests

`go test ./model/parsers/` passes, including four new cases: the three closing-tag shapes above, one asserting that an unrecoverable block becomes content rather than an error, and two asserting that values which look like markup survive unchanged. `go vet` and `gofmt` are clean, and the existing parser tests are unmodified.
