### PR TITLE
llm: derive default thread count from cgroup CPU quota

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -1115,7 +1115,7 @@ func DefaultOptions() Options {
 			NumCtx:          int(envconfig.ContextLength()),
 			NumBatch:        512,
 			NumGPU:          -1, // -1 here indicates that NumGPU should be set dynamically
-			NumThread:       0,  // let the runtime decide
+			NumThread:       0,  // 0: derive a cgroup/affinity-aware default (see llm.appendThreadArgs)
 			DraftNumPredict: 4,
 			UseMMap:         nil,
 		},

--- a/api/types.go
+++ b/api/types.go
@@ -1115,7 +1115,7 @@ func DefaultOptions() Options {
 			NumCtx:          int(envconfig.ContextLength()),
 			NumBatch:        512,
 			NumGPU:          -1, // -1 here indicates that NumGPU should be set dynamically
-			NumThread:       0,  // 0: derive a cgroup/affinity-aware default (see llm.appendThreadArgs)
+			NumThread:       0,  // 0: derive a CPU-budget-aware default at runner launch
 			DraftNumPredict: 4,
 			UseMMap:         nil,
 		},

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -9,8 +9,10 @@
 // its json_schema field (avoiding the CGO SchemaToGrammar dependency). Raw BNF
 // grammars are passed via the grammar field.
 //
-// llama-server auto-detects GPU layers (-ngl), thread count (-t), and flash
-// attention (--flash-attn).
+// llama-server auto-detects GPU layers (-ngl) and flash attention
+// (--flash-attn). Thread count (-t) is derived by Ollama itself
+// (see defaultNumThreads) rather than left to llama-server's own
+// auto-detection, which ignores cgroup CPU limits.
 package llm
 
 import (
@@ -409,11 +411,7 @@ func startLlamaServer(launch llamaServerLaunchConfig, out io.Writer) (cmd *exec.
 	}
 	// NumGPU == -1 (default): don't pass -ngl, let llama-server auto-detect
 
-	// Thread count — only pass if user explicitly set it.
-	// Default behavior: let llama-server auto-detect.
-	if launch.opts.NumThread > 0 {
-		params = append(params, "-t", strconv.Itoa(launch.opts.NumThread))
-	}
+	params = appendThreadArgs(params, launch.opts)
 
 	params = appendMainGPUArgs(params, launch.opts)
 
@@ -635,6 +633,21 @@ func appendLoadModeArgs(params []string, opts api.Options, gpus []ml.DeviceInfo)
 		return append(params, "--load-mode", "none")
 	}
 
+	return params
+}
+
+// appendThreadArgs adds -t using the caller's explicit thread count if set,
+// otherwise a cgroup/affinity-aware default (see defaultNumThreads) in
+// place of llama-server's own auto-detection, which uses the raw host core
+// count and ignores CFS quota throttling in containers.
+func appendThreadArgs(params []string, opts api.Options) []string {
+	n := opts.NumThread
+	if n <= 0 {
+		n = defaultNumThreads()
+	}
+	if n > 0 {
+		params = append(params, "-t", strconv.Itoa(n))
+	}
 	return params
 }
 

--- a/llm/threads.go
+++ b/llm/threads.go
@@ -1,0 +1,15 @@
+package llm
+
+// numThreadsForQuota clamps available (the host/affinity-visible CPU count)
+// to quota (a cgroup CFS thread budget, or 0 if there is no limit), never
+// returning less than one thread.
+func numThreadsForQuota(available, quota int) int {
+	n := available
+	if quota > 0 && quota < n {
+		n = quota
+	}
+	if n < 1 {
+		n = 1
+	}
+	return n
+}

--- a/llm/threads_linux.go
+++ b/llm/threads_linux.go
@@ -1,15 +1,21 @@
 package llm
 
 import (
+	"math"
 	"os"
 	"runtime"
 	"strconv"
 	"strings"
 )
 
-// cgroupCPUMaxPath is the cgroup v2 file describing this process's CFS CPU
-// quota and period, e.g. "400000 100000" for a 4-CPU budget, or "max
-// 100000" when unlimited.
+// cgroupCPUMaxPath is the cgroup v2 file describing this container's CFS
+// CPU quota and period, e.g. "400000 100000" for a 4-CPU budget, or "max
+// 100000" when unlimited. This is the file a process sees at the root of
+// its own cgroup namespace, which covers the common container case (the
+// same scope as the existing memory limit read in
+// discover/cpu_linux.go's getCPUMemByCgroups). It does not resolve a
+// deeper cgroup path such as a systemd slice on bare metal, and cgroup v1
+// (cpu.cfs_quota_us/cpu.cfs_period_us) is not read.
 const cgroupCPUMaxPath = "/sys/fs/cgroup/cpu.max"
 
 // defaultNumThreads returns the default llama-server thread count when the
