### PR TITLE
server: add experimental prefill cache persistence across runner reloads

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -368,6 +368,16 @@ How much the cache quantization impacts the model's response quality will depend
 
 You may need to experiment with different quantization types to find the best balance between memory usage and quality.
 
+## How can I avoid reprocessing the same prompt after a model reloads?
+
+Ollama normally discards processed prompt state when a model unloads. To save this state temporarily and restore it when the same model and runtime settings are loaded again, set `OLLAMA_PREFILL_CACHE=1` when starting the Ollama server. This can reduce prompt processing time when requests reuse the same prefix after a reload.
+
+Saved state is stored under the system temporary directory, has an 8 GiB soft limit, and is removed when the Ollama server shuts down. A restarted server never reuses state from a previous run. If it cannot be restored, Ollama processes the prompt normally.
+
+<Note>
+  This feature is experimental and off by default.
+</Note>
+
 ## Where can I find my Ollama Public Key?
 
 Your **Ollama Public Key** is the public part of the key pair that lets your local Ollama instance talk to [ollama.com](https://ollama.com).

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -236,6 +236,8 @@ var (
 	EnableIntegratedGPU = BoolWithDefault("OLLAMA_IGPU_ENABLE")
 	// NoCloudEnv checks the OLLAMA_NO_CLOUD environment variable.
 	NoCloudEnv = Bool("OLLAMA_NO_CLOUD")
+	// PrefillCache enables experimental prefill/KV cache persistence across runner reloads within a single daemon process.
+	PrefillCache = Bool("OLLAMA_PREFILL_CACHE")
 )
 
 func String(s string) func() string {
@@ -332,6 +334,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_NOPRUNE":              {"OLLAMA_NOPRUNE", NoPrune(), "Do not prune model blobs on startup"},
 		"OLLAMA_NUM_PARALLEL":         {"OLLAMA_NUM_PARALLEL", NumParallel(), "Maximum number of parallel requests"},
 		"OLLAMA_ORIGINS":              {"OLLAMA_ORIGINS", AllowedOrigins(), "A comma separated list of allowed origins"},
+		"OLLAMA_PREFILL_CACHE":        {"OLLAMA_PREFILL_CACHE", PrefillCache(), "Experimental: persist prefill/KV cache across model reloads within a daemon (default: false)"},
 		"OLLAMA_SCHED_SPREAD":         {"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
 		"OLLAMA_CONTEXT_LENGTH":       {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4k/32k/256k based on VRAM)"},
 		"OLLAMA_EDITOR":               {"OLLAMA_EDITOR", Editor(), "Path to editor for interactive prompt editing (Ctrl+G)"},

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -378,6 +378,8 @@ func startLlamaServer(launch llamaServerLaunchConfig, out io.Writer) (cmd *exec.
 	params = appendLlamaServerLogArgs(params)
 	params = appendJinjaArgs(params, launch.config)
 
+	params = appendPrefillCacheArgs(params, launch.config.PrefillCachePath)
+
 	params = appendMMProjArgs(params, launch)
 	params = appendDraftArgs(params, launch.draftType, launch.config.DraftModelPath, launch.opts)
 
@@ -576,6 +578,18 @@ func appendLlamaServerLogArgs(params []string) []string {
 		"--no-log-prefix",
 		"--no-log-timestamps",
 	)
+}
+
+func appendPrefillCacheArgs(params []string, cachePath string) []string {
+	if cachePath == "" {
+		return params
+	}
+	if err := os.MkdirAll(cachePath, 0o700); err != nil {
+		slog.Warn("failed to create prefill cache directory; continuing without prefill cache persistence", "path", cachePath, "error", err)
+		return params
+	}
+	path := filepath.Clean(cachePath) + string(os.PathSeparator)
+	return append(params, "--slot-save-path", path)
 }
 
 func appendBatchArgs(params []string, opts api.Options, embedding bool, numParallel int) []string {

--- a/llm/prefill_cache.go
+++ b/llm/prefill_cache.go
@@ -1,0 +1,284 @@
+// prefill_cache.go persists a llama-server runner's processed prompt across
+// unload and reload, by driving the slot save and restore that llama-server
+// already exposes on its internal /slots endpoint. llamaServerRunner satisfies
+// PrefillCachePersistor through the two exported methods here.
+//
+// The scheduler owns the lifecycle: it chooses the directory, hands it over as
+// LlamaServerConfig.PrefillCachePath, saves before a runner shuts down, and
+// restores once its replacement is running. An empty path disables persistence,
+// which is the default.
+//
+// Key properties:
+//   - Both directions hold every slot of the runner's semaphore, so they only
+//     ever run against a quiesced server.
+//   - manifest.json names the slots that hold a snapshot, with a checksum for
+//     each, and is replaced last, which makes it the commit point of a save.
+//   - Failures are returned rather than fatal so the caller can fall back to a
+//     cold prefill, and only a snapshot that is provably unusable is deleted.
+package llm
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// llamaPrefillCacheEraseTimeout bounds the slot erase that follows a failed
+// restore. The erase is best effort cleanup on a runner that is about to
+// serve requests, so it is kept short: leaving the slot dirty is recorded
+// as a warning, but blocking the load behind a wedged server is not.
+const llamaPrefillCacheEraseTimeout = 10 * time.Second
+
+type llamaPrefillCacheManifest struct {
+	Slots []llamaPrefillCacheSlot `json:"slots"`
+}
+
+type llamaPrefillCacheSlot struct {
+	ID  int    `json:"id"`
+	CRC uint32 `json:"crc32c"`
+}
+
+var errInvalidLlamaPrefillCache = errors.New("invalid llama prefill cache")
+
+// llamaPrefillCacheCRC is Castagnoli, which compiles down to a hardware
+// instruction on amd64 and arm64. The checksum only has to catch a snapshot
+// damaged after it was written, and the manifest holding it sits in the same
+// directory under the same permissions, so a cryptographic digest would defend
+// against nothing this does not while costing several times as much per byte.
+var llamaPrefillCacheCRC = crc32.MakeTable(crc32.Castagnoli)
+
+func checksumPrefillCacheSlot(path string) (uint32, int64, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return 0, 0, err
+	}
+	defer file.Close()
+	hash := crc32.New(llamaPrefillCacheCRC)
+	size, err := io.Copy(hash, file)
+	if err != nil {
+		return 0, 0, err
+	}
+	return hash.Sum32(), size, nil
+}
+
+func (s *llamaServerRunner) SavePrefillCache(ctx context.Context) error {
+	cachePath := s.launch.config.PrefillCachePath
+	if cachePath == "" {
+		return nil
+	}
+	// Check before creating anything: a canceled save must not rebuild a
+	// directory the daemon's exit cleanup is removing.
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(cachePath, 0o700); err != nil {
+		return fmt.Errorf("create prefill cache directory: %w", err)
+	}
+
+	if err := s.sem.Acquire(ctx, int64(s.launch.numParallel)); err != nil {
+		return err
+	}
+	defer s.sem.Release(int64(s.launch.numParallel))
+
+	start := time.Now()
+	var savedBytes int64
+	savedSlots := make([]llamaPrefillCacheSlot, 0, s.launch.numParallel)
+	for id := range s.launch.numParallel {
+		finalName := fmt.Sprintf("slot-%d.bin", id)
+		tempName := finalName + ".tmp"
+		finalPath := filepath.Join(cachePath, finalName)
+		tempPath := filepath.Join(cachePath, tempName)
+		result, err := s.slotCacheAction(ctx, id, "save", tempName)
+		if err != nil {
+			var httpErr *llamaSlotCacheHTTPError
+			if errors.As(err, &httpErr) && httpErr.StatusCode == http.StatusNotImplemented {
+				_ = os.Remove(tempPath)
+				if err := os.Remove(finalPath); err != nil && !os.IsNotExist(err) {
+					return fmt.Errorf("remove unsupported slot %d prefill cache: %w", id, err)
+				}
+				continue
+			}
+			return err
+		}
+		if result.NSaved == 0 {
+			_ = os.Remove(tempPath)
+			if err := os.Remove(finalPath); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("remove empty slot %d prefill cache: %w", id, err)
+			}
+			continue
+		}
+		if err := os.Remove(finalPath); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("replace slot %d prefill cache: %w", id, err)
+		}
+		if err := os.Rename(tempPath, finalPath); err != nil {
+			return fmt.Errorf("commit slot %d prefill cache: %w", id, err)
+		}
+		crc, size, err := checksumPrefillCacheSlot(finalPath)
+		if err != nil {
+			return fmt.Errorf("checksum slot %d prefill cache: %w", id, err)
+		}
+		savedBytes += size
+		savedSlots = append(savedSlots, llamaPrefillCacheSlot{ID: id, CRC: crc})
+	}
+
+	manifest, err := json.Marshal(llamaPrefillCacheManifest{Slots: savedSlots})
+	if err != nil {
+		return err
+	}
+	// Replace the manifest last, so a save that fails partway leaves the
+	// previous generation listed and restorable. Slot files are replaced one
+	// at a time and each is self-consistent, so a mixed generation restores a
+	// shorter prefix rather than a wrong one.
+	tempManifest := filepath.Join(cachePath, "manifest.json.tmp")
+	if err := os.WriteFile(tempManifest, manifest, 0o600); err != nil {
+		return fmt.Errorf("write prefill cache manifest: %w", err)
+	}
+	if err := os.Rename(tempManifest, filepath.Join(cachePath, "manifest.json")); err != nil {
+		return fmt.Errorf("commit prefill cache manifest: %w", err)
+	}
+	if len(savedSlots) > 0 {
+		slog.Info("saved prefill cache", "slots", len(savedSlots), "bytes", savedBytes, "duration", time.Since(start))
+	}
+	return nil
+}
+
+func (s *llamaServerRunner) RestorePrefillCache(ctx context.Context) error {
+	err := s.restorePrefillCache(ctx)
+	if errors.Is(err, errInvalidLlamaPrefillCache) && s.launch.config.PrefillCachePath != "" {
+		_ = os.RemoveAll(s.launch.config.PrefillCachePath)
+	}
+	return err
+}
+
+func (s *llamaServerRunner) restorePrefillCache(ctx context.Context) error {
+	cachePath := s.launch.config.PrefillCachePath
+	if cachePath == "" {
+		return nil
+	}
+
+	data, err := os.ReadFile(filepath.Join(cachePath, "manifest.json"))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("read prefill cache manifest: %w", err)
+	}
+	var manifest llamaPrefillCacheManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return fmt.Errorf("%w: decode manifest: %v", errInvalidLlamaPrefillCache, err)
+	}
+	seen := make(map[int]bool, len(manifest.Slots))
+	for _, slot := range manifest.Slots {
+		if slot.ID < 0 || slot.ID >= s.launch.numParallel || seen[slot.ID] {
+			return fmt.Errorf("%w: incompatible slot %d", errInvalidLlamaPrefillCache, slot.ID)
+		}
+		seen[slot.ID] = true
+	}
+	// Verify every slot before the server reads any of them. llama-server
+	// checks a save file's header against the model it is loaded with but not
+	// the payload behind it, so a snapshot damaged after it was written
+	// restores as garbage and the reply is wrong rather than merely cold.
+	// This also makes a half-saved generation a cold miss.
+	verifyStart := time.Now()
+	for _, slot := range manifest.Slots {
+		crc, _, err := checksumPrefillCacheSlot(filepath.Join(cachePath, fmt.Sprintf("slot-%d.bin", slot.ID)))
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("%w: slot %d is missing", errInvalidLlamaPrefillCache, slot.ID)
+		}
+		if err != nil {
+			return fmt.Errorf("read slot %d prefill cache: %w", slot.ID, err)
+		}
+		if crc != slot.CRC {
+			return fmt.Errorf("%w: slot %d checksum mismatch", errInvalidLlamaPrefillCache, slot.ID)
+		}
+	}
+	verify := time.Since(verifyStart)
+
+	if err := s.sem.Acquire(ctx, int64(s.launch.numParallel)); err != nil {
+		return err
+	}
+	defer s.sem.Release(int64(s.launch.numParallel))
+
+	start := time.Now()
+	for _, slot := range manifest.Slots {
+		if _, err := s.slotCacheAction(ctx, slot.ID, "restore", fmt.Sprintf("slot-%d.bin", slot.ID)); err != nil {
+			// Clear any partial state before falling back to cold prefill.
+			// The snapshot is left alone: llama-server answers 400 for a bad
+			// save file and for runtime failures such as insufficient KV
+			// space, so its status cannot prove the file is corrupt.
+			s.eraseSlotAfterFailedRestore(slot.ID)
+			return err
+		}
+	}
+	if len(manifest.Slots) > 0 {
+		slog.Info("restored prefill cache", "slots", len(manifest.Slots), "verify", verify, "duration", time.Since(start))
+	}
+	return nil
+}
+
+// eraseSlotAfterFailedRestore uses its own context: the restore may have
+// failed precisely because the caller's context was canceled, and the erase
+// must still run to clear any partially restored state.
+func (s *llamaServerRunner) eraseSlotAfterFailedRestore(id int) {
+	ctx, cancel := context.WithTimeout(context.Background(), llamaPrefillCacheEraseTimeout)
+	defer cancel()
+	if _, err := s.slotCacheAction(ctx, id, "erase", ""); err != nil {
+		slog.Warn("failed to erase slot after failed prefill cache restore; slot may hold partial state", "slot", id, "error", err)
+	}
+}
+
+type llamaSlotCacheHTTPError struct {
+	StatusCode int
+	Action     string
+	Slot       int
+	Message    string
+}
+
+func (e *llamaSlotCacheHTTPError) Error() string {
+	return fmt.Sprintf("%s slot %d prefill cache: status %d: %s", e.Action, e.Slot, e.StatusCode, e.Message)
+}
+
+type llamaSlotCacheActionResponse struct {
+	NSaved int `json:"n_saved"`
+}
+
+func (s *llamaServerRunner) slotCacheAction(ctx context.Context, id int, action, filename string) (llamaSlotCacheActionResponse, error) {
+	body, err := json.Marshal(map[string]string{"filename": filename})
+	if err != nil {
+		return llamaSlotCacheActionResponse{}, err
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/slots/%d?action=%s", s.port, id, action)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return llamaSlotCacheActionResponse{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.httpClient().Do(req)
+	if err != nil {
+		return llamaSlotCacheActionResponse{}, fmt.Errorf("%s slot %d prefill cache: %w", action, id, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		message, _ := io.ReadAll(io.LimitReader(resp.Body, 64<<10))
+		return llamaSlotCacheActionResponse{}, &llamaSlotCacheHTTPError{
+			StatusCode: resp.StatusCode,
+			Action:     action,
+			Slot:       id,
+			Message:    string(bytes.TrimSpace(message)),
+		}
+	}
+	var result llamaSlotCacheActionResponse
+	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
+		return llamaSlotCacheActionResponse{}, fmt.Errorf("decode %s slot %d prefill cache response: %w", action, id, err)
+	}
+	return result, nil
+}

--- a/llm/prefill_cache_test.go
+++ b/llm/prefill_cache_test.go
@@ -1,0 +1,543 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"hash/crc32"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"golang.org/x/sync/semaphore"
+)
+
+func mustExist(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+}
+
+func mustNotExist(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stat %s: got %v, want %v", path, err, os.ErrNotExist)
+	}
+}
+
+func mustReadFile(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(data)
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+// serverPort returns the port httptest bound, which the runner needs because
+// it addresses llama-server by port rather than by URL.
+func serverPort(t *testing.T, server *httptest.Server) int {
+	t.Helper()
+	parsed, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse %s: %v", server.URL, err)
+	}
+	_, portText, err := net.SplitHostPort(parsed.Host)
+	if err != nil {
+		t.Fatalf("split %s: %v", parsed.Host, err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatalf("parse port %s: %v", portText, err)
+	}
+	return port
+}
+
+func TestLlamaPrefillCacheSaveRestore(t *testing.T) {
+	cachePath := t.TempDir()
+	var mu sync.Mutex
+	var actions []string
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Filename string `json:"filename"`
+		}
+		// t.Fatalf must not run outside the test goroutine, so handler
+		// failures are reported and answered with an error status.
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode slot request: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		action := r.URL.Query().Get("action")
+		id := strings.TrimPrefix(r.URL.Path, "/slots/")
+		mu.Lock()
+		actions = append(actions, action+":"+id+":"+body.Filename)
+		mu.Unlock()
+		if action == "save" {
+			if err := os.WriteFile(filepath.Join(cachePath, body.Filename), []byte("slot "+id), 0o600); err != nil {
+				t.Errorf("write %s: %v", body.Filename, err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if action == "save" && id == "1" {
+			w.WriteHeader(http.StatusNotImplemented)
+			_, _ = w.Write([]byte(`{"error":"media slot"}`))
+			return
+		}
+		if id == "0" {
+			_, _ = w.Write([]byte(`{"n_saved":3}`))
+		} else {
+			_, _ = w.Write([]byte(`{"n_saved":0}`))
+		}
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	runner := &llamaServerRunner{
+		port:   serverPort(t, server),
+		client: server.Client(),
+		sem:    semaphore.NewWeighted(2),
+		launch: llamaServerLaunchConfig{
+			numParallel: 2,
+			config:      LlamaServerConfig{PrefillCachePath: cachePath},
+		},
+	}
+
+	// An unsupported slot must not retain its previous snapshot.
+	mustWriteFile(t, filepath.Join(cachePath, "slot-1.bin"), "stale")
+
+	if err := runner.SavePrefillCache(t.Context()); err != nil {
+		t.Fatalf("SavePrefillCache() = %v, want nil", err)
+	}
+	mustExist(t, filepath.Join(cachePath, "slot-0.bin"))
+	mustNotExist(t, filepath.Join(cachePath, "slot-1.bin"))
+	mustExist(t, filepath.Join(cachePath, "manifest.json"))
+	mustNotExist(t, filepath.Join(cachePath, "slot-0.bin.tmp"))
+	mustNotExist(t, filepath.Join(cachePath, "slot-1.bin.tmp"))
+
+	// Replacing an existing published checkpoint must also work on Windows.
+	if err := runner.SavePrefillCache(t.Context()); err != nil {
+		t.Fatalf("second SavePrefillCache() = %v, want nil", err)
+	}
+	mustExist(t, filepath.Join(cachePath, "manifest.json"))
+
+	mu.Lock()
+	actions = nil
+	mu.Unlock()
+	if err := runner.RestorePrefillCache(t.Context()); err != nil {
+		t.Fatalf("RestorePrefillCache() = %v, want nil", err)
+	}
+	mu.Lock()
+	defer mu.Unlock()
+	if want := []string{"restore:0:slot-0.bin"}; !slices.Equal(actions, want) {
+		t.Fatalf("slot actions = %v, want %v", actions, want)
+	}
+}
+
+func TestLlamaPrefillCacheSkipsEmptySlot(t *testing.T) {
+	cachePath := t.TempDir()
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body struct {
+			Filename string `json:"filename"`
+		}
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Errorf("decode slot request: %v", err)
+			w.WriteHeader(http.StatusBadRequest)
+			return
+		}
+		if err := os.WriteFile(filepath.Join(cachePath, body.Filename), []byte("empty slot"), 0o600); err != nil {
+			t.Errorf("write %s: %v", body.Filename, err)
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"n_saved":0}`))
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	runner := &llamaServerRunner{
+		port:   serverPort(t, server),
+		client: server.Client(),
+		sem:    semaphore.NewWeighted(1),
+		launch: llamaServerLaunchConfig{
+			numParallel: 1,
+			config:      LlamaServerConfig{PrefillCachePath: cachePath},
+		},
+	}
+
+	mustWriteFile(t, filepath.Join(cachePath, "slot-0.bin"), "stale")
+	if err := runner.SavePrefillCache(t.Context()); err != nil {
+		t.Fatalf("SavePrefillCache() = %v, want nil", err)
+	}
+	mustNotExist(t, filepath.Join(cachePath, "slot-0.bin.tmp"))
+	mustNotExist(t, filepath.Join(cachePath, "slot-0.bin"))
+
+	data, err := os.ReadFile(filepath.Join(cachePath, "manifest.json"))
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	var manifest llamaPrefillCacheManifest
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		t.Fatalf("decode manifest: %v", err)
+	}
+	if len(manifest.Slots) != 0 {
+		t.Fatalf("manifest = %+v, want no saved slots", manifest)
+	}
+}
+
+// manifestForSlots builds the manifest a save would have written for the slot
+// files already in cachePath. A named slot with no file gets a zero checksum,
+// which is what the missing-slot case needs.
+func manifestForSlots(t *testing.T, cachePath string, ids ...int) string {
+	t.Helper()
+	slots := make([]llamaPrefillCacheSlot, 0, len(ids))
+	for _, id := range ids {
+		crc, _, err := checksumPrefillCacheSlot(filepath.Join(cachePath, fmt.Sprintf("slot-%d.bin", id)))
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("checksum slot %d: %v", id, err)
+		}
+		slots = append(slots, llamaPrefillCacheSlot{ID: id, CRC: crc})
+	}
+	data, err := json.Marshal(llamaPrefillCacheManifest{Slots: slots})
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	return string(data)
+}
+
+func TestLlamaPrefillCacheErasesSlotOnFailedRestore(t *testing.T) {
+	// llama-server answers 400 both for a bad save file and for runtime
+	// failures such as insufficient KV space, so no status proves the
+	// snapshot is corrupt: every failed restore erases the slot and keeps
+	// the snapshot for the next load.
+	for name, status := range map[string]int{
+		"invalid request": http.StatusBadRequest,
+		"unavailable":     http.StatusServiceUnavailable,
+	} {
+		t.Run(name, func(t *testing.T) {
+			cachePath := t.TempDir()
+			mustWriteFile(t, filepath.Join(cachePath, "slot-0.bin"), "kv")
+			mustWriteFile(t, filepath.Join(cachePath, "manifest.json"), manifestForSlots(t, cachePath, 0))
+
+			var mu sync.Mutex
+			var actions []string
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				action := r.URL.Query().Get("action")
+				id := strings.TrimPrefix(r.URL.Path, "/slots/")
+				mu.Lock()
+				actions = append(actions, action+":"+id)
+				mu.Unlock()
+				w.Header().Set("Content-Type", "application/json")
+				if action == "restore" {
+					w.WriteHeader(status)
+					_, _ = w.Write([]byte(`{"error":"cannot restore"}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{}`))
+			})
+			server := httptest.NewServer(handler)
+			defer server.Close()
+
+			runner := &llamaServerRunner{
+				port:   serverPort(t, server),
+				client: server.Client(),
+				sem:    semaphore.NewWeighted(1),
+				launch: llamaServerLaunchConfig{
+					numParallel: 1,
+					config:      LlamaServerConfig{PrefillCachePath: cachePath},
+				},
+			}
+
+			if err := runner.RestorePrefillCache(t.Context()); err == nil {
+				t.Fatal("RestorePrefillCache() = nil, want an error")
+			}
+			// The slot must be erased so a partial restore cannot corrupt
+			// later completions.
+			mu.Lock()
+			if want := []string{"restore:0", "erase:0"}; !slices.Equal(actions, want) {
+				mu.Unlock()
+				t.Fatalf("slot actions = %v, want %v", actions, want)
+			}
+			mu.Unlock()
+			mustExist(t, filepath.Join(cachePath, "manifest.json"))
+			mustExist(t, filepath.Join(cachePath, "slot-0.bin"))
+		})
+	}
+}
+
+func TestLlamaPrefillCacheSaveRecreatesMissingDirectory(t *testing.T) {
+	// An unusable snapshot is deleted while the runner keeps serving, so the
+	// next save has to rebuild the directory llama-server was launched with.
+	cachePath := filepath.Join(t.TempDir(), "cache")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"n_saved":0}`))
+	}))
+	defer server.Close()
+	runner := &llamaServerRunner{
+		port:   serverPort(t, server),
+		client: server.Client(),
+		sem:    semaphore.NewWeighted(1),
+		launch: llamaServerLaunchConfig{
+			numParallel: 1,
+			config:      LlamaServerConfig{PrefillCachePath: cachePath},
+		},
+	}
+	if err := runner.SavePrefillCache(t.Context()); err != nil {
+		t.Fatalf("SavePrefillCache() = %v, want nil", err)
+	}
+	mustExist(t, filepath.Join(cachePath, "manifest.json"))
+}
+
+func TestLlamaPrefillCacheKeepsPreviousManifestOnFailedSave(t *testing.T) {
+	cachePath := t.TempDir()
+	mustWriteFile(t, filepath.Join(cachePath, "slot-0.bin"), "kv")
+	manifest := manifestForSlots(t, cachePath, 0)
+	mustWriteFile(t, filepath.Join(cachePath, "manifest.json"), manifest)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	runner := &llamaServerRunner{
+		port:   serverPort(t, server),
+		client: server.Client(),
+		sem:    semaphore.NewWeighted(1),
+		launch: llamaServerLaunchConfig{
+			numParallel: 1,
+			config:      LlamaServerConfig{PrefillCachePath: cachePath},
+		},
+	}
+	if err := runner.SavePrefillCache(t.Context()); err == nil {
+		t.Fatal("SavePrefillCache() = nil, want an error")
+	}
+	// A save that fails before replacing anything must leave the last good
+	// generation restorable rather than invalidating it up front.
+	if got := mustReadFile(t, filepath.Join(cachePath, "manifest.json")); got != manifest {
+		t.Fatalf("manifest.json = %q, want the previous generation %q", got, manifest)
+	}
+	if got := mustReadFile(t, filepath.Join(cachePath, "slot-0.bin")); got != "kv" {
+		t.Fatalf("slot-0.bin = %q, want %q", got, "kv")
+	}
+}
+
+func TestLlamaPrefillCacheMissingSlotFailsOpen(t *testing.T) {
+	cachePath := t.TempDir()
+	mustWriteFile(t, filepath.Join(cachePath, "slot-0.bin"), "kv0")
+	mustWriteFile(t, filepath.Join(cachePath, "manifest.json"), manifestForSlots(t, cachePath, 0, 1))
+
+	var actions atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		actions.Add(1)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+	runner := &llamaServerRunner{
+		port:   serverPort(t, server),
+		client: server.Client(),
+		sem:    semaphore.NewWeighted(2),
+		launch: llamaServerLaunchConfig{
+			numParallel: 2,
+			config:      LlamaServerConfig{PrefillCachePath: cachePath},
+		},
+	}
+	err := runner.RestorePrefillCache(t.Context())
+	if err == nil || !strings.Contains(err.Error(), "slot 1 is missing") {
+		t.Fatalf("RestorePrefillCache() = %v, want a missing slot error", err)
+	}
+	if got := actions.Load(); got != 0 {
+		t.Fatalf("slot actions = %d, want 0: every slot must be accounted for before restore", got)
+	}
+	mustNotExist(t, cachePath)
+}
+
+func TestLlamaPrefillCacheCanceledSaveCreatesNothing(t *testing.T) {
+	cachePath := filepath.Join(t.TempDir(), "cache")
+	runner := &llamaServerRunner{
+		sem: semaphore.NewWeighted(1),
+		launch: llamaServerLaunchConfig{
+			numParallel: 1,
+			config:      LlamaServerConfig{PrefillCachePath: cachePath},
+		},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	// Shutdown cancels in-flight saves while it removes the cache root, so a
+	// canceled save that still created its directory would leak it.
+	if err := runner.SavePrefillCache(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("SavePrefillCache() = %v, want %v", err, context.Canceled)
+	}
+	mustNotExist(t, cachePath)
+}
+
+func TestLlamaPrefillCacheKeepsSnapshotOnInterruptedRestore(t *testing.T) {
+	cachePath := t.TempDir()
+	mustWriteFile(t, filepath.Join(cachePath, "slot-0.bin"), "kv")
+	mustWriteFile(t, filepath.Join(cachePath, "manifest.json"), manifestForSlots(t, cachePath, 0))
+
+	runner := &llamaServerRunner{
+		sem: semaphore.NewWeighted(1),
+		launch: llamaServerLaunchConfig{
+			numParallel: 1,
+			config:      LlamaServerConfig{PrefillCachePath: cachePath},
+		},
+	}
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	if err := runner.RestorePrefillCache(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("RestorePrefillCache() = %v, want %v", err, context.Canceled)
+	}
+	mustExist(t, filepath.Join(cachePath, "manifest.json"))
+	mustExist(t, filepath.Join(cachePath, "slot-0.bin"))
+}
+
+func TestLlamaPrefillCacheRejectsInvalidManifest(t *testing.T) {
+	// A manifest that cannot describe this runner's slots is rejected before
+	// the server is touched, and is deleted rather than retried so the next
+	// load is a clean cold prefill instead of the same failure forever.
+	crc := crc32.Checksum([]byte("kv"), llamaPrefillCacheCRC)
+	for name, manifest := range map[string]string{
+		"slot out of range": fmt.Sprintf(`{"slots":[{"id":0,"crc32c":%d},{"id":1,"crc32c":%d}]}`, crc, crc),
+		"duplicate slot":    fmt.Sprintf(`{"slots":[{"id":0,"crc32c":%d},{"id":0,"crc32c":%d}]}`, crc, crc),
+		"checksum mismatch": fmt.Sprintf(`{"slots":[{"id":0,"crc32c":%d}]}`, crc+1),
+		"malformed json":    `{"slots":`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			cachePath := t.TempDir()
+			mustWriteFile(t, filepath.Join(cachePath, "manifest.json"), manifest)
+			// Every slot the manifests name has a file, so the manifest itself
+			// is the only thing that can make the snapshot unusable.
+			mustWriteFile(t, filepath.Join(cachePath, "slot-0.bin"), "kv")
+			mustWriteFile(t, filepath.Join(cachePath, "slot-1.bin"), "kv")
+
+			var actions atomic.Int32
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				actions.Add(1)
+				_, _ = w.Write([]byte(`{}`))
+			}))
+			defer server.Close()
+			runner := &llamaServerRunner{
+				port:   serverPort(t, server),
+				client: server.Client(),
+				sem:    semaphore.NewWeighted(1),
+				launch: llamaServerLaunchConfig{
+					numParallel: 1,
+					config:      LlamaServerConfig{PrefillCachePath: cachePath},
+				},
+			}
+			if err := runner.RestorePrefillCache(t.Context()); err == nil {
+				t.Fatal("RestorePrefillCache() = nil, want an error")
+			}
+			if got := actions.Load(); got != 0 {
+				t.Fatalf("slot actions = %d, want 0", got)
+			}
+			mustNotExist(t, cachePath)
+		})
+	}
+}
+
+func TestLlamaPrefillCacheWithoutManifestIsColdMiss(t *testing.T) {
+	cachePath := t.TempDir()
+	var actions atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		actions.Add(1)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+	runner := &llamaServerRunner{
+		port:   serverPort(t, server),
+		client: server.Client(),
+		sem:    semaphore.NewWeighted(1),
+		launch: llamaServerLaunchConfig{
+			numParallel: 1,
+			config:      LlamaServerConfig{PrefillCachePath: cachePath},
+		},
+	}
+	// Every runner starts without a manifest, so an absent one is the normal
+	// first load rather than a failure.
+	if err := runner.RestorePrefillCache(t.Context()); err != nil {
+		t.Fatalf("RestorePrefillCache() = %v, want nil", err)
+	}
+	if got := actions.Load(); got != 0 {
+		t.Fatalf("slot actions = %d, want 0", got)
+	}
+	mustExist(t, cachePath)
+}
+
+func TestLlamaPrefillCacheDisabledIsNoOp(t *testing.T) {
+	// With persistence off the configured path is empty. Both directions must
+	// return having touched nothing: without the guard, restore would read a
+	// relative manifest.json out of the daemon's working directory and save
+	// would report a failure on every unload.
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "slot-0.bin"), "kv")
+	mustWriteFile(t, filepath.Join(dir, "manifest.json"), manifestForSlots(t, dir, 0))
+	t.Chdir(dir)
+
+	var actions atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		actions.Add(1)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer server.Close()
+	runner := &llamaServerRunner{
+		port:   serverPort(t, server),
+		client: server.Client(),
+		sem:    semaphore.NewWeighted(1),
+		launch: llamaServerLaunchConfig{numParallel: 1},
+	}
+	if err := runner.SavePrefillCache(t.Context()); err != nil {
+		t.Fatalf("SavePrefillCache() = %v, want nil", err)
+	}
+	if err := runner.RestorePrefillCache(t.Context()); err != nil {
+		t.Fatalf("RestorePrefillCache() = %v, want nil", err)
+	}
+	if got := actions.Load(); got != 0 {
+		t.Fatalf("slot actions = %d, want 0", got)
+	}
+}
+
+func TestAppendPrefillCacheArgsFailOpen(t *testing.T) {
+	unchanged := []string{"--model", "m"}
+	if got := appendPrefillCacheArgs(unchanged, ""); !slices.Equal(got, unchanged) {
+		t.Fatalf("appendPrefillCacheArgs(%v, \"\") = %v, want %v", unchanged, got, unchanged)
+	}
+
+	cachePath := filepath.Join(t.TempDir(), "cache")
+	want := []string{"--slot-save-path", filepath.Clean(cachePath) + string(os.PathSeparator)}
+	if got := appendPrefillCacheArgs(nil, cachePath); !slices.Equal(got, want) {
+		t.Fatalf("appendPrefillCacheArgs(nil, %q) = %v, want %v", cachePath, got, want)
+	}
+	mustExist(t, cachePath)
+
+	// A path that cannot be created disables persistence instead of failing
+	// the load.
+	blocked := filepath.Join(t.TempDir(), "blocked")
+	mustWriteFile(t, blocked, "")
+	if got := appendPrefillCacheArgs(nil, filepath.Join(blocked, "cache")); len(got) != 0 {
+		t.Fatalf("appendPrefillCacheArgs(nil, <uncreatable>) = %v, want no args", got)
+	}
+}

