### PR TITLE
all: fix typos in comments and a tray log message

### DIFF
--- a/app/updater/updater_darwin.go
+++ b/app/updater/updater_darwin.go
@@ -149,7 +149,7 @@ func DoUpgrade(interactive bool) error {
 		}
 	}
 
-	// Get ready to try to unwind a partial upgade failure during unzip
+	// Get ready to try to unwind a partial upgrade failure during unzip
 	// If something goes wrong, we attempt to put the old version back.
 	anyFailures := false
 	defer func() {

--- a/app/wintray/eventloop.go
+++ b/app/wintray/eventloop.go
@@ -104,7 +104,7 @@ func (t *winTray) wndProc(hWnd windows.Handle, message uint32, wParam, lParam ui
 		}
 		err = t.wcex.unregister()
 		if err != nil {
-			slog.Error(fmt.Sprintf("failed to uregister windo %s", err))
+			slog.Error(fmt.Sprintf("failed to unregister window %s", err))
 		}
 	case WM_DESTROY:
 		// slog.Debug("XXX WM_DESTROY triggered")

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -330,7 +330,7 @@ Examples:
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			policy := defaultLaunchPolicy(isInteractiveSession(), yesFlag)
-			// reset when done to make sure state doens't leak between launches
+			// reset when done to make sure state doesn't leak between launches
 			restoreConfirmPolicy := withLaunchConfirmPolicy(policy.confirmPolicy())
 			defer restoreConfirmPolicy()
 

--- a/integration/api_test.go
+++ b/integration/api_test.go
@@ -413,7 +413,7 @@ func runAPIShowModel(t *testing.T) {
 	}
 	// llama3 omits system
 	verifyModelDetails(t, resp.Details)
-	// llama3 ommits messages
+	// llama3 omits messages
 	if len(resp.ModelInfo) == 0 {
 		t.Errorf("%s missing model_info: %#v", modelName, resp)
 	}

--- a/integration/context_test.go
+++ b/integration/context_test.go
@@ -136,7 +136,7 @@ func containsEmoji(s string) bool {
 	return false
 }
 
-// Send multiple generate requests with prior context and ensure the response is coherant and expected
+// Send multiple generate requests with prior context and ensure the response is coherent and expected
 func runParallelGenerateWithHistory(t *testing.T, modelName string) {
 	if testModel != "" {
 		// The Generate API's Context field (token array continuation) is not
@@ -194,7 +194,7 @@ func runParallelGenerateWithHistory(t *testing.T, modelName string) {
 	wg.Wait()
 }
 
-// Send generate requests with prior context and ensure the response is coherant and expected
+// Send generate requests with prior context and ensure the response is coherent and expected
 func runGenerateWithHistory(t *testing.T) {
 	if testModel != "" {
 		// The Generate API's Context field (token array continuation) is not
@@ -234,7 +234,7 @@ func runGenerateWithHistory(t *testing.T) {
 	}
 }
 
-// Send multiple chat requests with prior context and ensure the response is coherant and expected
+// Send multiple chat requests with prior context and ensure the response is coherent and expected
 func runParallelChatWithHistory(t *testing.T, modelName string) {
 	req, resp := ChatRequests()
 	numParallel := 2
@@ -299,7 +299,7 @@ func prepareParallelHistoryModel(ctx context.Context, t *testing.T, client *api.
 	skipIfModelTooLargeForSweepVRAM(ctx, t, client, modelName)
 }
 
-// Send generate requests with prior context and ensure the response is coherant and expected
+// Send generate requests with prior context and ensure the response is coherent and expected
 func runChatWithHistory(t *testing.T) {
 	req := api.ChatRequest{
 		Model:     smol,


### PR DESCRIPTION
Fixes a handful of misspellings I hit while reading through the code.

Comments only, except for one log message in the Windows tray, which had two typos in the same line:

```go
slog.Error(fmt.Sprintf("failed to uregister windo %s", err))
```

The rest: `doens't` in `cmd/launch/launch.go`, `upgade` in `app/updater/updater_darwin.go`, `ommits` in `integration/api_test.go`, and four occurrences of `coherant` in `integration/context_test.go`.

No behaviour change. I deliberately left the spelling alone in `app/webview/webview.h` (vendored upstream) and in the base64 test fixtures.