### PR TITLE
docs: add Ontheia to Community Integrations (fixes #17947)

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ console.log(response.message.content);
 - [Stakpak](https://github.com/stakpak/agent) - Open source DevOps agent
 - [Hexabot](https://github.com/hexastack/hexabot) - Conversational AI builder
 - [Neuro SAN](https://github.com/cognizant-ai-lab/neuro-san-studio) - Multi-agent orchestration ([docs](https://github.com/cognizant-ai-lab/neuro-san-studio/blob/main/docs/user_guide.md#ollama))
+- [Ontheia](https://github.com/Ontheia/ontheia) - Self-hosted AI agent platform with multi-agent orchestration and RAG ([docs](https://docs.ontheia.ai))
 
 ### RAG & Knowledge Bases
 


### PR DESCRIPTION
Fixes #17947

Add Ontheia — self-hosted AI agent platform with multi-agent orchestration and RAG — to Frameworks & Agents section, alphabetically after Neuro SAN.