### PR TITLE
app/ui: add back button to settings layout

### DIFF
--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -1,4 +1,5 @@
 import { Link } from "@tanstack/react-router";
+import { ArrowLeftIcon } from "@heroicons/react/20/solid";
 import { ChatIcon } from "@/components/ChatIcon";
 import { isWindowsPlatform } from "@/lib/platform";
 import { useState } from "react";
@@ -78,11 +79,18 @@ export function SidebarLayout({
           onMouseDown={() => window.drag && window.drag()}
         >
           {title && (
-            <h1
-              className={`${sidebarOpen ? "pl-6" : isWindows ? "pl-16" : "pl-36"} font-rounded text-md font-medium dark:text-white`}
-            >
-              {title}
-            </h1>
+            <div className={`flex items-center ${sidebarOpen ? "pl-6" : isWindows ? "pl-16" : "pl-36"}`}>
+              <Link
+                to="/"
+                title="Back"
+                className="mr-3 flex items-center justify-center h-8 w-8 rounded-full hover:bg-neutral-100 dark:hover:bg-neutral-800 transition-colors text-neutral-500 dark:text-neutral-400 cursor-pointer"
+              >
+                <ArrowLeftIcon className="h-5 w-5" />
+              </Link>
+              <h1 className="font-rounded text-md font-medium dark:text-white">
+                {title}
+              </h1>
+            </div>
           )}
         </div>
         {children}


### PR DESCRIPTION
## Problem                                                                                                                                                                           
Currently, the Settings window in the desktop application lacks a back/return button. If a user hides the sidebar while in the Settings view, there is no UI element available to navigate back to the main chat window, leaving the user trapped.                                                                                                                       
                                                                                                                                                                                         
## Solution                                                                                                                                                                          
This changes Ollama to provide a back/return button in the `SidebarLayout` header. By placing it in the layout header alongside the title, we ensure users can always navigate back to the main chat window, completely preventing them from getting stuck even if the sidebar is closed.

Fixes #17912