### PR TITLE
cmd: validate split GGUF files before upload

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -44,6 +44,7 @@ import (
 	"github.com/ollama/ollama/discover"
 	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/fs/ggml"
 	"github.com/ollama/ollama/internal/modelref"
 	"github.com/ollama/ollama/logutil"
 	"github.com/ollama/ollama/parser"
@@ -333,6 +334,15 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 		req.DraftQuantize = draftQuantize
 	}
 
+	fileNames := createRequestFileNames(req.Files)
+	adapterNames := createRequestFileNames(req.Adapters)
+	draftFileNames := createRequestFileNames(req.DraftFiles)
+	for _, files := range []map[string]string{fileNames, adapterNames, draftFileNames} {
+		if err := validateSplitGGUFFiles(files); err != nil {
+			return err
+		}
+	}
+
 	client, err := api.ClientFromEnvironment()
 	if err != nil {
 		return err
@@ -342,7 +352,6 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 	g.SetLimit(max(runtime.GOMAXPROCS(0)-1, 1))
 
 	files := syncmap.NewSyncMap[string, string]()
-	fileNames := createRequestFileNames(req.Files)
 	for f, digest := range req.Files {
 		g.Go(func() error {
 			if _, err := createBlob(cmd, client, f, digest, p); err != nil {
@@ -355,7 +364,6 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	adapters := syncmap.NewSyncMap[string, string]()
-	adapterNames := createRequestFileNames(req.Adapters)
 	for f, digest := range req.Adapters {
 		g.Go(func() error {
 			if _, err := createBlob(cmd, client, f, digest, p); err != nil {
@@ -368,7 +376,6 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 	}
 
 	draftFiles := syncmap.NewSyncMap[string, string]()
-	draftFileNames := createRequestFileNames(req.DraftFiles)
 	for f, digest := range req.DraftFiles {
 		g.Go(func() error {
 			if _, err := createBlob(cmd, client, f, digest, p); err != nil {
@@ -421,6 +428,41 @@ func CreateHandler(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	return nil
+}
+
+func validateSplitGGUFFiles(files map[string]string) error {
+	filePaths := make([]string, 0, len(files))
+	for filePath := range files {
+		filePaths = append(filePaths, filePath)
+	}
+	sort.Strings(filePaths)
+
+	for _, filePath := range filePaths {
+		if err := func() error {
+			f, err := os.Open(filePath)
+			if err != nil {
+				return err
+			}
+			defer f.Close()
+
+			var magic [4]byte
+			if _, err := io.ReadFull(f, magic[:]); err != nil || ggml.DetectContentType(magic[:]) != "gguf" {
+				return nil
+			}
+			if _, err := f.Seek(0, io.SeekStart); err != nil {
+				return err
+			}
+
+			model, err := ggml.Decode(f, 0)
+			if err != nil {
+				return err
+			}
+			return server.ValidateSplitGGUFFile(files[filePath], model)
+		}(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/cmd/cmd_test.go
+++ b/cmd/cmd_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/fs/ggml"
 	"github.com/ollama/ollama/types/model"
 )
 
@@ -1522,6 +1524,59 @@ func TestCreateHandler(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCreateHandlerRejectsInvalidSplitGGUFBeforeUpload(t *testing.T) {
+	dir := t.TempDir()
+	files := make(map[string]string)
+	for i, name := range []string{"bad-part-a.gguf", "bad-part-b.gguf"} {
+		filePath := filepath.Join(dir, name)
+		f, err := os.Create(filePath)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := ggml.WriteGGUF(f, ggml.KV{
+			"general.architecture": "llama",
+			"split.no":             uint32(i),
+			"split.count":          uint32(2),
+		}, nil); err != nil {
+			f.Close()
+			t.Fatal(err)
+		}
+		if err := f.Close(); err != nil {
+			t.Fatal(err)
+		}
+		files[filePath] = fmt.Sprintf("model-%05d-of-00002.gguf", i+1)
+	}
+	if err := validateSplitGGUFFiles(files); err != nil {
+		t.Fatalf("valid split filenames: %v", err)
+	}
+
+	modelfile := filepath.Join(dir, "Modelfile")
+	if err := os.WriteFile(modelfile, []byte("FROM .\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var requests atomic.Int32
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests.Add(1)
+		http.Error(w, "request should not be sent", http.StatusInternalServerError)
+	}))
+	t.Cleanup(mockServer.Close)
+	t.Setenv("OLLAMA_HOST", mockServer.URL)
+
+	cmd := &cobra.Command{}
+	cmd.Flags().String("file", modelfile, "")
+	cmd.Flags().Bool("insecure", false, "")
+	cmd.SetContext(t.Context())
+
+	err := CreateHandler(cmd, []string{"test-model"})
+	if err == nil || !strings.Contains(err.Error(), `split GGUF "bad-part-a.gguf" must use llama.cpp split filename pattern`) {
+		t.Fatalf("error = %v, want split filename validation error", err)
+	}
+	if got := requests.Load(); got != 0 {
+		t.Fatalf("HTTP request count = %d, want 0", got)
 	}
 }
 

--- a/server/create.go
+++ b/server/create.go
@@ -1106,6 +1106,15 @@ func prepareSplitGGUFInput(layer *layerGGML, dir string) (*os.File, func(), erro
 	return f, cleanup, nil
 }
 
+// ValidateSplitGGUFFile validates split metadata against the source filename.
+func ValidateSplitGGUFFile(name string, model *ggml.GGML) error {
+	_, _, err := splitGGUFGroupKey(&layerGGML{
+		Layer: manifest.Layer{From: name},
+		GGML:  model,
+	})
+	return err
+}
+
 var splitGGUFNameRe = regexp.MustCompile(`^(.*)-(\d{5})-of-(\d{5})\.gguf$`)
 
 func splitGGUFName(name string) (prefix string, index, count uint16, ok bool) {


### PR DESCRIPTION
## Summary

Fixes #17946.

Validate local split GGUF filenames and metadata before uploading blobs during `ollama create`.

The CLI currently uploads every file before `/api/create`, so invalid shard names are only detected after the blobs have already been copied. This change reuses the existing server-side validation before `createBlob`, covering filename, count, index, duplicate, and missing-shard errors.

## Testing

- Added tests for valid filenames, invalid filenames, and missing shards.
- Added a CLI regression test confirming invalid shards trigger no upload or `/api/create` request.
- Verified on a server with two 64 MiB shards:
  - model directory growth: `0`
  - blobs created: `0`
  - manifests created: `0`
  - original validation error preserved