### PR TITLE
app: reset Claude Desktop models to defaults

### DIFF
--- a/app/cmd/app/app_darwin.go
+++ b/app/cmd/app/app_darwin.go
@@ -80,11 +80,13 @@ var (
 	launchAgentPath    = filepath.Join(os.Getenv("HOME"), "Library", "LaunchAgents", "com.ollama.ollama.plist")
 	claudeAppProxy     *proxy.ClaudeDesktop
 	claudeProxyStartMu sync.Mutex
-	claudeProxyMu      sync.Mutex
-	claudeCatalogMu    sync.Mutex
-	claudeProxyErr     error
-	claudeProxyFail    claudeProxyFailure
-	claudeDesktop      claudeDesktopController = &launch.ClaudeDesktop{}
+	// Serialize default resets with connect and disconnect decisions.
+	claudeLifecycleMu sync.Mutex
+	claudeProxyMu     sync.Mutex
+	claudeCatalogMu   sync.Mutex
+	claudeProxyErr    error
+	claudeProxyFail   claudeProxyFailure
+	claudeDesktop     claudeDesktopController = &launch.ClaudeDesktop{}
 
 	claudeDesktopInstalled        = launch.ClaudeDesktopInstalled
 	claudeDesktopRunning          = launch.ClaudeDesktopRunning
@@ -985,6 +987,9 @@ func markClaudeDesktopIntegrationUsed() error {
 }
 
 func setClaudeGatewayInstalled(installed, restart bool) error {
+	claudeLifecycleMu.Lock()
+	defer claudeLifecycleMu.Unlock()
+
 	if installed && !claudeDesktopInstalled() {
 		return errors.New("Claude Desktop is not installed")
 	}
@@ -1318,6 +1323,9 @@ func applyClaudeDesktopMappings(mappings map[string]string, restartConfirmed boo
 }
 
 func resetClaudeDesktopMappings(restartConfirmed bool) (bool, error) {
+	claudeLifecycleMu.Lock()
+	defer claudeLifecycleMu.Unlock()
+
 	if !hasUsedClaudeDesktopIntegration() {
 		return false, nil
 	}

--- a/app/cmd/app/app_darwin.go
+++ b/app/cmd/app/app_darwin.go
@@ -836,6 +836,25 @@ func ensureClaudeDesktopModelsAvailable(ctx context.Context, models []proxy.Clau
 	}
 }
 
+func resolveClaudeDesktopAccessStateWithRetry(ctx context.Context) (proxy.ClaudeDesktopAccessState, error) {
+	deadline := time.Now().Add(claudeAccessRetryWait)
+	for {
+		state, err := claudeAccessStateResolver(ctx)
+		if err == nil || time.Now().After(deadline) {
+			return state, err
+		}
+		slog.Debug("could not resolve Claude model access while refreshing defaults", "error", err)
+
+		timer := time.NewTimer(claudeAccessRetryPoll)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return state, ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
 func hasCloudClaudeDesktopModel(models []proxy.ClaudeDesktopModel) bool {
 	for _, model := range models {
 		if model.Cloud {
@@ -1087,6 +1106,16 @@ func claudeDesktopConnectionSummary(used bool) claudeDesktopStatus {
 }
 
 func getClaudeDesktopConnectionStatus() claudeDesktopStatus {
+	return getClaudeDesktopConnectionStatusWithAccessResolver(claudeAccessStateResolver)
+}
+
+func getClaudeDesktopResetStatus() claudeDesktopStatus {
+	return getClaudeDesktopConnectionStatusWithAccessResolver(resolveClaudeDesktopAccessStateWithRetry)
+}
+
+func getClaudeDesktopConnectionStatusWithAccessResolver(
+	accessResolver func(context.Context) (proxy.ClaudeDesktopAccessState, error),
+) claudeDesktopStatus {
 	used := hasUsedClaudeDesktopIntegration()
 	var availableModels, selectedModels []proxy.ClaudeDesktopModel
 	var modelSource string
@@ -1094,13 +1123,13 @@ func getClaudeDesktopConnectionStatus() claudeDesktopStatus {
 		Cloud:   proxy.ClaudeDesktopCloudUnknown,
 		Account: proxy.ClaudeDesktopAccountUnknown,
 	}
+	var accessErr error
 	if used {
 		claudeProxyMu.Lock()
 		gateway := claudeAppProxy
 		cachedCatalogHasCloud := hasCloudClaudeDesktopModel(claudeAvailableModels)
 		claudeProxyMu.Unlock()
-		var accessErr error
-		accessState, accessErr = claudeAccessStateResolver(context.Background())
+		accessState, accessErr = accessResolver(context.Background())
 		if accessErr != nil {
 			slog.Debug("could not resolve Claude model access for Settings", "error", accessErr)
 		}
@@ -1161,11 +1190,21 @@ func getClaudeDesktopConnectionStatus() claudeDesktopStatus {
 		})
 	}
 	mappedModels := proxy.ClaudeDesktopMappings(selectedModels)
-	defaultMappedModels := proxy.DefaultClaudeDesktopMappingsForModels(
-		availableModels,
-		claudeDesktopHasFullDefaultAccess(accessState),
-	)
-	if len(launch.ClaudeDesktopModels()) == 0 {
+	var defaultMappedModels map[string]string
+	defaultMappingsComplete := false
+	if accessErr == nil {
+		if fullDefaultAccess, accountTierKnown := claudeDesktopDefaultAccessTier(accessState); accountTierKnown {
+			defaultMappedModels = proxy.DefaultClaudeDesktopMappingsForModels(
+				availableModels,
+				fullDefaultAccess,
+			)
+			defaultMappingsComplete = claudeDesktopDefaultMappingsComplete(defaultMappedModels, fullDefaultAccess)
+			if !defaultMappingsComplete {
+				slog.Debug("could not resolve every Claude mapping default", "full_access", fullDefaultAccess, "resolved", len(defaultMappedModels))
+			}
+		}
+	}
+	if defaultMappingsComplete && len(launch.ClaudeDesktopModels()) == 0 {
 		mappedModels = defaultMappedModels
 	}
 	mappingStatuses := make([]claudeDesktopMappingStatus, 0, proxy.MaxClaudeDesktopModels)
@@ -1176,11 +1215,13 @@ func getClaudeDesktopConnectionStatus() claudeDesktopStatus {
 			RouteName: route.DisplayName,
 			Model:     mappedModels[route.ID],
 		})
-		defaultMappingStatuses = append(defaultMappingStatuses, claudeDesktopMappingStatus{
-			RouteID:   route.ID,
-			RouteName: route.DisplayName,
-			Model:     defaultMappedModels[route.ID],
-		})
+		if defaultMappingsComplete {
+			defaultMappingStatuses = append(defaultMappingStatuses, claudeDesktopMappingStatus{
+				RouteID:   route.ID,
+				RouteName: route.DisplayName,
+				Model:     defaultMappedModels[route.ID],
+			})
+		}
 	}
 
 	status := claudeDesktopConnectionSummary(used)
@@ -1197,8 +1238,32 @@ func getClaudeDesktopConnectionStatus() claudeDesktopStatus {
 }
 
 func claudeDesktopHasFullDefaultAccess(state proxy.ClaudeDesktopAccessState) bool {
+	fullAccess, known := claudeDesktopDefaultAccessTier(state)
+	return known && fullAccess
+}
+
+func claudeDesktopDefaultAccessTier(state proxy.ClaudeDesktopAccessState) (fullAccess, known bool) {
+	if state.Account != proxy.ClaudeDesktopAccountSignedIn {
+		return false, false
+	}
 	plan := strings.TrimSpace(state.Plan)
-	return state.Account == proxy.ClaudeDesktopAccountSignedIn && plan != "" && !strings.EqualFold(plan, "free")
+	if plan == "" {
+		return false, false
+	}
+	return !strings.EqualFold(plan, "free"), true
+}
+
+func claudeDesktopDefaultMappingsComplete(mappings map[string]string, fullAccess bool) bool {
+	required := proxy.DefaultClaudeDesktopMappings(fullAccess)
+	if len(mappings) != len(required) {
+		return false
+	}
+	for route := range required {
+		if strings.TrimSpace(mappings[route]) == "" {
+			return false
+		}
+	}
+	return true
 }
 
 func setClaudeDesktopConnection(enabled, restartConfirmed bool) error {
@@ -1259,6 +1324,14 @@ func setClaudeDesktopAutoMode(enabled, restartConfirmed bool) error {
 }
 
 func applyClaudeDesktopMappings(mappings map[string]string, restartConfirmed bool) (bool, error) {
+	return applyClaudeDesktopMappingsWithOptions(mappings, restartConfirmed, true, true)
+}
+
+func resetClaudeDesktopMappings(mappings map[string]string, restartConfirmed bool) (bool, error) {
+	return applyClaudeDesktopMappingsWithOptions(mappings, restartConfirmed, false, claudeDesktop.UsesOllamaGateway())
+}
+
+func applyClaudeDesktopMappingsWithOptions(mappings map[string]string, restartConfirmed, openWhenStopped, activateIntegration bool) (bool, error) {
 	if !claudeDesktopInstalled() {
 		return false, errors.New("Claude Desktop is not installed")
 	}
@@ -1333,6 +1406,15 @@ func applyClaudeDesktopMappings(mappings map[string]string, restartConfirmed boo
 	if !mappingsChanged && claudeDesktop.Running() {
 		return false, nil
 	}
+	if !activateIntegration {
+		if !mappingsChanged {
+			return false, nil
+		}
+		if err := launch.SaveClaudeDesktopModelMappings(normalized); err != nil {
+			return false, fmt.Errorf("save Claude Desktop model mappings: %w", err)
+		}
+		return true, nil
+	}
 	restoreState := func() error {
 		var rollbackErr error
 		if gateway != nil && len(current) > 0 {
@@ -1371,7 +1453,7 @@ func applyClaudeDesktopMappings(mappings map[string]string, restartConfirmed boo
 			stopClaudeAppProxy()
 			return false, errors.Join(err, restoreState())
 		}
-		if !claudeDesktop.Running() {
+		if openWhenStopped && !claudeDesktop.Running() {
 			if err := claudeDesktop.Open(); err != nil {
 				if mappingsChanged {
 					return true, fmt.Errorf("Claude model mappings were saved, but Claude Desktop could not open: %w", err)
@@ -1409,7 +1491,7 @@ func applyClaudeDesktopMappings(mappings map[string]string, restartConfirmed boo
 		}
 		return false, errors.Join(err, restoreState())
 	}
-	if !claudeDesktop.Running() {
+	if openWhenStopped && !claudeDesktop.Running() {
 		if err := claudeDesktop.Open(); err != nil {
 			if mappingsChanged {
 				return true, fmt.Errorf("Claude model mappings were saved, but Claude Desktop could not open: %w", err)

--- a/app/cmd/app/app_darwin.go
+++ b/app/cmd/app/app_darwin.go
@@ -80,7 +80,7 @@ var (
 	launchAgentPath    = filepath.Join(os.Getenv("HOME"), "Library", "LaunchAgents", "com.ollama.ollama.plist")
 	claudeAppProxy     *proxy.ClaudeDesktop
 	claudeProxyStartMu sync.Mutex
-	// Serialize default resets with connect and disconnect decisions.
+	// Serialize default resets with connect, disconnect, and shutdown decisions.
 	claudeLifecycleMu sync.Mutex
 	claudeProxyMu     sync.Mutex
 	claudeCatalogMu   sync.Mutex
@@ -1683,6 +1683,9 @@ func restoreClaudeBeforeQuit(ctx context.Context, handoff, configured bool, rest
 }
 
 func restoreClaudeAppForTermination(ctx context.Context, handoff bool) error {
+	claudeLifecycleMu.Lock()
+	defer claudeLifecycleMu.Unlock()
+
 	if handoff {
 		stopClaudeAppProxy()
 		return nil

--- a/app/cmd/app/app_darwin.go
+++ b/app/cmd/app/app_darwin.go
@@ -1106,16 +1106,6 @@ func claudeDesktopConnectionSummary(used bool) claudeDesktopStatus {
 }
 
 func getClaudeDesktopConnectionStatus() claudeDesktopStatus {
-	return getClaudeDesktopConnectionStatusWithAccessResolver(claudeAccessStateResolver)
-}
-
-func getClaudeDesktopResetStatus() claudeDesktopStatus {
-	return getClaudeDesktopConnectionStatusWithAccessResolver(resolveClaudeDesktopAccessStateWithRetry)
-}
-
-func getClaudeDesktopConnectionStatusWithAccessResolver(
-	accessResolver func(context.Context) (proxy.ClaudeDesktopAccessState, error),
-) claudeDesktopStatus {
 	used := hasUsedClaudeDesktopIntegration()
 	var availableModels, selectedModels []proxy.ClaudeDesktopModel
 	var modelSource string
@@ -1123,13 +1113,13 @@ func getClaudeDesktopConnectionStatusWithAccessResolver(
 		Cloud:   proxy.ClaudeDesktopCloudUnknown,
 		Account: proxy.ClaudeDesktopAccountUnknown,
 	}
-	var accessErr error
 	if used {
 		claudeProxyMu.Lock()
 		gateway := claudeAppProxy
 		cachedCatalogHasCloud := hasCloudClaudeDesktopModel(claudeAvailableModels)
 		claudeProxyMu.Unlock()
-		accessState, accessErr = accessResolver(context.Background())
+		var accessErr error
+		accessState, accessErr = claudeAccessStateResolver(context.Background())
 		if accessErr != nil {
 			slog.Debug("could not resolve Claude model access for Settings", "error", accessErr)
 		}
@@ -1190,38 +1180,19 @@ func getClaudeDesktopConnectionStatusWithAccessResolver(
 		})
 	}
 	mappedModels := proxy.ClaudeDesktopMappings(selectedModels)
-	var defaultMappedModels map[string]string
-	defaultMappingsComplete := false
-	if accessErr == nil {
-		if fullDefaultAccess, accountTierKnown := claudeDesktopDefaultAccessTier(accessState); accountTierKnown {
-			defaultMappedModels = proxy.DefaultClaudeDesktopMappingsForModels(
-				availableModels,
-				fullDefaultAccess,
-			)
-			defaultMappingsComplete = claudeDesktopDefaultMappingsComplete(defaultMappedModels, fullDefaultAccess)
-			if !defaultMappingsComplete {
-				slog.Debug("could not resolve every Claude mapping default", "full_access", fullDefaultAccess, "resolved", len(defaultMappedModels))
-			}
-		}
-	}
-	if defaultMappingsComplete && len(launch.ClaudeDesktopModels()) == 0 {
-		mappedModels = defaultMappedModels
+	if len(launch.ClaudeDesktopModels()) == 0 {
+		mappedModels = proxy.DefaultClaudeDesktopMappingsForModels(
+			availableModels,
+			claudeDesktopHasFullDefaultAccess(accessState),
+		)
 	}
 	mappingStatuses := make([]claudeDesktopMappingStatus, 0, proxy.MaxClaudeDesktopModels)
-	defaultMappingStatuses := make([]claudeDesktopMappingStatus, 0, proxy.MaxClaudeDesktopModels)
 	for _, route := range proxy.ClaudeDesktopRoutes() {
 		mappingStatuses = append(mappingStatuses, claudeDesktopMappingStatus{
 			RouteID:   route.ID,
 			RouteName: route.DisplayName,
 			Model:     mappedModels[route.ID],
 		})
-		if defaultMappingsComplete {
-			defaultMappingStatuses = append(defaultMappingStatuses, claudeDesktopMappingStatus{
-				RouteID:   route.ID,
-				RouteName: route.DisplayName,
-				Model:     defaultMappedModels[route.ID],
-			})
-		}
 	}
 
 	status := claudeDesktopConnectionSummary(used)
@@ -1230,7 +1201,6 @@ func getClaudeDesktopConnectionStatusWithAccessResolver(
 	status.ModelSource = modelSource
 	status.Models = modelStatuses
 	status.Mappings = mappingStatuses
-	status.DefaultMappings = defaultMappingStatuses
 	if status.Error == "" && autoModeErr != nil {
 		status.Error = autoModeErr.Error()
 	}
@@ -1264,6 +1234,26 @@ func claudeDesktopDefaultMappingsComplete(mappings map[string]string, fullAccess
 		}
 	}
 	return true
+}
+
+func resolveClaudeDesktopDefaultMappings(ctx context.Context) (map[string]string, error) {
+	state, err := resolveClaudeDesktopAccessStateWithRetry(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("resolve Claude model access: %w", err)
+	}
+	if state.Cloud != proxy.ClaudeDesktopCloudOn {
+		return nil, errors.New("Claude model mapping defaults require Cloud to be enabled")
+	}
+	fullAccess, known := claudeDesktopDefaultAccessTier(state)
+	if !known {
+		return nil, errors.New("Claude model mapping defaults require a signed-in account")
+	}
+	available, _ := claudeModelsLoader(ctx)
+	mappings := proxy.DefaultClaudeDesktopMappingsForModels(available, fullAccess)
+	if !claudeDesktopDefaultMappingsComplete(mappings, fullAccess) {
+		return nil, errors.New("could not resolve every Claude model mapping default")
+	}
+	return mappings, nil
 }
 
 func setClaudeDesktopConnection(enabled, restartConfirmed bool) error {
@@ -1324,14 +1314,30 @@ func setClaudeDesktopAutoMode(enabled, restartConfirmed bool) error {
 }
 
 func applyClaudeDesktopMappings(mappings map[string]string, restartConfirmed bool) (bool, error) {
-	return applyClaudeDesktopMappingsWithOptions(mappings, restartConfirmed, true, true)
+	return applyClaudeDesktopMappingsWithOpen(mappings, restartConfirmed, true)
 }
 
-func resetClaudeDesktopMappings(mappings map[string]string, restartConfirmed bool) (bool, error) {
-	return applyClaudeDesktopMappingsWithOptions(mappings, restartConfirmed, false, claudeDesktop.UsesOllamaGateway())
+func resetClaudeDesktopMappings(restartConfirmed bool) (bool, error) {
+	if !hasUsedClaudeDesktopIntegration() {
+		return false, nil
+	}
+	mappings, err := resolveClaudeDesktopDefaultMappings(context.Background())
+	if err != nil {
+		return false, err
+	}
+	if !claudeDesktop.UsesOllamaGateway() {
+		if maps.Equal(launch.ClaudeDesktopModelMappings(), mappings) {
+			return false, nil
+		}
+		if err := launch.SaveClaudeDesktopModelMappings(mappings); err != nil {
+			return false, fmt.Errorf("save Claude Desktop model mappings: %w", err)
+		}
+		return true, nil
+	}
+	return applyClaudeDesktopMappingsWithOpen(mappings, restartConfirmed, false)
 }
 
-func applyClaudeDesktopMappingsWithOptions(mappings map[string]string, restartConfirmed, openWhenStopped, activateIntegration bool) (bool, error) {
+func applyClaudeDesktopMappingsWithOpen(mappings map[string]string, restartConfirmed, openWhenStopped bool) (bool, error) {
 	if !claudeDesktopInstalled() {
 		return false, errors.New("Claude Desktop is not installed")
 	}
@@ -1405,15 +1411,6 @@ func applyClaudeDesktopMappingsWithOptions(mappings map[string]string, restartCo
 	// to repair its profile and launch Claude.
 	if !mappingsChanged && claudeDesktop.Running() {
 		return false, nil
-	}
-	if !activateIntegration {
-		if !mappingsChanged {
-			return false, nil
-		}
-		if err := launch.SaveClaudeDesktopModelMappings(normalized); err != nil {
-			return false, fmt.Errorf("save Claude Desktop model mappings: %w", err)
-		}
-		return true, nil
 	}
 	restoreState := func() error {
 		var rollbackErr error

--- a/app/cmd/app/app_darwin_test.go
+++ b/app/cmd/app/app_darwin_test.go
@@ -1272,12 +1272,21 @@ func TestApplyClaudeDesktopMappingsStartsClaudeWhenStopped(t *testing.T) {
 
 func TestResetClaudeDesktopMappingsDoesNotOpenStoppedClaude(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	previousStore := appStore
+	appStore = &store.Store{DBPath: filepath.Join(t.TempDir(), "db.sqlite")}
+	if err := markClaudeDesktopIntegrationUsed(); err != nil {
+		t.Fatal(err)
+	}
 	if err := launch.SaveClaudeDesktopModels([]string{"glm-5.2:cloud"}); err != nil {
 		t.Fatal(err)
 	}
 	previousInstalled := claudeDesktopInstalled
 	previousDesktop := claudeDesktop
 	previousAddr := claudeProxyListenAddr
+	previousLoader := claudeModelsLoader
+	previousAccess := claudeAccessStateResolver
+	previousLocal := claudeLocalModelsResolver
+	previousCloud := claudeCloudModelsResolver
 	claudeProxyMu.Lock()
 	previousGateway := claudeAppProxy
 	previousAvailable := claudeAvailableModels
@@ -1292,11 +1301,30 @@ func TestResetClaudeDesktopMappingsDoesNotOpenStoppedClaude(t *testing.T) {
 	claudeProxyListenAddr = "127.0.0.1:0"
 	fake := &fakeClaudeDesktopController{configured: true}
 	claudeDesktop = fake
+	plan := "team"
+	claudeModelsLoader = func(context.Context) ([]proxy.ClaudeDesktopModel, string) {
+		return proxy.DefaultClaudeDesktopModels(), "endpoint"
+	}
+	claudeAccessStateResolver = func(context.Context) (proxy.ClaudeDesktopAccessState, error) {
+		return proxy.ClaudeDesktopAccessState{
+			Cloud:   proxy.ClaudeDesktopCloudOn,
+			Account: proxy.ClaudeDesktopAccountSignedIn,
+			Plan:    plan,
+		}, nil
+	}
+	claudeLocalModelsResolver = func(context.Context) ([]string, error) { return nil, nil }
+	claudeCloudModelsResolver = func(context.Context) ([]proxy.ClaudeDesktopModel, error) { return nil, nil }
 	t.Cleanup(func() {
 		stopClaudeAppProxy()
+		_ = appStore.Close()
+		appStore = previousStore
 		claudeDesktopInstalled = previousInstalled
 		claudeDesktop = previousDesktop
 		claudeProxyListenAddr = previousAddr
+		claudeModelsLoader = previousLoader
+		claudeAccessStateResolver = previousAccess
+		claudeLocalModelsResolver = previousLocal
+		claudeCloudModelsResolver = previousCloud
 		claudeProxyMu.Lock()
 		claudeAppProxy = previousGateway
 		claudeAvailableModels = previousAvailable
@@ -1305,14 +1333,15 @@ func TestResetClaudeDesktopMappingsDoesNotOpenStoppedClaude(t *testing.T) {
 		claudeProxyMu.Unlock()
 	})
 
-	applied, err := resetClaudeDesktopMappings(sharedClaudeDesktopMappings("kimi-k3:cloud"), false)
+	paidMappings := proxy.DefaultClaudeDesktopMappings(true)
+	applied, err := resetClaudeDesktopMappings(false)
 	if err != nil || !applied {
 		t.Fatalf("reset mappings = %v/%v, want persisted change", applied, err)
 	}
 	if !fake.configured || !fake.installed || fake.opened || fake.restart {
 		t.Fatalf("stopped Claude reset = %+v, want configured without open or restart", fake)
 	}
-	if got := launch.ClaudeDesktopModelMappings(); !maps.Equal(got, sharedClaudeDesktopMappings("kimi-k3:cloud")) {
+	if got := launch.ClaudeDesktopModelMappings(); !maps.Equal(got, paidMappings) {
 		t.Fatalf("persisted reset mappings = %v", got)
 	}
 
@@ -1320,8 +1349,9 @@ func TestResetClaudeDesktopMappingsDoesNotOpenStoppedClaude(t *testing.T) {
 	fake.configured = false
 	fake.installed = false
 	fake.configureCalls = 0
-	disconnectedMappings := sharedClaudeDesktopMappings("glm-5.2:cloud")
-	applied, err = resetClaudeDesktopMappings(disconnectedMappings, false)
+	plan = "free"
+	disconnectedMappings := proxy.DefaultClaudeDesktopMappings(false)
+	applied, err = resetClaudeDesktopMappings(false)
 	if err != nil || !applied {
 		t.Fatalf("disconnected reset mappings = %v/%v, want persisted change", applied, err)
 	}
@@ -1742,7 +1772,20 @@ func TestEnsureClaudeDesktopModelsAvailableRetriesStartupRace(t *testing.T) {
 	}
 }
 
-func TestClaudeDesktopResetStatusHandlesAccountVerificationRestartRace(t *testing.T) {
+func TestResolveClaudeDesktopDefaultMappingsHandlesAccountVerificationRestartRace(t *testing.T) {
+	previousLoader := claudeModelsLoader
+	previousAccess := claudeAccessStateResolver
+	previousRetryWait := claudeAccessRetryWait
+	previousRetryPoll := claudeAccessRetryPoll
+	claudeAccessRetryWait = 10 * time.Millisecond
+	claudeAccessRetryPoll = time.Millisecond
+	t.Cleanup(func() {
+		claudeModelsLoader = previousLoader
+		claudeAccessStateResolver = previousAccess
+		claudeAccessRetryWait = previousRetryWait
+		claudeAccessRetryPoll = previousRetryPoll
+	})
+
 	tests := []struct {
 		name             string
 		accessStateAfter int
@@ -1785,44 +1828,12 @@ func TestClaudeDesktopResetStatusHandlesAccountVerificationRestartRace(t *testin
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Setenv("HOME", t.TempDir())
-			previousStore := appStore
-			appStore = &store.Store{DBPath: filepath.Join(t.TempDir(), "db.sqlite")}
-			if err := markClaudeDesktopIntegrationUsed(); err != nil {
-				t.Fatal(err)
-			}
-
-			previousInstalled := claudeDesktopInstalled
-			previousDesktop := claudeDesktop
-			previousLoader := claudeModelsLoader
-			previousAccess := claudeAccessStateResolver
-			previousLocal := claudeLocalModelsResolver
-			previousCloud := claudeCloudModelsResolver
-			previousRetryWait := claudeAccessRetryWait
-			previousRetryPoll := claudeAccessRetryPoll
-			claudeProxyMu.Lock()
-			previousGateway := claudeAppProxy
-			previousAvailable := claudeAvailableModels
-			previousSource := claudeModelSource
-			previousUpdated := claudeCatalogUpdated
-			claudeAppProxy = nil
-			claudeAvailableModels = nil
-			claudeModelSource = ""
-			claudeCatalogUpdated = time.Time{}
-			claudeProxyMu.Unlock()
-
-			claudeDesktopInstalled = func() bool { return true }
-			claudeDesktop = &fakeClaudeDesktopController{installed: true}
 			claudeModelsLoader = func(context.Context) ([]proxy.ClaudeDesktopModel, string) {
 				if tt.catalog != nil {
 					return tt.catalog(), "endpoint"
 				}
 				return proxy.DefaultClaudeDesktopModels(), "endpoint"
 			}
-			claudeLocalModelsResolver = func(context.Context) ([]string, error) { return nil, nil }
-			claudeCloudModelsResolver = func(context.Context) ([]proxy.ClaudeDesktopModel, error) { return nil, nil }
-			claudeAccessRetryWait = 10 * time.Millisecond
-			claudeAccessRetryPoll = time.Millisecond
 			accessCalls := 0
 			claudeAccessStateResolver = func(context.Context) (proxy.ClaudeDesktopAccessState, error) {
 				accessCalls++
@@ -1836,40 +1847,21 @@ func TestClaudeDesktopResetStatusHandlesAccountVerificationRestartRace(t *testin
 				}, nil
 			}
 
-			t.Cleanup(func() {
-				_ = appStore.Close()
-				appStore = previousStore
-				claudeDesktopInstalled = previousInstalled
-				claudeDesktop = previousDesktop
-				claudeModelsLoader = previousLoader
-				claudeAccessStateResolver = previousAccess
-				claudeLocalModelsResolver = previousLocal
-				claudeCloudModelsResolver = previousCloud
-				claudeAccessRetryWait = previousRetryWait
-				claudeAccessRetryPoll = previousRetryPoll
-				claudeProxyMu.Lock()
-				claudeAppProxy = previousGateway
-				claudeAvailableModels = previousAvailable
-				claudeModelSource = previousSource
-				claudeCatalogUpdated = previousUpdated
-				claudeProxyMu.Unlock()
-			})
-
-			status := getClaudeDesktopResetStatus()
-			gotDefaults := make(map[string]string)
-			for _, mapping := range status.DefaultMappings {
-				if mapping.Model != "" {
-					gotDefaults[mapping.RouteID] = mapping.Model
+			gotDefaults, err := resolveClaudeDesktopDefaultMappings(context.Background())
+			if tt.wantDefaults == nil {
+				if err == nil {
+					t.Fatalf("reset defaults = %v, want an error", gotDefaults)
 				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
 			}
 			if !maps.Equal(gotDefaults, tt.wantDefaults) {
 				t.Fatalf("reset defaults = %v, want %v after %d access checks", gotDefaults, tt.wantDefaults, accessCalls)
 			}
 			if tt.accessStateAfter > 0 && accessCalls < tt.accessStateAfter {
 				t.Fatalf("access checks = %d, want at least %d", accessCalls, tt.accessStateAfter)
-			}
-			if tt.wantDefaults == nil && len(status.DefaultMappings) != 0 {
-				t.Fatalf("unverified reset defaults = %+v, want none", status.DefaultMappings)
 			}
 		})
 	}

--- a/app/cmd/app/app_darwin_test.go
+++ b/app/cmd/app/app_darwin_test.go
@@ -739,6 +739,7 @@ type fakeClaudeDesktopController struct {
 	configureOnSet bool
 	requireRestart bool
 	autoMode       bool
+	restoreCalls   int
 }
 
 func (f *fakeClaudeDesktopController) UsesOllamaGateway() bool { return f.configured }
@@ -817,7 +818,13 @@ func (f *fakeClaudeDesktopController) ApplyProfileChange(change func() error, re
 	return f.setErr
 }
 
-func (f *fakeClaudeDesktopController) RestoreForShutdown(context.Context) error { return nil }
+func (f *fakeClaudeDesktopController) RestoreForShutdown(context.Context) error {
+	f.restoreCalls++
+	f.configured = false
+	f.profileCurrent = false
+	f.installed = false
+	return nil
+}
 
 func TestUpdateClaudeDesktopProfileRepairsExistingConnectionOnce(t *testing.T) {
 	previousDesktop := claudeDesktop
@@ -1370,6 +1377,19 @@ func TestResetClaudeDesktopMappingsDoesNotOpenStoppedClaude(t *testing.T) {
 }
 
 func TestResetClaudeDesktopMappingsSerializesDisconnectDuringCatalogRefresh(t *testing.T) {
+	testResetClaudeDesktopMappingsSerializesLifecycleChange(t, "disconnect", func() error {
+		return setClaudeDesktopConnection(false, false)
+	})
+}
+
+func TestResetClaudeDesktopMappingsSerializesShutdownDuringCatalogRefresh(t *testing.T) {
+	testResetClaudeDesktopMappingsSerializesLifecycleChange(t, "shutdown", func() error {
+		return restoreClaudeAppForTermination(context.Background(), false)
+	})
+}
+
+func testResetClaudeDesktopMappingsSerializesLifecycleChange(t *testing.T, name string, change func() error) {
+	t.Helper()
 	t.Setenv("HOME", t.TempDir())
 	previousMappings := sharedClaudeDesktopMappings("glm-5.2:cloud")
 	if err := launch.SaveClaudeDesktopModelMappings(previousMappings); err != nil {
@@ -1467,18 +1487,18 @@ func TestResetClaudeDesktopMappingsSerializesDisconnectDuringCatalogRefresh(t *t
 		t.Fatal("reset did not pause during the forced catalog refresh")
 	}
 
-	disconnectStarted := make(chan struct{})
-	disconnectDone := make(chan error, 1)
+	changeStarted := make(chan struct{})
+	changeDone := make(chan error, 1)
 	go func() {
-		close(disconnectStarted)
-		disconnectDone <- setClaudeDesktopConnection(false, false)
+		close(changeStarted)
+		changeDone <- change()
 	}()
-	<-disconnectStarted
+	<-changeStarted
 
-	disconnectedEarly := false
+	completedEarly := false
 	select {
-	case <-disconnectDone:
-		disconnectedEarly = true
+	case <-changeDone:
+		completedEarly = true
 	case <-time.After(50 * time.Millisecond):
 	}
 	close(releaseRefresh)
@@ -1492,26 +1512,29 @@ func TestResetClaudeDesktopMappingsSerializesDisconnectDuringCatalogRefresh(t *t
 	if reset.err != nil || !reset.applied {
 		t.Fatalf("reset mappings = %v/%v, want a persisted reset", reset.applied, reset.err)
 	}
-	if disconnectedEarly {
-		t.Fatal("disconnect completed while reset still owned the Claude profile lifecycle")
+	if completedEarly {
+		t.Fatalf("%s completed while reset still owned the Claude profile lifecycle", name)
 	}
 	select {
-	case err := <-disconnectDone:
+	case err := <-changeDone:
 		if err != nil {
 			t.Fatal(err)
 		}
 	case <-time.After(2 * time.Second):
-		t.Fatal("disconnect did not finish after reset released the lifecycle")
+		t.Fatalf("%s did not finish after reset released the lifecycle", name)
 	}
 
 	if fake.configured || fake.installed {
-		t.Fatalf("Claude was reconnected after disconnect: %+v", fake)
+		t.Fatalf("Claude was reconnected after %s: %+v", name, fake)
+	}
+	if name == "shutdown" && fake.restoreCalls != 1 {
+		t.Fatalf("shutdown restores = %d, want 1", fake.restoreCalls)
 	}
 	claudeProxyMu.Lock()
 	activeGateway := claudeAppProxy
 	claudeProxyMu.Unlock()
 	if activeGateway != nil {
-		t.Fatal("Claude gateway remained active after disconnect")
+		t.Fatalf("Claude gateway remained active after %s", name)
 	}
 }
 

--- a/app/cmd/app/app_darwin_test.go
+++ b/app/cmd/app/app_darwin_test.go
@@ -1369,6 +1369,152 @@ func TestResetClaudeDesktopMappingsDoesNotOpenStoppedClaude(t *testing.T) {
 	}
 }
 
+func TestResetClaudeDesktopMappingsSerializesDisconnectDuringCatalogRefresh(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	previousMappings := sharedClaudeDesktopMappings("glm-5.2:cloud")
+	if err := launch.SaveClaudeDesktopModelMappings(previousMappings); err != nil {
+		t.Fatal(err)
+	}
+
+	previousStore := appStore
+	appStore = &store.Store{DBPath: filepath.Join(t.TempDir(), "db.sqlite")}
+	if err := markClaudeDesktopIntegrationUsed(); err != nil {
+		t.Fatal(err)
+	}
+
+	current := proxy.MapClaudeDesktopModels(proxy.DefaultClaudeDesktopModels(), previousMappings)
+	gateway, err := proxy.NewClaudeDesktop(proxy.ClaudeDesktopConfig{
+		ListenAddr: "127.0.0.1:0",
+		OllamaURL:  "http://127.0.0.1:11434",
+		Model:      current[0].OllamaModel,
+		Models:     current,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	previousInstalled := claudeDesktopInstalled
+	previousDesktop := claudeDesktop
+	previousLoader := claudeModelsLoader
+	previousAccess := claudeAccessStateResolver
+	previousLocal := claudeLocalModelsResolver
+	previousCloud := claudeCloudModelsResolver
+	claudeProxyMu.Lock()
+	previousGateway := claudeAppProxy
+	previousAvailable := claudeAvailableModels
+	previousSource := claudeModelSource
+	previousUpdated := claudeCatalogUpdated
+	claudeAppProxy = gateway
+	claudeAvailableModels = proxy.DefaultClaudeDesktopModels()
+	claudeModelSource = "endpoint"
+	claudeCatalogUpdated = claudeCatalogNow()
+	claudeProxyMu.Unlock()
+
+	claudeDesktopInstalled = func() bool { return true }
+	fake := &fakeClaudeDesktopController{configured: true, configureOnSet: true}
+	claudeDesktop = fake
+	refreshStarted := make(chan struct{})
+	releaseRefresh := make(chan struct{})
+	loaderCalls := 0
+	claudeModelsLoader = func(context.Context) ([]proxy.ClaudeDesktopModel, string) {
+		loaderCalls++
+		if loaderCalls == 2 {
+			close(refreshStarted)
+			<-releaseRefresh
+		}
+		return proxy.DefaultClaudeDesktopModels(), "endpoint"
+	}
+	claudeAccessStateResolver = func(context.Context) (proxy.ClaudeDesktopAccessState, error) {
+		return proxy.ClaudeDesktopAccessState{
+			Cloud:   proxy.ClaudeDesktopCloudOn,
+			Account: proxy.ClaudeDesktopAccountSignedIn,
+			Plan:    "team",
+		}, nil
+	}
+	claudeLocalModelsResolver = func(context.Context) ([]string, error) { return nil, nil }
+	claudeCloudModelsResolver = func(context.Context) ([]proxy.ClaudeDesktopModel, error) { return nil, nil }
+	t.Cleanup(func() {
+		stopClaudeAppProxy()
+		_ = appStore.Close()
+		appStore = previousStore
+		claudeDesktopInstalled = previousInstalled
+		claudeDesktop = previousDesktop
+		claudeModelsLoader = previousLoader
+		claudeAccessStateResolver = previousAccess
+		claudeLocalModelsResolver = previousLocal
+		claudeCloudModelsResolver = previousCloud
+		claudeProxyMu.Lock()
+		claudeAppProxy = previousGateway
+		claudeAvailableModels = previousAvailable
+		claudeModelSource = previousSource
+		claudeCatalogUpdated = previousUpdated
+		claudeProxyMu.Unlock()
+	})
+
+	type resetResult struct {
+		applied bool
+		err     error
+	}
+	resetDone := make(chan resetResult, 1)
+	go func() {
+		applied, err := resetClaudeDesktopMappings(false)
+		resetDone <- resetResult{applied: applied, err: err}
+	}()
+
+	select {
+	case <-refreshStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reset did not pause during the forced catalog refresh")
+	}
+
+	disconnectStarted := make(chan struct{})
+	disconnectDone := make(chan error, 1)
+	go func() {
+		close(disconnectStarted)
+		disconnectDone <- setClaudeDesktopConnection(false, false)
+	}()
+	<-disconnectStarted
+
+	disconnectedEarly := false
+	select {
+	case <-disconnectDone:
+		disconnectedEarly = true
+	case <-time.After(50 * time.Millisecond):
+	}
+	close(releaseRefresh)
+
+	var reset resetResult
+	select {
+	case reset = <-resetDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("reset did not finish after the catalog refresh resumed")
+	}
+	if reset.err != nil || !reset.applied {
+		t.Fatalf("reset mappings = %v/%v, want a persisted reset", reset.applied, reset.err)
+	}
+	if disconnectedEarly {
+		t.Fatal("disconnect completed while reset still owned the Claude profile lifecycle")
+	}
+	select {
+	case err := <-disconnectDone:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("disconnect did not finish after reset released the lifecycle")
+	}
+
+	if fake.configured || fake.installed {
+		t.Fatalf("Claude was reconnected after disconnect: %+v", fake)
+	}
+	claudeProxyMu.Lock()
+	activeGateway := claudeAppProxy
+	claudeProxyMu.Unlock()
+	if activeGateway != nil {
+		t.Fatal("Claude gateway remained active after disconnect")
+	}
+}
+
 func TestApplyClaudeDesktopMappingsKeepsCommittedMappingsWhenOpenFails(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	previousInstalled := claudeDesktopInstalled

--- a/app/cmd/app/app_darwin_test.go
+++ b/app/cmd/app/app_darwin_test.go
@@ -1270,6 +1270,75 @@ func TestApplyClaudeDesktopMappingsStartsClaudeWhenStopped(t *testing.T) {
 	}
 }
 
+func TestResetClaudeDesktopMappingsDoesNotOpenStoppedClaude(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if err := launch.SaveClaudeDesktopModels([]string{"glm-5.2:cloud"}); err != nil {
+		t.Fatal(err)
+	}
+	previousInstalled := claudeDesktopInstalled
+	previousDesktop := claudeDesktop
+	previousAddr := claudeProxyListenAddr
+	claudeProxyMu.Lock()
+	previousGateway := claudeAppProxy
+	previousAvailable := claudeAvailableModels
+	previousSource := claudeModelSource
+	previousUpdated := claudeCatalogUpdated
+	claudeAppProxy = nil
+	claudeAvailableModels = nil
+	claudeModelSource = ""
+	claudeCatalogUpdated = time.Time{}
+	claudeProxyMu.Unlock()
+	claudeDesktopInstalled = func() bool { return true }
+	claudeProxyListenAddr = "127.0.0.1:0"
+	fake := &fakeClaudeDesktopController{configured: true}
+	claudeDesktop = fake
+	t.Cleanup(func() {
+		stopClaudeAppProxy()
+		claudeDesktopInstalled = previousInstalled
+		claudeDesktop = previousDesktop
+		claudeProxyListenAddr = previousAddr
+		claudeProxyMu.Lock()
+		claudeAppProxy = previousGateway
+		claudeAvailableModels = previousAvailable
+		claudeModelSource = previousSource
+		claudeCatalogUpdated = previousUpdated
+		claudeProxyMu.Unlock()
+	})
+
+	applied, err := resetClaudeDesktopMappings(sharedClaudeDesktopMappings("kimi-k3:cloud"), false)
+	if err != nil || !applied {
+		t.Fatalf("reset mappings = %v/%v, want persisted change", applied, err)
+	}
+	if !fake.configured || !fake.installed || fake.opened || fake.restart {
+		t.Fatalf("stopped Claude reset = %+v, want configured without open or restart", fake)
+	}
+	if got := launch.ClaudeDesktopModelMappings(); !maps.Equal(got, sharedClaudeDesktopMappings("kimi-k3:cloud")) {
+		t.Fatalf("persisted reset mappings = %v", got)
+	}
+
+	stopClaudeAppProxy()
+	fake.configured = false
+	fake.installed = false
+	fake.configureCalls = 0
+	disconnectedMappings := sharedClaudeDesktopMappings("glm-5.2:cloud")
+	applied, err = resetClaudeDesktopMappings(disconnectedMappings, false)
+	if err != nil || !applied {
+		t.Fatalf("disconnected reset mappings = %v/%v, want persisted change", applied, err)
+	}
+	if fake.configured || fake.installed || fake.opened || fake.restart || fake.configureCalls != 0 {
+		t.Fatalf("disconnected Claude reset = %+v, want no connection side effects", fake)
+	}
+	claudeProxyMu.Lock()
+	gateway := claudeAppProxy
+	claudeProxyMu.Unlock()
+	if gateway != nil {
+		t.Fatal("resetting disconnected Claude must not start the gateway")
+	}
+	if got := launch.ClaudeDesktopModelMappings(); !maps.Equal(got, disconnectedMappings) {
+		t.Fatalf("persisted disconnected reset mappings = %v", got)
+	}
+}
+
 func TestApplyClaudeDesktopMappingsKeepsCommittedMappingsWhenOpenFails(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	previousInstalled := claudeDesktopInstalled
@@ -1670,6 +1739,162 @@ func TestEnsureClaudeDesktopModelsAvailableRetriesStartupRace(t *testing.T) {
 	}
 	if calls != 2 {
 		t.Fatalf("access checks = %d, want 2", calls)
+	}
+}
+
+func TestClaudeDesktopResetStatusHandlesAccountVerificationRestartRace(t *testing.T) {
+	tests := []struct {
+		name             string
+		accessStateAfter int
+		plan             string
+		catalog          func() []proxy.ClaudeDesktopModel
+		wantDefaults     map[string]string
+	}{
+		{
+			name:             "retry restores paid defaults",
+			accessStateAfter: 2,
+			plan:             "team",
+			wantDefaults:     proxy.DefaultClaudeDesktopMappings(true),
+		},
+		{
+			name:             "free account restores only the free default",
+			accessStateAfter: 1,
+			plan:             "free",
+			wantDefaults:     proxy.DefaultClaudeDesktopMappings(false),
+		},
+		{
+			name:             "incomplete paid catalog does not clear routes",
+			accessStateAfter: 1,
+			plan:             "team",
+			catalog: func() []proxy.ClaudeDesktopModel {
+				return proxy.DefaultClaudeDesktopModels()[:4]
+			},
+		},
+		{
+			name:             "missing free default does not clear routes",
+			accessStateAfter: 1,
+			plan:             "free",
+			catalog: func() []proxy.ClaudeDesktopModel {
+				return proxy.DefaultClaudeDesktopModels()[:4]
+			},
+		},
+		{
+			name: "persistent failure does not synthesize free defaults",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			previousStore := appStore
+			appStore = &store.Store{DBPath: filepath.Join(t.TempDir(), "db.sqlite")}
+			if err := markClaudeDesktopIntegrationUsed(); err != nil {
+				t.Fatal(err)
+			}
+
+			previousInstalled := claudeDesktopInstalled
+			previousDesktop := claudeDesktop
+			previousLoader := claudeModelsLoader
+			previousAccess := claudeAccessStateResolver
+			previousLocal := claudeLocalModelsResolver
+			previousCloud := claudeCloudModelsResolver
+			previousRetryWait := claudeAccessRetryWait
+			previousRetryPoll := claudeAccessRetryPoll
+			claudeProxyMu.Lock()
+			previousGateway := claudeAppProxy
+			previousAvailable := claudeAvailableModels
+			previousSource := claudeModelSource
+			previousUpdated := claudeCatalogUpdated
+			claudeAppProxy = nil
+			claudeAvailableModels = nil
+			claudeModelSource = ""
+			claudeCatalogUpdated = time.Time{}
+			claudeProxyMu.Unlock()
+
+			claudeDesktopInstalled = func() bool { return true }
+			claudeDesktop = &fakeClaudeDesktopController{installed: true}
+			claudeModelsLoader = func(context.Context) ([]proxy.ClaudeDesktopModel, string) {
+				if tt.catalog != nil {
+					return tt.catalog(), "endpoint"
+				}
+				return proxy.DefaultClaudeDesktopModels(), "endpoint"
+			}
+			claudeLocalModelsResolver = func(context.Context) ([]string, error) { return nil, nil }
+			claudeCloudModelsResolver = func(context.Context) ([]proxy.ClaudeDesktopModel, error) { return nil, nil }
+			claudeAccessRetryWait = 10 * time.Millisecond
+			claudeAccessRetryPoll = time.Millisecond
+			accessCalls := 0
+			claudeAccessStateResolver = func(context.Context) (proxy.ClaudeDesktopAccessState, error) {
+				accessCalls++
+				if tt.accessStateAfter == 0 || accessCalls < tt.accessStateAfter {
+					return proxy.ClaudeDesktopAccessState{}, errors.New("server restarting")
+				}
+				return proxy.ClaudeDesktopAccessState{
+					Cloud:   proxy.ClaudeDesktopCloudOn,
+					Account: proxy.ClaudeDesktopAccountSignedIn,
+					Plan:    tt.plan,
+				}, nil
+			}
+
+			t.Cleanup(func() {
+				_ = appStore.Close()
+				appStore = previousStore
+				claudeDesktopInstalled = previousInstalled
+				claudeDesktop = previousDesktop
+				claudeModelsLoader = previousLoader
+				claudeAccessStateResolver = previousAccess
+				claudeLocalModelsResolver = previousLocal
+				claudeCloudModelsResolver = previousCloud
+				claudeAccessRetryWait = previousRetryWait
+				claudeAccessRetryPoll = previousRetryPoll
+				claudeProxyMu.Lock()
+				claudeAppProxy = previousGateway
+				claudeAvailableModels = previousAvailable
+				claudeModelSource = previousSource
+				claudeCatalogUpdated = previousUpdated
+				claudeProxyMu.Unlock()
+			})
+
+			status := getClaudeDesktopResetStatus()
+			gotDefaults := make(map[string]string)
+			for _, mapping := range status.DefaultMappings {
+				if mapping.Model != "" {
+					gotDefaults[mapping.RouteID] = mapping.Model
+				}
+			}
+			if !maps.Equal(gotDefaults, tt.wantDefaults) {
+				t.Fatalf("reset defaults = %v, want %v after %d access checks", gotDefaults, tt.wantDefaults, accessCalls)
+			}
+			if tt.accessStateAfter > 0 && accessCalls < tt.accessStateAfter {
+				t.Fatalf("access checks = %d, want at least %d", accessCalls, tt.accessStateAfter)
+			}
+			if tt.wantDefaults == nil && len(status.DefaultMappings) != 0 {
+				t.Fatalf("unverified reset defaults = %+v, want none", status.DefaultMappings)
+			}
+		})
+	}
+}
+
+func TestClaudeDesktopDefaultAccessTierRequiresVerifiedAccount(t *testing.T) {
+	tests := []struct {
+		name      string
+		state     proxy.ClaudeDesktopAccessState
+		wantFull  bool
+		wantKnown bool
+	}{
+		{name: "cloud off", state: proxy.ClaudeDesktopAccessState{Cloud: proxy.ClaudeDesktopCloudOff}},
+		{name: "signed out", state: proxy.ClaudeDesktopAccessState{Cloud: proxy.ClaudeDesktopCloudOn, Account: proxy.ClaudeDesktopAccountSignedOut}},
+		{name: "missing plan", state: proxy.ClaudeDesktopAccessState{Cloud: proxy.ClaudeDesktopCloudOn, Account: proxy.ClaudeDesktopAccountSignedIn}},
+		{name: "free", state: proxy.ClaudeDesktopAccessState{Cloud: proxy.ClaudeDesktopCloudOn, Account: proxy.ClaudeDesktopAccountSignedIn, Plan: "free"}, wantKnown: true},
+		{name: "team", state: proxy.ClaudeDesktopAccessState{Cloud: proxy.ClaudeDesktopCloudOn, Account: proxy.ClaudeDesktopAccountSignedIn, Plan: "team"}, wantFull: true, wantKnown: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			full, known := claudeDesktopDefaultAccessTier(tt.state)
+			if full != tt.wantFull || known != tt.wantKnown {
+				t.Fatalf("default access tier = %v/%v, want %v/%v", full, known, tt.wantFull, tt.wantKnown)
+			}
+		})
 	}
 }
 

--- a/app/cmd/app/claude_desktop_bindings_darwin.go
+++ b/app/cmd/app/claude_desktop_bindings_darwin.go
@@ -13,9 +13,6 @@ func bindClaudeDesktop(wv webview.WebView) {
 	wv.Bind("getClaudeDesktopStatus", func() claudeDesktopStatus {
 		return getClaudeDesktopConnectionStatus()
 	})
-	wv.Bind("getClaudeDesktopResetStatus", func() claudeDesktopStatus {
-		return getClaudeDesktopResetStatus()
-	})
 	wv.Bind("getClaudeDesktopConnectionSummary", func() claudeDesktopStatus {
 		return getClaudeDesktopConnectionSummary()
 	})
@@ -68,8 +65,8 @@ func bindClaudeDesktop(wv webview.WebView) {
 		}
 		return result
 	})
-	wv.Bind("resetClaudeDesktopMappings", func(mappings map[string]string, restartConfirmed bool) claudeDesktopActionResult {
-		applied, err := resetClaudeDesktopMappings(mappings, restartConfirmed)
+	wv.Bind("resetClaudeDesktopMappings", func(restartConfirmed bool) claudeDesktopActionResult {
+		applied, err := resetClaudeDesktopMappings(restartConfirmed)
 		result := claudeDesktopActionResult{
 			Status:          getClaudeDesktopConnectionStatus(),
 			MappingsApplied: applied,

--- a/app/cmd/app/claude_desktop_bindings_darwin.go
+++ b/app/cmd/app/claude_desktop_bindings_darwin.go
@@ -13,6 +13,9 @@ func bindClaudeDesktop(wv webview.WebView) {
 	wv.Bind("getClaudeDesktopStatus", func() claudeDesktopStatus {
 		return getClaudeDesktopConnectionStatus()
 	})
+	wv.Bind("getClaudeDesktopResetStatus", func() claudeDesktopStatus {
+		return getClaudeDesktopResetStatus()
+	})
 	wv.Bind("getClaudeDesktopConnectionSummary", func() claudeDesktopStatus {
 		return getClaudeDesktopConnectionSummary()
 	})
@@ -55,6 +58,18 @@ func bindClaudeDesktop(wv webview.WebView) {
 
 	wv.Bind("applyClaudeDesktopMappings", func(mappings map[string]string, restartConfirmed bool) claudeDesktopActionResult {
 		applied, err := applyClaudeDesktopMappings(mappings, restartConfirmed)
+		result := claudeDesktopActionResult{
+			Status:          getClaudeDesktopConnectionStatus(),
+			MappingsApplied: applied,
+		}
+		if err != nil {
+			result.Error = err.Error()
+			result.RestartConfirmationRequired = errors.Is(err, launch.ErrClaudeDesktopRestartConfirmationRequired)
+		}
+		return result
+	})
+	wv.Bind("resetClaudeDesktopMappings", func(mappings map[string]string, restartConfirmed bool) claudeDesktopActionResult {
+		applied, err := resetClaudeDesktopMappings(mappings, restartConfirmed)
 		result := claudeDesktopActionResult{
 			Status:          getClaudeDesktopConnectionStatus(),
 			MappingsApplied: applied,

--- a/app/cmd/app/claude_desktop_status.go
+++ b/app/cmd/app/claude_desktop_status.go
@@ -13,22 +13,21 @@ const (
 )
 
 type claudeDesktopStatus struct {
-	Supported       bool                         `json:"supported"`
-	Used            bool                         `json:"used"`
-	Installed       bool                         `json:"installed"`
-	Configured      bool                         `json:"configured"`
-	Connected       bool                         `json:"connected"`
-	Running         bool                         `json:"running"`
-	StartFailed     bool                         `json:"startFailed"`
-	PortConflict    bool                         `json:"portConflict"`
-	GatewayPort     int                          `json:"gatewayPort,omitempty"`
-	RoutedRequests  uint64                       `json:"routedRequests"`
-	Error           string                       `json:"error,omitempty"`
-	AutoMode        bool                         `json:"autoMode"`
-	ModelSource     string                       `json:"modelSource,omitempty"`
-	Models          []claudeDesktopModelStatus   `json:"models,omitempty"`
-	Mappings        []claudeDesktopMappingStatus `json:"mappings,omitempty"`
-	DefaultMappings []claudeDesktopMappingStatus `json:"defaultMappings,omitempty"`
+	Supported      bool                         `json:"supported"`
+	Used           bool                         `json:"used"`
+	Installed      bool                         `json:"installed"`
+	Configured     bool                         `json:"configured"`
+	Connected      bool                         `json:"connected"`
+	Running        bool                         `json:"running"`
+	StartFailed    bool                         `json:"startFailed"`
+	PortConflict   bool                         `json:"portConflict"`
+	GatewayPort    int                          `json:"gatewayPort,omitempty"`
+	RoutedRequests uint64                       `json:"routedRequests"`
+	Error          string                       `json:"error,omitempty"`
+	AutoMode       bool                         `json:"autoMode"`
+	ModelSource    string                       `json:"modelSource,omitempty"`
+	Models         []claudeDesktopModelStatus   `json:"models,omitempty"`
+	Mappings       []claudeDesktopMappingStatus `json:"mappings,omitempty"`
 }
 
 type claudeDesktopMappingStatus struct {

--- a/app/ui/app/src/components/ClaudeDesktopModelsSettings.interaction.test.tsx
+++ b/app/ui/app/src/components/ClaudeDesktopModelsSettings.interaction.test.tsx
@@ -29,7 +29,6 @@ function testStatus(model = "glm-5.2:cloud", running = false) {
     autoMode: false,
     modelSource: "user" as const,
     mappings: [{ ...fableRoute, model }],
-    defaultMappings: [{ ...fableRoute, model: "glm-5.2:cloud" }],
     models: [
       {
         name: "glm-5.2:cloud",
@@ -450,7 +449,6 @@ describe("ClaudeDesktopModelsSettings interactions", () => {
       focus() {}
     }
     const currentStatus = testStatus("kimi-k3:cloud", true);
-    const getResetStatus = vi.fn().mockResolvedValue(currentStatus);
     const resetMappings = vi.fn().mockResolvedValue({
       status: currentStatus,
       restartConfirmationRequired: true,
@@ -460,7 +458,6 @@ describe("ClaudeDesktopModelsSettings interactions", () => {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
       HTMLElement: TestHTMLElement,
-      getClaudeDesktopResetStatus: getResetStatus,
       resetClaudeDesktopMappings: resetMappings,
       confirm,
     });
@@ -492,10 +489,7 @@ describe("ClaudeDesktopModelsSettings interactions", () => {
 
       expect(resetSucceeded).toBe(false);
       expect(confirm).toHaveBeenCalledOnce();
-      expect(resetMappings).toHaveBeenCalledWith(
-        { "claude-fable-5": "glm-5.2:cloud" },
-        false,
-      );
+      expect(resetMappings).toHaveBeenCalledWith(false);
       const picker = renderer!.root.findByProps({
         "aria-label": "Ollama model for Fable 5",
       });
@@ -511,7 +505,7 @@ describe("ClaudeDesktopModelsSettings interactions", () => {
     }
   });
 
-  it("resets sparse mappings to the defaults for the current account", async () => {
+  it("applies the native reset result and shows progress", async () => {
     class TestHTMLElement {
       focus() {}
     }
@@ -525,17 +519,10 @@ describe("ClaudeDesktopModelsSettings interactions", () => {
           model: "kimi-k3:cloud",
         },
       ],
-      defaultMappings: [
-        { ...fableRoute, model: "kimi-k3:cloud" },
-        {
-          routeId: "claude-sonnet-5",
-          routeName: "Sonnet 5",
-        },
-      ],
     };
-    const refreshedStatus = {
+    const resetStatus = {
       ...initialStatus,
-      defaultMappings: [
+      mappings: [
         { ...fableRoute },
         {
           routeId: "claude-sonnet-5",
@@ -544,25 +531,19 @@ describe("ClaudeDesktopModelsSettings interactions", () => {
         },
       ],
     };
-    let resolveResetStatus!: (status: typeof refreshedStatus) => void;
-    const resetStatus = new Promise<typeof refreshedStatus>((resolve) => {
-      resolveResetStatus = resolve;
-    });
-    const getResetStatus = vi.fn(() => resetStatus);
-    const getStatus = vi.fn();
-    const resetMappings = vi.fn().mockResolvedValue({
-      status: {
-        ...refreshedStatus,
-        mappings: refreshedStatus.defaultMappings,
-      },
+    const resetResult = {
+      status: resetStatus,
       mappingsApplied: true,
+    };
+    let resolveReset!: (result: typeof resetResult) => void;
+    const resetRequestResult = new Promise<typeof resetResult>((resolve) => {
+      resolveReset = resolve;
     });
+    const resetMappings = vi.fn(() => resetRequestResult);
     vi.stubGlobal("window", {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
       HTMLElement: TestHTMLElement,
-      getClaudeDesktopStatus: getStatus,
-      getClaudeDesktopResetStatus: getResetStatus,
       resetClaudeDesktopMappings: resetMappings,
     });
     vi.stubGlobal("document", {
@@ -594,19 +575,14 @@ describe("ClaudeDesktopModelsSettings interactions", () => {
       expect(actionButton(renderer!).props.disabled).toBe(true);
       expect(textContent(actionButton(renderer!))).toContain("Resetting…");
 
-      resolveResetStatus(refreshedStatus);
+      resolveReset(resetResult);
       let resetSucceeded = false;
       await act(async () => {
         resetSucceeded = (await resetRequest) ?? false;
       });
 
       expect(resetSucceeded).toBe(true);
-      expect(getResetStatus).toHaveBeenCalledTimes(1);
-      expect(getStatus).not.toHaveBeenCalled();
-      expect(resetMappings).toHaveBeenCalledWith(
-        { "claude-sonnet-5": "glm-5.2:cloud" },
-        false,
-      );
+      expect(resetMappings).toHaveBeenCalledWith(false);
 
       const fable = renderer!.root.findByProps({
         "aria-label": "Ollama model for Fable 5",

--- a/app/ui/app/src/components/ClaudeDesktopModelsSettings.interaction.test.tsx
+++ b/app/ui/app/src/components/ClaudeDesktopModelsSettings.interaction.test.tsx
@@ -1,7 +1,16 @@
-import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import {
+  act,
+  create,
+  type ReactTestInstance,
+  type ReactTestRenderer,
+} from "react-test-renderer";
+import { createRef } from "react";
 import { describe, expect, it, vi } from "vitest";
 import { Switch } from "./ui/switch";
-import { ClaudeDesktopModelsSettings } from "./ClaudeDesktopModelsSettings";
+import {
+  ClaudeDesktopModelsSettings,
+  type ClaudeDesktopModelsSettingsHandle,
+} from "./ClaudeDesktopModelsSettings";
 
 const fableRoute = {
   routeId: "claude-fable-5",
@@ -63,6 +72,12 @@ function actionButton(renderer: ReactTestRenderer) {
     );
   if (!button) throw new Error("Claude action button not found");
   return button;
+}
+
+function textContent(node: ReactTestInstance): string {
+  return node.children
+    .map((child) => (typeof child === "string" ? child : textContent(child)))
+    .join("");
 }
 
 describe("ClaudeDesktopModelsSettings interactions", () => {
@@ -430,6 +445,72 @@ describe("ClaudeDesktopModelsSettings interactions", () => {
     }
   });
 
+  it("keeps the previous mappings when reset restart is canceled", async () => {
+    class TestHTMLElement {
+      focus() {}
+    }
+    const currentStatus = testStatus("kimi-k3:cloud", true);
+    const getResetStatus = vi.fn().mockResolvedValue(currentStatus);
+    const resetMappings = vi.fn().mockResolvedValue({
+      status: currentStatus,
+      restartConfirmationRequired: true,
+    });
+    const confirm = vi.fn(() => false);
+    vi.stubGlobal("window", {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      HTMLElement: TestHTMLElement,
+      getClaudeDesktopResetStatus: getResetStatus,
+      resetClaudeDesktopMappings: resetMappings,
+      confirm,
+    });
+    vi.stubGlobal("document", {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+
+    let renderer: ReactTestRenderer | undefined;
+    const settingsRef = createRef<ClaudeDesktopModelsSettingsHandle>();
+    try {
+      await act(async () => {
+        renderer = create(
+          <ClaudeDesktopModelsSettings
+            ref={settingsRef}
+            initialLocalModels={[]}
+            initialStatus={currentStatus}
+          />,
+        );
+        await Promise.resolve();
+      });
+
+      let resetSucceeded = true;
+      await act(async () => {
+        resetSucceeded =
+          (await settingsRef.current?.resetToDefaults()) ?? false;
+      });
+
+      expect(resetSucceeded).toBe(false);
+      expect(confirm).toHaveBeenCalledOnce();
+      expect(resetMappings).toHaveBeenCalledWith(
+        { "claude-fable-5": "glm-5.2:cloud" },
+        false,
+      );
+      const picker = renderer!.root.findByProps({
+        "aria-label": "Ollama model for Fable 5",
+      });
+      expect(picker.findAllByType("span")[0].children.join("")).toBe(
+        "kimi-k3:cloud",
+      );
+    } finally {
+      await act(async () => {
+        renderer?.unmount();
+        await Promise.resolve();
+      });
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("resets sparse mappings to the defaults for the current account", async () => {
     class TestHTMLElement {
       focus() {}
@@ -463,12 +544,26 @@ describe("ClaudeDesktopModelsSettings interactions", () => {
         },
       ],
     };
-    const getStatus = vi.fn().mockResolvedValue(refreshedStatus);
+    let resolveResetStatus!: (status: typeof refreshedStatus) => void;
+    const resetStatus = new Promise<typeof refreshedStatus>((resolve) => {
+      resolveResetStatus = resolve;
+    });
+    const getResetStatus = vi.fn(() => resetStatus);
+    const getStatus = vi.fn();
+    const resetMappings = vi.fn().mockResolvedValue({
+      status: {
+        ...refreshedStatus,
+        mappings: refreshedStatus.defaultMappings,
+      },
+      mappingsApplied: true,
+    });
     vi.stubGlobal("window", {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
       HTMLElement: TestHTMLElement,
       getClaudeDesktopStatus: getStatus,
+      getClaudeDesktopResetStatus: getResetStatus,
+      resetClaudeDesktopMappings: resetMappings,
     });
     vi.stubGlobal("document", {
       addEventListener: vi.fn(),
@@ -477,32 +572,41 @@ describe("ClaudeDesktopModelsSettings interactions", () => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
 
     let renderer: ReactTestRenderer | undefined;
+    const settingsRef = createRef<ClaudeDesktopModelsSettingsHandle>();
     try {
       await act(async () => {
         renderer = create(
           <ClaudeDesktopModelsSettings
+            ref={settingsRef}
             initialLocalModels={[]}
             initialStatus={initialStatus}
-            resetVersion={0}
           />,
         );
         await Promise.resolve();
         await Promise.resolve();
       });
 
+      let resetRequest: Promise<boolean> | undefined;
       await act(async () => {
-        renderer!.update(
-          <ClaudeDesktopModelsSettings
-            initialLocalModels={[]}
-            initialStatus={initialStatus}
-            resetVersion={1}
-          />,
-        );
-        await Promise.resolve();
+        resetRequest = settingsRef.current?.resetToDefaults();
         await Promise.resolve();
       });
+      expect(actionButton(renderer!).props.disabled).toBe(true);
+      expect(textContent(actionButton(renderer!))).toContain("Resetting…");
 
-      expect(getStatus).toHaveBeenCalledTimes(1);
+      resolveResetStatus(refreshedStatus);
+      let resetSucceeded = false;
+      await act(async () => {
+        resetSucceeded = (await resetRequest) ?? false;
+      });
+
+      expect(resetSucceeded).toBe(true);
+      expect(getResetStatus).toHaveBeenCalledTimes(1);
+      expect(getStatus).not.toHaveBeenCalled();
+      expect(resetMappings).toHaveBeenCalledWith(
+        { "claude-sonnet-5": "glm-5.2:cloud" },
+        false,
+      );
 
       const fable = renderer!.root.findByProps({
         "aria-label": "Ollama model for Fable 5",

--- a/app/ui/app/src/components/ClaudeDesktopModelsSettings.tsx
+++ b/app/ui/app/src/components/ClaudeDesktopModelsSettings.tsx
@@ -300,9 +300,7 @@ export const ClaudeDesktopModelsSettings = forwardRef<
   const draftRef = useRef({ mappings, savedMappings });
   const statusRequestRef = useRef(0);
   const operationInFlightRef = useRef(false);
-  const statusRef = useRef(status);
   draftRef.current = { mappings, savedMappings };
-  statusRef.current = status;
 
   const applyStatus = useCallback(
     (next: ClaudeDesktopStatus, preserveDraft = false) => {
@@ -414,26 +412,13 @@ export const ClaudeDesktopModelsSettings = forwardRef<
     );
   };
 
-  const runMappingApply = useCallback(
+  const runMappingAction = useCallback(
     async (
-      nextMappings: ClaudeDesktopMappingStatus[],
-      applyMappings: (
-        mappings: Record<string, string>,
-        restartConfirmed: boolean,
-      ) => Promise<ClaudeDesktopActionResult>,
-      refreshedStatus?: ClaudeDesktopStatus,
+      action: (restartConfirmed: boolean) => Promise<ClaudeDesktopActionResult>,
+      failureMessage: string,
     ): Promise<boolean> => {
-      const mappingsToApply = mappingRecord(nextMappings);
-      if (Object.keys(mappingsToApply).length === 0) {
-        setError("Choose at least one Ollama model for Claude.");
-        return false;
-      }
-
-      if (refreshedStatus) {
-        applyStatus(refreshedStatus, true);
-      }
       try {
-        let result = await applyMappings(mappingsToApply, false);
+        let result = await action(false);
         if (result.restartConfirmationRequired) {
           applyStatus(result.status, true);
           if (
@@ -443,7 +428,7 @@ export const ClaudeDesktopModelsSettings = forwardRef<
           ) {
             return false;
           }
-          result = await applyMappings(mappingsToApply, true);
+          result = await action(true);
         }
         ++statusRequestRef.current;
         if (result.error) {
@@ -454,43 +439,16 @@ export const ClaudeDesktopModelsSettings = forwardRef<
         applyStatus(result.status);
         return true;
       } catch {
-        setError("Ollama could not apply the Claude model mappings.");
+        setError(failureMessage);
         return false;
       }
     },
     [applyStatus],
   );
 
-  const persistMappings = useCallback(
-    async (nextMappings: ClaudeDesktopMappingStatus[]): Promise<boolean> => {
-      if (!window.applyClaudeDesktopMappings) {
-        setError(
-          "Claude routing settings are available in the Ollama macOS app.",
-        );
-        return false;
-      }
-      if (operationInFlightRef.current) return false;
-
-      setApplying(true);
-      setError(null);
-      operationInFlightRef.current = true;
-      ++statusRequestRef.current;
-      try {
-        return await runMappingApply(
-          nextMappings,
-          window.applyClaudeDesktopMappings,
-        );
-      } finally {
-        ++statusRequestRef.current;
-        operationInFlightRef.current = false;
-        setApplying(false);
-      }
-    },
-    [runMappingApply],
-  );
-
   const applyChanges = async () => {
-    if (!window.applyClaudeDesktopMappings) {
+    const applyMappings = window.applyClaudeDesktopMappings;
+    if (!applyMappings) {
       setError(
         "Claude routing settings are available in the Ollama macOS app.",
       );
@@ -504,7 +462,23 @@ export const ClaudeDesktopModelsSettings = forwardRef<
       setError("Choose models available to your account and device.");
       return;
     }
-    await persistMappings(mappings);
+    if (operationInFlightRef.current) return;
+
+    const mappingsToApply = mappingRecord(mappings);
+    setApplying(true);
+    setError(null);
+    operationInFlightRef.current = true;
+    ++statusRequestRef.current;
+    try {
+      await runMappingAction(
+        (restartConfirmed) => applyMappings(mappingsToApply, restartConfirmed),
+        "Ollama could not apply the Claude model mappings.",
+      );
+    } finally {
+      ++statusRequestRef.current;
+      operationInFlightRef.current = false;
+      setApplying(false);
+    }
   };
 
   const toggleAutoMode = async (checked: boolean) => {
@@ -545,12 +519,9 @@ export const ClaudeDesktopModelsSettings = forwardRef<
 
   const resetToDefaults = useCallback(async (): Promise<boolean> => {
     if (operationInFlightRef.current) return false;
-    if (statusRef.current && !statusRef.current.used) return true;
 
-    const getResetStatus =
-      window.getClaudeDesktopResetStatus ?? window.getClaudeDesktopStatus;
-    if (!getResetStatus) return true;
-    if (!window.resetClaudeDesktopMappings) {
+    const resetMappings = window.resetClaudeDesktopMappings;
+    if (!resetMappings) {
       setError("Ollama could not reset the Claude model mappings.");
       return false;
     }
@@ -560,26 +531,16 @@ export const ClaudeDesktopModelsSettings = forwardRef<
     operationInFlightRef.current = true;
     ++statusRequestRef.current;
     try {
-      const next = await getResetStatus();
-      if (!next.used) return true;
-      if (!next.defaultMappings?.length) {
-        setError("Ollama could not refresh the Claude mapping defaults.");
-        return false;
-      }
-      return await runMappingApply(
-        next.defaultMappings,
-        window.resetClaudeDesktopMappings,
-        next,
+      return await runMappingAction(
+        resetMappings,
+        "Ollama could not reset the Claude model mappings.",
       );
-    } catch {
-      setError("Ollama could not refresh the Claude mapping defaults.");
-      return false;
     } finally {
       ++statusRequestRef.current;
       operationInFlightRef.current = false;
       setResettingMappings(false);
     }
-  }, [runMappingApply]);
+  }, [runMappingAction]);
 
   useImperativeHandle(ref, () => ({ resetToDefaults }), [resetToDefaults]);
 

--- a/app/ui/app/src/components/ClaudeDesktopModelsSettings.tsx
+++ b/app/ui/app/src/components/ClaudeDesktopModelsSettings.tsx
@@ -5,6 +5,7 @@ import { Switch } from "@/components/ui/switch";
 import { claudeDesktopRecoveryMessage } from "@/lib/claudeDesktop";
 import { claudeDesktopModelStatusLabel } from "@/lib/claudeDesktopModelStatus";
 import type {
+  ClaudeDesktopActionResult,
   ClaudeDesktopMappingStatus,
   ClaudeDesktopModelStatus,
   ClaudeDesktopStatus,
@@ -16,7 +17,19 @@ import {
   ChevronUpDownIcon,
   MagnifyingGlassIcon,
 } from "@heroicons/react/20/solid";
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  forwardRef,
+  useCallback,
+  useEffect,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+
+export interface ClaudeDesktopModelsSettingsHandle {
+  resetToDefaults: () => Promise<boolean>;
+}
 
 interface ClaudeDesktopModelsSettingsProps {
   initialStatus?: ClaudeDesktopStatus;
@@ -24,7 +37,6 @@ interface ClaudeDesktopModelsSettingsProps {
   initialCloudModels?: string[];
   includeCloudModels?: boolean;
   onDraftChange?: (hasChanges: boolean) => void;
-  resetVersion?: number;
 }
 
 const fallbackRoutes: ClaudeDesktopMappingStatus[] = [
@@ -246,14 +258,19 @@ function ClaudeModelPicker({
   );
 }
 
-export function ClaudeDesktopModelsSettings({
-  initialStatus,
-  initialLocalModels,
-  initialCloudModels,
-  includeCloudModels = false,
-  onDraftChange,
-  resetVersion = 0,
-}: ClaudeDesktopModelsSettingsProps) {
+export const ClaudeDesktopModelsSettings = forwardRef<
+  ClaudeDesktopModelsSettingsHandle,
+  ClaudeDesktopModelsSettingsProps
+>(function ClaudeDesktopModelsSettings(
+  {
+    initialStatus,
+    initialLocalModels,
+    initialCloudModels,
+    includeCloudModels = false,
+    onDraftChange,
+  },
+  ref,
+) {
   const [status, setStatus] = useState<ClaudeDesktopStatus | null>(
     initialStatus ?? null,
   );
@@ -275,6 +292,7 @@ export function ClaudeDesktopModelsSettings({
   const [modelsLoading, setModelsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [applying, setApplying] = useState(false);
+  const [resettingMappings, setResettingMappings] = useState(false);
   const [autoModeApplying, setAutoModeApplying] = useState(false);
   const [autoModeOverride, setAutoModeOverride] = useState<boolean | null>(
     null,
@@ -282,7 +300,6 @@ export function ClaudeDesktopModelsSettings({
   const draftRef = useRef({ mappings, savedMappings });
   const statusRequestRef = useRef(0);
   const operationInFlightRef = useRef(false);
-  const lastResetVersionRef = useRef(resetVersion);
   const statusRef = useRef(status);
   draftRef.current = { mappings, savedMappings };
   statusRef.current = status;
@@ -380,43 +397,11 @@ export function ClaudeDesktopModelsSettings({
     const model = catalogModels.find((candidate) => candidate.name === name);
     return !model || !modelIsAvailable(model);
   });
-  const busy = applying || autoModeApplying;
+  const busy = applying || resettingMappings || autoModeApplying;
 
   useEffect(() => {
     onDraftChange?.(hasDraftChanges);
   }, [hasDraftChanges, onDraftChange]);
-
-  useEffect(() => {
-    if (resetVersion === lastResetVersionRef.current) return;
-    let cancelled = false;
-
-    const resetToFreshDefaults = async () => {
-      try {
-        const next = window.getClaudeDesktopStatus
-          ? await window.getClaudeDesktopStatus()
-          : statusRef.current;
-        if (cancelled) return;
-        if (!next?.defaultMappings?.length) {
-          setError("Ollama could not refresh the Claude mapping defaults.");
-          return;
-        }
-        // Reset is an explicit action and wins over older focus refreshes.
-        ++statusRequestRef.current;
-        applyStatus(next, true);
-        setMappings(next.defaultMappings.map((mapping) => ({ ...mapping })));
-        lastResetVersionRef.current = resetVersion;
-      } catch {
-        if (!cancelled) {
-          setError("Ollama could not refresh the Claude mapping defaults.");
-        }
-      }
-    };
-
-    void resetToFreshDefaults();
-    return () => {
-      cancelled = true;
-    };
-  }, [applyStatus, resetVersion]);
 
   const updateMapping = (routeId: string, model: string) => {
     setError(null);
@@ -428,6 +413,81 @@ export function ClaudeDesktopModelsSettings({
       ),
     );
   };
+
+  const runMappingApply = useCallback(
+    async (
+      nextMappings: ClaudeDesktopMappingStatus[],
+      applyMappings: (
+        mappings: Record<string, string>,
+        restartConfirmed: boolean,
+      ) => Promise<ClaudeDesktopActionResult>,
+      refreshedStatus?: ClaudeDesktopStatus,
+    ): Promise<boolean> => {
+      const mappingsToApply = mappingRecord(nextMappings);
+      if (Object.keys(mappingsToApply).length === 0) {
+        setError("Choose at least one Ollama model for Claude.");
+        return false;
+      }
+
+      if (refreshedStatus) {
+        applyStatus(refreshedStatus, true);
+      }
+      try {
+        let result = await applyMappings(mappingsToApply, false);
+        if (result.restartConfirmationRequired) {
+          applyStatus(result.status, true);
+          if (
+            !window.confirm(
+              "Restart Claude Desktop? Any running task will stop.",
+            )
+          ) {
+            return false;
+          }
+          result = await applyMappings(mappingsToApply, true);
+        }
+        ++statusRequestRef.current;
+        if (result.error) {
+          applyStatus(result.status, !result.mappingsApplied);
+          setError(result.error);
+          return Boolean(result.mappingsApplied);
+        }
+        applyStatus(result.status);
+        return true;
+      } catch {
+        setError("Ollama could not apply the Claude model mappings.");
+        return false;
+      }
+    },
+    [applyStatus],
+  );
+
+  const persistMappings = useCallback(
+    async (nextMappings: ClaudeDesktopMappingStatus[]): Promise<boolean> => {
+      if (!window.applyClaudeDesktopMappings) {
+        setError(
+          "Claude routing settings are available in the Ollama macOS app.",
+        );
+        return false;
+      }
+      if (operationInFlightRef.current) return false;
+
+      setApplying(true);
+      setError(null);
+      operationInFlightRef.current = true;
+      ++statusRequestRef.current;
+      try {
+        return await runMappingApply(
+          nextMappings,
+          window.applyClaudeDesktopMappings,
+        );
+      } finally {
+        ++statusRequestRef.current;
+        operationInFlightRef.current = false;
+        setApplying(false);
+      }
+    },
+    [runMappingApply],
+  );
 
   const applyChanges = async () => {
     if (!window.applyClaudeDesktopMappings) {
@@ -444,41 +504,7 @@ export function ClaudeDesktopModelsSettings({
       setError("Choose models available to your account and device.");
       return;
     }
-    setApplying(true);
-    setError(null);
-    operationInFlightRef.current = true;
-    ++statusRequestRef.current;
-    try {
-      let result = await window.applyClaudeDesktopMappings(
-        mappingRecord(mappings),
-        false,
-      );
-      if (result.restartConfirmationRequired) {
-        applyStatus(result.status, true);
-        if (
-          !window.confirm("Restart Claude Desktop? Any running task will stop.")
-        ) {
-          return;
-        }
-        result = await window.applyClaudeDesktopMappings(
-          mappingRecord(mappings),
-          true,
-        );
-      }
-      ++statusRequestRef.current;
-      if (result.error) {
-        applyStatus(result.status, !result.mappingsApplied);
-        setError(result.error);
-      } else {
-        applyStatus(result.status);
-      }
-    } catch {
-      setError("Ollama could not apply the Claude model mappings.");
-    } finally {
-      ++statusRequestRef.current;
-      operationInFlightRef.current = false;
-      setApplying(false);
-    }
+    await persistMappings(mappings);
   };
 
   const toggleAutoMode = async (checked: boolean) => {
@@ -516,6 +542,46 @@ export function ClaudeDesktopModelsSettings({
       setAutoModeApplying(false);
     }
   };
+
+  const resetToDefaults = useCallback(async (): Promise<boolean> => {
+    if (operationInFlightRef.current) return false;
+    if (statusRef.current && !statusRef.current.used) return true;
+
+    const getResetStatus =
+      window.getClaudeDesktopResetStatus ?? window.getClaudeDesktopStatus;
+    if (!getResetStatus) return true;
+    if (!window.resetClaudeDesktopMappings) {
+      setError("Ollama could not reset the Claude model mappings.");
+      return false;
+    }
+
+    setResettingMappings(true);
+    setError(null);
+    operationInFlightRef.current = true;
+    ++statusRequestRef.current;
+    try {
+      const next = await getResetStatus();
+      if (!next.used) return true;
+      if (!next.defaultMappings?.length) {
+        setError("Ollama could not refresh the Claude mapping defaults.");
+        return false;
+      }
+      return await runMappingApply(
+        next.defaultMappings,
+        window.resetClaudeDesktopMappings,
+        next,
+      );
+    } catch {
+      setError("Ollama could not refresh the Claude mapping defaults.");
+      return false;
+    } finally {
+      ++statusRequestRef.current;
+      operationInFlightRef.current = false;
+      setResettingMappings(false);
+    }
+  }, [runMappingApply]);
+
+  useImperativeHandle(ref, () => ({ resetToDefaults }), [resetToDefaults]);
 
   if (!status?.supported || !status.used) return null;
 
@@ -592,16 +658,18 @@ export function ClaudeDesktopModelsSettings({
                 }
                 className="flex-shrink-0"
               >
-                {applying && (
+                {(applying || resettingMappings) && (
                   <ArrowPathIcon data-slot="icon" className="animate-spin" />
                 )}
-                {applying
-                  ? status.running
-                    ? "Restarting…"
-                    : "Starting…"
-                  : status.running
-                    ? "Restart Claude"
-                    : "Start Claude"}
+                {resettingMappings
+                  ? "Resetting…"
+                  : applying
+                    ? status.running
+                      ? "Restarting…"
+                      : "Starting…"
+                    : status.running
+                      ? "Restart Claude"
+                      : "Start Claude"}
               </Button>
             </div>
 
@@ -664,4 +732,4 @@ export function ClaudeDesktopModelsSettings({
       </div>
     </section>
   );
-}
+});

--- a/app/ui/app/src/components/Settings.interaction.test.tsx
+++ b/app/ui/app/src/components/Settings.interaction.test.tsx
@@ -3,7 +3,6 @@ import { forwardRef, useImperativeHandle } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Settings as SettingsType } from "@/gotypes";
 import { Badge } from "./ui/badge";
-import { Slider } from "./ui/slider";
 import Settings from "./Settings";
 
 const mocks = vi.hoisted(() => ({
@@ -166,14 +165,8 @@ describe("Settings reset interactions", () => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
   });
 
-  it("locks every control and hides stale Saved state until reset succeeds", async () => {
-    const pendingSettingUpdate = deferred<{
-      settings: SettingsType | null;
-    }>();
+  it("locks every control and shows Saved after reset succeeds", async () => {
     const pendingClaudeReset = deferred<boolean>();
-    mocks.updateSettings
-      .mockImplementationOnce(() => pendingSettingUpdate.promise)
-      .mockResolvedValue({ settings: mocks.settings });
     mocks.resetClaudeMappings.mockImplementation(
       () => pendingClaudeReset.promise,
     );
@@ -184,12 +177,6 @@ describe("Settings reset interactions", () => {
         renderer = create(<Settings />);
         await Promise.resolve();
       });
-
-      await act(async () => {
-        renderer!.root.findByType(Slider).props.onChange(32_768);
-        await Promise.resolve();
-      });
-      expect(renderer!.root.findAllByType(Badge)).toHaveLength(1);
 
       const resetButton = renderer!.root
         .findAllByType("button")
@@ -204,12 +191,7 @@ describe("Settings reset interactions", () => {
       const settingsFieldset = renderer!.root.findByType("fieldset");
       expect(settingsFieldset.props.disabled).toBe(true);
       expect(settingsFieldset.props["aria-busy"]).toBe(true);
-      expect(renderer!.root.findAllByType(Badge)).toHaveLength(0);
-
-      await act(async () => {
-        pendingSettingUpdate.resolve({ settings: mocks.settings });
-        await pendingSettingUpdate.promise;
-      });
+      expect(textContent(resetButton)).toContain("Resetting…");
       expect(renderer!.root.findAllByType(Badge)).toHaveLength(0);
 
       await act(async () => {

--- a/app/ui/app/src/components/Settings.interaction.test.tsx
+++ b/app/ui/app/src/components/Settings.interaction.test.tsx
@@ -1,0 +1,230 @@
+import { act, create, type ReactTestInstance } from "react-test-renderer";
+import { forwardRef, useImperativeHandle } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Settings as SettingsType } from "@/gotypes";
+import { Badge } from "./ui/badge";
+import { Slider } from "./ui/slider";
+import Settings from "./Settings";
+
+const mocks = vi.hoisted(() => ({
+  resetClaudeMappings: vi.fn(),
+  updateSettings: vi.fn(),
+  updateCloudSetting: vi.fn(),
+  setShowAppsInMenu: vi.fn(),
+  refetchUser: vi.fn(),
+  queryClient: {
+    cancelQueries: vi.fn().mockResolvedValue(undefined),
+    getQueryData: vi.fn(),
+    setQueryData: vi.fn(),
+    invalidateQueries: vi.fn(),
+  },
+  settings: null as SettingsType | null,
+}));
+
+vi.mock("@/components/ClaudeDesktopModelsSettings", () => ({
+  ClaudeDesktopModelsSettings: forwardRef(
+    function MockClaudeDesktopSettings(_props, ref) {
+      useImperativeHandle(ref, () => ({
+        resetToDefaults: mocks.resetClaudeMappings,
+      }));
+      return <section aria-label="Claude settings" />;
+    },
+  ),
+}));
+
+vi.mock("@/hooks/useUser", () => ({
+  useUser: () => ({
+    user: { name: "Paid user", email: "paid@example.com", plan: "pro" },
+    isAuthenticated: true,
+    refreshUser: vi.fn(),
+    isRefreshing: false,
+    refetchUser: mocks.refetchUser,
+    fetchConnectUrl: vi.fn(),
+    isLoading: false,
+    disconnectUser: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useCloudStatus", () => ({
+  useCloudStatus: () => ({
+    cloudDisabled: false,
+    cloudStatus: { disabled: false, source: "none" },
+    isKnown: true,
+  }),
+}));
+
+vi.mock("@/lib/platform", () => ({
+  isWindowsPlatform: () => false,
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useBlocker: vi.fn(),
+}));
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => mocks.queryClient,
+  useQuery: ({ queryKey }: { queryKey: string[] }) => {
+    if (queryKey[0] === "settings") {
+      return {
+        data: { settings: mocks.settings },
+        isLoading: false,
+        error: null,
+      };
+    }
+    return { data: { defaultContextLength: 65_536 } };
+  },
+  useMutation: ({
+    mutationFn,
+    onMutate,
+    onSuccess,
+    onError,
+    onSettled,
+  }: {
+    mutationFn: (value: unknown) => Promise<unknown>;
+    onMutate?: (value: unknown) => Promise<unknown>;
+    onSuccess?: (result: unknown, value: unknown, context: unknown) => void;
+    onError?: (error: unknown, value: unknown, context: unknown) => void;
+    onSettled?: (
+      result: unknown,
+      error: unknown,
+      value: unknown,
+      context: unknown,
+    ) => void;
+  }) => {
+    const run = async (
+      value: unknown,
+      callbacks?: { onSuccess?: () => void },
+    ) => {
+      const context = await onMutate?.(value);
+      try {
+        const result = await mutationFn(value);
+        onSuccess?.(result, value, context);
+        callbacks?.onSuccess?.();
+        onSettled?.(result, null, value, context);
+        return result;
+      } catch (error) {
+        onError?.(error, value, context);
+        onSettled?.(undefined, error, value, context);
+        throw error;
+      }
+    };
+
+    return {
+      mutate: (value: unknown, callbacks?: { onSuccess?: () => void }) => {
+        void run(value, callbacks);
+      },
+      mutateAsync: (value: unknown) => run(value),
+    };
+  },
+}));
+
+vi.mock("@/api", () => ({
+  getSettings: vi.fn(),
+  getInferenceCompute: vi.fn(),
+  updateSettings: mocks.updateSettings,
+  updateCloudSetting: mocks.updateCloudSetting,
+}));
+
+function textContent(node: ReactTestInstance): string {
+  return node.children
+    .map((child) => (typeof child === "string" ? child : textContent(child)))
+    .join("");
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+describe("Settings reset interactions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.settings = new SettingsType({ ContextLength: 65_536 });
+    mocks.updateSettings.mockResolvedValue({ settings: mocks.settings });
+    mocks.updateCloudSetting.mockResolvedValue({
+      disabled: false,
+      source: "none",
+    });
+    mocks.setShowAppsInMenu.mockResolvedValue(undefined);
+
+    vi.stubGlobal("window", {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      setTimeout: globalThis.setTimeout.bind(globalThis),
+      clearTimeout: globalThis.clearTimeout.bind(globalThis),
+      getShowAppsInMenu: vi.fn().mockResolvedValue(true),
+      setShowAppsInMenu: mocks.setShowAppsInMenu,
+      open: vi.fn(),
+      confirm: vi.fn(() => true),
+      OLLAMA_TOOLS: false,
+    });
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  });
+
+  it("locks every control and hides stale Saved state until reset succeeds", async () => {
+    const pendingSettingUpdate = deferred<{
+      settings: SettingsType | null;
+    }>();
+    const pendingClaudeReset = deferred<boolean>();
+    mocks.updateSettings
+      .mockImplementationOnce(() => pendingSettingUpdate.promise)
+      .mockResolvedValue({ settings: mocks.settings });
+    mocks.resetClaudeMappings.mockImplementation(
+      () => pendingClaudeReset.promise,
+    );
+
+    let renderer;
+    try {
+      await act(async () => {
+        renderer = create(<Settings />);
+        await Promise.resolve();
+      });
+
+      await act(async () => {
+        renderer!.root.findByType(Slider).props.onChange(32_768);
+        await Promise.resolve();
+      });
+      expect(renderer!.root.findAllByType(Badge)).toHaveLength(1);
+
+      const resetButton = renderer!.root
+        .findAllByType("button")
+        .find((button) => textContent(button).includes("Reset to defaults"));
+      if (!resetButton) throw new Error("Reset button not found");
+
+      await act(async () => {
+        resetButton.props.onClick();
+        await Promise.resolve();
+      });
+
+      const settingsFieldset = renderer!.root.findByType("fieldset");
+      expect(settingsFieldset.props.disabled).toBe(true);
+      expect(settingsFieldset.props["aria-busy"]).toBe(true);
+      expect(renderer!.root.findAllByType(Badge)).toHaveLength(0);
+
+      await act(async () => {
+        pendingSettingUpdate.resolve({ settings: mocks.settings });
+        await pendingSettingUpdate.promise;
+      });
+      expect(renderer!.root.findAllByType(Badge)).toHaveLength(0);
+
+      await act(async () => {
+        pendingClaudeReset.resolve(true);
+        await pendingClaudeReset.promise;
+        await Promise.resolve();
+        await Promise.resolve();
+      });
+
+      expect(renderer!.root.findByType("fieldset").props.disabled).toBe(false);
+      expect(renderer!.root.findAllByType(Badge)).toHaveLength(1);
+    } finally {
+      await act(async () => {
+        renderer?.unmount();
+        await Promise.resolve();
+      });
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/app/ui/app/src/components/Settings.interaction.test.tsx
+++ b/app/ui/app/src/components/Settings.interaction.test.tsx
@@ -12,6 +12,7 @@ const mocks = vi.hoisted(() => ({
   updateCloudSetting: vi.fn(),
   setShowAppsInMenu: vi.fn(),
   refetchUser: vi.fn(),
+  isWindows: false,
   queryClient: {
     cancelQueries: vi.fn().mockResolvedValue(undefined),
     getQueryData: vi.fn(),
@@ -54,7 +55,7 @@ vi.mock("@/hooks/useCloudStatus", () => ({
 }));
 
 vi.mock("@/lib/platform", () => ({
-  isWindowsPlatform: () => false,
+  isWindowsPlatform: () => mocks.isWindows,
 }));
 
 vi.mock("@tanstack/react-router", () => ({
@@ -142,6 +143,7 @@ function deferred<T>() {
 describe("Settings reset interactions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.isWindows = false;
     mocks.settings = new SettingsType({ ContextLength: 65_536 });
     mocks.updateSettings.mockResolvedValue({ settings: mocks.settings });
     mocks.updateCloudSetting.mockResolvedValue({
@@ -219,6 +221,40 @@ describe("Settings reset interactions", () => {
 
       expect(renderer!.root.findByType("fieldset").props.disabled).toBe(false);
       expect(renderer!.root.findAllByType(Badge)).toHaveLength(1);
+    } finally {
+      await act(async () => {
+        renderer?.unmount();
+        await Promise.resolve();
+      });
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("hides Claude Desktop settings and skips its reset on Windows", async () => {
+    mocks.isWindows = true;
+
+    let renderer;
+    try {
+      await act(async () => {
+        renderer = create(<Settings />);
+        await Promise.resolve();
+      });
+
+      expect(
+        renderer!.root.findAllByProps({ "aria-label": "Claude settings" }),
+      ).toHaveLength(0);
+
+      const resetButton = renderer!.root
+        .findAllByType("button")
+        .find((button) => textContent(button).includes("Reset to defaults"));
+      if (!resetButton) throw new Error("Reset button not found");
+
+      await act(async () => {
+        resetButton.props.onClick();
+        await vi.waitFor(() => expect(mocks.updateSettings).toHaveBeenCalled());
+      });
+
+      expect(mocks.resetClaudeMappings).not.toHaveBeenCalled();
     } finally {
       await act(async () => {
         renderer?.unmount();

--- a/app/ui/app/src/components/Settings.test.ts
+++ b/app/ui/app/src/components/Settings.test.ts
@@ -39,18 +39,17 @@ describe("Settings defaults", () => {
         Expose: true,
         Models: "/custom/models",
       }),
+      currentShowAppsInMenu: false,
       cloudSource: "config",
       onSaved,
     });
 
-    await vi.waitFor(() => expect(resetClaudeMappings).toHaveBeenCalledOnce());
+    await vi.waitFor(() => expect(updateSettings).toHaveBeenCalledOnce());
     expect(updateCloud).toHaveBeenCalledWith(true);
-    expect(updateSettings).not.toHaveBeenCalled();
     expect(updateShowAppsInMenu).not.toHaveBeenCalled();
+    expect(resetClaudeMappings).not.toHaveBeenCalled();
     expect(onSaved).not.toHaveBeenCalled();
 
-    resolveClaudeReset(true);
-    await vi.waitFor(() => expect(updateSettings).toHaveBeenCalledOnce());
     expect(updateSettings.mock.calls[0][0]).toMatchObject({
       Expose: false,
       Models: "",
@@ -59,21 +58,24 @@ describe("Settings defaults", () => {
     });
     expect(onSaved).not.toHaveBeenCalled();
     settingsUpdate.resolve();
+    await vi.waitFor(() => expect(resetClaudeMappings).toHaveBeenCalledOnce());
+    expect(updateShowAppsInMenu).toHaveBeenCalledWith(true);
+    expect(onSaved).not.toHaveBeenCalled();
+
+    resolveClaudeReset(true);
     await reset;
 
-    expect(updateShowAppsInMenu).toHaveBeenCalledWith(true);
-    expect(resetClaudeMappings).toHaveBeenCalledOnce();
     expect(onSaved).toHaveBeenCalledOnce();
     expect(updateCloud.mock.invocationCallOrder[0]).toBeLessThan(
-      resetClaudeMappings.mock.invocationCallOrder[0],
-    );
-    expect(resetClaudeMappings.mock.invocationCallOrder[0]).toBeLessThan(
       updateSettings.mock.invocationCallOrder[0],
     );
     expect(updateSettings.mock.invocationCallOrder[0]).toBeLessThan(
       updateShowAppsInMenu.mock.invocationCallOrder[0],
     );
     expect(updateShowAppsInMenu.mock.invocationCallOrder[0]).toBeLessThan(
+      resetClaudeMappings.mock.invocationCallOrder[0],
+    );
+    expect(resetClaudeMappings.mock.invocationCallOrder[0]).toBeLessThan(
       onSaved.mock.invocationCallOrder[0],
     );
   });
@@ -88,6 +90,7 @@ describe("Settings defaults", () => {
       updateShowAppsInMenu,
       resetClaudeMappings: vi.fn().mockResolvedValue(true),
       currentSettings: currentSettings(),
+      currentShowAppsInMenu: true,
       cloudSource: "env",
       onSaved: vi.fn(),
     });
@@ -109,6 +112,7 @@ describe("Settings defaults", () => {
       updateShowAppsInMenu: vi.fn().mockResolvedValue(undefined),
       resetClaudeMappings: vi.fn().mockResolvedValue(true),
       currentSettings: currentSettings(),
+      currentShowAppsInMenu: true,
       cloudSource: "both",
       onSaved: vi.fn(),
     });
@@ -129,6 +133,7 @@ describe("Settings defaults", () => {
       updateShowAppsInMenu: vi.fn().mockResolvedValue(undefined),
       resetClaudeMappings: vi.fn().mockResolvedValue(true),
       currentSettings: currentSettings(),
+      currentShowAppsInMenu: true,
       cloudSource: "none",
       onSaved: vi.fn(),
     });
@@ -136,7 +141,7 @@ describe("Settings defaults", () => {
     expect(updateCloud).not.toHaveBeenCalled();
   });
 
-  it("does not show Saved or continue after settings fail", async () => {
+  it("restores Cloud and leaves Claude untouched when settings fail", async () => {
     const updateCloud = vi.fn().mockResolvedValue(undefined);
     const updateShowAppsInMenu = vi.fn().mockResolvedValue(undefined);
     const resetClaudeMappings = vi.fn().mockResolvedValue(true);
@@ -152,18 +157,19 @@ describe("Settings defaults", () => {
           Expose: true,
           Models: "/custom/models",
         }),
-        cloudSource: "none",
+        currentShowAppsInMenu: false,
+        cloudSource: "config",
         onSaved,
       }),
     ).rejects.toThrow("restart failed");
 
-    expect(updateCloud).not.toHaveBeenCalled();
-    expect(resetClaudeMappings).toHaveBeenCalledOnce();
+    expect(updateCloud.mock.calls).toEqual([[true], [false]]);
+    expect(resetClaudeMappings).not.toHaveBeenCalled();
     expect(updateShowAppsInMenu).not.toHaveBeenCalled();
     expect(onSaved).not.toHaveBeenCalled();
   });
 
-  it("does not show Saved when a later reset update fails", async () => {
+  it("does not continue when the Cloud reset fails", async () => {
     const updateShowAppsInMenu = vi.fn().mockResolvedValue(undefined);
     const onSaved = vi.fn();
 
@@ -174,6 +180,7 @@ describe("Settings defaults", () => {
         updateShowAppsInMenu,
         resetClaudeMappings: vi.fn().mockResolvedValue(true),
         currentSettings: currentSettings(),
+        currentShowAppsInMenu: true,
         cloudSource: "config",
         onSaved,
       }),
@@ -183,25 +190,33 @@ describe("Settings defaults", () => {
     expect(onSaved).not.toHaveBeenCalled();
   });
 
-  it("restores Cloud and does not show Saved when Claude mappings cannot be reset", async () => {
+  it("rolls earlier changes back when Claude mappings cannot be reset", async () => {
     const onSaved = vi.fn();
     const updateSettings = vi.fn().mockResolvedValue(undefined);
     const updateCloud = vi.fn().mockResolvedValue(undefined);
+    const updateShowAppsInMenu = vi.fn().mockResolvedValue(undefined);
+    const previousSettings = currentSettings({
+      Expose: true,
+      Models: "/custom/models",
+    });
 
     await expect(
       applySettingsDefaults({
         updateSettings,
         updateCloud,
-        updateShowAppsInMenu: vi.fn().mockResolvedValue(undefined),
+        updateShowAppsInMenu,
         resetClaudeMappings: vi.fn().mockResolvedValue(false),
-        currentSettings: currentSettings(),
+        currentSettings: previousSettings,
+        currentShowAppsInMenu: false,
         cloudSource: "config",
         onSaved,
       }),
     ).rejects.toThrow("Claude model mappings could not be reset");
 
     expect(updateCloud.mock.calls).toEqual([[true], [false]]);
-    expect(updateSettings).not.toHaveBeenCalled();
+    expect(updateSettings).toHaveBeenCalledTimes(2);
+    expect(updateSettings.mock.calls[1][0]).toBe(previousSettings);
+    expect(updateShowAppsInMenu.mock.calls).toEqual([[true], [false]]);
     expect(onSaved).not.toHaveBeenCalled();
   });
 });

--- a/app/ui/app/src/components/Settings.test.ts
+++ b/app/ui/app/src/components/Settings.test.ts
@@ -23,12 +23,18 @@ describe("Settings defaults", () => {
     const updateSettings = vi.fn(() => settingsUpdate.promise);
     const updateCloud = vi.fn().mockResolvedValue(undefined);
     const updateShowAppsInMenu = vi.fn().mockResolvedValue(undefined);
+    let resolveClaudeReset!: (succeeded: boolean) => void;
+    const claudeReset = new Promise<boolean>((resolve) => {
+      resolveClaudeReset = resolve;
+    });
+    const resetClaudeMappings = vi.fn(() => claudeReset);
     const onSaved = vi.fn();
 
     const reset = applySettingsDefaults({
       updateSettings,
       updateCloud,
       updateShowAppsInMenu,
+      resetClaudeMappings,
       currentSettings: currentSettings({
         Expose: true,
         Models: "/custom/models",
@@ -37,27 +43,34 @@ describe("Settings defaults", () => {
       onSaved,
     });
 
-    expect(updateSettings).toHaveBeenCalledOnce();
+    await vi.waitFor(() => expect(resetClaudeMappings).toHaveBeenCalledOnce());
+    expect(updateCloud).toHaveBeenCalledWith(true);
+    expect(updateSettings).not.toHaveBeenCalled();
+    expect(updateShowAppsInMenu).not.toHaveBeenCalled();
+    expect(onSaved).not.toHaveBeenCalled();
+
+    resolveClaudeReset(true);
+    await vi.waitFor(() => expect(updateSettings).toHaveBeenCalledOnce());
     expect(updateSettings.mock.calls[0][0]).toMatchObject({
       Expose: false,
       Models: "",
       ContextLength: 65_536,
       AutoUpdateEnabled: true,
     });
-    expect(updateCloud).not.toHaveBeenCalled();
-    expect(updateShowAppsInMenu).not.toHaveBeenCalled();
     expect(onSaved).not.toHaveBeenCalled();
-
     settingsUpdate.resolve();
     await reset;
 
-    expect(updateCloud).toHaveBeenCalledWith(true);
     expect(updateShowAppsInMenu).toHaveBeenCalledWith(true);
+    expect(resetClaudeMappings).toHaveBeenCalledOnce();
     expect(onSaved).toHaveBeenCalledOnce();
-    expect(updateSettings.mock.invocationCallOrder[0]).toBeLessThan(
-      updateCloud.mock.invocationCallOrder[0],
-    );
     expect(updateCloud.mock.invocationCallOrder[0]).toBeLessThan(
+      resetClaudeMappings.mock.invocationCallOrder[0],
+    );
+    expect(resetClaudeMappings.mock.invocationCallOrder[0]).toBeLessThan(
+      updateSettings.mock.invocationCallOrder[0],
+    );
+    expect(updateSettings.mock.invocationCallOrder[0]).toBeLessThan(
       updateShowAppsInMenu.mock.invocationCallOrder[0],
     );
     expect(updateShowAppsInMenu.mock.invocationCallOrder[0]).toBeLessThan(
@@ -73,6 +86,7 @@ describe("Settings defaults", () => {
       updateSettings: vi.fn().mockResolvedValue(undefined),
       updateCloud,
       updateShowAppsInMenu,
+      resetClaudeMappings: vi.fn().mockResolvedValue(true),
       currentSettings: currentSettings(),
       cloudSource: "env",
       onSaved: vi.fn(),
@@ -93,6 +107,7 @@ describe("Settings defaults", () => {
       updateSettings: vi.fn().mockResolvedValue(undefined),
       updateCloud,
       updateShowAppsInMenu: vi.fn().mockResolvedValue(undefined),
+      resetClaudeMappings: vi.fn().mockResolvedValue(true),
       currentSettings: currentSettings(),
       cloudSource: "both",
       onSaved: vi.fn(),
@@ -112,6 +127,7 @@ describe("Settings defaults", () => {
       updateSettings: vi.fn().mockResolvedValue(undefined),
       updateCloud,
       updateShowAppsInMenu: vi.fn().mockResolvedValue(undefined),
+      resetClaudeMappings: vi.fn().mockResolvedValue(true),
       currentSettings: currentSettings(),
       cloudSource: "none",
       onSaved: vi.fn(),
@@ -123,6 +139,7 @@ describe("Settings defaults", () => {
   it("does not show Saved or continue after settings fail", async () => {
     const updateCloud = vi.fn().mockResolvedValue(undefined);
     const updateShowAppsInMenu = vi.fn().mockResolvedValue(undefined);
+    const resetClaudeMappings = vi.fn().mockResolvedValue(true);
     const onSaved = vi.fn();
 
     await expect(
@@ -130,16 +147,18 @@ describe("Settings defaults", () => {
         updateSettings: vi.fn().mockRejectedValue(new Error("restart failed")),
         updateCloud,
         updateShowAppsInMenu,
+        resetClaudeMappings,
         currentSettings: currentSettings({
           Expose: true,
           Models: "/custom/models",
         }),
-        cloudSource: "config",
+        cloudSource: "none",
         onSaved,
       }),
     ).rejects.toThrow("restart failed");
 
     expect(updateCloud).not.toHaveBeenCalled();
+    expect(resetClaudeMappings).toHaveBeenCalledOnce();
     expect(updateShowAppsInMenu).not.toHaveBeenCalled();
     expect(onSaved).not.toHaveBeenCalled();
   });
@@ -153,6 +172,7 @@ describe("Settings defaults", () => {
         updateSettings: vi.fn().mockResolvedValue(undefined),
         updateCloud: vi.fn().mockRejectedValue(new Error("cloud failed")),
         updateShowAppsInMenu,
+        resetClaudeMappings: vi.fn().mockResolvedValue(true),
         currentSettings: currentSettings(),
         cloudSource: "config",
         onSaved,
@@ -160,6 +180,28 @@ describe("Settings defaults", () => {
     ).rejects.toThrow("cloud failed");
 
     expect(updateShowAppsInMenu).not.toHaveBeenCalled();
+    expect(onSaved).not.toHaveBeenCalled();
+  });
+
+  it("restores Cloud and does not show Saved when Claude mappings cannot be reset", async () => {
+    const onSaved = vi.fn();
+    const updateSettings = vi.fn().mockResolvedValue(undefined);
+    const updateCloud = vi.fn().mockResolvedValue(undefined);
+
+    await expect(
+      applySettingsDefaults({
+        updateSettings,
+        updateCloud,
+        updateShowAppsInMenu: vi.fn().mockResolvedValue(undefined),
+        resetClaudeMappings: vi.fn().mockResolvedValue(false),
+        currentSettings: currentSettings(),
+        cloudSource: "config",
+        onSaved,
+      }),
+    ).rejects.toThrow("Claude model mappings could not be reset");
+
+    expect(updateCloud.mock.calls).toEqual([[true], [false]]);
+    expect(updateSettings).not.toHaveBeenCalled();
     expect(onSaved).not.toHaveBeenCalled();
   });
 });

--- a/app/ui/app/src/components/Settings.tsx
+++ b/app/ui/app/src/components/Settings.tsx
@@ -57,6 +57,7 @@ interface SettingsDefaultsActions {
   updateShowAppsInMenu: (visible: boolean) => Promise<unknown>;
   resetClaudeMappings: () => Promise<boolean>;
   currentSettings: SettingsType;
+  currentShowAppsInMenu: boolean;
   cloudSource: CloudStatusSource;
   onSaved: () => void;
 }
@@ -75,37 +76,55 @@ export async function applySettingsDefaults({
   updateShowAppsInMenu,
   resetClaudeMappings,
   currentSettings,
+  currentShowAppsInMenu,
   cloudSource,
   onSaved,
 }: SettingsDefaultsActions): Promise<void> {
   const cloudNeedsReset = cloudSource === "config" || cloudSource === "both";
-  if (cloudNeedsReset) {
-    await updateCloud(true);
-  }
+  const rollbacks: Array<() => Promise<unknown>> = [];
 
   try {
+    if (cloudNeedsReset) {
+      await updateCloud(true);
+      rollbacks.push(() => updateCloud(false));
+    }
+
+    await updateSettings(
+      new SettingsType({
+        Expose: false,
+        Browser: false,
+        Models: "",
+        Agent: false,
+        Tools: false,
+        ContextLength: currentSettings.ContextLength,
+        AutoUpdateEnabled: true,
+      }),
+    );
+    rollbacks.push(() => updateSettings(currentSettings));
+
+    await updateShowAppsInMenu(true);
+    rollbacks.push(() => updateShowAppsInMenu(currentShowAppsInMenu));
+
+    // Apply Claude last so no later settings failure can leave its mappings
+    // reset while the rest of the page rolls back.
     if (!(await resetClaudeMappings())) {
       throw new Error("Claude model mappings could not be reset");
     }
   } catch (error) {
-    if (cloudNeedsReset) {
-      await updateCloud(false);
+    const rollbackErrors: unknown[] = [];
+    for (const rollback of rollbacks.reverse()) {
+      try {
+        await rollback();
+      } catch (rollbackError) {
+        rollbackErrors.push(rollbackError);
+      }
+    }
+    if (rollbackErrors.length > 0) {
+      console.error("Failed to roll back settings reset:", rollbackErrors);
     }
     throw error;
   }
 
-  await updateSettings(
-    new SettingsType({
-      Expose: false,
-      Browser: false,
-      Models: "",
-      Agent: false,
-      Tools: false,
-      ContextLength: currentSettings.ContextLength,
-      AutoUpdateEnabled: true,
-    }),
-  );
-  await updateShowAppsInMenu(true);
   onSaved();
 }
 
@@ -381,6 +400,7 @@ export default function Settings() {
         resetClaudeMappings: async () =>
           (await claudeModelsSettingsRef.current?.resetToDefaults()) ?? true,
         currentSettings: settings,
+        currentShowAppsInMenu: showAppsInMenu,
         cloudSource,
         onSaved: showSavedConfirmation,
       });

--- a/app/ui/app/src/components/Settings.tsx
+++ b/app/ui/app/src/components/Settings.tsx
@@ -759,13 +759,15 @@ export default function Settings() {
             </div>
           </div>
 
-          <ClaudeDesktopModelsSettings
-            ref={claudeModelsSettingsRef}
-            includeCloudModels={
-              isAuthenticated && cloudStatusKnown && !cloudDisabled
-            }
-            onDraftChange={setHasClaudeDraftChanges}
-          />
+          {!isWindows && (
+            <ClaudeDesktopModelsSettings
+              ref={claudeModelsSettingsRef}
+              includeCloudModels={
+                isAuthenticated && cloudStatusKnown && !cloudDisabled
+              }
+              onDraftChange={setHasClaudeDraftChanges}
+            />
+          )}
 
           {/* Agent Mode */}
           {window.OLLAMA_TOOLS && (

--- a/app/ui/app/src/components/Settings.tsx
+++ b/app/ui/app/src/components/Settings.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { Switch } from "@/components/ui/switch";
 import { Text } from "@/components/ui/text";
 import { Input } from "@/components/ui/input";
@@ -6,7 +6,10 @@ import { Field, Label, Description } from "@/components/ui/fieldset";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Slider } from "@/components/ui/slider";
-import { ClaudeDesktopModelsSettings } from "@/components/ClaudeDesktopModelsSettings";
+import {
+  ClaudeDesktopModelsSettings,
+  type ClaudeDesktopModelsSettingsHandle,
+} from "@/components/ClaudeDesktopModelsSettings";
 import {
   WifiIcon,
   FolderIcon,
@@ -15,6 +18,7 @@ import {
   CloudIcon,
   CogIcon,
   ArrowDownTrayIcon,
+  ArrowPathIcon,
   Squares2X2Icon,
 } from "@heroicons/react/20/solid";
 import { Settings as SettingsType } from "@/gotypes";
@@ -51,8 +55,9 @@ interface SettingsDefaultsActions {
   updateSettings: (settings: SettingsType) => Promise<unknown>;
   updateCloud: (enabled: boolean) => Promise<unknown>;
   updateShowAppsInMenu: (visible: boolean) => Promise<unknown>;
+  resetClaudeMappings: () => Promise<boolean>;
   currentSettings: SettingsType;
-  cloudSource?: CloudStatusSource;
+  cloudSource: CloudStatusSource;
   onSaved: () => void;
 }
 
@@ -62,15 +67,33 @@ interface CloudUpdateRequest {
 }
 
 let latestCloudRequestId = 0;
+const savedConfirmationDuration = 3000;
 
 export async function applySettingsDefaults({
   updateSettings,
   updateCloud,
   updateShowAppsInMenu,
+  resetClaudeMappings,
   currentSettings,
   cloudSource,
   onSaved,
 }: SettingsDefaultsActions): Promise<void> {
+  const cloudNeedsReset = cloudSource === "config" || cloudSource === "both";
+  if (cloudNeedsReset) {
+    await updateCloud(true);
+  }
+
+  try {
+    if (!(await resetClaudeMappings())) {
+      throw new Error("Claude model mappings could not be reset");
+    }
+  } catch (error) {
+    if (cloudNeedsReset) {
+      await updateCloud(false);
+    }
+    throw error;
+  }
+
   await updateSettings(
     new SettingsType({
       Expose: false,
@@ -82,9 +105,6 @@ export async function applySettingsDefaults({
       AutoUpdateEnabled: true,
     }),
   );
-  if (cloudSource === "config" || cloudSource === "both") {
-    await updateCloud(true);
-  }
   await updateShowAppsInMenu(true);
   onSaved();
 }
@@ -96,9 +116,13 @@ export default function Settings() {
   const [showAppsInMenu, setShowAppsInMenuState] = useState(true);
   const [showAppsInMenuPending, setShowAppsInMenuPending] = useState(false);
   const [resettingToDefaults, setResettingToDefaults] = useState(false);
+  const [resetError, setResetError] = useState<string | null>(null);
   const [hasClaudeDraftChanges, setHasClaudeDraftChanges] = useState(false);
-  const [claudeMappingsResetVersion, setClaudeMappingsResetVersion] =
-    useState(0);
+  const claudeModelsSettingsRef =
+    useRef<ClaudeDesktopModelsSettingsHandle>(null);
+  const resetInFlightRef = useRef(false);
+  const savedConfirmationTimeoutRef = useRef<number | null>(null);
+  const restartMessageTimeoutRef = useRef<number | null>(null);
   useBlocker({
     shouldBlockFn: () =>
       !window.confirm("Discard unapplied Claude routing changes?"),
@@ -124,10 +148,47 @@ export default function Settings() {
     isKnown: cloudStatusKnown,
   } = useCloudStatus();
 
-  const showSavedConfirmation = useCallback(() => {
+  const displaySavedConfirmation = useCallback(() => {
+    if (savedConfirmationTimeoutRef.current !== null) {
+      window.clearTimeout(savedConfirmationTimeoutRef.current);
+    }
     setShowSaved(true);
-    setTimeout(() => setShowSaved(false), 1500);
+    savedConfirmationTimeoutRef.current = window.setTimeout(() => {
+      setShowSaved(false);
+      savedConfirmationTimeoutRef.current = null;
+    }, savedConfirmationDuration);
   }, []);
+
+  const showSavedConfirmation = useCallback(() => {
+    if (!resetInFlightRef.current) {
+      displaySavedConfirmation();
+    }
+  }, [displaySavedConfirmation]);
+
+  const clearSavedIndicators = useCallback(() => {
+    if (savedConfirmationTimeoutRef.current !== null) {
+      window.clearTimeout(savedConfirmationTimeoutRef.current);
+      savedConfirmationTimeoutRef.current = null;
+    }
+    if (restartMessageTimeoutRef.current !== null) {
+      window.clearTimeout(restartMessageTimeoutRef.current);
+      restartMessageTimeoutRef.current = null;
+    }
+    setShowSaved(false);
+    setRestartMessage(false);
+  }, []);
+
+  useEffect(
+    () => () => {
+      if (savedConfirmationTimeoutRef.current !== null) {
+        window.clearTimeout(savedConfirmationTimeoutRef.current);
+      }
+      if (restartMessageTimeoutRef.current !== null) {
+        window.clearTimeout(restartMessageTimeoutRef.current);
+      }
+    },
+    [],
+  );
 
   const {
     data: settingsData,
@@ -273,9 +334,15 @@ export default function Settings() {
 
         // If context length is being changed, show restart message
         if (field === "ContextLength" && value !== settings.ContextLength) {
+          if (restartMessageTimeoutRef.current !== null) {
+            window.clearTimeout(restartMessageTimeoutRef.current);
+          }
           setRestartMessage(true);
           // Hide restart message after 3 seconds
-          setTimeout(() => setRestartMessage(false), 3000);
+          restartMessageTimeoutRef.current = window.setTimeout(() => {
+            setRestartMessage(false);
+            restartMessageTimeoutRef.current = null;
+          }, savedConfirmationDuration);
         }
 
         updateSettingsMutation.mutate(updatedSettings, {
@@ -321,24 +388,32 @@ export default function Settings() {
   const cloudToggleDisabled = cloudOverriddenByEnv;
 
   const handleResetToDefaults = async () => {
-    if (!settings || resettingToDefaults) return;
+    const cloudSource = cloudStatus?.source;
+    if (!settings || resettingToDefaults || !cloudSource) return;
 
+    resetInFlightRef.current = true;
     setResettingToDefaults(true);
-    setShowSaved(false);
+    clearSavedIndicators();
+    setResetError(null);
     try {
       await applySettingsDefaults({
         updateSettings: (defaultSettings) =>
           updateSettingsMutation.mutateAsync(defaultSettings),
         updateCloud: requestCloudUpdate,
         updateShowAppsInMenu: updateShowAppsInMenuVisibility,
+        resetClaudeMappings: async () =>
+          (await claudeModelsSettingsRef.current?.resetToDefaults()) ?? true,
         currentSettings: settings,
-        cloudSource: cloudStatus?.source,
-        onSaved: showSavedConfirmation,
+        cloudSource,
+        onSaved: displaySavedConfirmation,
       });
-      setClaudeMappingsResetVersion((version) => version + 1);
     } catch (error) {
       console.error("Failed to reset settings:", error);
+      setResetError(
+        "Ollama could not reset every setting. Check the settings above and try again.",
+      );
     } finally {
+      resetInFlightRef.current = false;
       setResettingToDefaults(false);
     }
   };
@@ -395,7 +470,11 @@ export default function Settings() {
   return (
     <main className="flex min-h-0 w-full flex-1 flex-col select-none dark:bg-neutral-900">
       <div className="w-full p-6 overflow-y-auto flex-1 overscroll-contain">
-        <div className="mx-auto max-w-4xl space-y-4">
+        <fieldset
+          disabled={resettingToDefaults}
+          aria-busy={resettingToDefaults}
+          className="mx-auto max-w-4xl space-y-4 border-0 p-0"
+        >
           {/* Connect Ollama Account */}
           <div className="overflow-hidden rounded-xl bg-white dark:bg-neutral-800">
             <div className="p-4">
@@ -680,25 +759,12 @@ export default function Settings() {
             </div>
           </div>
 
-          {/* Reset button */}
-          <div className="flex justify-end px-4">
-            <Button
-              type="button"
-              color="white"
-              className="px-3"
-              disabled={resettingToDefaults}
-              onClick={() => void handleResetToDefaults()}
-            >
-              Reset to defaults
-            </Button>
-          </div>
-
           <ClaudeDesktopModelsSettings
+            ref={claudeModelsSettingsRef}
             includeCloudModels={
               isAuthenticated && cloudStatusKnown && !cloudDisabled
             }
             onDraftChange={setHasClaudeDraftChanges}
-            resetVersion={claudeMappingsResetVersion}
           />
 
           {/* Agent Mode */}
@@ -744,7 +810,33 @@ export default function Settings() {
               </div>
             </div>
           )}
-        </div>
+
+          {/* Reset button */}
+          <div className="flex items-center justify-between gap-4 px-4">
+            {resetError ? (
+              <p
+                role="alert"
+                className="text-xs text-red-600 dark:text-red-400"
+              >
+                {resetError}
+              </p>
+            ) : (
+              <span />
+            )}
+            <Button
+              type="button"
+              color="white"
+              className="px-3"
+              disabled={resettingToDefaults || !cloudStatusKnown}
+              onClick={() => void handleResetToDefaults()}
+            >
+              {resettingToDefaults && (
+                <ArrowPathIcon data-slot="icon" className="animate-spin" />
+              )}
+              {resettingToDefaults ? "Resetting…" : "Reset to defaults"}
+            </Button>
+          </div>
+        </fieldset>
 
         {/* Saved indicator */}
         {(showSaved || restartMessage) && (

--- a/app/ui/app/src/components/Settings.tsx
+++ b/app/ui/app/src/components/Settings.tsx
@@ -120,9 +120,7 @@ export default function Settings() {
   const [hasClaudeDraftChanges, setHasClaudeDraftChanges] = useState(false);
   const claudeModelsSettingsRef =
     useRef<ClaudeDesktopModelsSettingsHandle>(null);
-  const resetInFlightRef = useRef(false);
   const savedConfirmationTimeoutRef = useRef<number | null>(null);
-  const restartMessageTimeoutRef = useRef<number | null>(null);
   useBlocker({
     shouldBlockFn: () =>
       !window.confirm("Discard unapplied Claude routing changes?"),
@@ -148,7 +146,7 @@ export default function Settings() {
     isKnown: cloudStatusKnown,
   } = useCloudStatus();
 
-  const displaySavedConfirmation = useCallback(() => {
+  const showSavedConfirmation = useCallback(() => {
     if (savedConfirmationTimeoutRef.current !== null) {
       window.clearTimeout(savedConfirmationTimeoutRef.current);
     }
@@ -159,32 +157,10 @@ export default function Settings() {
     }, savedConfirmationDuration);
   }, []);
 
-  const showSavedConfirmation = useCallback(() => {
-    if (!resetInFlightRef.current) {
-      displaySavedConfirmation();
-    }
-  }, [displaySavedConfirmation]);
-
-  const clearSavedIndicators = useCallback(() => {
-    if (savedConfirmationTimeoutRef.current !== null) {
-      window.clearTimeout(savedConfirmationTimeoutRef.current);
-      savedConfirmationTimeoutRef.current = null;
-    }
-    if (restartMessageTimeoutRef.current !== null) {
-      window.clearTimeout(restartMessageTimeoutRef.current);
-      restartMessageTimeoutRef.current = null;
-    }
-    setShowSaved(false);
-    setRestartMessage(false);
-  }, []);
-
   useEffect(
     () => () => {
       if (savedConfirmationTimeoutRef.current !== null) {
         window.clearTimeout(savedConfirmationTimeoutRef.current);
-      }
-      if (restartMessageTimeoutRef.current !== null) {
-        window.clearTimeout(restartMessageTimeoutRef.current);
       }
     },
     [],
@@ -334,15 +310,12 @@ export default function Settings() {
 
         // If context length is being changed, show restart message
         if (field === "ContextLength" && value !== settings.ContextLength) {
-          if (restartMessageTimeoutRef.current !== null) {
-            window.clearTimeout(restartMessageTimeoutRef.current);
-          }
           setRestartMessage(true);
           // Hide restart message after 3 seconds
-          restartMessageTimeoutRef.current = window.setTimeout(() => {
-            setRestartMessage(false);
-            restartMessageTimeoutRef.current = null;
-          }, savedConfirmationDuration);
+          window.setTimeout(
+            () => setRestartMessage(false),
+            savedConfirmationDuration,
+          );
         }
 
         updateSettingsMutation.mutate(updatedSettings, {
@@ -391,9 +364,13 @@ export default function Settings() {
     const cloudSource = cloudStatus?.source;
     if (!settings || resettingToDefaults || !cloudSource) return;
 
-    resetInFlightRef.current = true;
     setResettingToDefaults(true);
-    clearSavedIndicators();
+    if (savedConfirmationTimeoutRef.current !== null) {
+      window.clearTimeout(savedConfirmationTimeoutRef.current);
+      savedConfirmationTimeoutRef.current = null;
+    }
+    setShowSaved(false);
+    setRestartMessage(false);
     setResetError(null);
     try {
       await applySettingsDefaults({
@@ -405,7 +382,7 @@ export default function Settings() {
           (await claudeModelsSettingsRef.current?.resetToDefaults()) ?? true,
         currentSettings: settings,
         cloudSource,
-        onSaved: displaySavedConfirmation,
+        onSaved: showSavedConfirmation,
       });
     } catch (error) {
       console.error("Failed to reset settings:", error);
@@ -413,7 +390,6 @@ export default function Settings() {
         "Ollama could not reset every setting. Check the settings above and try again.",
       );
     } finally {
-      resetInFlightRef.current = false;
       setResettingToDefaults(false);
     }
   };

--- a/app/ui/app/src/types/webview.d.ts
+++ b/app/ui/app/src/types/webview.d.ts
@@ -29,7 +29,6 @@ interface ClaudeDesktopStatus {
   maxModels?: number;
   models?: ClaudeDesktopModelStatus[];
   mappings?: ClaudeDesktopMappingStatus[];
-  defaultMappings?: ClaudeDesktopMappingStatus[];
 }
 
 interface ClaudeDesktopMappingStatus {
@@ -78,7 +77,6 @@ declare global {
     doubleClick?: () => void;
     activateOllama?: () => void;
     getClaudeDesktopStatus?: () => Promise<ClaudeDesktopStatus>;
-    getClaudeDesktopResetStatus?: () => Promise<ClaudeDesktopStatus>;
     getClaudeDesktopConnectionSummary?: () => Promise<ClaudeDesktopStatus>;
     getClaudeDesktopRequestCount?: () => Promise<number>;
     setClaudeDesktopConnected?: (
@@ -95,7 +93,6 @@ declare global {
       restartConfirmed: boolean,
     ) => Promise<ClaudeDesktopActionResult>;
     resetClaudeDesktopMappings?: (
-      mappings: Record<string, string>,
       restartConfirmed: boolean,
     ) => Promise<ClaudeDesktopActionResult>;
     setClaudeDesktopAutoMode?: (

--- a/app/ui/app/src/types/webview.d.ts
+++ b/app/ui/app/src/types/webview.d.ts
@@ -78,6 +78,7 @@ declare global {
     doubleClick?: () => void;
     activateOllama?: () => void;
     getClaudeDesktopStatus?: () => Promise<ClaudeDesktopStatus>;
+    getClaudeDesktopResetStatus?: () => Promise<ClaudeDesktopStatus>;
     getClaudeDesktopConnectionSummary?: () => Promise<ClaudeDesktopStatus>;
     getClaudeDesktopRequestCount?: () => Promise<number>;
     setClaudeDesktopConnected?: (
@@ -90,6 +91,10 @@ declare global {
     getShowAppsInMenu?: () => Promise<boolean>;
     setShowAppsInMenu?: (visible: boolean) => Promise<void>;
     applyClaudeDesktopMappings?: (
+      mappings: Record<string, string>,
+      restartConfirmed: boolean,
+    ) => Promise<ClaudeDesktopActionResult>;
+    resetClaudeDesktopMappings?: (
       mappings: Record<string, string>,
       restartConfirmed: boolean,
     ) => Promise<ClaudeDesktopActionResult>;


### PR DESCRIPTION
## Summary

- make Reset to defaults invoke one native Claude Desktop reset operation that resolves and applies the current account defaults
- restore the paid defaults: Fable 5 → Kimi, Opus 5 → GLM, Sonnet 5 → DeepSeek Flash, Sonnet 4.6 → DeepSeek Pro, and Haiku 4.5 → Gemma
- restore the free default: Sonnet 5 → Gemma, with the other Claude routes unassigned
- resolve defaults by explicit model and route identity rather than recommendation list order, and fail closed when the account or complete default set cannot be verified
- keep default resolution and persistence in the native layer; the renderer only handles restart confirmation and reset progress
- preserve existing mappings until Reset is explicitly confirmed; canceling a required Claude restart leaves them unchanged
- keep stopped Claude stopped and persist defaults without activating a disconnected Claude integration
- hide Claude Desktop model settings on Windows; Reset to defaults still resets general Windows settings without invoking Claude Desktop
- move Reset to defaults to the bottom of Settings, lock settings and show a spinner while it runs, surface reset failures, and keep the Saved badge visible longer after success
- temporarily enable Cloud when the reset requires it and roll that change back if the Claude reset fails

## Test plan

- [x] npm test -- --run
- [x] npm run build
- [x] go test ./app/cmd/app
- [x] go test ./internal/proxy ./cmd/launch
- [x] focused UI reset and restart-cancellation interaction tests
- [x] focused account-verification race, access-tier, stopped, and disconnected tests
- [x] Windows Claude Desktop visibility and reset regression test
- [x] targeted ESLint, Prettier check, and git diff --check