### PR TITLE
Enable explicit thinking for the Qwen3 parser

### DIFF
--- a/model/parsers/parsers.go
+++ b/model/parsers/parsers.go
@@ -49,7 +49,7 @@ func ParserForName(name string) Parser {
 
 	switch name {
 	case "qwen3":
-		p = &Qwen3Parser{hasThinkingSupport: false, defaultThinking: false}
+		p = &Qwen3Parser{hasThinkingSupport: true, defaultThinking: false}
 	case "qwen3-thinking":
 		p = &Qwen3Parser{hasThinkingSupport: true, defaultThinking: true}
 	case "qwen3.5":

--- a/model/parsers/qwen3_test.go
+++ b/model/parsers/qwen3_test.go
@@ -26,6 +26,19 @@ func TestQwen3ParserThinkingEnabled(t *testing.T) {
 	}
 }
 
+func TestQwen3ParserFactorySupportsExplicitThinking(t *testing.T) {
+	parser := ParserForName("qwen3")
+	parser.Init(nil, nil, &api.ThinkValue{Value: true})
+
+	content, thinking, _, err := parser.Add("reasoning</think>answer", true)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if thinking != "reasoning" || content != "answer" {
+		t.Fatalf("expected thinking/content split, got thinking=%q content=%q", thinking, content)
+	}
+}
+
 func TestQwen3ParserThinkingEnabledWithExplicitOpeningTag(t *testing.T) {
 	parser := &Qwen3Parser{hasThinkingSupport: true, defaultThinking: true}
 	parser.Init(nil, nil, &api.ThinkValue{Value: true})


### PR DESCRIPTION
Closes #17937

Summary:
- Enable explicit thinking support in the Qwen3 parser while keeping it disabled by default.
- Add parser-factory coverage.

Tests:
- Go tests could not run because Go is not installed in the environment.