--- a/llm/server.go
+++ b/llm/server.go
@@ -77,11 +77,18 @@ type LlamaServer interface {
 	ContextLength() int
 }
 
+// PrefillCachePersistor saves and restores a runner's processed prompt state.
+type PrefillCachePersistor interface {
+	SavePrefillCache(context.Context) error
+	RestorePrefillCache(context.Context) error
+}
+
 type LlamaServerConfig struct {
-	DisableJinja   bool
-	ContextShift   bool
-	EnableMTP      bool
-	DraftModelPath string
+	DisableJinja     bool
+	ContextShift     bool
+	EnableMTP        bool
+	DraftModelPath   string
+	PrefillCachePath string
 }
 
 // LoadModel will load a model from disk. The model must be in the GGML format.

--- a/server/prefill_cache.go
+++ b/server/prefill_cache.go
@@ -1,0 +1,226 @@
+// prefill_cache.go owns the lifecycle of the prefill caches that runners save
+// and restore: where a snapshot lives, which runner may reuse it, when it is
+// written and read, and how much disk the set of them may hold. Runners are
+// reached only through llm.PrefillCachePersistor, so nothing here knows how a
+// snapshot is produced.
+//
+// Key properties:
+//   - The feature is off unless OLLAMA_PREFILL_CACHE is set. Without it the
+//     cache root is empty and every entry point returns having done nothing.
+//   - The root is a fresh temporary directory per daemon, removed when the
+//     daemon's context ends, so a snapshot never outlives the process that
+//     wrote it.
+//   - A snapshot's directory is named by a hash of the same model, adapter and
+//     option set that needsReload compares, so a runner only ever finds a
+//     snapshot it would not have reloaded for.
+//   - Saving talks to the runner over HTTP, so it runs before loadedMu is
+//     taken; pruning takes loadedMu, so it runs after the runner's refMu is
+//     released. Neither holds one scheduler lock across the other.
+package server
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/llm"
+)
+
+const (
+	maxPrefillCacheDiskBytes   int64 = 8 << 30
+	prefillCachePersistTimeout       = time.Minute
+	prefillCacheRootPrefix           = "ollama-prefill-cache-"
+)
+
+func initPrefillCacheRoot(ctx context.Context) string {
+	if !envconfig.PrefillCache() {
+		return ""
+	}
+	root, err := os.MkdirTemp("", prefillCacheRootPrefix)
+	if err != nil {
+		slog.Warn("prefill cache persistence disabled", "error", err)
+		return ""
+	}
+	go func() {
+		<-ctx.Done()
+		if err := os.RemoveAll(root); err != nil {
+			slog.Debug("failed to remove prefill cache directory", "path", root, "error", err)
+		}
+	}()
+
+	return root
+}
+
+type prefillCacheIdentity struct {
+	Runner       string     `json:"runner"`
+	Model        string     `json:"model"`
+	Draft        string     `json:"draft,omitempty"`
+	Adapters     []string   `json:"adapters,omitempty"`
+	Projectors   []string   `json:"projectors,omitempty"`
+	Options      api.Runner `json:"options"`
+	NumParallel  int        `json:"num_parallel"`
+	KVCacheType  string     `json:"kv_cache_type,omitempty"`
+	ContextShift bool       `json:"context_shift,omitempty"`
+}
+
+func (s *Scheduler) prefillCachePath(identity prefillCacheIdentity) string {
+	if s.prefillCacheRoot == "" {
+		return ""
+	}
+	data, err := json.Marshal(identity)
+	if err != nil {
+		slog.Debug("failed to identify prefill cache", "error", err)
+		return ""
+	}
+	sum := sha256.Sum256(data)
+	return filepath.Join(s.prefillCacheRoot, hex.EncodeToString(sum[:]))
+}
+
+func (s *Scheduler) llamaPrefillCachePath(req *LlmRequest, opts api.Runner, numParallel int) string {
+	return s.prefillCachePath(prefillCacheIdentity{
+		Runner:       "llama.cpp",
+		Model:        schedulerModelKey(req.model),
+		Draft:        req.model.DraftPath,
+		Adapters:     req.model.AdapterPaths,
+		Projectors:   req.model.ProjectorPaths,
+		Options:      opts,
+		NumParallel:  numParallel,
+		KVCacheType:  envconfig.KvCacheType(),
+		ContextShift: req.contextShift,
+	})
+}
+
+// restorePrefillCache runs with refMu held, while the runner is still loading
+// and before any request can reach it.
+func (runner *runnerRef) restorePrefillCache(ctx context.Context) {
+	cache, ok := runner.llama.(llm.PrefillCachePersistor)
+	if !ok {
+		return
+	}
+	if runner.prefillCacheDir != "" {
+		// Prefer other entries if another unload prunes while restore reads this one.
+		now := time.Now()
+		_ = os.Chtimes(runner.prefillCacheDir, now, now)
+	}
+	restoreCtx, cancel := context.WithTimeout(ctx, prefillCachePersistTimeout)
+	defer cancel()
+	if err := cache.RestorePrefillCache(restoreCtx); err != nil {
+		slog.Warn(
+			"failed to restore prefill cache; continuing with cold cache",
+			"model", runner.modelKey,
+			"error", err,
+		)
+	}
+}
+
+// savePrefillCache runs with refMu held. A runner that is still loading has
+// no state worth saving.
+func (runner *runnerRef) savePrefillCache(ctx context.Context) {
+	if runner.llama == nil || runner.loading {
+		return
+	}
+	if cache, ok := runner.llama.(llm.PrefillCachePersistor); ok && !runner.llama.HasExited() {
+		saveCtx, cancel := context.WithTimeout(ctx, prefillCachePersistTimeout)
+		defer cancel()
+		if err := cache.SavePrefillCache(saveCtx); err != nil {
+			slog.Warn("failed to save prefill cache; runner will unload without a snapshot", "model", runner.modelKey, "error", err)
+		}
+	}
+}
+
+// prunePrefillCache evicts the oldest entries until the cache is under
+// maxPrefillCacheDiskBytes. Entries belonging to loaded runners are kept: a
+// live runner writes into its own directory and holds it open.
+func (s *Scheduler) prunePrefillCache() {
+	if s.prefillCacheRoot == "" {
+		return
+	}
+	prunePrefillCache(s.prefillCacheRoot, maxPrefillCacheDiskBytes, s.prefillCacheDirsInUse())
+}
+
+func (s *Scheduler) prefillCacheDirsInUse() map[string]struct{} {
+	s.loadedMu.Lock()
+	defer s.loadedMu.Unlock()
+	dirs := make(map[string]struct{}, len(s.loaded))
+	for _, runner := range s.loaded {
+		if runner.prefillCacheDir != "" {
+			dirs[runner.prefillCacheDir] = struct{}{}
+		}
+	}
+	return dirs
+}
+
+func prunePrefillCache(root string, maxBytes int64, keep map[string]struct{}) {
+	if root == "" || maxBytes < 0 {
+		return
+	}
+	type cacheDir struct {
+		path    string
+		size    int64
+		modTime time.Time
+	}
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			slog.Debug("failed to scan prefill cache", "path", root, "error", err)
+		}
+		return
+	}
+	var dirs []cacheDir
+	var total int64
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		info, err := entry.Info()
+		if err != nil {
+			continue
+		}
+		dir := cacheDir{
+			path:    filepath.Join(root, entry.Name()),
+			size:    prefillCacheDiskUsage(filepath.Join(root, entry.Name())),
+			modTime: info.ModTime(),
+		}
+		dirs = append(dirs, dir)
+		total += dir.size
+	}
+	if total <= maxBytes {
+		return
+	}
+	slices.SortFunc(dirs, func(a, b cacheDir) int { return a.modTime.Compare(b.modTime) })
+	for _, dir := range dirs {
+		if total <= maxBytes {
+			break
+		}
+		if _, ok := keep[dir.path]; ok {
+			continue
+		}
+		if err := os.RemoveAll(dir.path); err != nil {
+			// RemoveAll may have removed part of the directory before failing.
+			total = prefillCacheDiskUsage(root)
+			slog.Debug("failed to evict prefill cache", "path", dir.path, "error", err)
+			continue
+		}
+		total -= dir.size
+		slog.Debug("evicted prefill cache", "path", dir.path, "size", dir.size)
+	}
+}
+
+func prefillCacheDiskUsage(path string) int64 {
+	var size int64
+	_ = filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err == nil && info.Mode().IsRegular() {
+			size += info.Size()
+		}
+		return nil
+	})
+	return size
+}

