### PR TITLE
llm: disable MTP backend sampling on Metal

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -379,7 +379,7 @@ func startLlamaServer(launch llamaServerLaunchConfig, out io.Writer) (cmd *exec.
 	params = appendJinjaArgs(params, launch.config)
 
 	params = appendMMProjArgs(params, launch)
-	params = appendDraftArgs(params, launch.draftType, launch.config.DraftModelPath, launch.opts)
+	params = appendDraftArgs(params, launch.draftType, launch.config.DraftModelPath, launch.opts, launch.gpus)
 
 	params = append(params, qwenVLServerArgs(launch.modelArch)...)
 
@@ -804,7 +804,7 @@ const (
 	draftTypeDFlash = "draft-dflash"
 )
 
-func appendDraftArgs(params []string, draftType, draftModelPath string, opts api.Options) []string {
+func appendDraftArgs(params []string, draftType, draftModelPath string, opts api.Options, gpus []ml.DeviceInfo) []string {
 	if draftType == "" {
 		return params
 	}
@@ -815,7 +815,12 @@ func appendDraftArgs(params []string, draftType, draftModelPath string, opts api
 	params = append(params, "--spec-type", draftType)
 	params = append(params, "--spec-draft-n-max", strconv.Itoa(opts.DraftNumPredict))
 	if draftType == draftTypeMTP {
-		params = append(params, "--spec-draft-backend-sampling")
+		// Metal backend sampling adds draft-side overhead without changing MTP acceptance.
+		if slices.ContainsFunc(gpus, func(gpu ml.DeviceInfo) bool { return gpu.Library == "Metal" }) {
+			params = append(params, "--no-spec-draft-backend-sampling")
+		} else {
+			params = append(params, "--spec-draft-backend-sampling")
+		}
 	}
 	if draftModelPath != "" {
 		params = append(params, "--spec-draft-model", draftModelPath)

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -2475,6 +2475,7 @@ func TestAppendDraftArgs(t *testing.T) {
 		draftType string
 		draftPath string
 		opts      api.Options
+		gpus      []ml.DeviceInfo
 		want      []string
 	}{
 		{
@@ -2496,6 +2497,13 @@ func TestAppendDraftArgs(t *testing.T) {
 			want:      []string{"base", "--spec-type", "draft-mtp", "--spec-draft-n-max", "8", "--spec-draft-backend-sampling", "--spec-draft-model", "draft.gguf"},
 		},
 		{
+			name:      "MTP draft disables backend sampling on Metal",
+			draftType: draftTypeMTP,
+			opts:      api.Options{Runner: api.Runner{DraftNumPredict: 4}},
+			gpus:      []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Metal"}}},
+			want:      []string{"base", "--spec-type", "draft-mtp", "--spec-draft-n-max", "4", "--no-spec-draft-backend-sampling"},
+		},
+		{
 			name:      "DFlash draft omits MTP backend sampling",
 			draftType: draftTypeDFlash,
 			draftPath: "draft.gguf",
@@ -2513,7 +2521,7 @@ func TestAppendDraftArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := appendDraftArgs([]string{"base"}, tt.draftType, tt.draftPath, tt.opts)
+			got := appendDraftArgs([]string{"base"}, tt.draftType, tt.draftPath, tt.opts, tt.gpus)
 			if !slices.Equal(got, tt.want) {
 				t.Fatalf("appendDraftArgs = %v, want %v", got, tt.want)
 			}


### PR DESCRIPTION
## Summary

Disable llama.cpp's draft backend sampling for MTP models on Metal while preserving the existing behavior on CUDA, Vulkan, and CPU.

Addresses #17776.

## Why

llama.cpp's Metal top-k backend sampler adds overhead to MTP decoding without changing the sampled draft tokens or their acceptance. This is most visible when acceptance is low, which is the failure mode reported in #17776.

On an Apple M4 with Qwen3.5 9B Q4_K_M, two deterministic 100-token probes produced identical draft counters with backend sampling on and off:

| case | backend sampling | accepted / drafted | throughput |
| --- | --- | ---: | ---: |
| lower acceptance | on | 41 / 231 | 2.20 tok/s |
| lower acceptance | off | 41 / 231 | 2.54 tok/s |
| higher acceptance | on | 61 / 151 | 3.93 tok/s |
| higher acceptance | off | 61 / 151 | 3.96 tok/s |

Disabling backend sampling improves the lower-acceptance case by 15.5% and is neutral in the higher-acceptance case. Since the accepted and drafted token counts are byte-for-byte identical, the change removes sampler overhead rather than altering generation behavior.

## Implementation

- Pass the selected GPU list into draft argument construction.
- Emit `--no-spec-draft-backend-sampling` for MTP on Metal.
- Keep `--spec-draft-backend-sampling` for all non-Metal MTP launches.
- Leave DFlash argument behavior unchanged.

## Testing

```text
go test ./llm -count=1
```

Added an argument-construction regression test for Metal MTP launches.
