### PR TITLE
docs: fix broken links in community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ console.log(response.message.content);
 - [any-llm](https://github.com/mozilla-ai/any-llm) - Unified LLM interface by Mozilla
 - [OllamaSharp for .NET](https://github.com/awaescher/OllamaSharp) - .NET SDK
 - [LangChainRust](https://github.com/Abraxas-365/langchain-rust) - Rust LangChain ([example](https://github.com/Abraxas-365/langchain-rust/blob/main/examples/llm_ollama.rs))
-- [Agents-Flex for Java](https://github.com/agents-flex/agents-flex) - Java agent framework ([example](https://github.com/agents-flex/agents-flex/tree/main/agents-flex-llm/agents-flex-llm-ollama/src/test/java/com/agentsflex/llm/ollama))
+- [Agents-Flex for Java](https://github.com/agents-flex/agents-flex) - Java agent framework
 - [Elixir LangChain](https://github.com/brainlid/langchain) - Elixir LangChain
 - [Ollama-rs for Rust](https://github.com/pepperoni21/ollama-rs) - Rust SDK
 - [LangChain for .NET](https://github.com/tryAGI/LangChain) - .NET LangChain ([example](https://github.com/tryAGI/LangChain/blob/main/examples/LangChain.Samples.OpenAI/Program.cs))
@@ -260,7 +260,7 @@ console.log(response.message.content);
 
 ### Frameworks & Agents
 
-- [AutoGPT](https://github.com/Significant-Gravitas/AutoGPT/blob/master/docs/content/platform/ollama.md) - Autonomous AI agent platform
+- [AutoGPT](https://github.com/Significant-Gravitas/AutoGPT/blob/master/docs/platform/ollama.md) - Autonomous AI agent platform
 - [crewAI](https://github.com/crewAIInc/crewAI) - Multi-agent orchestration framework
 - [Strands Agents](https://github.com/strands-agents/sdk-python) - Model-driven agent building by AWS
 - [Cheshire Cat](https://github.com/cheshire-cat-ai/core) - AI assistant framework
@@ -284,7 +284,7 @@ console.log(response.message.content);
 ### Bots & Messaging
 
 - [LangBot](https://github.com/RockChinQ/LangBot) - Multi-platform messaging bots with agents and RAG
-- [AstrBot](https://github.com/Soulter/AstrBot/) - Multi-platform chatbot with RAG and plugins
+- [AstrBot](https://github.com/AstrBotDevs/AstrBot) - Multi-platform chatbot with RAG and plugins
 - [Discord-Ollama Chat Bot](https://github.com/kevinthedang/discord-ollama) - TypeScript Discord bot
 - [Ollama Telegram Bot](https://github.com/ruecat/ollama-telegram) - Telegram bot
 - [LLM Telegram Bot](https://github.com/innightwolfsleep/llm_telegram_bot) - Telegram bot for roleplay
@@ -332,7 +332,6 @@ console.log(response.message.content);
 ### Database & Embeddings
 
 - [pgai](https://github.com/timescale/pgai) - PostgreSQL as a vector database ([guide](https://github.com/timescale/pgai/blob/main/docs/vectorizer-quick-start.md))
-- [MindsDB](https://github.com/mindsdb/mindsdb/blob/staging/mindsdb/integrations/handlers/ollama_handler/README.md) - Connect Ollama with 200+ data platforms
 - [chromem-go](https://github.com/philippgille/chromem-go/blob/v0.5.0/embed_ollama.go) - Embeddable vector database for Go ([example](https://github.com/philippgille/chromem-go/tree/v0.5.0/examples/rag-wikipedia-ollama))
 - [Kangaroo](https://github.com/dbkangaroo/kangaroo) - AI-powered SQL client
 


### PR DESCRIPTION
## What

Fixes four broken links in the Community Integrations section of README.md:

1. **Agents-Flex** — the example link pointed to a test path (`agents-flex-llm/agents-flex-llm-ollama/src/test/java/...`) that no longer exists in the repo. Removed the example link; the main repo link still works.

2. **AutoGPT** — the docs link used the old path `docs/content/platform/ollama.md`. AutoGPT restructured their docs and the file now lives at `docs/platform/ollama.md`. Updated accordingly.

3. **AstrBot** — the repo transferred from `Soulter/AstrBot` to `AstrBotDevs/AstrBot`. The old URL 404s; updated to the new org.

4. **MindsDB** — the `ollama_handler` was removed from the mindsdb repo entirely (no trace on `main` or `staging` branches). Removed the entry since there's nothing to link to.

## Verification

All four original links confirmed 404 via `curl -sL`:

```
404 https://github.com/agents-flex/agents-flex/tree/main/agents-flex-llm/...
404 https://github.com/Significant-Gravitas/AutoGPT/blob/master/docs/content/platform/ollama.md
404 https://github.com/Soulter/AstrBot/
404 https://github.com/mindsdb/mindsdb/blob/staging/mindsdb/integrations/handlers/ollama_handler/README.md
```

Replacement links confirmed 200:

```
200 https://github.com/Significant-Gravitas/AutoGPT/blob/master/docs/platform/ollama.md
200 https://github.com/AstrBotDevs/AstrBot
```

Note: the Gentoo link on line 354 is also broken but PR #11617 already covers that fix.
