### PR TITLE
app: add Back to chat button on Settings page

### DIFF
--- a/app/ui/app/src/components/Settings.tsx
+++ b/app/ui/app/src/components/Settings.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, useCallback } from "react";
+import { useNavigate } from "@tanstack/react-router";
 import { Switch } from "@/components/ui/switch";
 import { Text } from "@/components/ui/text";
 import { Input } from "@/components/ui/input";
@@ -60,6 +61,7 @@ export default function Settings() {
     isLoading,
     disconnectUser,
   } = useUser();
+  const navigate = useNavigate();
   const [isAwaitingConnection, setIsAwaitingConnection] = useState(false);
   const [connectionError, setConnectionError] = useState<string | null>(null);
   const [pollingInterval, setPollingInterval] = useState<number | null>(null);
@@ -304,6 +306,15 @@ export default function Settings() {
     <main className="flex min-h-0 w-full flex-1 flex-col select-none dark:bg-neutral-900">
       <div className="w-full p-6 overflow-y-auto flex-1 overscroll-contain">
         <div className="mx-auto max-w-4xl space-y-4">
+          <button
+            type="button"
+            onClick={() => navigate({ to: "/" })}
+            aria-label="Back to chat"
+            className="inline-flex items-center gap-1 text-sm text-neutral-600 dark:text-neutral-300 hover:text-neutral-900 dark:hover:text-white transition-colors"
+          >
+            <span aria-hidden="true">←</span>
+            <span>Back to chat</span>
+          </button>
           {/* Connect Ollama Account */}
           <div className="overflow-hidden rounded-xl bg-white dark:bg-neutral-800">
             <div className="p-4">


### PR DESCRIPTION
app: add Back to chat button on Settings page

## Summary

Partially addresses #17912.

The Settings page is a route inside the main webview window (see `app/ui/app/src/routes/settings.tsx`). It has no built-in way to return to the chat view. On Windows, users were clicking the system window "X" button to leave Settings, which hides the entire window to the system tray via `hideWindow` in `app/cmd/app/app_windows.go` instead of navigating back to the chat route.

This PR adds a small "Back to chat" button at the top of the Settings page that calls `useNavigate({ to: "/" })` to return to the chat route. It gives users a discoverable in-app exit without needing the system window controls.

## Why a separate PR

Issue #17912 describes two related but distinct issues:

1. **No back/return button in Settings UI**: fixed in this PR. Low-risk, additive UI change.
2. **Closing Settings via the system "X" hides the main chat window on Windows**: will be addressed in a follow-up PR. The current "hide on close" behavior is intentional for tray-style apps, but the discoverability story needs work. I want to keep the two changes isolated so a review issue on the window-management side doesn't block the simple UI fix.

## Test plan

The UI change is 11 additive lines in one component:

```
 app/ui/app/src/components/Settings.tsx | 11 +++++++++++
 1 file changed, 11 insertions(+)
```

- Import `useNavigate` from `@tanstack/react-router`.
- Call `const navigate = useNavigate();` inside the component.
- Render a back button at the top of the content area.

Imports + route conventions match existing `useNavigate` usage in `ChatForm.tsx:18` and `Chat.tsx:27`. `/` is the chat index route.

## Why this matters

On Windows, the system window "X" button hides the entire window to the system tray via `hideWindow` in `app/cmd/app/app_windows.go`. Without a back button, Settings was effectively a dead end. A human dev clicking around Windows Settings would notice this within a minute.
