### PR TITLE
docs: fix wording in compatibility and gpu docs

### DIFF
--- a/docs/api/openai-compatibility.mdx
+++ b/docs/api/openai-compatibility.mdx
@@ -322,7 +322,7 @@ For tooling that relies on default OpenAI model names such as `gpt-3.5-turbo`, u
 ollama cp llama3.2 gpt-3.5-turbo
 ```
 
-Afterwards, this new model name can be specified the `model` field:
+Afterwards, this new model name can be specified in the `model` field:
 
 ```shell
 curl http://localhost:11434/v1/chat/completions \

--- a/docs/gpu.mdx
+++ b/docs/gpu.mdx
@@ -87,7 +87,7 @@ Ollama requires an AMD ROCm v7 / HIP7-capable driver stack on Windows.
 
 Ollama leverages the AMD ROCm library, which does not support all AMD GPUs. In
 some cases you can force the system to try to use a similar LLVM target that is
-close. For example The Radeon RX 5400 is `gfx1034` (also known as 10.3.4)
+close. For example, the Radeon RX 5400 is `gfx1034` (also known as 10.3.4)
 however, ROCm does not currently support this target. The closest support is
 `gfx1030`. You can use the environment variable `HSA_OVERRIDE_GFX_VERSION` with
 `x.y.z` syntax. So for example, to force the system to run on the RX 5400, you
@@ -142,7 +142,7 @@ Ollama supports GPU acceleration on Apple devices via the Metal API.
 
 Additional GPU support on Windows and Linux is provided via
 [Vulkan](https://www.vulkan.org/). Vulkan is enabled by default when the
-backend is installed. On Windows most GPU vendors drivers come
+backend is installed. On Windows most GPU vendors' drivers come
 bundled with Vulkan support and require no additional setup steps. Most Linux
 distributions require installing additional components, and you may have
 multiple options for Vulkan drivers between Mesa and GPU Vendor specific packages


### PR DESCRIPTION
## What changed

Fixed three small wording issues:

- `docs/api/openai-compatibility.mdx`: `specified the model field` → `specified in the model field`
  (the Anthropic compatibility doc uses the correct wording)
- `docs/gpu.mdx`: `For example The Radeon RX 5400` → `For example, the Radeon RX 5400`
- `docs/gpu.mdx`: `GPU vendors drivers` → `GPU vendors' drivers`

## How verified

Diff inspection — documentation only, no code changes.