### PR TITLE
thinking: flush buffered content at the end of a stream

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -696,6 +696,13 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 				}
 			} else if thinkingState != nil {
 				thinking, content := thinkingState.AddContent(cr.Content)
+				if cr.Done {
+					// The parser buffers partial tags; drain it so trailing
+					// content isn't dropped when generation stops mid-tag.
+					flushedThinking, flushedContent := thinkingState.Flush()
+					thinking += flushedThinking
+					content += flushedContent
+				}
 				res.Thinking = thinking
 				res.Response = content
 			}
@@ -2840,6 +2847,13 @@ func (s *Server) ChatHandler(c *gin.Context) {
 
 				if thinkingState != nil {
 					thinkingContent, remainingContent := thinkingState.AddContent(res.Message.Content)
+					if r.Done {
+						// The parser buffers partial tags; drain it so trailing
+						// content isn't dropped when generation stops mid-tag.
+						flushedThinking, flushedContent := thinkingState.Flush()
+						thinkingContent += flushedThinking
+						remainingContent += flushedContent
+					}
 					if thinkingContent == "" && remainingContent == "" && !r.Done {
 						// need to accumulate more to decide what to send
 						return
@@ -3140,7 +3154,8 @@ func filterThinkTags(msgs []api.Message, m *Model) []api.Message {
 					ClosingTag: "</think>",
 				}
 				_, content := thinkingState.AddContent(msg.Content)
-				msgs[i].Content = content
+				_, flushed := thinkingState.Flush()
+				msgs[i].Content = content + flushed
 			}
 		}
 	}

--- a/thinking/parser.go
+++ b/thinking/parser.go
@@ -73,6 +73,27 @@ func (s *Parser) AddContent(content string) (string, string) {
 	return thinkingSb.String(), remainingSb.String()
 }
 
+// Flush drains any content the parser is still buffering and reports it as
+// (thinking, content). AddContent buffers whenever the accumulated output is
+// still an ambiguous prefix of the opening tag or a partial closing tag, and
+// only drains that buffer on a later call. Callers must call Flush once the
+// stream is finished, otherwise those trailing bytes are never emitted.
+func (s *Parser) Flush() (string, string) {
+	acc := s.acc.String()
+	s.acc.Reset()
+	if acc == "" {
+		return "", ""
+	}
+	// A partial closing tag was buffered mid-thinking, so it is thinking text.
+	// Anything else was buffered before the opening tag was confirmed, which
+	// means thinking never started and the bytes are ordinary content.
+	if s.state == thinkingState_Thinking {
+		return acc, ""
+	}
+	s.state = thinkingState_ThinkingDone
+	return "", acc
+}
+
 // the additional bool return is true iff we should continue eating
 func eat(s *Parser) (string, string, bool) {
 	switch s.state {

--- a/thinking/parser_test.go
+++ b/thinking/parser_test.go
@@ -285,3 +285,53 @@ func TestThinkingStreaming(t *testing.T) {
 		}
 	}
 }
+
+func TestFlush(t *testing.T) {
+	cases := []struct {
+		desc         string
+		inputs       []string
+		wantThinking string
+		wantContent  string
+	}{
+		{
+			desc:        "partial opening tag at end of stream",
+			inputs:      []string{"<thi"},
+			wantContent: "<thi",
+		},
+		{
+			desc:        "whitespace only",
+			inputs:      []string{"  "},
+			wantContent: "  ",
+		},
+		{
+			desc:         "partial closing tag at end of stream",
+			inputs:       []string{"<think>", "reasoning</"},
+			wantThinking: "</",
+		},
+		{
+			desc:   "nothing buffered after a complete thinking block",
+			inputs: []string{"<think>reasoning</think>answer"},
+		},
+		{
+			desc:   "nothing buffered when thinking was skipped",
+			inputs: []string{"answer"},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			parser := Parser{OpeningTag: "<think>", ClosingTag: "</think>"}
+			for _, input := range c.inputs {
+				parser.AddContent(input)
+			}
+			thinking, content := parser.Flush()
+			if thinking != c.wantThinking || content != c.wantContent {
+				t.Errorf("Flush() = (%q, %q), want (%q, %q)", thinking, content, c.wantThinking, c.wantContent)
+			}
+			// Flush must be idempotent: a second call has nothing left to drain.
+			if thinking, content := parser.Flush(); thinking != "" || content != "" {
+				t.Errorf("second Flush() = (%q, %q), want empty", thinking, content)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #18009

## Problem

`thinking.Parser` buffers output whenever what it has accumulated so far is still
ambiguous — either a prefix of the opening tag (`<thi` could become `<think>`, or could
be the start of ordinary `<html>`) or a suffix that overlaps the closing tag (`</` could
become `</think>`). That buffer is only ever drained by a *subsequent* `AddContent` call.

Nothing drained it at the end of a stream. If generation stopped while the parser was
still mid-disambiguation, the buffered bytes were silently discarded — no error, no hint
in `done_reason`.

This was an asymmetry with the other two parsers in the same code path. The built-in
parsers take an explicit done flag (`builtinParser.Add(cr.Content, cr.Done)`), and the
tool parser is explicitly drained on done (`toolParser.Content()`). Only the generic
thinking parser had no end-of-stream path.

Two ways it shows up today:

```go
p := &Parser{OpeningTag: "<think>", ClosingTag: "</think>"}
p.AddContent("<thi")          // ("", "") — "<thi" is buffered and unreachable

p2 := &Parser{OpeningTag: "<think>", ClosingTag: "</think>"}
p2.AddContent("<think>")
p2.AddContent("reasoning</")  // ("reasoning", "") — the trailing "</" is buffered and unreachable
```

In the first case the response body can come back entirely empty. Realistic triggers are
`num_predict` or a context limit cutting generation off mid-tag, EOS landing right after
a `<`, or a very short reply whose whole text is a prefix of the opening tag.

## Change

Add `Parser.Flush`, which drains the buffer and classifies it by the state the parser is
in:

- buffered mid-`Thinking` → the bytes are a partial closing tag, so they are thinking text
- buffered anywhere else → the opening tag was never confirmed, so thinking never started
  and the bytes are ordinary content

`Flush` is idempotent, so calling it on a parser with nothing buffered is a no-op and
returns `("", "")`.

Wire it into the three places that drive the parser:

- `GenerateHandler` — flush when `cr.Done`, merging into the final chunk
- `ChatHandler` — flush when `r.Done`, before the "still accumulating" early return so a
  wholly-buffered response is no longer swallowed
- `filterThinkTags` — feeds an entire history message in one shot, so it should always
  flush; without it an assistant message that is a bare prefix of `<think>` was wiped
  from history

## Notes

- Behaviour is unchanged for every stream that ends cleanly — `Flush` only has something
  to return when the parser was mid-disambiguation, which is exactly the case that was
  previously lossy.
- The choice to report a dangling `</` as thinking rather than content is deliberate: it
  was emitted inside the thinking block, so attributing it to `content` would leak a tag
  fragment into the user-visible answer.

## Testing

`TestFlush` in `thinking/parser_test.go` covers both lossy states, the two non-lossy
states, and idempotency. Existing `thinking` tests pass unchanged.

```
$ go test ./thinking/
ok      github.com/ollama/ollama/thinking
```
