### PR TITLE
app: prevent Apps title bar overlap

### DIFF
--- a/app/ui/app/src/components/layout/layout.test.tsx
+++ b/app/ui/app/src/components/layout/layout.test.tsx
@@ -1,0 +1,23 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { SidebarLayout } from "./layout";
+
+describe("SidebarLayout", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("keeps the macOS title offset in step with the sidebar transition", () => {
+    vi.stubGlobal("window", { OLLAMA_PLATFORM: "darwin" });
+
+    const html = renderToStaticMarkup(
+      <SidebarLayout title="Connect your apps" sidebar={<nav />}>
+        <div />
+      </SidebarLayout>,
+    );
+
+    expect(html).toContain("pl-36");
+    expect(html).toContain("transition-[padding-left]");
+    expect(html).toContain("duration-300");
+  });
+});

--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -79,7 +79,7 @@ export function SidebarLayout({
         >
           {title && (
             <h1
-              className={`${sidebarOpen ? "pl-6" : isWindows ? "pl-16" : "pl-36"} font-rounded text-md font-medium dark:text-white`}
+              className={`${sidebarOpen ? "pl-6" : isWindows ? "pl-16" : "pl-36"} transition-[padding-left] duration-300 font-rounded text-md font-medium dark:text-white`}
             >
               {title}
             </h1>


### PR DESCRIPTION
## Summary

- keep the Apps header clear of the macOS traffic lights during sidebar transitions
- synchronize the header padding animation with the sidebar width animation
- add regression coverage for the macOS title offset

## Root cause

The macOS web view extends beneath the transparent title bar. When opening the sidebar, its width animated over 300ms while the header padding changed immediately, briefly moving “Connect your apps” through the traffic-light area. Animating both values together preserves the existing final layout without changing the window chrome.