### PR TITLE
fix(compat): honor tool_choice across OpenAI and Anthropic layers (#17921)

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -400,6 +401,11 @@ func FromMessagesRequest(r MessagesRequest) (*api.ChatRequest, error) {
 	}
 
 	stream := r.Stream
+	messages, tools, err := applyToolChoice(messages, tools, r.ToolChoice)
+	if err != nil {
+		return nil, err
+	}
+
 	convertedRequest := &api.ChatRequest{
 		Model:    r.Model,
 		Messages: messages,
@@ -411,6 +417,40 @@ func FromMessagesRequest(r MessagesRequest) (*api.ChatRequest, error) {
 	logutil.Trace("anthropic: converted request", "req", TraceChatRequest(convertedRequest))
 
 	return convertedRequest, nil
+}
+
+// applyToolChoice maps an Anthropic tool_choice onto the converted request.
+// The underlying capability layer has no native constraint mechanism, so
+// "none" strips tools and forced modes append a system instruction; a named
+// tool is additionally constrained by only exposing that tool to the template.
+func applyToolChoice(messages []api.Message, tools api.Tools, choice *ToolChoice) ([]api.Message, api.Tools, error) {
+	if choice == nil || choice.Type == "" || choice.Type == "auto" {
+		return messages, tools, nil
+	}
+
+	switch choice.Type {
+	case "none":
+		tools = nil
+	case "any":
+		if len(tools) == 0 {
+			return messages, tools, errors.New("'tools' must be specified when 'tool_choice' type is \"any\"")
+		}
+		messages = append(messages, api.Message{Role: "system", Content: "You must call one of the available tools instead of replying with plain text."})
+	case "tool":
+		if choice.Name == "" {
+			return messages, tools, errors.New("'tool_choice.name' is required when 'tool_choice' type is \"tool\"")
+		}
+		idx := slices.IndexFunc(tools, func(t api.Tool) bool { return t.Function.Name == choice.Name })
+		if idx < 0 {
+			return messages, tools, fmt.Errorf("invalid value for 'tool_choice': no tool named %q was provided in 'tools'", choice.Name)
+		}
+		tools = tools[idx : idx+1]
+		messages = append(messages, api.Message{Role: "system", Content: fmt.Sprintf("You must call the %q function instead of replying with plain text.", choice.Name)})
+	default:
+		return messages, tools, fmt.Errorf("invalid value for 'tool_choice.type': %q (must be \"auto\", \"any\", \"tool\", or \"none\")", choice.Type)
+	}
+
+	return messages, tools, nil
 }
 
 // convertMessage converts an Anthropic MessageParam to Ollama api.Message(s)

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -1956,3 +1956,82 @@ func TestCitation(t *testing.T) {
 		t.Errorf("cited_text mismatch: expected 'Some cited text...', got %q", unmarshaled.CitedText)
 	}
 }
+
+func TestFromMessagesRequest_ToolChoice(t *testing.T) {
+	tools := []Tool{
+		{Name: "get_weather", Description: "Get the weather", InputSchema: json.RawMessage(`{"type":"object"}`)},
+		{Name: "get_time", Description: "Get the time", InputSchema: json.RawMessage(`{"type":"object"}`)},
+	}
+
+	forcedAny := "You must call one of the available tools instead of replying with plain text."
+	forcedTime := "You must call the \"get_time\" function instead of replying with plain text."
+
+	cases := []struct {
+		name        string
+		toolChoice  *ToolChoice
+		tools       []Tool
+		wantTools   int
+		wantForced  string
+		wantNoForce bool
+		wantErr     bool
+	}{
+		{name: "unset keeps tools", toolChoice: nil, tools: tools, wantTools: 2, wantNoForce: true},
+		{name: "auto keeps tools", toolChoice: &ToolChoice{Type: "auto"}, tools: tools, wantTools: 2, wantNoForce: true},
+		{name: "none strips tools", toolChoice: &ToolChoice{Type: "none"}, tools: tools, wantTools: 0, wantNoForce: true},
+		{name: "any forces a tool call", toolChoice: &ToolChoice{Type: "any"}, tools: tools, wantTools: 2, wantForced: forcedAny},
+		{name: "named tool constrains to that tool", toolChoice: &ToolChoice{Type: "tool", Name: "get_time"}, tools: tools, wantTools: 1, wantForced: forcedTime},
+		{name: "named tool without name errors", toolChoice: &ToolChoice{Type: "tool"}, tools: tools, wantErr: true},
+		{name: "unknown named tool errors", toolChoice: &ToolChoice{Type: "tool", Name: "nope"}, tools: tools, wantErr: true},
+		{name: "any without tools errors", toolChoice: &ToolChoice{Type: "any"}, tools: nil, wantErr: true},
+		{name: "invalid type errors", toolChoice: &ToolChoice{Type: "sometimes"}, tools: tools, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := MessagesRequest{
+				Model:      "test-model",
+				MaxTokens:  1024,
+				Messages:   []MessageParam{{Role: "user", Content: textContent("Hello")}},
+				Tools:      tc.tools,
+				ToolChoice: tc.toolChoice,
+			}
+
+			result, err := FromMessagesRequest(req)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(result.Tools) != tc.wantTools {
+				t.Fatalf("expected %d tools, got %d", tc.wantTools, len(result.Tools))
+			}
+			if tc.wantTools == 1 && result.Tools[0].Function.Name != "get_time" {
+				t.Errorf("expected constrained tool 'get_time', got %q", result.Tools[0].Function.Name)
+			}
+
+			wantMessages := 1
+			var wantLast *api.Message
+			if !tc.wantNoForce {
+				wantMessages = 2
+				wantLast = &api.Message{Role: "system", Content: tc.wantForced}
+			}
+			if len(result.Messages) != wantMessages {
+				t.Fatalf("expected %d messages, got %d", wantMessages, len(result.Messages))
+			}
+			if tc.wantNoForce && result.Messages[0].Content != "Hello" {
+				t.Errorf("unexpected first message: %+v", result.Messages[0])
+			}
+			if wantLast != nil {
+				got := result.Messages[len(result.Messages)-1]
+				if got.Role != wantLast.Role || got.Content != wantLast.Content {
+					t.Errorf("expected forcing message %+v, got %+v", *wantLast, got)
+				}
+			}
+		})
+	}
+}

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -116,6 +117,7 @@ type ChatCompletionRequest struct {
 	TopP             *float64        `json:"top_p"`
 	ResponseFormat   *ResponseFormat `json:"response_format"`
 	Tools            []api.Tool      `json:"tools"`
+	ToolChoice       any             `json:"tool_choice"`
 	Reasoning        *Reasoning      `json:"reasoning,omitempty"`
 	ReasoningEffort  *string         `json:"reasoning_effort,omitempty"`
 	Logprobs         *bool           `json:"logprobs"`
@@ -707,18 +709,93 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 		return nil, err
 	}
 
