### PR TITLE
docs: Claude Desktop integration

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -157,6 +157,7 @@
             "group": "Assistants",
             "expanded": true,
             "pages": [
+              "/integrations/claude-desktop",
               "/integrations/openclaw",
               "/integrations/hermes",
               "/integrations/hermes-desktop"

--- a/docs/integrations/claude-desktop.mdx
+++ b/docs/integrations/claude-desktop.mdx
@@ -1,13 +1,47 @@
 ---
 title: Claude Desktop
+description: Use Ollama models in Claude on macOS.
 ---
 
-Claude Desktop is no longer supported by `ollama launch`.
+Connect Claude to Ollama, choose a model, and start a new chat.
 
-Existing installations can be restored to the usual Claude profile:
+## Supported features
+
+- **Subagents** - Split larger tasks across agents
+- **Web search** - Supported by default through [Ollama's web search](/capabilities/web-search)
+- **Cowork** - Run longer coding and research tasks in Claude's Cowork workspace
+- **Auto mode** - Let the agent decide when to ask before making changes
+
+## Prerequisites
+
+- The [Ollama app for macOS](https://ollama.com/download/mac). Windows support is coming soon.
+- To use a local model, [download it](/quickstart#3-start-a-chat) before setup.
+- To use a cloud model, sign in to Ollama and enable cloud models. Some models require a [paid plan](https://ollama.com/pricing).
+
+If Claude is not installed, Ollama offers to download it during setup.
+
+## Set up Claude
+
+1. Open Ollama and select **Apps**.
+2. Find **Claude** under **Desktop** and turn it on.
+3. If Claude is not installed, let Ollama download it and finish the installation.
+4. Open Ollama **Settings**. Under **Apps**, choose an Ollama model for at least one Claude model option.
+5. Select **Start Claude** or **Restart Claude**. In Claude, start a new chat.
+
+If Claude is open when its connection or model changes, Ollama asks to restart it. Restarting stops any running task.
+
+## Switch models
+
+Open Ollama **Settings**. Under **Apps**, choose a model for each Claude model option you want to use, then select **Restart Claude**. You can assign the same Ollama model to more than one option.
+
+## Disconnect Claude
+
+Open Ollama **Apps** and turn Claude off. Ollama restores Claude's previous configuration. If Claude is open, Ollama asks to restart it so the change takes effect.
+
+You can also restore Claude from the terminal:
 
 ```shell
 ollama launch claude-desktop --restore
 ```
 
-Use [Claude Code](/integrations/claude-code) for Anthropic-compatible coding workflows with Ollama.
+Quitting Ollama while Claude is connected also restores Claude's usual configuration.

--- a/docs/integrations/index.mdx
+++ b/docs/integrations/index.mdx
@@ -25,9 +25,13 @@ Run `ollama launch` to see the latest integrations you can run from the terminal
 
 ## Connect an assistant
 
-Assistants with memory, skills, and messaging app access.
+Use open models in assistant apps.
 
 <CardGroup cols={2}>
+  <Card title="Claude" href="/integrations/claude-desktop">
+    Desktop assistant with local and cloud Ollama models.
+  </Card>
+
   <Card title="OpenClaw" icon="/images/launch-icons/openclaw.svg" href="/integrations/openclaw">
     Personal assistant for messaging apps and everyday tasks.
   </Card>


### PR DESCRIPTION
## Summary

- replace the obsolete Claude Desktop notice with setup, supported features, model switching, and restore guidance
- add Claude Desktop to the integrations overview and navigation