### PR TITLE
docs: fix manual tar.zst extraction to use zstd (#17860)

### DIFF
--- a/docs/linux.mdx
+++ b/docs/linux.mdx
@@ -17,11 +17,11 @@ curl -fsSL https://ollama.com/install.sh | sh
   with `sudo rm -rf /usr/lib/ollama` first.
 </Note>
 
-Download and extract the package:
+Download and extract the package (requires `zstd` — `sudo apt-get install zstd` on Debian/Ubuntu):
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-amd64.tar.zst \
-    | sudo tar x -C /usr
+    | zstd -d | sudo tar x -C /usr
 ```
 
 Start Ollama:
@@ -42,7 +42,7 @@ If you have an AMD GPU, also download and extract the additional ROCm package:
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-amd64-rocm.tar.zst \
-    | sudo tar x -C /usr
+    | zstd -d | sudo tar x -C /usr
 ```
 
 ### ARM64 install
@@ -51,7 +51,7 @@ Download and extract the ARM64-specific package:
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-arm64.tar.zst \
-    | sudo tar x -C /usr
+    | zstd -d | sudo tar x -C /usr
 ```
 
 ### Adding Ollama as a startup service (recommended)
@@ -147,7 +147,7 @@ Or by re-downloading Ollama:
 
 ```shell
 curl -fsSL https://ollama.com/download/ollama-linux-amd64.tar.zst \
-    | sudo tar x -C /usr
+    | zstd -d | sudo tar x -C /usr
 ```
 
 ## Installing specific versions


### PR DESCRIPTION
docs: fix manual tar.zst extraction to use zstd (#17860)

Manual install docs piped \.tar.zst\ directly to \	ar x\, which fails
silently on systems whose tar lacks zstd support (fresh Ubuntu 26.04
reports no output, #17860). The install script already does
\zstd -d | tar -xf\.

Update all four manual curl examples to \zstd -d | sudo tar x\ and note
the zstd prerequisite. Mirrors the install.sh fix for the same issue.
