### PR TITLE
server: auto-detect ornith and qwen35 renderer and parser

### DIFF
--- a/server/create.go
+++ b/server/create.go
@@ -813,8 +813,12 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 					case "nemotron_h", "nemotron_h_moe", "nemotron_h_omni":
 						config.Renderer = cmp.Or(config.Renderer, "nemotron-3-nano")
 						config.Parser = cmp.Or(config.Parser, "nemotron-3-nano")
+					case "ornith":
+						config.Renderer = cmp.Or(config.Renderer, "ornith")
+						config.Parser = cmp.Or(config.Parser, "ornith")
 					case "qwen35", "qwen35moe":
-						if strings.Contains(strings.ToLower(r.Name), "ornith") || strings.Contains(strings.ToLower(layer.GGML.KV().Architecture()), "ornith") {
+						generalName := strings.ToLower(layer.GGML.KV().String("general.name"))
+						if strings.Contains(generalName, "ornith") {
 							config.Renderer = cmp.Or(config.Renderer, "ornith")
 							config.Parser = cmp.Or(config.Parser, "ornith")
 						} else {

--- a/server/create.go
+++ b/server/create.go
@@ -813,6 +813,14 @@ func createModel(r api.CreateRequest, name model.Name, baseLayers []*layerGGML, 
 					case "nemotron_h", "nemotron_h_moe", "nemotron_h_omni":
 						config.Renderer = cmp.Or(config.Renderer, "nemotron-3-nano")
 						config.Parser = cmp.Or(config.Parser, "nemotron-3-nano")
+					case "qwen35", "qwen35moe":
+						if strings.Contains(strings.ToLower(r.Name), "ornith") || strings.Contains(strings.ToLower(layer.GGML.KV().Architecture()), "ornith") {
+							config.Renderer = cmp.Or(config.Renderer, "ornith")
+							config.Parser = cmp.Or(config.Parser, "ornith")
+						} else {
+							config.Renderer = cmp.Or(config.Renderer, "qwen3.5")
+							config.Parser = cmp.Or(config.Parser, "qwen3.5")
+						}
 					}
 				}
 			case manifest.MediaTypeImageDraft:

--- a/server/images.go
+++ b/server/images.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/json"

--- a/server/images.go
+++ b/server/images.go
@@ -726,6 +726,14 @@ func GetModel(name string) (*Model, error) {
 				ggufChatTemplate = f.KeyValue("tokenizer.chat_template").String()
 				m.HasChatTemplate = ggufChatTemplate != ""
 				modelHasPooling = f.KeyValue("pooling_type").Valid()
+				if m.Config.Renderer == "" || m.Config.Parser == "" {
+					arch := strings.ToLower(f.KeyValue("general.architecture").String())
+					generalName := strings.ToLower(f.KeyValue("general.name").String())
+					if arch == "ornith" || ((arch == "qwen35" || arch == "qwen35moe") && strings.Contains(generalName, "ornith")) {
+						m.Config.Renderer = cmp.Or(m.Config.Renderer, "ornith")
+						m.Config.Parser = cmp.Or(m.Config.Parser, "ornith")
+					}
+				}
 				f.Close()
 			}
 		case manifest.MediaTypeImageDraft:
@@ -784,15 +792,6 @@ func GetModel(name string) (*Model, error) {
 				return nil, err
 			}
 			m.License = append(m.License, string(bts))
-		}
-	}
-
-	if m.Config.Renderer == "" || m.Config.Parser == "" {
-		nameLower := strings.ToLower(m.Name)
-		shortNameLower := strings.ToLower(m.ShortName)
-		if strings.Contains(nameLower, "ornith") || strings.Contains(shortNameLower, "ornith") {
-			m.Config.Renderer = cmp.Or(m.Config.Renderer, "ornith")
-			m.Config.Parser = cmp.Or(m.Config.Parser, "ornith")
 		}
 	}
 

--- a/server/images.go
+++ b/server/images.go
@@ -787,6 +787,15 @@ func GetModel(name string) (*Model, error) {
 		}
 	}
 
+	if m.Config.Renderer == "" || m.Config.Parser == "" {
+		nameLower := strings.ToLower(m.Name)
+		shortNameLower := strings.ToLower(m.ShortName)
+		if strings.Contains(nameLower, "ornith") || strings.Contains(shortNameLower, "ornith") {
+			m.Config.Renderer = cmp.Or(m.Config.Renderer, "ornith")
+			m.Config.Parser = cmp.Or(m.Config.Parser, "ornith")
+		}
+	}
+
 	ggufCaps := chatTemplateCapabilities(nil, ggufChatTemplate)
 	goCaps := goTemplateCapabilities(m.Template)
 	usesHarmony := m.Template != nil && shouldUseHarmony(m)

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -1731,6 +1731,50 @@ func TestCreateNemotronHDefaultsKeepExplicitRendererParser(t *testing.T) {
 	}
 }
 
