### PR TITLE
app: keep Claude toggle active while connecting

### DIFF
--- a/app/ui/app/src/components/Onboarding.test.tsx
+++ b/app/ui/app/src/components/Onboarding.test.tsx
@@ -157,6 +157,112 @@ describe("Onboarding", () => {
     }
   });
 
+  it("keeps the Claude switch on and busy through installer detection", async () => {
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+
+    const disconnectedStatus = {
+      supported: true,
+      used: false,
+      installed: false,
+      configured: false,
+      connected: false,
+      running: false,
+      startFailed: false,
+      portConflict: false,
+    };
+    let finishInstall!: (result: "opened") => void;
+    const install = new Promise<"opened">((resolve) => {
+      finishInstall = resolve;
+    });
+
+    vi.stubGlobal("navigator", { platform: "MacIntel" });
+    vi.stubGlobal("window", {
+      OLLAMA_PLATFORM: "darwin",
+      innerHeight: 660,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: globalThis.clearTimeout,
+      setInterval: globalThis.setInterval,
+      clearInterval: globalThis.clearInterval,
+      getClaudeDesktopConnectionSummary: vi
+        .fn()
+        .mockResolvedValue(disconnectedStatus),
+      setClaudeDesktopConnected: vi.fn(),
+      installClaudeDesktop: vi.fn().mockReturnValue(install),
+    });
+
+    let renderer: ReactTestRenderer | undefined;
+    try {
+      await act(async () => {
+        renderer = create(
+          <ConnectAppsScreen
+            initialClaudeStatus={disconnectedStatus}
+            initialIntegrations={[
+              {
+                id: "claude-desktop",
+                name: "Claude",
+                description: "Use Ollama models in Claude Desktop",
+                installed: false,
+                action: "connect",
+              },
+            ]}
+          />,
+        );
+        await Promise.resolve();
+      });
+
+      const claudeSwitch = () => renderer!.root.findByProps({ role: "switch" });
+      let clickResult!: Promise<void>;
+      await act(async () => {
+        clickResult = claudeSwitch().props.onClick();
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(claudeSwitch().props["aria-checked"]).toBe(true);
+      expect(claudeSwitch().props["aria-busy"]).toBe(true);
+      expect(claudeSwitch().props.disabled).toBe(true);
+      expect(claudeSwitch().props.className).toContain("disabled:opacity-50");
+      expect(renderer.root.findByProps({ role: "status" }).children).toContain(
+        "Downloading…",
+      );
+      expect(
+        renderer.root.findAll(
+          (node) =>
+            typeof node.props.className === "string" &&
+            node.props.className.includes("animate-spin"),
+        ),
+      ).not.toHaveLength(0);
+
+      await act(async () => {
+        finishInstall("opened");
+        await clickResult;
+        await Promise.resolve();
+      });
+
+      expect(claudeSwitch().props["aria-checked"]).toBe(true);
+      expect(claudeSwitch().props["aria-busy"]).toBe(true);
+      expect(claudeSwitch().props.disabled).toBe(true);
+      expect(claudeSwitch().props.className).toContain("disabled:opacity-50");
+      expect(renderer.root.findByProps({ role: "status" }).children).toContain(
+        "Finish installing…",
+      );
+      expect(
+        renderer.root.findAll(
+          (node) =>
+            typeof node.props.className === "string" &&
+            node.props.className.includes("animate-spin"),
+        ),
+      ).not.toHaveLength(0);
+    } finally {
+      if (renderer) {
+        act(() => renderer?.unmount());
+      }
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("preserves a late native error after the Connect Apps action times out", async () => {
     vi.useFakeTimers();
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);

--- a/app/ui/app/src/components/Onboarding.tsx
+++ b/app/ui/app/src/components/Onboarding.tsx
@@ -888,7 +888,10 @@ export function ConnectAppsScreen({
     ? isClaudeConfigured(claudeStatus)
     : false;
   const pendingClaudeConnection =
-    claudePhase === "connecting" || claudePhase === "launching"
+    claudePhase === "installing" ||
+    claudePhase === "waiting-for-install" ||
+    claudePhase === "connecting" ||
+    claudePhase === "launching"
       ? true
       : claudePhase === "disconnecting"
         ? false
@@ -1016,7 +1019,7 @@ export function ConnectAppsScreen({
           title={claudeConfigured ? "Disconnect" : "Connect"}
           disabled={isConnectingClaude}
           onClick={connectClaude}
-          className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-500 disabled:cursor-wait ${claudeToggleConfigured ? "bg-neutral-950" : "bg-neutral-300"}`}
+          className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-500 disabled:cursor-wait disabled:opacity-50 ${claudeToggleConfigured ? "bg-neutral-950" : "bg-neutral-300"}`}
         >
           <span
             aria-hidden="true"


### PR DESCRIPTION
## Summary

Keeps the Claude switch on the Apps page visually active throughout the enable flow, avoiding the brief on-to-off flicker while Claude is downloading or connecting.

## What changed

- Treats downloading, waiting for installation, connecting, and launching as pending-on states.
- Disables and visually mutes the switch while work is in progress.
- Keeps the spinner and progress label visible until the action settles.
- Preserves the actual native state after cancellation, failure, or timeout.
- Leaves disconnect and the first-use Claude modal flow unchanged.
- Adds regression coverage across the download-to-install-detection transition.

## Testing

- `npm test -- --run` (102 tests)
- `npm run build`
- `npx prettier --check src/components/Onboarding.tsx src/components/Onboarding.test.tsx`
- `npx eslint src/components/Onboarding.tsx src/components/Onboarding.test.tsx` (one pre-existing Fast Refresh warning)