### PR TITLE
app: avoid sidebar animation on initial render

### DIFF
--- a/app/ui/app/src/components/layout/layout.test.tsx
+++ b/app/ui/app/src/components/layout/layout.test.tsx
@@ -1,0 +1,17 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { SidebarLayout } from "./layout";
+
+describe("SidebarLayout", () => {
+  it("does not animate its initial layout", () => {
+    const html = renderToStaticMarkup(
+      <SidebarLayout title="Settings" sidebar={<div />}>
+        <div />
+      </SidebarLayout>,
+    );
+
+    expect(html).not.toContain("transition-[left]");
+    expect(html).not.toContain("transition-[width]");
+    expect(html).not.toContain("transition-all");
+  });
+});

--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -1,7 +1,7 @@
 import { Link } from "@tanstack/react-router";
 import { ChatIcon } from "@/components/ChatIcon";
 import { isWindowsPlatform } from "@/lib/platform";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 let sessionSidebarOpen = false;
 
@@ -14,7 +14,12 @@ export function SidebarLayout({
   title?: string;
 }>) {
   const [sidebarOpen, setSidebarOpen] = useState(sessionSidebarOpen);
+  const [isInitialRender, setIsInitialRender] = useState(true);
   const isWindows = isWindowsPlatform();
+
+  useEffect(() => {
+    setIsInitialRender(false);
+  }, []);
 
   const toggleSidebar = () => {
     sessionSidebarOpen = !sidebarOpen;
@@ -24,7 +29,7 @@ export function SidebarLayout({
   return (
     <div className="flex h-screen w-full overflow-hidden dark:bg-neutral-900">
       <div
-        className={`absolute flex mx-2 py-2 z-20 items-center transition-[left] duration-375 text-neutral-500 dark:text-neutral-400 ${sidebarOpen ? (isWindows ? "left-2" : "left-[140px]") : isWindows ? "left-2" : "left-20"}`}
+        className={`absolute flex mx-2 py-2 z-20 items-center ${isInitialRender ? "" : "transition-[left] duration-375"} text-neutral-500 dark:text-neutral-400 ${sidebarOpen ? (isWindows ? "left-2" : "left-[140px]") : isWindows ? "left-2" : "left-20"}`}
       >
         <button
           onClick={toggleSidebar}
@@ -49,7 +54,7 @@ export function SidebarLayout({
             to="/c/$chatId"
             params={{ chatId: "new" }}
             title="New chat"
-            className={`flex ml-1 items-center justify-center rounded-full transition-opacity duration-375 h-9 w-9 hover:bg-neutral-100 dark:hover:bg-neutral-700 ${
+            className={`flex ml-1 items-center justify-center rounded-full ${isInitialRender ? "" : "transition-opacity duration-375"} h-9 w-9 hover:bg-neutral-100 dark:hover:bg-neutral-700 ${
               sidebarOpen ? "opacity-0 pointer-events-none" : "opacity-100"
             }`}
           >
@@ -58,7 +63,7 @@ export function SidebarLayout({
         )}
       </div>
       <div
-        className={`flex max-h-screen flex-col transition-[width] duration-300 ${
+        className={`flex max-h-screen flex-col ${isInitialRender ? "" : "transition-[width] duration-300"} ${
           sidebarOpen
             ? "w-48 border-r border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-950/40"
             : "w-0"
@@ -71,7 +76,9 @@ export function SidebarLayout({
         ></div>
         {sidebarOpen && sidebar}
       </div>
-      <main className="flex min-w-0 flex-1 flex-col transition-all duration-300">
+      <main
+        className={`flex min-w-0 flex-1 flex-col ${isInitialRender ? "" : "transition-all duration-300"}`}
+      >
         <div
           className={`h-13 z-10 flex w-full flex-none items-center bg-white dark:bg-neutral-900 ${title ? "" : isWindows ? "xl:hidden" : "xl:fixed xl:bg-transparent xl:dark:bg-transparent"}`}
           onDoubleClick={() => window.doubleClick && window.doubleClick()}


### PR DESCRIPTION
Fixes #12954

When the sidebar is already open on first render, the layout currently mounts with width, position, and opacity transition classes. This makes the sidebar animate into place instead of appearing immediately.

This change keeps those transitions disabled for the initial render and enables them after mount, so subsequent user toggles retain the existing animations. It also adds a regression test for the initial server-rendered layout.

Validation:
- `npx prettier --check src/components/layout/layout.tsx src/components/layout/layout.test.tsx`
- `npx eslint src/components/layout/layout.tsx src/components/layout/layout.test.tsx`
- `npm test -- --run src/components/layout/layout.test.tsx`
- `npm run build`