--- a/server/prefill_cache_test.go
+++ b/server/prefill_cache_test.go
@@ -1,0 +1,407 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/fs/ggml"
+	"github.com/ollama/ollama/llm"
+	"github.com/ollama/ollama/ml"
+)
+
+func mustMkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.Mkdir(path, 0o700); err != nil {
+		t.Fatalf("mkdir %s: %v", path, err)
+	}
+}
+
+func mustWriteFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func mustDirExist(t *testing.T, path string) {
+	t.Helper()
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat %s: %v", path, err)
+	}
+	if !info.IsDir() {
+		t.Fatalf("%s is not a directory", path)
+	}
+}
+
+func mustNotExist(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("stat %s: got %v, want %v", path, err, os.ErrNotExist)
+	}
+}
+
+type prefillCacheMock struct {
+	*mockLlm
+	calls        []string
+	restoreErr   error
+	saveErr      error
+	exited       bool
+	saveStarted  chan struct{}
+	saveContinue chan struct{}
+}
+
+func (m *prefillCacheMock) HasExited() bool {
+	return m.exited
+}
+
+func (m *prefillCacheMock) RestorePrefillCache(context.Context) error {
+	m.calls = append(m.calls, "restore")
+	return m.restoreErr
+}
+
+func (m *prefillCacheMock) SavePrefillCache(ctx context.Context) error {
+	m.calls = append(m.calls, "save")
+	if m.saveStarted != nil {
+		close(m.saveStarted)
+		select {
+		case <-m.saveContinue:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+	return m.saveErr
+}
+
+func (m *prefillCacheMock) Close() error {
+	m.calls = append(m.calls, "close")
+	return m.mockLlm.Close()
+}
+
+func TestInitSchedulerPrefillCacheGate(t *testing.T) {
+	temp := t.TempDir()
+	t.Setenv("TMPDIR", temp)
+	t.Setenv("TMP", temp)
+	t.Setenv("TEMP", temp)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	if got := InitScheduler(ctx).prefillCacheRoot; got != "" {
+		t.Fatalf("prefillCacheRoot = %q, want empty: persistence must be opt-in", got)
+	}
+
+	t.Setenv("OLLAMA_PREFILL_CACHE", "1")
+	root := InitScheduler(ctx).prefillCacheRoot
+	if !strings.HasPrefix(root, temp) {
+		t.Fatalf("prefillCacheRoot = %q, want a directory under %q", root, temp)
+	}
+	mustDirExist(t, root)
+
+	// The cache does not outlive the daemon, and nothing else reclaims it.
+	cancel()
+	for deadline := time.Now().Add(5 * time.Second); ; {
+		if _, err := os.Stat(root); errors.Is(err, os.ErrNotExist) {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("%s still exists after the scheduler context was canceled", root)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func TestPrefillCachePathIdentity(t *testing.T) {
+	s := &Scheduler{prefillCacheRoot: t.TempDir()}
+	base := func() *LlmRequest {
+		return &LlmRequest{
+			model: &Model{ModelPath: "/models/a.gguf"},
+			opts:  api.Options{Runner: api.Runner{NumCtx: 8192}},
+		}
+	}
+	llama := func(req *LlmRequest) string {
+		return s.llamaPrefillCachePath(req, req.opts.Runner, 1)
+	}
+
+	want := llama(base())
+	if want == "" {
+		t.Fatal("llamaPrefillCachePath() = empty, want a path")
+	}
+	if got := llama(base()); got != want {
+		t.Fatalf("llamaPrefillCachePath() = %q, want %q for the same inputs", got, want)
+	}
+
+	// Anything that changes what the runner writes into a slot has to change
+	// the directory those slot files land in, or a snapshot is restored into a
+	// runner it does not fit.
+	for name, mutate := range map[string]func(*LlmRequest){
+		"model":         func(r *LlmRequest) { r.model.ModelPath = "/models/b.gguf" },
+		"draft":         func(r *LlmRequest) { r.model.DraftPath = "/models/draft.gguf" },
+		"adapters":      func(r *LlmRequest) { r.model.AdapterPaths = []string{"/lora/a"} },
+		"projectors":    func(r *LlmRequest) { r.model.ProjectorPaths = []string{"/mmproj/a"} },
+		"options":       func(r *LlmRequest) { r.opts.NumCtx = 4096 },
+		"context shift": func(r *LlmRequest) { r.contextShift = true },
+	} {
+		t.Run(name, func(t *testing.T) {
+			req := base()
+			mutate(req)
+			if got := llama(req); got == want {
+				t.Fatalf("llamaPrefillCachePath() is unchanged after changing %s", name)
+			}
+		})
+	}
+
+	t.Run("kv cache type", func(t *testing.T) {
+		t.Setenv("OLLAMA_KV_CACHE_TYPE", "q8_0")
+		if got := llama(base()); got == want {
+			t.Fatal("llamaPrefillCachePath() is unchanged after changing the kv cache type")
+		}
+	})
+
+	t.Run("num parallel", func(t *testing.T) {
+		req := base()
+		if got := s.llamaPrefillCachePath(req, req.opts.Runner, 2); got == want {
+			t.Fatal("llamaPrefillCachePath() is unchanged after changing num parallel")
+		}
+	})
+
+	t.Run("persistence off", func(t *testing.T) {
+		req := base()
+		if got := (&Scheduler{}).llamaPrefillCachePath(req, req.opts.Runner, 1); got != "" {
+			t.Fatalf("llamaPrefillCachePath() = %q with persistence off, want empty", got)
+		}
+	})
+}
+
+func TestPrunePrefillCache(t *testing.T) {
+	root := t.TempDir()
+	inUse := filepath.Join(root, "in-use")
+	old := filepath.Join(root, "old")
+	recent := filepath.Join(root, "recent")
+	for _, dir := range []string{inUse, old, recent} {
+		mustMkdir(t, dir)
+		mustWriteFile(t, filepath.Join(dir, "cache"), "1234")
+	}
+	past := time.Now().Add(-time.Hour)
+	for _, dir := range []string{inUse, old} {
+		if err := os.Chtimes(dir, past, past); err != nil {
+			t.Fatalf("chtimes %s: %v", dir, err)
+		}
+	}
+
+	s := &Scheduler{loaded: map[string]*runnerRef{"in-use": {prefillCacheDir: inUse}}}
+	prunePrefillCache(root, 8, s.prefillCacheDirsInUse())
+
+	// Oldest first, but never a directory a loaded runner is still writing
+	// into, even when it is the oldest and the cache is over the limit.
+	mustDirExist(t, inUse)
+	mustNotExist(t, old)
+	mustDirExist(t, recent)
+}
+
+func TestRunnerUnloadDoesNotSavePrefillCache(t *testing.T) {
+	// The expired path saves explicitly before waiting for VRAM recovery.
+	// unload must not save on its own: it is also reached by a failed load and
+	// by a leaked duplicate runner, neither of which has state worth keeping.
+	persist := &prefillCacheMock{mockLlm: &mockLlm{}}
+	runner := &runnerRef{llama: persist}
+	runner.refMu.Lock()
+	defer runner.refMu.Unlock()
+
+	runner.unload()
+	if want := []string{"close"}; !slices.Equal(persist.calls, want) {
+		t.Fatalf("runner calls = %v, want %v", persist.calls, want)
+	}
+}
+
+func TestRunnerSavePrefillCacheSkipsLoadingRunner(t *testing.T) {
+	persist := &prefillCacheMock{mockLlm: &mockLlm{}}
+	runner := &runnerRef{llama: persist, loading: true}
+	runner.refMu.Lock()
+	defer runner.refMu.Unlock()
+
+	runner.savePrefillCache(t.Context())
+	if len(persist.calls) != 0 {
+		t.Fatalf("runner calls = %v, want none: a loading runner has no prefix to save", persist.calls)
+	}
+}
+
+func TestRunnerSavePrefillCacheSkipsExitedRunner(t *testing.T) {
+	// The endpoint the save would talk to is gone, so asking only spends the
+	// persist timeout on the unload path before failing.
+	persist := &prefillCacheMock{mockLlm: &mockLlm{}, exited: true}
+	runner := &runnerRef{llama: persist}
+	runner.refMu.Lock()
+	defer runner.refMu.Unlock()
+
+	runner.savePrefillCache(t.Context())
+	if len(persist.calls) != 0 {
+		t.Fatalf("runner calls = %v, want none: an exited runner cannot be asked to save", persist.calls)
+	}
+}
+
+func TestRunnerRestorePrefillCacheMarksEntryRecentlyUsed(t *testing.T) {
+	root := t.TempDir()
+	restored := filepath.Join(root, "restored")
+	other := filepath.Join(root, "other")
+	for dir, age := range map[string]time.Duration{restored: time.Hour, other: time.Minute} {
+		mustMkdir(t, dir)
+		mustWriteFile(t, filepath.Join(dir, "cache"), "1234")
+		at := time.Now().Add(-age)
+		if err := os.Chtimes(dir, at, at); err != nil {
+			t.Fatalf("chtimes %s: %v", dir, err)
+		}
+	}
+
+	runner := &runnerRef{llama: &prefillCacheMock{mockLlm: &mockLlm{}}, prefillCacheDir: restored}
+	runner.refMu.Lock()
+	runner.restorePrefillCache(t.Context())
+	runner.refMu.Unlock()
+
+	// Reading an entry makes it the most recently used, so the next unload
+	// that prunes evicts something else even though this one is older on disk.
+	prunePrefillCache(root, 4, nil)
+	mustDirExist(t, restored)
+	mustNotExist(t, other)
+}
+
+func TestSchedSavesPrefillCacheWithoutHoldingLoadedLock(t *testing.T) {
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+
+	persist := &prefillCacheMock{
+		mockLlm:      &mockLlm{},
+		saveStarted:  make(chan struct{}),
+		saveContinue: make(chan struct{}),
+	}
+	runner := &runnerRef{llama: persist, modelKey: "model"}
+	s := InitScheduler(ctx)
+	s.loaded[runner.modelKey] = runner
+	go s.processCompleted(ctx)
+	s.expiredCh <- runner
+
+	select {
+	case <-persist.saveStarted:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for prefill cache save")
+	}
+
+	// Saving talks to the runner over HTTP. Holding the loaded lock across it
+	// would stall ps, stop, and every other model waiting to be scheduled.
+	locked := make(chan struct{})
+	go func() {
+		s.loadedMu.Lock()
+		_ = len(s.loaded)
+		s.loadedMu.Unlock()
+		close(locked)
+	}()
+	select {
+	case <-locked:
+	case <-time.After(time.Second):
+		t.Fatal("loadedMu was held for the duration of the prefill cache save")
+	}
+
+	close(persist.saveContinue)
+	select {
+	case <-s.unloadedCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runner unload")
+	}
+	if want := []string{"save", "close"}; !slices.Equal(persist.calls, want) {
+		t.Fatalf("runner calls = %v, want %v", persist.calls, want)
+	}
+}
+
+func TestSchedPrefillCachePathSurvivesActiveLoadingRetry(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+
+	s := InitScheduler(ctx)
+	s.prefillCacheRoot = t.TempDir()
+	scenario := newScenarioRequest(t, ctx, "prefill-retry-test", 20, nil, map[ml.DeviceID]uint64{})
+	persist := &prefillCacheMock{mockLlm: scenario.srv}
+	var configuredPath string
+	s.newServerFn = func(_ ml.SystemInfo, _ []ml.DeviceInfo, model string, _ *ggml.GGML, _, _ []string, _ api.Options, _ int, config llm.LlamaServerConfig) (llm.LlamaServer, error) {
+		configuredPath = config.PrefillCachePath
+		persist.modelPath = model
+		return persist, nil
+	}
+
+	gpu := ml.DeviceInfo{DeviceID: ml.DeviceID{Library: "Metal"}, TotalMemory: 30, FreeMemory: 10}
+	if needEvict := s.load(scenario.req, ml.SystemInfo{}, []ml.DeviceInfo{gpu}, true); !needEvict {
+		t.Fatal("first load did not request eviction")
+	}
+	if configuredPath == "" {
+		t.Fatal("configured prefill cache path is empty")
+	}
+	if got := scenario.req.prefillCachePath; got != configuredPath {
+		t.Fatalf("active loading prefill cache path = %q, want %q", got, configuredPath)
+	}
+
+	gpu.FreeMemory = 30
+	if needEvict := s.load(scenario.req, ml.SystemInfo{}, []ml.DeviceInfo{gpu}, true); needEvict {
+		t.Fatal("second load unexpectedly requested eviction")
+	}
+	select {
+	case err := <-scenario.req.errCh:
+		t.Fatalf("load returned %v, want a runner", err)
+	case runner := <-scenario.req.successCh:
+		if got := runner.prefillCacheDir; got != configuredPath {
+			t.Fatalf("runner prefill cache path = %q, want %q", got, configuredPath)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for retried runner")
+	}
+}
+
+func TestSchedRestoresPrefillCacheBeforeReturningRunner(t *testing.T) {
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	defer cancel()
+	s := InitScheduler(ctx)
+	scenario := newScenarioRequest(t, ctx, "prefill-test", 10, nil, map[ml.DeviceID]uint64{})
+	// A restore failure still has to produce a runner: the fallback is a cold
+	// prefill, not a failed load.
+	persist := &prefillCacheMock{mockLlm: scenario.srv, restoreErr: errors.New("corrupt snapshot")}
+	s.newServerFn = func(_ ml.SystemInfo, _ []ml.DeviceInfo, model string, _ *ggml.GGML, _, _ []string, _ api.Options, _ int, _ llm.LlamaServerConfig) (llm.LlamaServer, error) {
+		persist.modelPath = model
+		return persist, nil
+	}
+
+	s.load(scenario.req, ml.SystemInfo{}, nil, false)
+	var runner *runnerRef
+	select {
+	case err := <-scenario.req.errCh:
+		t.Fatalf("load returned %v, want a runner", err)
+	case runner = <-scenario.req.successCh:
+		if want := []string{"restore"}; !slices.Equal(persist.calls, want) {
+			t.Fatalf("runner calls = %v, want %v: restore must finish before the runner is handed out", persist.calls, want)
+		}
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for loaded runner")
+	}
+	if runner == nil {
+		t.Fatal("load returned a nil runner, want a fall back to a cold cache")
+	}
+}
+
+func TestRunnerSavesPrefillCacheAfterFailedRestore(t *testing.T) {
+	// A snapshot that would not load is no reason to stop producing one: the
+	// runner still served requests, and its prefix is worth keeping.
+	persist := &prefillCacheMock{mockLlm: &mockLlm{}, restoreErr: errors.New("corrupt snapshot")}
+	runner := &runnerRef{llama: persist}
+	runner.refMu.Lock()
+	defer runner.refMu.Unlock()
+
+	runner.restorePrefillCache(t.Context())
+	runner.savePrefillCache(t.Context())
+	if want := []string{"restore", "save"}; !slices.Equal(persist.calls, want) {
+		t.Fatalf("runner calls = %v, want %v", persist.calls, want)
+	}
+}

--- a/server/sched.go
+++ b/server/sched.go
@@ -27,13 +27,14 @@ import (
 )
 
 type LlmRequest struct {
-	ctx             context.Context //nolint:containedctx
-	model           *Model
-	opts            api.Options
-	sessionDuration *api.Duration
-	successCh       chan *runnerRef
-	errCh           chan error
-	schedAttempts   uint
+	ctx              context.Context //nolint:containedctx
+	model            *Model
+	opts             api.Options
+	sessionDuration  *api.Duration
+	successCh        chan *runnerRef
+	errCh            chan error
+	schedAttempts    uint
+	prefillCachePath string
 
 	// oomRetryAttempted is set after a llama-server load crash triggers an
 	// evict-all-and-retry. Prevents infinite retry on persistent load failures.
@@ -73,11 +74,12 @@ type Scheduler struct {
 	activeLoading llm.LlamaServer
 	loaded        map[string]*runnerRef
 
-	loadFn          func(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, requireFull bool) bool
-	newServerFn     func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, model string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int, config llm.LlamaServerConfig) (llm.LlamaServer, error)
-	getGpuFn        func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo
-	getSystemInfoFn func() ml.SystemInfo
-	waitForRecovery time.Duration
+	loadFn           func(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, requireFull bool) bool
+	newServerFn      func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, model string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int, config llm.LlamaServerConfig) (llm.LlamaServer, error)
+	getGpuFn         func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo
+	getSystemInfoFn  func() ml.SystemInfo
+	waitForRecovery  time.Duration
+	prefillCacheRoot string
 }
 
 // Default automatic value for number of models we allow per GPU
@@ -89,16 +91,18 @@ var ErrMaxQueue = errors.New("server busy, please try again.  maximum pending re
 
 func InitScheduler(ctx context.Context) *Scheduler {
 	maxQueue := envconfig.MaxQueue()
+	prefillCacheRoot := initPrefillCacheRoot(ctx)
 	sched := &Scheduler{
-		pendingReqCh:    make(chan *LlmRequest, maxQueue),
-		finishedReqCh:   make(chan *LlmRequest, maxQueue),
-		expiredCh:       make(chan *runnerRef, maxQueue),
-		unloadedCh:      make(chan any, maxQueue),
-		loaded:          make(map[string]*runnerRef),
-		newServerFn:     llm.NewLlamaServer,
-		getGpuFn:        discover.GPUDevices,
-		getSystemInfoFn: discover.GetSystemInfo,
-		waitForRecovery: 5 * time.Second,
+		pendingReqCh:     make(chan *LlmRequest, maxQueue),
+		finishedReqCh:    make(chan *LlmRequest, maxQueue),
+		expiredCh:        make(chan *runnerRef, maxQueue),
+		unloadedCh:       make(chan any, maxQueue),
+		loaded:           make(map[string]*runnerRef),
+		newServerFn:      llm.NewLlamaServer,
+		getGpuFn:         discover.GPUDevices,
+		getSystemInfoFn:  discover.GetSystemInfo,
+		waitForRecovery:  5 * time.Second,
+		prefillCacheRoot: prefillCacheRoot,
 	}
 	sched.loadFn = sched.load
 	return sched
@@ -425,6 +429,9 @@ func (s *Scheduler) processCompleted(ctx context.Context) {
 				runner.refMu.Unlock()
 				continue
 			}
+			// Save before taking the loaded lock: this talks to the runner over
+			// HTTP and is far too slow to hold the scheduler's lock across.
+			runner.savePrefillCache(ctx)
 
 			s.loadedMu.Lock()
 			slog.Debug("got lock to unload expired event", "runner", runner)
@@ -462,6 +469,7 @@ func (s *Scheduler) processCompleted(ctx context.Context) {
 				slog.Debug("runner terminated and removed from list, blocking for VRAM recovery", "runner", runner)
 				<-finished
 				runner.refMu.Unlock()
+				s.prunePrefillCache()
 				slog.Debug("sending an unloaded event", "runner", runner)
 				s.unloadedCh <- struct{}{}
 			}
@@ -519,6 +527,7 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 	var f *ggml.GGML
 	loadGpus := gpus
 	var launchOpts api.Options
+	prefillCachePath := req.prefillCachePath
 
 	if llama == nil {
 		var err error
@@ -531,6 +540,9 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 				s.loadedMu.Unlock()
 				return false
 			}
+
+			// Preserve request options before placement tuning mutates them.
+			identityOpts := req.opts.Runner
 
 			predictedCtx := effectiveLlamaServerContext(req.opts.NumCtx, f, numParallel)
 			predicted := llm.PredictServerVRAM(req.model.ModelPath, f, predictedCtx)
@@ -574,6 +586,8 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 
 			config := llamaServerConfigForModel(req.model)
 			config.ContextShift = req.contextShift
+			prefillCachePath = s.llamaPrefillCachePath(req, identityOpts, numParallel)
+			config.PrefillCachePath = prefillCachePath
 			llama, err = s.newServerFn(systemInfo, loadGpus, req.model.ModelPath, f, req.model.AdapterPaths, req.model.ProjectorPaths, launchOpts, numParallel, config)
 			if err != nil {
 				// some older models are not compatible with newer versions of llama.cpp
@@ -594,6 +608,7 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 			return false
 		}
 
+		req.prefillCachePath = prefillCachePath
 		s.activeLoading = llama
 	} else {
 		wantPath := req.model.ModelPath
@@ -711,6 +726,7 @@ iGPUScan:
 		useMMapAuto:     req.useMMapAuto,
 		contextShift:    req.contextShift,
 		trainContext:    trainContext,
+		prefillCacheDir: prefillCachePath,
 	}
 	runner.numParallel = numParallel
 	runner.refMu.Lock() // hold lock until running or aborted
@@ -737,6 +753,7 @@ iGPUScan:
 			s.expiredCh <- runner
 			return
 		}
+		runner.restorePrefillCache(req.ctx)
 		slog.Debug("finished setting up", "runner", runner)
 		if runner.pid < 0 {
 			runner.pid = llama.Pid()
@@ -1351,15 +1368,16 @@ type runnerRef struct {
 	expireTimer     *time.Timer
 	expiresAt       time.Time
 
-	model        *Model
-	modelPath    string
-	modelKey     string
-	numParallel  int
-	numCtxAuto   bool
-	numBatchAuto bool
-	useMMapAuto  bool
-	contextShift bool
-	trainContext int
+	model           *Model
+	modelPath       string
+	modelKey        string
+	numParallel     int
+	numCtxAuto      bool
+	numBatchAuto    bool
+	useMMapAuto     bool
+	contextShift    bool
+	trainContext    int
+	prefillCacheDir string
 	*api.Options
 }
 

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -22,6 +22,7 @@ import (
 
 func TestMain(m *testing.M) {
 	os.Setenv("OLLAMA_DEBUG", "1")
+	os.Unsetenv("OLLAMA_PREFILL_CACHE")
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	slog.SetDefault(logger)
 	os.Exit(m.Run())


### PR DESCRIPTION
### What

This PR adds experimental prefill/KV cache persistence across llama-server runner reloads.

Ollama currently loses the processed prompt state when a runner unloads, so the next request must recompute the full prefill. With `OLLAMA_PREFILL_CACHE=1`, the scheduler now saves the cache before unload and restores it after the same model and runtime settings are loaded again.

This is the llama-server implementation of the scheduler-owned design from #17247. It introduces a runner-neutral `PrefillCachePersistor` interface. I intend to carry the same design over to MLX as well, while keeping this change focused on establishing and validating the common lifecycle and llama-server path first.

Unlike #16836, this adds no public API and no user-managed cache path.

### Implementation

- Scheduler-owned save before unload and restore after `WaitUntilRunning`
- Runner-neutral `llm.PrefillCachePersistor`
- llama-server slot save/restore backend
- SHA-256 cache identity based on model/runtime settings
- Daemon-local temporary storage with an 8 GiB LRU limit
- CRC-32C verification and manifest-last commit semantics
- Fail-open fallback to normal cold prefill
- Experimental and off by default

#17278 also targets #17247, but its current branch does not wire the llama-server persistence path through `server/sched.go` and `llm/`; this PR focuses on that lifecycle integration.

### Measured benefit

`llama3.2:3b`, RTX 4070, CUDA 12.8, f16 KV, `num_ctx=34000`, `OLLAMA_NUM_PARALLEL=1`:

| prompt tokens | verify + restore | cold prefill | warm prefill | TTFT reduction |
|---:|---:|---:|---:|---:|
| 3,806 | 90 ms | 431 ms | 7.9 ms | 77% |
| 5,181 | 121 ms | 604 ms | 8.7 ms | 78% |
| 9,932 | 239 ms | 1,348 ms | 11.5 ms | 81% |
| 19,805 | 480 ms | 3,472 ms | 13.6 ms | 86% |
| 30,643 | 765 ms | 6,891 ms | 19.5 ms | 89% |

TTFT reduction includes verification, restore, and warm prefill. Save runs on the unload path and is therefore excluded.

Generated text was identical between cold and warm runs at all five sizes.

### Testing

`gofmt`, `go vet`, and:

```bash
go test ./envconfig/ ./llm/ ./server/
```

pass.

The PR adds 23 unit tests covering persistence, fingerprinting, LRU behavior, scheduler ordering, cancellation, corruption, and fail-open behavior.

Fault injection with corrupted slot data, truncated manifests, and unwritable storage all fell back to cold prefill. Corrupted slot payloads motivated the CRC-32C check because llama-server can otherwise accept a restore before producing corrupted output.

### AI assistance

Developed with Claude Code assistance. I reviewed the implementation and tests line by line and ran all measurements and fault-injection tests on my own hardware.

Refs #17247. Related: #16835, #16836, #17278.