### PR TITLE
server: don't override a model's own template with a renderer

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -67,6 +67,13 @@ func (s *Server) CreateHandler(c *gin.Context) {
 	config.Parser = r.Parser
 	config.Requires = r.Requires
 
+	// renderPrompt returns early when a renderer is set, so a model that sets both a
+	// renderer and a template never uses the template. This is easy to hit by copying the output of
+	// "ollama show --modelfile" and adding a TEMPLATE to it.
+	if r.Template != "" && r.Renderer != "" {
+		slog.Warn("template is ignored because the model sets an explicit renderer", "renderer", r.Renderer)
+	}
+
 	for v, digest := range r.Files {
 		if !fs.ValidPath(v) {
 			c.AbortWithStatusJSON(http.StatusBadRequest, gin.H{"error": errFilePath.Error()})
@@ -166,7 +173,9 @@ func (s *Server) CreateHandler(c *gin.Context) {
 							if cfgFile, fErr := os.Open(configPath); fErr == nil {
 								var baseConfig model.ConfigV2
 								if decErr := json.NewDecoder(cfgFile).Decode(&baseConfig); decErr == nil {
-									if config.Renderer == "" {
+									// Inheriting the parent's renderer would silently override a template
+									// the child model set for itself.
+									if config.Renderer == "" && r.Template == "" {
 										config.Renderer = baseConfig.Renderer
 									}
 									if config.Parser == "" {
@@ -797,9 +806,15 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 				// need architecture-based renderer/parser/stop defaults.
 				if config.Renderer == "" || config.Parser == "" {
 					arch := layer.GGML.KV().Architecture()
+					// A template set by the model file takes precedence over a renderer, so
+					// don't auto-detect one here. The parser and stop tokens still apply: they
+					// describe the output and the architecture, not the prompt format.
+					autodetect := r.Template == ""
 					switch arch {
 					case "gemma4":
-						config.Renderer = cmp.Or(config.Renderer, gemma4RendererLegacy)
+						if autodetect {
+							config.Renderer = cmp.Or(config.Renderer, gemma4RendererLegacy)
+						}
 						config.Parser = cmp.Or(config.Parser, "gemma4")
 						if _, ok := r.Parameters["stop"]; !ok {
 							if r.Parameters == nil {
@@ -808,10 +823,14 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 							r.Parameters["stop"] = []string{"<turn|>"}
 						}
 					case "laguna":
-						config.Renderer = cmp.Or(config.Renderer, "laguna")
+						if autodetect {
+							config.Renderer = cmp.Or(config.Renderer, "laguna")
+						}
 						config.Parser = cmp.Or(config.Parser, "laguna")
 					case "nemotron_h", "nemotron_h_moe", "nemotron_h_omni":
-						config.Renderer = cmp.Or(config.Renderer, "nemotron-3-nano")
+						if autodetect {
+							config.Renderer = cmp.Or(config.Renderer, "nemotron-3-nano")
+						}
 						config.Parser = cmp.Or(config.Parser, "nemotron-3-nano")
 					}
 				}

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -885,6 +885,128 @@ func TestCreateFromModelInheritsRendererParser(t *testing.T) {
 	}
 }
 
+func TestCreateFromModelSkipsRendererInheritanceWithCustomTemplate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	p := t.TempDir()
+	t.Setenv("OLLAMA_MODELS", p)
+	var s Server
+
+	_, digest := createBinFile(t, nil, nil)
+
+	w := createRequest(t, s.CreateHandler, api.CreateRequest{
+		Name:     "base",
+		Files:    map[string]string{"base.gguf": digest},
+		Renderer: "custom-renderer",
+		Parser:   "custom-parser",
+		Stream:   &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status code 200, actual %d", w.Code)
+	}
+
+	// The child sets its own template, so it must not inherit the parent's renderer:
+	// renderPrompt short-circuits on a non-empty renderer and the template would be
+	// silently ignored.
+	w = createRequest(t, s.CreateHandler, api.CreateRequest{
+		Name:     "child",
+		From:     "base",
+		Template: "{{ .Prompt }}",
+		Stream:   &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status code 200, actual %d", w.Code)
+	}
+
+	mf, err := manifest.ParseNamedManifest(model.ParseName("child"))
+	if err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	if mf.Config.Digest == "" {
+		t.Fatalf("unexpected empty config digest for child manifest")
+	}
+
+	configPath, err := manifest.BlobsPath(mf.Config.Digest)
+	if err != nil {
+		t.Fatalf("config blob path: %v", err)
+	}
+
+	cfgFile, err := os.Open(configPath)
+	if err != nil {
+		t.Fatalf("open config blob: %v", err)
+	}
+	defer cfgFile.Close()
+
+	var cfg model.ConfigV2
+	if err := json.NewDecoder(cfgFile).Decode(&cfg); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+
+	if cfg.Renderer != "" {
+		t.Fatalf("expected no inherited renderer, got %q", cfg.Renderer)
+	}
+	// The parser reads model output rather than building the prompt, so it is still
+	// inherited: dropping it would take CapabilityTools and CapabilityThinking with it.
+	if cfg.Parser != "custom-parser" {
+		t.Fatalf("expected parser %q, got %q", "custom-parser", cfg.Parser)
+	}
+}
+
+func TestCreateGemma4SkipsRendererAutodetectWithCustomTemplate(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	p := t.TempDir()
+	t.Setenv("OLLAMA_MODELS", p)
+	var s Server
+
+	_, digest := createBinFile(t, ggml.KV{
+		"general.architecture":    "gemma4",
+		"general.parameter_count": uint64(25_200_000_000),
+	}, nil)
+
+	w := createRequest(t, s.CreateHandler, api.CreateRequest{
+		Name:     "test",
+		Files:    map[string]string{"test.gguf": digest},
+		Template: "{{ .Prompt }}",
+		Stream:   &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status code 200, actual %d", w.Code)
+	}
+
+	mf, err := manifest.ParseNamedManifest(model.ParseName("test"))
+	if err != nil {
+		t.Fatalf("parse manifest: %v", err)
+	}
+	if mf.Config.Digest == "" {
+		t.Fatalf("unexpected empty config digest for manifest")
+	}
+
+	configPath, err := manifest.BlobsPath(mf.Config.Digest)
+	if err != nil {
+		t.Fatalf("config blob path: %v", err)
+	}
+
+	cfgFile, err := os.Open(configPath)
+	if err != nil {
+		t.Fatalf("open config blob: %v", err)
+	}
+	defer cfgFile.Close()
+
+	var cfg model.ConfigV2
+	if err := json.NewDecoder(cfgFile).Decode(&cfg); err != nil {
+		t.Fatalf("decode config: %v", err)
+	}
+
+	if cfg.Renderer != "" {
+		t.Fatalf("expected no auto-detected renderer, got %q", cfg.Renderer)
+	}
+	// Parser and stop tokens describe the output and the architecture, so they still apply.
+	if cfg.Parser != "gemma4" {
+		t.Fatalf("expected parser %q, got %q", "gemma4", cfg.Parser)
+	}
+}
+
 func TestCreateRemovesLayers(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
Fixes #14560.

`renderPrompt` returns as soon as a model has a renderer and never reads the template:

```go
// server/prompt.go:135
func renderPrompt(m *Model, msgs []api.Message, tools []api.Tool, think *api.ThinkValue) (string, error) {
	if m.Config.Renderer != "" {
		rendererName := resolveRendererName(m)
		rendered, err := renderers.RenderWithRenderer(rendererName, msgs, tools, think)
		...
		return rendered, nil
	}
```

Two paths put a renderer on a model that asked for its own template:

1. `server/create.go:169` — `FROM <model>` copied the parent's renderer into the child whenever the child left it empty, without consulting `TEMPLATE`. This is the case in the issue.
2. `server/create.go:807` — the renderer auto-detected from the GGUF architecture (gemma4/laguna/nemotron_h). This is what @cipriancraciun reported on 2026-04-03, where `FROM /.../blobs/sha256-...` stopped working as a workaround in 0.20.0.

Either way the user's `TEMPLATE` became dead config, silently. This skips both when the model sets its own template. Models without a template are unaffected.

This is approach (A) from the issue, which @drifkin preferred, plus the warning @cipriancraciun suggested.

## One deliberate deviation: the parser is left alone

The issue and approach (A) say to skip inheriting *both* renderer and parser. I've only skipped the renderer, because the rationale doesn't extend to the parser and skipping it looks actively harmful:

- The parser reads model **output** (`server/routes.go:2682`), it doesn't build the prompt. There's no early-return equivalent to `renderPrompt`'s, so a parser and a template don't conflict.
- `parserCapabilities` (`server/images.go:436-446`) derives `CapabilityTools` and `CapabilityThinking` **solely** from `Config.Parser`. Dropping it means `FROM nemotron-3-nano` + any `TEMPLATE` produces a child that rejects `/api/chat` requests carrying tools with `errCapabilityTools`, and emits raw tool-call syntax as plain content. Trading a silently-ignored template for silently-broken tool calling isn't a good deal.
- Keeping it also matters for a subtler reason: the `PreferChatTemplate` gate at `server/images.go:793` requires `Renderer == "" && Parser == ""`. If the parser were cleared too, that gate would become reachable and the GGUF `tokenizer.chat_template` could override the user's template instead — moving the bug rather than fixing it. Keeping the parser keeps that gate closed.

Stop tokens are kept in the auto-detect path for the same reason: `<turn|>` is emitted by the weights regardless of prompt format.

Happy to skip the parser as well if you'd rather have (A) literally — just say so.

## The warning

`slog.Warn` when a model sets a `TEMPLATE` alongside an explicit `RENDERER`, since that combination still ignores the template.

It currently goes to the server log. That covers `ollama serve` in a terminal, but not someone on the bundled app — and @cipriancraciun's point was about people copy-pasting `ollama show --modelfile`. I left it there rather than expand this PR's scope: surfacing it in the CLI needs a persistent line rather than a `ch <- api.ProgressResponse{...}` status, because `cmd/cmd.go:406` overwrites the spinner on each status update. Glad to add that if you want it.

## How I tested

```
go test ./server/... ./api/... ./parser/... ./model/... -count=1    # all ok
go vet ./server/                                                    # clean
gofmt -l server/create.go server/routes_create_test.go              # clean
```

Two tests added:

- `TestCreateFromModelSkipsRendererInheritanceWithCustomTemplate` — `FROM base` + `TEMPLATE`; asserts no renderer is inherited **and that the parser still is**.
- `TestCreateGemma4SkipsRendererAutodetectWithCustomTemplate` — gemma4 GGUF + `TEMPLATE`; asserts no renderer is auto-detected and the `gemma4` parser still is.

Both fail without the change, for the right reason:

```
--- FAIL: TestCreateFromModelSkipsRendererInheritanceWithCustomTemplate
    routes_create_test.go:946: expected no inherited renderer, got "custom-renderer"
--- FAIL: TestCreateGemma4SkipsRendererAutodetectWithCustomTemplate
    routes_create_test.go:1002: expected no auto-detected renderer, got "gemma4"
```

The existing `TestCreateFromModelInheritsRendererParser` and `TestCreateGemma4KeepsDynamicRendererAlias` still pass, which is the back-compat check that matters here.

Credit to @majiayu000, who traced the root cause in the issue thread.

---

> [!NOTE]
> This contribution was AI-assisted (Claude Code). The parser and `PreferChatTemplate` findings above came out of reviewing an earlier version of this change that did skip the parser; every claim here was checked against the source.
