### PR TITLE
docs: add NVIDIA driver version guidance by compute capability

### DIFF
--- a/docs/gpu.mdx
+++ b/docs/gpu.mdx
@@ -37,6 +37,33 @@ Check your compute compatibility to see if your card is supported:
 
 For building locally to support older GPUs, see [development](./development.md).
 
+### Driver version guidance by compute capability
+
+Ollama requires CUDA driver version 550 or newer. For older GPUs (compute
+capability 5.0 through 6.2) you also need driver version 570 or newer. NVIDIA
+publishes multiple driver branches at any time — pick the one that matches
+your card family:
+
+| Compute capability | Card family                          | Recommended branch        | Example version |
+| ------------------ | ------------------------------------ | ------------------------- | --------------- |
+| 12.x               | Blackwell (RTX 50xx, DGX Spark)      | Production Branch         | 580.x or newer  |
+| 9.x – 11.x         | Hopper / Ada / pre-Blackwell         | Production Branch         | 580.x           |
+| 8.x                | Ampere (RTX 30xx, A100)              | Production Branch         | 580.x           |
+| 7.x                | Turing / Volta (RTX 20xx, V100, T4)  | Long-Lived Branch         | 570.x or 580.x  |
+| 6.x                | Pascal (GTX 10xx, P40, P100)         | Long-Lived Branch         | 575.x or 580.x  |
+| 5.x                | Maxwell (GTX 750/980, M-class)       | Long-Lived Branch         | 570.x (last branch with 5.x support) |
+
+If you're unsure which branch is right for your card, NVIDIA's
+[CUDA Toolkit and Driver Compatibility](https://docs.nvidia.com/deploy/cuda-compatibility/)
+table is the canonical reference. Newer GPUs (Blackwell and Ada) can stay
+on the newest Production Branch release; older GPUs (Turing, Pascal, Maxwell)
+typically want the latest Long-Lived Branch release because Production Branch
+tends to drop legacy card support first.
+
+If a newer driver breaks your older card, fall back to the latest Long-Lived
+Branch release for that compute capability. NVIDIA's 470.x legacy branch is
+*not* sufficient for Ollama — it predates the 550 minimum.
+
 ### GPU Selection
 
 If you have multiple NVIDIA GPUs in your system and want to limit Ollama to use


### PR DESCRIPTION
docs: add NVIDIA driver version guidance by compute capability

## Summary

Closes #17789.

The user wanted concrete examples of which NVIDIA driver versions work with which older GPUs, noting that older GPUs are 'getting into chaos support land'. The existing gpu.mdx only mentioned the minimum driver version (550+; 570+ for compute capability 5.0-6.2) without any guidance on which NVIDIA branch to choose per card family.

This PR adds a 'Driver version guidance by compute capability' subsection that maps compute capability brackets to NVIDIA's driver branches (Production Branch for Blackwell/Ada/Ampere, Long-Lived Branch for Turing/Pascal/Maxwell), gives example versions for each bracket, and links to NVIDIA's CUDA Toolkit and Driver Compatibility table as the canonical reference.

## Why this matters

The existing docs tell users the minimum driver version but don't address the practical question the issue is asking: 'I have an older GPU, which driver should I actually install?' Without this guidance, users tend to grab the newest Production Branch driver, which often drops legacy card support and breaks Ollama. Routing them to the Long-Lived Branch instead is the right answer for older cards.

## What changed

```
docs/gpu.mdx | 27 +++++++++++++++++++++++++++
1 file changed, 27 insertions(+)
```

Adds a single subsection under '## Nvidia', immediately after the existing compute-capability table and before '### GPU Selection'. The new subsection covers:

- A bracket-by-bracket table: compute capability → recommended driver branch → example version
- A note explaining why older cards want the Long-Lived Branch (Production Branch drops legacy support first)
- A note that NVIDIA's 470.x legacy branch is not sufficient for Ollama (predates the 550 minimum)
- A link to NVIDIA's CUDA Toolkit and Driver Compatibility table as the canonical reference

Pure docs change. No code, no schema, no behavioral impact.