+	messages, tools, err := applyToolChoice(messages, r.Tools, r.ToolChoice)
+	if err != nil {
+		return nil, err
+	}
+
 	return &api.ChatRequest{
 		Model:           r.Model,
 		Messages:        messages,
 		Format:          format,
 		Options:         options,
 		Stream:          &r.Stream,
-		Tools:           r.Tools,
+		Tools:           tools,
 		Think:           think,
 		Logprobs:        r.Logprobs != nil && *r.Logprobs,
 		TopLogprobs:     r.TopLogprobs,
 		DebugRenderOnly: r.DebugRenderOnly,
 	}, nil
+}
+
+// parseToolChoice parses an OpenAI tool_choice value (a string or a
+// {type: "function", function: {name: ...}} object) into a mode and an
+// optional forced function name.
+func parseToolChoice(choice any) (mode string, name string, err error) {
+	switch c := choice.(type) {
+	case nil:
+		return "", "", nil
+	case string:
+		switch strings.ToLower(strings.TrimSpace(c)) {
+		case "":
+			return "", "", nil
+		case "auto":
+			return "auto", "", nil
+		case "none":
+			return "none", "", nil
+		case "required":
+			return "required", "", nil
+		default:
+			return "", "", fmt.Errorf("invalid value for 'tool_choice': %q (must be \"auto\", \"none\", \"required\", or an object naming a function)", c)
+		}
+	case map[string]any:
+		t, _ := c["type"].(string)
+		if t != "function" {
+			return "", "", fmt.Errorf("invalid value for 'tool_choice': unsupported type %q (only \"function\" is supported)", t)
+		}
+		fn, ok := c["function"].(map[string]any)
+		if !ok {
+			return "", "", errors.New("invalid value for 'tool_choice': missing function")
+		}
+		name, ok = fn["name"].(string)
+		if !ok || name == "" {
+			return "", "", errors.New("invalid value for 'tool_choice': missing function name")
+		}
+		return "function", name, nil
+	default:
+		return "", "", fmt.Errorf("invalid type for 'tool_choice': %T", choice)
+	}
+}
+
+// applyToolChoice maps an OpenAI tool_choice onto the converted request. The
+// underlying capability layer has no native constraint mechanism, so "none"
+// strips tools and forced modes append a system instruction; a named function
+// is additionally constrained by only exposing that tool to the template.
+func applyToolChoice(messages []api.Message, tools api.Tools, choice any) ([]api.Message, api.Tools, error) {
+	mode, name, err := parseToolChoice(choice)
+	if err != nil {
+		return messages, tools, err
+	}
+
+	switch mode {
+	case "", "auto":
+	case "none":
+		tools = nil
+	case "required":
+		if len(tools) == 0 {
+			return messages, tools, errors.New("'tools' must be specified when 'tool_choice' is \"required\"")
+		}
+		messages = append(messages, api.Message{Role: "system", Content: "You must call one of the available tools instead of replying with plain text."})
+	case "function":
+		idx := slices.IndexFunc(tools, func(t api.Tool) bool { return t.Function.Name == name })
+		if idx < 0 {
+			return messages, tools, fmt.Errorf("invalid value for 'tool_choice': no function named %q was provided in 'tools'", name)
+		}
+		tools = tools[idx : idx+1]
+		messages = append(messages, api.Message{Role: "system", Content: fmt.Sprintf("You must call the %q function instead of replying with plain text.", name)})
+	}
+
+	return messages, tools, nil
 }
 
 func nameFromToolCallID(messages []Message, toolCallID string) string {

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -1050,3 +1050,89 @@ func TestFromChatRequest_TopLogprobsRange(t *testing.T) {
 		})
 	}
 }
