### PR TITLE
Add Musaeus to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ console.log(response.message.content);
 - [Stakpak](https://github.com/stakpak/agent) - Open source DevOps agent
 - [Hexabot](https://github.com/hexastack/hexabot) - Conversational AI builder
 - [Neuro SAN](https://github.com/cognizant-ai-lab/neuro-san-studio) - Multi-agent orchestration ([docs](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#ollama))
+- [Musaeus](https://github.com/MUSE-CODE-SPACE/musaeus) - Local-first agent and teaching codebase, one concept per module
 
 ### RAG & Knowledge Bases
 


### PR DESCRIPTION
Adds [Musaeus](https://github.com/MUSE-CODE-SPACE/musaeus) to the Frameworks & Agents section.

Musaeus is an Apache-2.0, local-first LLM agent that runs on Ollama by default (OpenAI-compatible endpoint, tool calling, `/embeddings` for RAG). It doubles as a teaching codebase: each core concept — tool registry, ReAct loop, RAG, guardrails, evaluation, MCP — lives in its own small, readable module with no framework dependencies.