### PR TITLE
app: always show all apps on Connect your apps screen

### DIFF
--- a/app/ui/app/src/components/Onboarding.test.tsx
+++ b/app/ui/app/src/components/Onboarding.test.tsx
@@ -6,7 +6,6 @@ import {
   IntroScreen,
   default as Onboarding,
   RunOllamaScreen,
-  terminalRowsForWindowHeight,
   WelcomeScreen,
 } from "./Onboarding";
 import {
@@ -44,12 +43,6 @@ describe("Onboarding", () => {
     expect(html).toContain("Your prompt data is never logged or trained on.");
     expect(html).toContain("Continue");
     expect(html).not.toContain("Skip");
-  });
-
-  it("shows more terminal integrations as the window gets taller", () => {
-    expect(terminalRowsForWindowHeight(400)).toBe(1);
-    expect(terminalRowsForWindowHeight(660)).toBe(4);
-    expect(terminalRowsForWindowHeight(960)).toBe(8);
   });
 
   it("renders the apps screen without browser platform globals", () => {
@@ -295,9 +288,8 @@ describe("Onboarding", () => {
     expect(html).not.toContain("ChatGPT");
     expect(html).toContain("OpenCode");
     expect(html).toContain("Terminal");
-    expect(html).toContain('aria-label="Show more apps"');
-    expect(html).toContain('aria-expanded="false"');
-    expect(html).toContain("grid-rows-[0fr]");
+    expect(html).not.toContain("Show more apps");
+    expect(html).not.toContain("aria-expanded");
     expect(html).not.toContain("Collapse");
     expect(html).toContain("/launch-icons/claude.svg");
     expect(html).toContain("/launch-icons/claude-code.svg");

--- a/app/ui/app/src/components/Onboarding.tsx
+++ b/app/ui/app/src/components/Onboarding.tsx
@@ -24,11 +24,7 @@ import {
   Square2StackIcon,
   XMarkIcon,
 } from "@heroicons/react/24/outline";
-import {
-  CheckIcon,
-  ChevronDownIcon,
-  ChevronUpIcon,
-} from "@heroicons/react/20/solid";
+import { CheckIcon } from "@heroicons/react/20/solid";
 import {
   useCallback,
   useEffect,
@@ -50,9 +46,6 @@ type ClaudeConnectPhase =
 const CLAUDE_CONNECTION_POLL_INTERVAL_MS = 500;
 const CLAUDE_CONNECTION_TIMEOUT_MS = 45_000;
 const CLAUDE_CONNECTED_INTRO_KEY = "ollama.claude-connected-intro-seen";
-const MINIMUM_APP_WINDOW_HEIGHT = 660;
-const TERMINAL_ROW_HEIGHT_WITH_GAP = 80;
-const TERMINAL_LIST_RESERVED_HEIGHT = 296;
 
 function hasSeenClaudeConnectedIntro() {
   return window.localStorage.getItem(CLAUDE_CONNECTED_INTRO_KEY) === "true";
@@ -66,15 +59,6 @@ function setClaudeConnection(enabled: boolean, deferLaunch = false) {
     throw new Error("Claude Desktop connection is unavailable");
   }
   return window.setClaudeDesktopConnected(enabled);
-}
-
-export function terminalRowsForWindowHeight(height: number): number {
-  return Math.max(
-    1,
-    Math.floor(
-      (height - TERMINAL_LIST_RESERVED_HEIGHT) / TERMINAL_ROW_HEIGHT_WITH_GAP,
-    ),
-  );
 }
 
 interface ScreenProps {
@@ -391,29 +375,7 @@ export function ConnectAppsScreen({
   const claudeConnectedIntroPending = useRef(false);
   const [integrationStatuses, setIntegrationStatuses] =
     useState<IntegrationStatuses | null>(initialIntegrations ?? null);
-  const [showAllIntegrations, setShowAllIntegrations] = useState(false);
-  const [collapsedIntegrationCount, setCollapsedIntegrationCount] = useState(
-    () =>
-      terminalRowsForWindowHeight(
-        typeof window === "undefined"
-          ? MINIMUM_APP_WINDOW_HEIGHT
-          : window.innerHeight,
-      ),
-  );
   const [statusError, setStatusError] = useState(false);
-
-  useEffect(() => {
-    const updateCollapsedIntegrationCount = () => {
-      setCollapsedIntegrationCount(
-        terminalRowsForWindowHeight(window.innerHeight),
-      );
-    };
-
-    window.addEventListener("resize", updateCollapsedIntegrationCount);
-    return () => {
-      window.removeEventListener("resize", updateCollapsedIntegrationCount);
-    };
-  }, []);
 
   useEffect(() => {
     if (!copiedCommand) return;
@@ -739,15 +701,6 @@ export function ConnectAppsScreen({
   const claudeInstalled =
     claudeStatus?.installed ?? claudeIntegration?.installed ?? false;
   const isConnectingClaude = claudePhase !== "idle";
-  const initialLaunchIntegrations = launchIntegrations.slice(
-    0,
-    collapsedIntegrationCount,
-  );
-  const additionalLaunchIntegrations = launchIntegrations.slice(
-    collapsedIntegrationCount,
-  );
-  const canToggleIntegrations =
-    launchIntegrations.length > collapsedIntegrationCount;
   const claudeStatusLabel =
     claudePhase === "installing"
       ? "Downloading…"
@@ -902,60 +855,10 @@ export function ConnectAppsScreen({
                     >
                       Terminal
                     </h2>
-                    <div className="mt-2 overflow-hidden bg-white">
+                    <div className="mt-2 bg-white">
                       <div className="space-y-2">
-                        {initialLaunchIntegrations.map(launchIntegrationRow)}
+                        {launchIntegrations.map(launchIntegrationRow)}
                       </div>
-                      {canToggleIntegrations && (
-                        <div
-                          aria-hidden={!showAllIntegrations}
-                          inert={!showAllIntegrations}
-                          className={`grid transition-[grid-template-rows] ease-in-out motion-reduce:duration-0 ${
-                            showAllIntegrations
-                              ? "duration-[750ms]"
-                              : "duration-[825ms]"
-                          } ${
-                            showAllIntegrations
-                              ? "grid-rows-[1fr]"
-                              : "grid-rows-[0fr]"
-                          }`}
-                        >
-                          <div className="min-h-0 overflow-hidden">
-                            <div className="space-y-2 pt-2">
-                              {additionalLaunchIntegrations.map(
-                                launchIntegrationRow,
-                              )}
-                            </div>
-                          </div>
-                        </div>
-                      )}
-                      {canToggleIntegrations && (
-                        <button
-                          type="button"
-                          aria-label={
-                            showAllIntegrations
-                              ? "Collapse apps"
-                              : "Show more apps"
-                          }
-                          aria-expanded={showAllIntegrations}
-                          className="mx-auto mt-3 flex h-10 w-10 items-center justify-center rounded-full text-neutral-600 transition-colors hover:text-neutral-950 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-500"
-                          onClick={() =>
-                            setShowAllIntegrations((current) => !current)
-                          }
-                        >
-                          {showAllIntegrations ? (
-                            <ChevronUpIcon
-                              aria-hidden="true"
-                              className="h-5 w-5"
-                            />
-                          ) : (
-                            <ChevronDownIcon
-                              aria-hidden="true"
-                              className="h-5 w-5"
-                            />
-                          )}
-                        </button>
-                      )}
                     </div>
                   </section>
                 )}


### PR DESCRIPTION
The chevron button at the bottom of the terminal apps list looked like a scroll indicator but instead expanded a collapsed section.

Removes the "Show more apps" toggle, the window-height-based truncation and resize listener, and the grid-rows animation. All detected apps now render directly in the scrollable list.