+
+func TestFromChatRequest_ToolChoice(t *testing.T) {
+	tools := []api.Tool{
+		{Type: "function", Function: api.ToolFunction{Name: "get_weather", Description: "Get the weather"}},
+		{Type: "function", Function: api.ToolFunction{Name: "get_time", Description: "Get the time"}},
+	}
+
+	forcedAny := "You must call one of the available tools instead of replying with plain text."
+	forcedTime := "You must call the \"get_time\" function instead of replying with plain text."
+
+	cases := []struct {
+		name        string
+		toolChoice  any
+		tools       []api.Tool
+		wantTools   int
+		wantForced  string
+		wantNoForce bool
+		wantErr     bool
+	}{
+		{name: "unset keeps tools", toolChoice: nil, tools: tools, wantTools: 2, wantNoForce: true},
+		{name: "auto keeps tools", toolChoice: "auto", tools: tools, wantTools: 2, wantNoForce: true},
+		{name: "none strips tools", toolChoice: "none", tools: tools, wantTools: 0, wantNoForce: true},
+		{name: "none without tools", toolChoice: "none", tools: nil, wantTools: 0, wantNoForce: true},
+		{name: "required forces a tool call", toolChoice: "required", tools: tools, wantTools: 2, wantForced: forcedAny},
+		{
+			name:       "named function constrains to that tool",
+			toolChoice: map[string]any{"type": "function", "function": map[string]any{"name": "get_time"}},
+			tools:      tools,
+			wantTools:  1,
+			wantForced: forcedTime,
+		},
+		{name: "unknown function errors", toolChoice: map[string]any{"type": "function", "function": map[string]any{"name": "nope"}}, tools: tools, wantErr: true},
+		{name: "required without tools errors", toolChoice: "required", tools: nil, wantErr: true},
+		{name: "invalid string errors", toolChoice: "sometimes", tools: tools, wantErr: true},
+		{name: "unsupported object type errors", toolChoice: map[string]any{"type": "allowed_tools"}, tools: tools, wantErr: true},
+		{name: "object missing function name errors", toolChoice: map[string]any{"type": "function", "function": map[string]any{}}, tools: tools, wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := ChatCompletionRequest{
+				Model:      "test-model",
+				Messages:   []Message{{Role: "user", Content: "Hello"}},
+				Tools:      tc.tools,
+				ToolChoice: tc.toolChoice,
+			}
+
+			result, err := FromChatRequest(req)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got none")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(result.Tools) != tc.wantTools {
+				t.Fatalf("expected %d tools, got %d", tc.wantTools, len(result.Tools))
+			}
+			if tc.wantTools == 1 && result.Tools[0].Function.Name != "get_time" {
+				t.Errorf("expected constrained tool 'get_time', got %q", result.Tools[0].Function.Name)
+			}
+
+			wantMessages := 1
+			var wantLast *api.Message
+			if !tc.wantNoForce {
+				wantMessages = 2
+				wantLast = &api.Message{Role: "system", Content: tc.wantForced}
+			}
+			if len(result.Messages) != wantMessages {
+				t.Fatalf("expected %d messages, got %d", wantMessages, len(result.Messages))
+			}
+			if tc.wantNoForce && result.Messages[0].Content != "Hello" {
+				t.Errorf("unexpected first message: %+v", result.Messages[0])
+			}
+			if wantLast != nil {
+				got := result.Messages[len(result.Messages)-1]
+				if got.Role != wantLast.Role || got.Content != wantLast.Content {
+					t.Errorf("expected forcing message %+v, got %+v", *wantLast, got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #17921

tool_choice was silently ignored on both compat layers in 0.32.15: forced choices returned plain text and "none" still allowed tool calls.

- none: tools stripped from the model-bound request on both layers
- required: explicit must-call-a-tool instruction appended
- named function/tool: validated against provided tools (400 on unknown name), tool list narrowed to that function plus trailing must-call instruction
- api.ChatRequest has no native tool_choice field, so enforcement is prompt-level; noted as a capability-layer limitation
- disable_parallel_tool_use remains unimplemented upstream-wide (unchanged)

Tests: table cases for auto/none/required/named across both layers; go test ./openai/... ./anthropic/... green locally.