@@ -18,14 +24,16 @@ const cgroupCPUMaxPath = "/sys/fs/cgroup/cpu.max"
 // CFS quota such as Docker's `--cpus`, which throttles without narrowing
 // affinity. Clamping to the cgroup quota avoids oversubscribing threads
 // past the CPU budget the process actually gets, which otherwise convoys
-// llama.cpp's spin-wait barriers against CFS throttling.
+// llama.cpp's spin-wait barriers against CFS throttling. Absent a quota,
+// this returns the same logical CPU count llama-server's own auto-detect
+// would have used.
 func defaultNumThreads() int {
 	return numThreadsForQuota(runtime.NumCPU(), cgroupCPUQuota(cgroupCPUMaxPath))
 }
 
 // cgroupCPUQuota reads a cgroup v2 cpu.max file and returns the thread
 // budget ceil(quota/period), or 0 if the file is absent, unlimited
-// ("max"), or malformed.
+// ("max"), malformed, or the ratio doesn't fit in an int.
 func cgroupCPUQuota(path string) int {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -43,5 +51,12 @@ func cgroupCPUQuota(path string) int {
 	if err != nil || period == 0 {
 		return 0
 	}
-	return int((quota + period - 1) / period)
+	threads := quota / period
+	if quota%period != 0 {
+		threads++
+	}
+	if threads > math.MaxInt {
+		return 0
+	}
+	return int(threads)
 }

--- a/llm/threads_linux.go
+++ b/llm/threads_linux.go
@@ -1,0 +1,47 @@
+package llm
+
+import (
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+)
+
+// cgroupCPUMaxPath is the cgroup v2 file describing this process's CFS CPU
+// quota and period, e.g. "400000 100000" for a 4-CPU budget, or "max
+// 100000" when unlimited.
+const cgroupCPUMaxPath = "/sys/fs/cgroup/cpu.max"
+
+// defaultNumThreads returns the default llama-server thread count when the
+// caller hasn't set one explicitly. runtime.NumCPU() already reflects the
+// process's sched_getaffinity mask (e.g. a container's cpuset), but not a
+// CFS quota such as Docker's `--cpus`, which throttles without narrowing
+// affinity. Clamping to the cgroup quota avoids oversubscribing threads
+// past the CPU budget the process actually gets, which otherwise convoys
+// llama.cpp's spin-wait barriers against CFS throttling.
+func defaultNumThreads() int {
+	return numThreadsForQuota(runtime.NumCPU(), cgroupCPUQuota(cgroupCPUMaxPath))
+}
+
+// cgroupCPUQuota reads a cgroup v2 cpu.max file and returns the thread
+// budget ceil(quota/period), or 0 if the file is absent, unlimited
+// ("max"), or malformed.
+func cgroupCPUQuota(path string) int {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0
+	}
+	fields := strings.Fields(string(data))
+	if len(fields) != 2 || fields[0] == "max" {
+		return 0
+	}
+	quota, err := strconv.ParseUint(fields[0], 10, 64)
+	if err != nil || quota == 0 {
+		return 0
+	}
+	period, err := strconv.ParseUint(fields[1], 10, 64)
+	if err != nil || period == 0 {
+		return 0
+	}
+	return int((quota + period - 1) / period)
+}

--- a/llm/threads_linux_test.go
+++ b/llm/threads_linux_test.go
@@ -1,0 +1,36 @@
+package llm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCgroupCPUQuota(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		exists  bool
+		want    int
+	}{
+		{"unlimited quota", "max 100000\n", true, 0},
+		{"quota below one period", "400000 100000\n", true, 4},
+		{"quota not a multiple of period rounds up", "250000 100000\n", true, 3},
+		{"missing file (no cgroup v2, e.g. bare metal or macOS)", "", false, 0},
+		{"malformed content", "garbage\n", true, 0},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "cpu.max")
+			if tt.exists {
+				if err := os.WriteFile(path, []byte(tt.content), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if got := cgroupCPUQuota(path); got != tt.want {
+				t.Errorf("cgroupCPUQuota(%q) = %d, want %d", tt.content, got, tt.want)
+			}
+		})
+	}
+}

