### PR TITLE
readme: add Grux to Community Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ console.log(response.message.content);
 - [Serene Pub](https://github.com/doolijb/serene-pub) - AI roleplaying app
 - [Mayan EDMS](https://gitlab.com/mayan-edms/mayan-edms) - Document management with Ollama workflows
 - [TagSpaces](https://www.tagspaces.org) - File management with [AI tagging](https://docs.tagspaces.org/ai/)
+- [Grux](https://github.com/dotcomjack/grux) - Native macOS menu bar assistant that reads your active window, running fully local with Ollama
 
 ### Observability & Monitoring
 


### PR DESCRIPTION
Adds **Grux** to Community Integrations, under Productivity & Apps.

Grux is a native macOS menu bar assistant, Swift and SwiftUI, MIT licensed. It
reads the window you are currently in through the Accessibility API and reaches
the mail, calendar, notes and files already on the machine.

Ollama is a first-class backend rather than a passing mention, and it is the
option that lets Grux run with no API key and no network at all:

- `Sources/Grux/LocalLLM.swift` discovers a running instance against
  `/api/tags` and streams chat from it.
- `Sources/Grux/LocalModelCookbook/` recommends models per machine based on the
  Mac's own memory and chip, and installs them through Ollama.
- The base URL is user configurable in Settings, defaulting to
  `http://localhost:11434`.

Links:

- Source: https://github.com/dotcomjack/grux
- Site: https://gruxai.com

One line added, no other changes.
