### PR TITLE
cmake: make external compat patches idempotent

### DIFF
--- a/cmake/apply-git-patches.cmake
+++ b/cmake/apply-git-patches.cmake
@@ -1,16 +1,21 @@
-# Idempotent patch applier used by compat.cmake.
+# Idempotent external-source patch applier.
 #
 # Invocation (from a CMake PATCH_COMMAND):
-#   cmake -DPATCH_DIR=<dir of *.patch> -P apply-patch.cmake
+#   cmake -DPATCH_DIR=<dir of *.patch> [-DPATCH_LABEL=<name>]
+#     -P cmake/apply-git-patches.cmake
 #
 # Every *.patch under PATCH_DIR is applied in numeric filename order in the
 # current working directory (which ExternalProject / FetchContent sets to the
 # fetched source's SOURCE_DIR). A patch already applied — detected via
 # `git apply --reverse --check` — is skipped. This makes re-configuring and
-# re-building safe.
+# re-building safe when the source directory outlives its CMake patch stamp.
 
 if(NOT DEFINED PATCH_DIR)
-    message(FATAL_ERROR "apply-patch.cmake: PATCH_DIR not set")
+    message(FATAL_ERROR "apply-git-patches.cmake: PATCH_DIR not set")
+endif()
+
+if(NOT DEFINED PATCH_LABEL)
+    set(PATCH_LABEL "external patches")
 endif()
 
 find_package(Git QUIET REQUIRED)
@@ -39,7 +44,7 @@ foreach(_patch_entry IN LISTS _patch_entries)
         OUTPUT_QUIET ERROR_QUIET
     )
     if(_reverse_check EQUAL 0)
-        message(STATUS "llama/compat: ${_patch_rel} already applied, skipping")
+        message(STATUS "${PATCH_LABEL}: ${_patch_rel} already applied, skipping")
         continue()
     endif()
 
@@ -51,10 +56,11 @@ foreach(_patch_entry IN LISTS _patch_entries)
     )
     if(NOT _apply_result EQUAL 0)
         message(FATAL_ERROR
-            "llama/compat: failed to apply ${_patch_rel}\n"
-            "This usually means the pinned llama.cpp source has changed. "
-            "Regenerate the patch against the pinned LLAMA_CPP_VERSION and retry.")
+            "${PATCH_LABEL}: failed to apply ${_patch_rel}\n"
+            "The pinned source is neither clean nor compatible with this patch. "
+            "Remove the retained source directory (${_patch_workdir}), or "
+            "regenerate the patch against the pinned source before retrying.")
     endif()
 
-    message(STATUS "llama/compat: applied ${_patch_rel}")
+    message(STATUS "${PATCH_LABEL}: applied ${_patch_rel}")
 endforeach()

--- a/cmake/local.cmake
+++ b/cmake/local.cmake
@@ -174,7 +174,10 @@ if(OLLAMA_MLX_BACKENDS)
     # ml-explore/mlx-c. Then bump MLX_C_VERSION and delete mlx/compat/.
     find_package(Git REQUIRED)
     set(OLLAMA_MLX_C_COMPAT_PATCH_COMMAND
-        ${GIT_EXECUTABLE} apply ${CMAKE_SOURCE_DIR}/mlx/compat/0001-mlx-c-regen-0.32.1.patch
+        ${CMAKE_COMMAND}
+            -DPATCH_DIR=${CMAKE_SOURCE_DIR}/mlx/compat
+            -DPATCH_LABEL=mlx/compat
+            -P ${CMAKE_SOURCE_DIR}/cmake/apply-git-patches.cmake
         CACHE INTERNAL "MLX-C carry patch")
 
     if(DEFINED "FETCHCONTENT_SOURCE_DIR_MLX-C" AND NOT "${FETCHCONTENT_SOURCE_DIR_MLX-C}" STREQUAL "")

--- a/llama/compat/README.md
+++ b/llama/compat/README.md
@@ -27,8 +27,9 @@ intentionally skipped so a developer can iterate on a local llama.cpp tree.
   It currently touches `src/llama-model-loader.cpp` and `tools/mtmd/clip.cpp`.
 - `002-llama-cpp-ui-empty-assets.patch` - lets the llama.cpp UI embed helper
   generate an empty asset table when no UI assets are present.
-- `compat.cmake`, `apply-patch.cmake` - CMake glue and an idempotent applier
-  (used by `llama/server/CMakeLists.txt`) that applies every `*.patch` under
+- `compat.cmake` - CMake glue that invokes the shared
+  `cmake/apply-git-patches.cmake` idempotent applier (used by
+  `llama/server/CMakeLists.txt`) for every `*.patch` under
   this directory by numeric filename order — the hooks patch plus each
   `models/` architecture patch.
 - `models/` - the sibling **new-architecture** layer: implementations of

--- a/llama/compat/compat.cmake
+++ b/llama/compat/compat.cmake
@@ -21,6 +21,9 @@
 #   2. A small ordered patch set that adds call-sites in llama.cpp loaders.
 
 set(_compat_dir ${CMAKE_CURRENT_LIST_DIR})
+get_filename_component(_ollama_patch_applier
+    "${_compat_dir}/../../cmake/apply-git-patches.cmake"
+    ABSOLUTE)
 
 # Expose a single variable the main CMakeLists passes into FetchContent's
 # PATCH_COMMAND. The patch is applied via a small CMake script so the step
@@ -34,7 +37,8 @@ set(_compat_dir ${CMAKE_CURRENT_LIST_DIR})
 set(OLLAMA_LLAMA_CPP_COMPAT_PATCH_COMMAND
     ${CMAKE_COMMAND}
         -DPATCH_DIR=${_compat_dir}
-        -P ${_compat_dir}/apply-patch.cmake
+        -DPATCH_LABEL=llama/compat
+        -P ${_ollama_patch_applier}
     CACHE INTERNAL "llama.cpp compat patch command for FetchContent")
 
 # Where the compat source files live, so the main CMakeLists can wire them


### PR DESCRIPTION
Fix MLX-C rebuilds when CMake reruns the temporary carry-patch step against a retained source directory.

The MLX-C source directory can outlive CMake's ExternalProject patch stamp. After a reconfigure or dependency-step invalidation, CMake invokes PATCH_COMMAND again, while the retained MLX-C checkout already contains
the carry patch from #17850. The prior raw `git apply` command then fails with 'patch does not apply', preventing incremental macOS MLX builds until generated native sources are manually cleaned.

Move the existing idempotent patch logic out of `llama/compat` into shared CMake infrastructure and reuse it for both llama.cpp and MLX-C. It detects an already-applied patch with `git apply --reverse --check`
and skips it; otherwise it applies the patch normally. A genuinely incompatible source still fails with a clear remediation message.

The MLX-C carry patch was introduced in #17850 while carrying ml-explore/mlx-c#127.