### PR TITLE
proxy: preserve string content during image fallback

### DIFF
--- a/internal/proxy/claude_desktop.go
+++ b/internal/proxy/claude_desktop.go
@@ -900,6 +900,10 @@ func replaceUnsupportedImages(payload map[string]json.RawMessage) (bool, error) 
 func replaceImagesInContent(content json.RawMessage) (json.RawMessage, bool, error) {
 	var blocks []json.RawMessage
 	if err := json.Unmarshal(content, &blocks); err != nil {
+		var text string
+		if json.Unmarshal(content, &text) == nil {
+			return content, false, nil
+		}
 		return content, false, fmt.Errorf("decode Claude content for image fallback: %w", err)
 	}
 

--- a/internal/proxy/claude_desktop_test.go
+++ b/internal/proxy/claude_desktop_test.go
@@ -1319,6 +1319,16 @@ func TestGatewayLazilyRetriesUnsupportedVision(t *testing.T) {
 			body:     `{"model":"glm-5.2:cloud","messages":[{"role":"user","content":[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"aW1hZ2U="}},{"type":"text","text":"what dis"}]},{"role":"assistant","content":[{"type":"text","text":"I cannot inspect it"}]},{"role":"user","content":[{"type":"text","text":"kk"}]}]}`,
 			preserve: "kk",
 		},
+		{
+			name:     "string message history",
+			body:     `{"model":"glm-5.2:cloud","messages":[{"role":"user","content":"plain history"},{"role":"user","content":[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"aW1hZ2U="}},{"type":"text","text":"what dis"}]}]}`,
+			preserve: "plain history",
+		},
+		{
+			name:     "string tool result history",
+			body:     `{"model":"glm-5.2:cloud","messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool_1","content":"plain tool output"}]},{"role":"user","content":[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"aW1hZ2U="}},{"type":"text","text":"what dis"}]}]}`,
+			preserve: "plain tool output",
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			var upstreamBodies [][]byte
@@ -1360,6 +1370,13 @@ func TestGatewayLazilyRetriesUnsupportedVision(t *testing.T) {
 				t.Fatalf("sanitized fallback body = %s", upstreamBodies[1])
 			}
 		})
+	}
+}
+
+func TestReplaceImagesInContentRejectsUnsupportedShape(t *testing.T) {
+	_, _, err := replaceImagesInContent(json.RawMessage(`{"type":"text","text":"not a content array"}`))
+	if err == nil {
+		t.Fatal("expected unsupported content shape to fail")
 	}
 }
 


### PR DESCRIPTION
## Summary

Claude Desktop can send message and tool-result content as either a string or an array of content blocks. The unsupported-image fallback only accepted arrays, so valid string history aborted the fallback and exposed the original 400 response.

This change preserves valid string-form content while continuing to replace unsupported image blocks. Invalid content shapes still return an error.