+func TestCreateQwen35AndOrnithDefaults(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	tests := []struct {
+		arch         string
+		name         string
+		wantRenderer string
+		wantParser   string
+	}{
+		{arch: "qwen35", name: "qwen35-test", wantRenderer: "qwen3.5", wantParser: "qwen3.5"},
+		{arch: "qwen35moe", name: "qwen35moe-test", wantRenderer: "qwen3.5", wantParser: "qwen3.5"},
+		{arch: "qwen35moe", name: "ornith-1.5:35b", wantRenderer: "ornith", wantParser: "ornith"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := t.TempDir()
+			t.Setenv("OLLAMA_MODELS", p)
+			var s Server
+
+			_, digest := createBinFile(t, ggml.KV{
+				"general.architecture": tt.arch,
+			}, nil)
+
+			w := createRequest(t, s.CreateHandler, api.CreateRequest{
+				Name:   tt.name,
+				Files:  map[string]string{"test.gguf": digest},
+				Stream: &stream,
+			})
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected status code 200, actual %d", w.Code)
+			}
+
+			cfg := readCreatedModelConfig(t, tt.name)
+			if cfg.Renderer != tt.wantRenderer {
+				t.Fatalf("expected renderer %q, got %q", tt.wantRenderer, cfg.Renderer)
+			}
+			if cfg.Parser != tt.wantParser {
+				t.Fatalf("expected parser %q, got %q", tt.wantParser, cfg.Parser)
+			}
+		})
+	}
+}
+
 func TestDetectModelTypeFromFiles(t *testing.T) {
 	t.Run("gguf file", func(t *testing.T) {
 		_, digest := createBinFile(t, nil, nil)

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -1735,30 +1735,84 @@ func TestCreateQwen35AndOrnithDefaults(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	tests := []struct {
+		desc         string
 		arch         string
+		generalName  string
 		name         string
+		reqRenderer  string
+		reqParser    string
 		wantRenderer string
 		wantParser   string
 	}{
-		{arch: "qwen35", name: "qwen35-test", wantRenderer: "qwen3.5", wantParser: "qwen3.5"},
-		{arch: "qwen35moe", name: "qwen35moe-test", wantRenderer: "qwen3.5", wantParser: "qwen3.5"},
-		{arch: "qwen35moe", name: "ornith-1.5:35b", wantRenderer: "ornith", wantParser: "ornith"},
+		{
+			desc:         "qwen35 architecture defaults to qwen3.5",
+			arch:         "qwen35",
+			name:         "qwen35-test",
+			wantRenderer: "qwen3.5",
+			wantParser:   "qwen3.5",
+		},
+		{
+			desc:         "qwen35moe architecture defaults to qwen3.5",
+			arch:         "qwen35moe",
+			name:         "qwen35moe-test",
+			wantRenderer: "qwen3.5",
+			wantParser:   "qwen3.5",
+		},
+		{
+			desc:         "qwen35moe with Ornith general.name defaults to ornith",
+			arch:         "qwen35moe",
+			generalName:  "Ornith-1.5-35B",
+			name:         "custom-model-tag",
+			wantRenderer: "ornith",
+			wantParser:   "ornith",
+		},
+		{
+			desc:         "ornith architecture defaults to ornith",
+			arch:         "ornith",
+			name:         "custom-ornith-model",
+			wantRenderer: "ornith",
+			wantParser:   "ornith",
+		},
+		{
+			desc:         "non-ornith model with 'ornith' in name does not get ornith renderer",
+			arch:         "llama",
+			name:         "my-ornith-experiment",
+			wantRenderer: "",
+			wantParser:   "",
+		},
+		{
+			desc:         "explicit renderer and parser override auto-detection",
+			arch:         "qwen35moe",
+			generalName:  "Ornith-1.5-35B",
+			name:         "explicit-override",
+			reqRenderer:  "custom-renderer",
+			reqParser:    "custom-parser",
+			wantRenderer: "custom-renderer",
+			wantParser:   "custom-parser",
+		},
 	}
 
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+		t.Run(tt.desc, func(t *testing.T) {
 			p := t.TempDir()
 			t.Setenv("OLLAMA_MODELS", p)
 			var s Server
 
-			_, digest := createBinFile(t, ggml.KV{
+			kv := ggml.KV{
 				"general.architecture": tt.arch,
-			}, nil)
+			}
+			if tt.generalName != "" {
+				kv["general.name"] = tt.generalName
+			}
+
+			_, digest := createBinFile(t, kv, nil)
 
 			w := createRequest(t, s.CreateHandler, api.CreateRequest{
-				Name:   tt.name,
-				Files:  map[string]string{"test.gguf": digest},
-				Stream: &stream,
+				Name:     tt.name,
+				Files:    map[string]string{"test.gguf": digest},
+				Renderer: tt.reqRenderer,
+				Parser:   tt.reqParser,
+				Stream:   &stream,
 			})
 			if w.Code != http.StatusOK {
 				t.Fatalf("expected status code 200, actual %d", w.Code)

--- a/x/create/client/create.go
+++ b/x/create/client/create.go
@@ -581,7 +581,7 @@ func alwaysSupportsThinking(architectures []string, modelType string) bool {
 
 func isQwen35Family(s string) bool {
 	s = strings.ToLower(s)
-	return strings.Contains(s, "qwen3_5") || strings.Contains(s, "qwen3next")
+	return strings.Contains(s, "qwen3_5") || strings.Contains(s, "qwen35") || strings.Contains(s, "qwen3next")
 }
 
 func qwen35RendererName(modelDir string) string {
@@ -676,6 +676,8 @@ func parserNameForIdentifier(modelDir, s string) string {
 		return "deepseek3"
 	case strings.Contains(s, "gemma4"):
 		return "gemma4"
+	case strings.Contains(s, "ornith"):
+		return "ornith"
 	case isQwen35Family(s):
 		return "qwen3.5"
 	case strings.Contains(s, "qwen3"):
@@ -739,6 +741,8 @@ func rendererNameForIdentifier(modelDir, s string) string {
 		return "glm-4.7"
 	case strings.Contains(s, "deepseek"):
 		return "deepseek3"
+	case strings.Contains(s, "ornith"):
+		return "ornith"
 	case isQwen35Family(s):
 		return qwen35RendererName(modelDir)
 	case strings.Contains(s, "qwen3"):

--- a/x/create/client/create_test.go
+++ b/x/create/client/create_test.go
@@ -82,6 +82,20 @@ func TestNemotron35MetadataInference(t *testing.T) {
 	}
 }
 
+func TestOrnithMetadataInference(t *testing.T) {
+	dir := t.TempDir()
+	config := `{"architectures":["OrnithForCausalLM"],"model_type":"ornith"}`
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(config), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := getParserName(dir), "ornith"; got != want {
+		t.Fatalf("parser = %q, want %q", got, want)
+	}
+	if got, want := getRendererName(dir), "ornith"; got != want {
+		t.Fatalf("renderer = %q, want %q", got, want)
+	}
+}
+
 func TestConfigFromModelfile(t *testing.T) {
 	modelfile, err := parser.ParseFile(strings.NewReader(`
 FROM ./model


### PR DESCRIPTION
### Summary

Fixes #17957

When `ornith-1.5:35b` or models based on `qwen35` / `qwen35moe` architectures are loaded without an explicit renderer or parser specified in their manifest config, Ollama defaults to `gguf_chat_template` (`chatExecutionModeNative`). In native mode, passing both `tools` and a JSON schema `response_format` causes `llama-server`'s Jinja-to-grammar generator to output malformed GBNF (`root ::=` with empty alternatives), failing with:
```
Failed to initialize samplers: failed to parse grammar
```

Ollama already has dedicated `OrnithRenderer` (wrapping `Qwen35Renderer`) and `Qwen35Parser` implementations, but lacked auto-detection for `ornith` and `qwen35`/`qwen35moe` architectures during model creation and loading.

### Behavioral Flow

| Scenario | Before | After |
| :--- | :--- | :--- |
| `ornith-1.5:35b` with tools + JSON schema | `chatExecutionModeNative` → malformed GBNF → request fails | `OrnithRenderer` + `Qwen35Parser` (`chatExecutionModeRendered`) → succeeds |
| Other `qwen35` / `qwen35moe` models | `chatExecutionModeNative` | `qwen3.5` renderer + parser (`chatExecutionModeRendered`) |
| Explicit custom renderer/parser | Preserved | Preserved |

### Changes
1. **`server/create.go`**: Architecture- and GGUF metadata-driven auto-detection for `ornith` and `qwen35`/`qwen35moe` models (inspecting `general.architecture` and GGUF `general.name`).
2. **`server/images.go`**: Metadata-driven fallback during GGUF model load when unconfigured in the manifest.
3. **`x/create/client/create.go`**: Updated `isQwen35Family` to match `qwen35` and added `ornith` renderer/parser detection.
4. **Comprehensive Unit Tests**:
   - `TestCreateQwen35AndOrnithDefaults` in `server/routes_create_test.go` covering:
     - `qwen35` → `qwen3.5`
     - `qwen35moe` → `qwen3.5`
     - `qwen35moe` with `general.name: Ornith-1.5-35B` → `ornith`
     - `ornith` architecture → `ornith`
     - Non-ornith model with "ornith" in model tag name does NOT trigger detection
     - Explicit renderer/parser overrides are strictly preserved
   - `TestOrnithMetadataInference` in `x/create/client/create_test.go`