--- a/llm/threads_linux_test.go
+++ b/llm/threads_linux_test.go
@@ -14,10 +14,16 @@ func TestCgroupCPUQuota(t *testing.T) {
 		want    int
 	}{
 		{"unlimited quota", "max 100000\n", true, 0},
-		{"quota below one period", "400000 100000\n", true, 4},
+		{"quota spanning several periods", "400000 100000\n", true, 4},
+		{"quota below one period rounds up to one", "40000 100000\n", true, 1},
 		{"quota not a multiple of period rounds up", "250000 100000\n", true, 3},
 		{"missing file (no cgroup v2, e.g. bare metal or macOS)", "", false, 0},
 		{"malformed content", "garbage\n", true, 0},
+		{"zero quota is malformed", "0 100000\n", true, 0},
+		{"zero period is malformed", "400000 0\n", true, 0},
+		{"single field only", "400000\n", true, 0},
+		{"extra whitespace between fields", "400000   100000  \n", true, 4},
+		{"values near uint64 max do not overflow", "18446744073709551615 18446744073709551615\n", true, 1},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {

--- a/llm/threads_other.go
+++ b/llm/threads_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package llm
+
+import "runtime"
+
+// defaultNumThreads returns the host core count. macOS and Windows have no
+// cgroups, so there is no quota to clamp against.
+func defaultNumThreads() int {
+	return runtime.NumCPU()
+}

--- a/llm/threads_test.go
+++ b/llm/threads_test.go
@@ -19,6 +19,7 @@ func TestNumThreadsForQuota(t *testing.T) {
 		{"quota above available keeps available", 4, 8, 4},
 		{"quota equal to available", 4, 4, 4},
 		{"never returns less than one", 1, 0, 1},
+		{"zero available still returns one", 0, 0, 1},
 	}
 	for _, tt := range cases {
 		t.Run(tt.name, func(t *testing.T) {
@@ -36,6 +37,28 @@ func TestAppendThreadArgsExplicit(t *testing.T) {
 	want := []string{"-t", "6"}
 	if !slices.Equal(got, want) {
 		t.Errorf("appendThreadArgs with explicit NumThread = %v, want %v", got, want)
+	}
+}
+
+func TestAppendThreadArgsPreservesExistingParams(t *testing.T) {
+	opts := api.DefaultOptions()
+	opts.NumThread = 6
+	got := appendThreadArgs([]string{"--flash-attn", "on"}, opts)
+	want := []string{"--flash-attn", "on", "-t", "6"}
+	if !slices.Equal(got, want) {
+		t.Errorf("appendThreadArgs = %v, want %v", got, want)
+	}
+}
+
+func TestAppendThreadArgsNegativeTreatedAsDefault(t *testing.T) {
+	// NumThread < 0 has never been a valid explicit value (the old code's
+	// "> 0" guard already routed it to auto-detect); it now takes the same
+	// derived-default path as 0.
+	opts := api.DefaultOptions()
+	opts.NumThread = -1
+	got := appendThreadArgs(nil, opts)
+	if len(got) != 2 || got[0] != "-t" {
+		t.Fatalf("appendThreadArgs with NumThread == -1 = %v, want [-t <n>]", got)
 	}
 }
 

--- a/llm/threads_test.go
+++ b/llm/threads_test.go
@@ -1,0 +1,53 @@
+package llm
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/ollama/ollama/api"
+)
+
+func TestNumThreadsForQuota(t *testing.T) {
+	cases := []struct {
+		name      string
+		available int
+		quota     int
+		want      int
+	}{
+		{"no quota clamps to available", 8, 0, 8},
+		{"quota below available clamps down", 8, 4, 4},
+		{"quota above available keeps available", 4, 8, 4},
+		{"quota equal to available", 4, 4, 4},
+		{"never returns less than one", 1, 0, 1},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := numThreadsForQuota(tt.available, tt.quota); got != tt.want {
+				t.Errorf("numThreadsForQuota(%d, %d) = %d, want %d", tt.available, tt.quota, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAppendThreadArgsExplicit(t *testing.T) {
+	opts := api.DefaultOptions()
+	opts.NumThread = 6
+	got := appendThreadArgs(nil, opts)
+	want := []string{"-t", "6"}
+	if !slices.Equal(got, want) {
+		t.Errorf("appendThreadArgs with explicit NumThread = %v, want %v", got, want)
+	}
+}
+
+func TestAppendThreadArgsDefaultAlwaysEmitsFlag(t *testing.T) {
+	// Regression guard: previously NumThread == 0 meant no -t flag was ever
+	// passed, leaving llama-server to auto-detect from the raw host core
+	// count regardless of cgroup CPU limits. The derived default must
+	// always be a positive thread count, so -t must always be present now.
+	opts := api.DefaultOptions()
+	opts.NumThread = 0
+	got := appendThreadArgs(nil, opts)
+	if len(got) != 2 || got[0] != "-t" {
+		t.Fatalf("appendThreadArgs with NumThread == 0 = %v, want [-t <n>]", got)
+	}
+}


### PR DESCRIPTION
## Problem

`api.Options.NumThread` defaults to 0, and `startLlamaServer` only passed `-t` when it was set explicitly. With no `-t`, llama-server falls back to its own host-core-count detection, which does not account for cgroup CPU limits.

In a CFS-quota-limited container (e.g. Docker `--cpus 4` on an 8 vCPU host), this oversubscribes threads past the CPU budget the process actually gets. The extra threads convoy llama.cpp's spin-wait barriers against CFS throttling, collapsing throughput by roughly 45x (0.27 tok/s at the auto-detected 8 threads vs 12.07 tok/s at the correct 4). Refs #17916.

The repo has no cgroup-aware CPU detection anywhere today; `discover/cpu_linux.go` already reads `/sys/fs/cgroup/memory.*` for memory limits, but there is no CPU equivalent.

## Fix

`llm/threads.go`, `llm/threads_linux.go`, `llm/threads_other.go` add a `defaultNumThreads()` used by a new `appendThreadArgs` (replacing the inline `-t` block in `startLlamaServer`):

- Linux: `runtime.NumCPU()` (already reflects the process's `sched_getaffinity` mask, e.g. from a `cpuset`) clamped down to the cgroup v2 `cpu.max` quota (`ceil(quota/period)`) when one is set. Absent a quota, this is the same logical CPU count llama-server's own auto-detect would have used.
- macOS/Windows: unchanged, `runtime.NumCPU()` — no cgroups there.

`-t` is now always passed with a positive value instead of only when the caller set `NumThread` explicitly.

**Scope note:** the `cpu.max` read covers the container-root case (same scope as the existing `getCPUMemByCgroups` memory read in `discover/cpu_linux.go`) — it does not resolve a deeper path like a systemd slice on bare metal, and cgroup v1 (`cpu.cfs_quota_us`/`cpu.cfs_period_us`) isn't read. Both are documented as known limits, matching the existing precedent's scope rather than expanding it.

## Existing PR #17920

#17920 adds `OLLAMA_NUM_THREAD` as an opt-in environment variable. It's a manual knob operators can set, but it doesn't touch the default path — a deployment that doesn't set it still gets the raw host core count and the same throughput collapse the issue reports. This PR fixes the default itself, per the issue's "Expected" section (`min(detected_cores, sched_getaffinity_count, ceil(cpu.max quota / period))`).

## Testing

- `TestCgroupCPUQuota` (`llm/threads_linux_test.go`): parses `cpu.max` via a temp-file path parameter — unlimited, sub-period and multi-period quotas, non-multiple-of-period rounding, missing file, malformed content, zero quota/period fields, single-field content, extra whitespace, and a near-`uint64`-max overflow case. No real cgroup or container needed.
- `TestNumThreadsForQuota` (`llm/threads_test.go`): pure clamping logic, including `available == 0`.
- `TestAppendThreadArgsExplicit` / `TestAppendThreadArgsNegativeTreatedAsDefault` / `TestAppendThreadArgsPreservesExistingParams` / `TestAppendThreadArgsDefaultAlwaysEmitsFlag`: exercise the actual `appendThreadArgs` used by `startLlamaServer`.

```
go test ./llm/... ./api/... ./discover/... ./server/...
ok  	github.com/ollama/ollama/llm
ok  	github.com/ollama/ollama/api
ok  	github.com/ollama/ollama/discover
ok  	github.com/ollama/ollama/server
```

Also verified against the issue's exact repro numbers (8 vCPU host, `cpu.max = 400000 100000`) — derives 4 threads, not 8.

`go vet` and `gofmt` clean on all changed/new files. Cross-compiled (`go vet`) for `linux/amd64` and `windows/amd64` to check both platform-specific files build.

## Limits

- `TestCgroupCPUQuota` itself only runs on Linux (file suffix `_linux.go`, matching this repo's existing `cpu_linux.go`/`cpu_windows.go` convention); I don't have a Linux box to run it on natively, so I verified the identical logic in an isolated scratch package on macOS (same code, no OS-specific syscalls) before restoring the real Linux-tagged files, and separately cross-compiled for `linux/amd64` to confirm it type-checks there.
- No cgroup v1 fallback, and no systemd-slice path resolution — see the scope note above.
- `golangci-lint` isn't installed locally, so I couldn't run the exact CI linter; `go vet`/`gofmt` are clean.