### PR TITLE
app/ui: prevent sidebar animation on initial load

### DIFF
--- a/app/ui/app/src/components/layout/layout.test.tsx
+++ b/app/ui/app/src/components/layout/layout.test.tsx
@@ -1,4 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
+import { act, create } from "react-test-renderer";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { SidebarLayout } from "./layout";
 
@@ -7,7 +8,7 @@ describe("SidebarLayout", () => {
     vi.unstubAllGlobals();
   });
 
-  it("keeps the macOS title offset in step with the sidebar transition", () => {
+  it("renders sidebar open without initial transition classes to avoid animation on load", () => {
     vi.stubGlobal("window", { OLLAMA_PLATFORM: "darwin" });
 
     const html = renderToStaticMarkup(
@@ -16,8 +17,99 @@ describe("SidebarLayout", () => {
       </SidebarLayout>,
     );
 
-    expect(html).toContain("pl-36");
-    expect(html).toContain("transition-[padding-left]");
-    expect(html).toContain("duration-300");
+    // Should render open initially
+    expect(html).toContain("w-48");
+    expect(html).toContain("pl-6");
+    expect(html).toContain("left-[140px]");
+
+    // Initial render should not have transition classes active
+    expect(html).not.toContain("transition-[padding-left]");
+    expect(html).not.toContain("transition-[width]");
+    expect(html).not.toContain("transition-[left]");
+  });
+
+  it("enables transitions once mounted for smooth user interactions", () => {
+    vi.stubGlobal("window", { OLLAMA_PLATFORM: "darwin" });
+
+    let renderer: ReturnType<typeof create>;
+    act(() => {
+      renderer = create(
+        <SidebarLayout title="Connect your apps" sidebar={<nav />}>
+          <div />
+        </SidebarLayout>,
+      );
+    });
+
+    const root = renderer!.root;
+    const title = root.findByType("h1");
+    expect(title.props.className).toContain("transition-[padding-left]");
+    expect(title.props.className).toContain("duration-300");
+    expect(title.props.className).toContain("pl-6");
+  });
+
+  it("toggles sidebar between open and closed when the toggle button is clicked", () => {
+    vi.stubGlobal("window", { OLLAMA_PLATFORM: "darwin" });
+
+    let renderer: ReturnType<typeof create>;
+    act(() => {
+      renderer = create(
+        <SidebarLayout title="Connect your apps" sidebar={<nav />}>
+          <div />
+        </SidebarLayout>,
+      );
+    });
+
+    const root = renderer!.root;
+    const button = root.findByType("button");
+
+    // Initially open
+    expect(button.props["aria-label"]).toBe("Hide sidebar");
+    const title = root.findByType("h1");
+    expect(title.props.className).toContain("pl-6");
+
+    // Click to close
+    act(() => {
+      button.props.onClick();
+    });
+
+    expect(button.props["aria-label"]).toBe("Show sidebar");
+    expect(title.props.className).toContain("pl-36");
+
+    // Click to open again
+    act(() => {
+      button.props.onClick();
+    });
+
+    expect(button.props["aria-label"]).toBe("Hide sidebar");
+    expect(title.props.className).toContain("pl-6");
+  });
+
+  it("adjusts offsets for Windows platform", () => {
+    vi.stubGlobal("window", { OLLAMA_PLATFORM: "windows" });
+
+    let renderer: ReturnType<typeof create>;
+    act(() => {
+      renderer = create(
+        <SidebarLayout title="Settings" sidebar={<nav />}>
+          <div />
+        </SidebarLayout>,
+      );
+    });
+
+    const root = renderer!.root;
+    const button = root.findByType("button");
+    const title = root.findByType("h1");
+
+    // On Windows, toggle button is at left-2 when open
+    expect(button.parent?.props.className).toContain("left-2");
+    expect(title.props.className).toContain("pl-6");
+
+    // Toggle closed on Windows: title gets pl-16
+    act(() => {
+      button.props.onClick();
+    });
+
+    expect(title.props.className).toContain("pl-16");
+    expect(button.parent?.props.className).toContain("left-2");
   });
 });

--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -1,9 +1,9 @@
 import { Link } from "@tanstack/react-router";
 import { ChatIcon } from "@/components/ChatIcon";
 import { isWindowsPlatform } from "@/lib/platform";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
-let sessionSidebarOpen = false;
+let sessionSidebarOpen = true;
 
 export function SidebarLayout({
   sidebar,
@@ -14,7 +14,12 @@ export function SidebarLayout({
   title?: string;
 }>) {
   const [sidebarOpen, setSidebarOpen] = useState(sessionSidebarOpen);
+  const [isMounted, setIsMounted] = useState(false);
   const isWindows = isWindowsPlatform();
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
 
   const toggleSidebar = () => {
     sessionSidebarOpen = !sidebarOpen;
@@ -24,7 +29,7 @@ export function SidebarLayout({
   return (
     <div className="flex h-screen w-full overflow-hidden dark:bg-neutral-900">
       <div
-        className={`absolute flex mx-2 py-2 z-20 items-center transition-[left] duration-375 text-neutral-500 dark:text-neutral-400 ${sidebarOpen ? (isWindows ? "left-2" : "left-[140px]") : isWindows ? "left-2" : "left-20"}`}
+        className={`absolute flex mx-2 py-2 z-20 items-center ${isMounted ? "transition-[left] duration-375" : ""} text-neutral-500 dark:text-neutral-400 ${sidebarOpen ? (isWindows ? "left-2" : "left-[140px]") : isWindows ? "left-2" : "left-20"}`}
       >
         <button
           onClick={toggleSidebar}
@@ -49,7 +54,7 @@ export function SidebarLayout({
             to="/c/$chatId"
             params={{ chatId: "new" }}
             title="New chat"
-            className={`flex ml-1 items-center justify-center rounded-full transition-opacity duration-375 h-9 w-9 hover:bg-neutral-100 dark:hover:bg-neutral-700 ${
+            className={`flex ml-1 items-center justify-center rounded-full ${isMounted ? "transition-opacity duration-375" : ""} h-9 w-9 hover:bg-neutral-100 dark:hover:bg-neutral-700 ${
               sidebarOpen ? "opacity-0 pointer-events-none" : "opacity-100"
             }`}
           >
@@ -58,7 +63,7 @@ export function SidebarLayout({
         )}
       </div>
       <div
-        className={`flex max-h-screen flex-col transition-[width] duration-300 ${
+        className={`flex max-h-screen flex-col ${isMounted ? "transition-[width] duration-300" : ""} ${
           sidebarOpen
             ? "w-48 border-r border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-950/40"
             : "w-0"
@@ -71,7 +76,9 @@ export function SidebarLayout({
         ></div>
         {sidebarOpen && sidebar}
       </div>
-      <main className="flex min-w-0 flex-1 flex-col transition-all duration-300">
+      <main
+        className={`flex min-w-0 flex-1 flex-col ${isMounted ? "transition-all duration-300" : ""}`}
+      >
         <div
           className={`h-13 z-10 flex w-full flex-none items-center bg-white dark:bg-neutral-900 ${title ? "" : isWindows ? "xl:hidden" : "xl:fixed xl:bg-transparent xl:dark:bg-transparent"}`}
           onDoubleClick={() => window.doubleClick && window.doubleClick()}
@@ -79,7 +86,7 @@ export function SidebarLayout({
         >
           {title && (
             <h1
-              className={`${sidebarOpen ? "pl-6" : isWindows ? "pl-16" : "pl-36"} transition-[padding-left] duration-300 font-rounded text-md font-medium dark:text-white`}
+              className={`${sidebarOpen ? "pl-6" : isWindows ? "pl-16" : "pl-36"} ${isMounted ? "transition-[padding-left] duration-300" : ""} font-rounded text-md font-medium dark:text-white`}
             >
               {title}
             </h1>


### PR DESCRIPTION
### Summary

Fixes #12954

When Ollama's app loads, the sidebar previously animated open on first load instead of appearing open immediately.

### Changes
- Initialized `sessionSidebarOpen = true` so the sidebar opens by default on launch.
- Added `isMounted` state in `SidebarLayout` to suppress CSS transitions during initial render, ensuring the sidebar renders open immediately without any opening animation glitch.
- Enabled transitions once mounted to preserve smooth animation for subsequent user toggle interactions.
- Added unit tests in `layout.test.tsx` verifying initial render state, transition activation after mount, and platform offsets.
