### PR TITLE
app: rename Connect your apps page title to Apps

### DIFF
--- a/app/ui/app/src/routes/connect.tsx
+++ b/app/ui/app/src/routes/connect.tsx
@@ -10,7 +10,7 @@ export const Route = createFileRoute("/connect")({
 function ConnectRoute() {
   return (
     <SidebarLayout
-      title="Connect your apps"
+      title="Apps"
       sidebar={<AppSidebar current="apps" />}
     >
       <ConnectAppsScreen />


### PR DESCRIPTION
Shortens the header on the Apps page (`/connect` route) from "Connect your apps" to "Apps", matching the sidebar item label.