### PR TITLE
server: refuse exited runners and bound embed concurrency

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -221,6 +221,13 @@ func (s *llamaServerRunner) GetPort() int {
 }
 
 func (s *llamaServerRunner) HasExited() bool {
+	if s.done != nil {
+		select {
+		case <-s.done:
+			return true
+		default:
+		}
+	}
 	return s.cmd != nil && s.cmd.ProcessState != nil && s.cmd.ProcessState.ExitCode() >= 0
 }
 

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -106,6 +106,26 @@ func TestLlamaServerHealthParsing(t *testing.T) {
 	}
 }
 
+func TestLlamaServerRunnerHasExited(t *testing.T) {
+	t.Run("no process", func(t *testing.T) {
+		if (&llamaServerRunner{}).HasExited() {
+			t.Fatal("expected runner without a process to be running")
+		}
+	})
+
+	t.Run("done channel closed", func(t *testing.T) {
+		done := make(chan struct{})
+		runner := &llamaServerRunner{done: done}
+		if runner.HasExited() {
+			t.Fatal("expected open done channel to indicate running")
+		}
+		close(done)
+		if !runner.HasExited() {
+			t.Fatal("expected closed done channel to indicate exited")
+		}
+	})
+}
+
 func TestBoundedNumPredict(t *testing.T) {
 	tests := []struct {
 		name       string

--- a/server/routes.go
+++ b/server/routes.go
@@ -971,7 +971,14 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 		return r.Embedding(ctx, truncated)
 	}
 
+	// Bound the number of in-flight embedding calls. /api/embed fans out one
+	// goroutine per input; a large batch (thousands of chunks) would otherwise
+	// open thousands of simultaneous HTTP connections to the single
+	// llama-server runner and can crash or stall it mid-batch on Windows.
+	// Every call that lands after the runner exits fails with
+	// "connection refused" against its now-closed port.
 	var g errgroup.Group
+	g.SetLimit(8)
 	embeddings := make([][]float32, len(input))
 	var totalTokens uint64
 	for i, text := range input {

--- a/server/routes.go
+++ b/server/routes.go
@@ -55,6 +55,14 @@ import (
 
 const signinURLStr = "https://ollama.com/connect?name=%s&key=%s"
 
+// maxConcurrentEmbedRequests bounds the number of in-flight llama-server
+// requests a single /api/embed call may open. The value was chosen
+// empirically: batches that opened thousands of simultaneous connections
+// could stall or crash the runner on Windows. Embedding models are always
+// scheduled with numParallel=1, so this limit bounds connection fan-out
+// rather than inference slot parallelism.
+const maxConcurrentEmbedRequests = 8
+
 const (
 	cloudErrRemoteInferenceUnavailable    = "remote model is unavailable"
 	cloudErrRemoteModelDetailsUnavailable = "remote model details are unavailable"
@@ -978,7 +986,7 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 	// Every call that lands after the runner exits fails with
 	// "connection refused" against its now-closed port.
 	var g errgroup.Group
-	g.SetLimit(8)
+	g.SetLimit(maxConcurrentEmbedRequests)
 	embeddings := make([][]float32, len(input))
 	var totalTokens uint64
 	for i, text := range input {

--- a/server/sched.go
+++ b/server/sched.go
@@ -495,7 +495,7 @@ func (pending *LlmRequest) useLoadedRunner(runner *runnerRef, finished chan *Llm
 		// The runner's llama-server process is no longer running. Handing it
 		// out would make every tokenize/embedding HTTP call fail with
 		// "connection refused" against its (closed) port.
-		slog.Debug("refusing to use exited runner", "runner", runner, "pid", runner.pid)
+		slog.Warn("refusing to use exited runner", "runner", runner, "pid", runner.pid)
 		return false
 	}
 	runner.refCount++

--- a/server/sched.go
+++ b/server/sched.go
@@ -199,7 +199,16 @@ func (s *Scheduler) getRunner(c context.Context, m *Model, opts api.Options, ses
 	runner := s.loaded[key]
 	s.loadedMu.Unlock()
 	if runner != nil && !runner.needsReload(c, req) {
-		req.useLoadedRunner(runner, s.finishedReqCh)
+		if !req.useLoadedRunner(runner, s.finishedReqCh) {
+			// The runner exited between the health ping and the acquire
+			// (keep-alive expiry/eviction or a crash). Enqueue so the
+			// scheduler can unload the stale entry and load a fresh runner.
+			select {
+			case s.pendingReqCh <- req:
+			default:
+				req.errCh <- ErrMaxQueue
+			}
+		}
 	} else {
 		select {
 		case s.pendingReqCh <- req:
@@ -259,8 +268,15 @@ func (s *Scheduler) processPending(ctx context.Context) {
 					} else {
 						// Runner is usable, return it
 						logutil.Trace("using existing loaded runner", "model", pendingKey)
-						pending.useLoadedRunner(runner, s.finishedReqCh)
-						break
+						if !pending.useLoadedRunner(runner, s.finishedReqCh) {
+							// Runner died before we could acquire it; unload the
+							// stale entry so a fresh runner is loaded on the
+							// next pass.
+							slog.Debug("loaded runner exited before acquire, unloading", "runner", runner)
+							runnerToExpire = runner
+						} else {
+							break
+						}
 					}
 				} else if maxRunners > 0 && loadedCount >= int(maxRunners) {
 					slog.Debug("max runners achieved, unloading one to make room", "runner_count", loadedCount)
@@ -472,9 +488,16 @@ func (s *Scheduler) processCompleted(ctx context.Context) {
 // Complete the pending request and send the runner back to the requester
 // Wires up a finished event after the request context is completed
 // Updates session duration, and resets expiration timer
-func (pending *LlmRequest) useLoadedRunner(runner *runnerRef, finished chan *LlmRequest) {
+func (pending *LlmRequest) useLoadedRunner(runner *runnerRef, finished chan *LlmRequest) bool {
 	runner.refMu.Lock()
 	defer runner.refMu.Unlock()
+	if runner.HasExited() {
+		// The runner's llama-server process is no longer running. Handing it
+		// out would make every tokenize/embedding HTTP call fail with
+		// "connection refused" against its (closed) port.
+		slog.Debug("refusing to use exited runner", "runner", runner, "pid", runner.pid)
+		return false
+	}
 	runner.refCount++
 	if runner.expireTimer != nil {
 		runner.expireTimer.Stop()
@@ -489,6 +512,7 @@ func (pending *LlmRequest) useLoadedRunner(runner *runnerRef, finished chan *Llm
 		slog.Debug("context for request finished", "runner", runner)
 		finished <- pending
 	}()
+	return true
 }
 
 // load creates a new model based on req and loads it. If requireFull is true then the model must be loaded fully onto GPUs

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -769,7 +769,7 @@ func TestSchedUseLoadedRunner(t *testing.T) {
 	finished := make(chan *LlmRequest)
 	llm1 := &mockLlm{vramByGPU: map[ml.DeviceID]uint64{}}
 	r1 := &runnerRef{llama: llm1, sessionDuration: 1, numParallel: 1}
-	req.useLoadedRunner(r1, finished)
+	require.True(t, req.useLoadedRunner(r1, finished))
 	require.Equal(t, uint(1), r1.refCount)
 	require.Equal(t, time.Duration(2), r1.sessionDuration)
 	select {
@@ -783,6 +783,103 @@ func TestSchedUseLoadedRunner(t *testing.T) {
 	done()
 	fin := <-finished
 	require.Equal(t, req, fin)
+}
+
+func TestSchedUseLoadedRunnerRefusesExitedRunner(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer done()
+
+	req := &LlmRequest{
+		ctx:       ctx,
+		opts:      api.DefaultOptions(),
+		successCh: make(chan *runnerRef, 1),
+	}
+	finished := make(chan *LlmRequest)
+	runner := &runnerRef{
+		llama:       &mockLlm{vramByGPU: map[ml.DeviceID]uint64{}, hasExited: true},
+		numParallel: 1,
+	}
+
+	require.False(t, req.useLoadedRunner(runner, finished))
+	require.Zero(t, runner.refCount)
+	require.Empty(t, req.successCh)
+	select {
+	case <-finished:
+		t.Fatal("expected no finished event for refused runner")
+	default:
+	}
+}
+
+func TestSchedGetRunnerRequeuesWhenLoadedRunnerExited(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer done()
+
+	s := InitScheduler(ctx)
+	opts := api.DefaultOptions()
+	opts.NumCtx = 4
+
+	loadedModel := &Model{Name: "safetensors-a", Digest: "sha-a"}
+	loadedRunner := &runnerRef{
+		model:       loadedModel,
+		modelKey:    schedulerModelKey(loadedModel),
+		llama:       &mockLlm{vramByGPU: map[ml.DeviceID]uint64{}, hasExited: true},
+		Options:     &opts,
+		numParallel: 1,
+	}
+
+	s.loadedMu.Lock()
+	s.loaded[loadedRunner.modelKey] = loadedRunner
+	s.loadedMu.Unlock()
+
+	successCh, errCh := s.getRunner(ctx, &Model{Name: "safetensors-b", Digest: "sha-a"}, opts, nil, false, false, nil)
+
+	require.Empty(t, successCh)
+	require.Empty(t, errCh)
+	require.Len(t, s.pendingReqCh, 1)
+}
+
+func TestSchedProcessPendingReloadsExitedRunner(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 3*time.Second)
+	defer done()
+
+	scenario := newScenarioRequest(t, ctx, "ollama-stale-model", 10, &api.Duration{Duration: 5 * time.Millisecond}, nil)
+	s := InitScheduler(ctx)
+	s.waitForRecovery = 10 * time.Millisecond
+	s.getGpuFn = getGpuFn
+	s.getSystemInfoFn = getSystemInfoFn
+	s.newServerFn = scenario.newServer
+
+	// Simulate a runner that exited but is still registered as loaded.
+	opts := api.DefaultOptions()
+	stale := &runnerRef{
+		model:       scenario.req.model,
+		modelKey:    schedulerModelKey(scenario.req.model),
+		llama:       &mockLlm{vramByGPU: map[ml.DeviceID]uint64{}, hasExited: true},
+		Options:     &opts,
+		numParallel: 1,
+	}
+	s.loadedMu.Lock()
+	s.loaded[stale.modelKey] = stale
+	s.loadedMu.Unlock()
+
+	s.Run(ctx)
+	s.pendingReqCh <- scenario.req
+
+	select {
+	case runner := <-scenario.req.successCh:
+		require.Equal(t, scenario.srv, runner.llama)
+		require.NotEqual(t, stale, runner)
+		require.True(t, stale.llama.(*mockLlm).closeCalled)
+		s.loadedMu.Lock()
+		current := s.loaded[stale.modelKey]
+		s.loadedMu.Unlock()
+		require.Equal(t, scenario.srv, current.llama)
+	case err := <-scenario.req.errCh:
+		t.Fatal(err.Error())
+	case <-ctx.Done():
+		t.Fatal("timeout")
+	}
+	scenario.ctxDone()
 }
 
 func TestSchedUpdateFreeSpace(t *testing.T) {
@@ -2088,7 +2185,8 @@ type mockLlm struct {
 
 	// loadErr, if non-nil, is returned from Load() to simulate a post-spawn
 	// load failure (e.g. llama-server crashing due to under-predicted VRAM).
-	loadErr error
+	loadErr   error
+	hasExited bool
 }
 
 func (s *mockLlm) ModelPath() string {
@@ -2154,7 +2252,7 @@ func (s *mockLlm) VRAMByGPU(id ml.DeviceID) uint64                    { return s
 func (s *mockLlm) Pid() int                                           { return -1 }
 func (s *mockLlm) GetPort() int                                       { return -1 }
 func (s *mockLlm) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo { return nil }
-func (s *mockLlm) HasExited() bool                                    { return false }
+func (s *mockLlm) HasExited() bool                                    { return s.hasExited }
 func (s *mockLlm) GetActiveDeviceIDs() []ml.DeviceID                  { return nil }
 func (s *mockLlm) ContextLength() int                                 { return s.contextLength }
 


### PR DESCRIPTION
This changes Ollama to detect llama-server exit via the runner's done channel, refuse to hand out exited runners in the scheduler, and re-queue requests whose loaded runner exited so a fresh runner is loaded instead. It also bounds /api/embed fan-out concurrency so large batches cannot open thousands of simultaneous connections to a single runner.

Adds scheduler tests for exited-runner refusal, requeueing, and reload, plus a llama-server test for done-channel exit detection.