### PR TITLE
docs: fix README agent list spacing (OpenCode, Codex, Copilot)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The official [Ollama Docker image](https://hub.docker.com/r/ollama/ollama) `olla
 ollama
 ```
 
-You'll be prompted to run a model or connect Ollama to your existing agents or applications such as `Claude Code`, `OpenClaw`, `OpenCode` , `Codex`, `Copilot`,  and more.
+You'll be prompted to run a model or connect Ollama to your existing agents or applications such as `Claude Code`, `OpenClaw`, `OpenCode`, `Codex`, `Copilot`, and more.
 
 ### Coding
 


### PR DESCRIPTION
docs: fix README agent list spacing

Fixes spacing in the agent list: "OpenCode , Codex" -> "OpenCode, Codex"
and removes double space before "and" after Copilot.

No functional change.
