### PR TITLE
agent/tools: confine the read tool's absolute paths to the working directory

### DIFF
--- a/agent/tools/file.go
+++ b/agent/tools/file.go
@@ -35,7 +35,7 @@ func (r *Read) Schema() api.ToolFunction {
 	props := api.NewToolPropertiesMap()
 	props.Set("path", api.ToolProperty{
 		Type:        api.PropertyType{"string"},
-		Description: "Path to the file to read, relative to the working directory.",
+		Description: "Path to the file to read, relative to the working directory. Absolute paths are accepted only when they point inside the working directory.",
 	})
 	props.Set("start", api.ToolProperty{
 		Type:        api.PropertyType{"integer"},
@@ -387,31 +387,16 @@ func openRegularFile(workingDir, path string, allowAbsolute bool) (*os.File, os.
 		return nil, nil, fmt.Errorf("path parameter is required")
 	}
 	if allowAbsolute && filepath.IsAbs(path) {
-		cleaned := filepath.Clean(path)
-		info, err := os.Lstat(cleaned)
+		// Rewrite to a working-directory-relative path and fall through, so
+		// absolute paths get the same os.Root confinement and symlink
+		// rejection as relative ones. Opening them directly would let the
+		// tool read anything on the filesystem, which both its schema and the
+		// symlink guard below say it must not do.
+		relative, err := workingDirRelative(workingDir, path)
 		if err != nil {
 			return nil, nil, err
 		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			return nil, nil, fmt.Errorf("%s is a symlink; read the target file directly", path)
-		}
-		if err := rejectNonRegularFile(path, info); err != nil {
-			return nil, nil, err
-		}
-		file, err := os.Open(cleaned)
-		if err != nil {
-			return nil, nil, err
-		}
-		info, err = file.Stat()
-		if err != nil {
-			file.Close()
-			return nil, nil, err
-		}
-		if err := rejectNonRegularFile(path, info); err != nil {
-			file.Close()
-			return nil, nil, err
-		}
-		return file, info, nil
+		path = relative
 	}
 
 	rel, err := cleanRelativePath(path)
@@ -441,6 +426,29 @@ func openRegularFile(workingDir, path string, allowAbsolute bool) (*os.File, os.
 		return nil, nil, err
 	}
 	return file, info, nil
+}
+
+// workingDirRelative converts an absolute path into a path relative to the
+// working directory, rejecting anything that resolves outside it.
+func workingDirRelative(workingDir, path string) (string, error) {
+	base, err := workingDirAbs(workingDir)
+	if err != nil {
+		return "", err
+	}
+	// Canonicalize the parent chain so a symlinked working directory (/tmp on
+	// macOS, for example) still matches the canonicalized base. The final
+	// component is left as-is: resolving it here would silently follow a
+	// symlink that the os.Root walk is supposed to reject.
+	dir, name := filepath.Split(filepath.Clean(path))
+	parent, err := canonicalPath(dir)
+	if err != nil {
+		return "", err
+	}
+	rel, err := filepath.Rel(base, filepath.Join(parent, name))
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("path escapes working directory")
+	}
+	return rel, nil
 }
 
 func regularRootFileInfo(root *os.Root, rel, path string) (os.FileInfo, error) {

--- a/agent/tools/file_test.go
+++ b/agent/tools/file_test.go
@@ -421,7 +421,7 @@ func TestReadDefaultsToEntireFile(t *testing.T) {
 	}
 }
 
-func TestReadAllowsAbsolutePath(t *testing.T) {
+func TestReadAllowsAbsolutePathInsideWorkingDir(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "note.txt")
 	content := "one\ntwo\nthree\n"
@@ -429,7 +429,7 @@ func TestReadAllowsAbsolutePath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := (&Read{}).Execute(context.Background(), agent.ToolContext{WorkingDir: t.TempDir()}, map[string]any{
+	result, err := (&Read{}).Execute(context.Background(), agent.ToolContext{WorkingDir: dir}, map[string]any{
 		"path": path,
 	})
 	if err != nil {
@@ -451,7 +451,7 @@ func TestReadRejectsAbsoluteSymlink(t *testing.T) {
 		t.Skipf("symlinks unavailable: %v", err)
 	}
 
-	_, err := (&Read{}).Execute(context.Background(), agent.ToolContext{WorkingDir: t.TempDir()}, map[string]any{
+	_, err := (&Read{}).Execute(context.Background(), agent.ToolContext{WorkingDir: dir}, map[string]any{
 		"path": link,
 	})
 	if err == nil {
@@ -567,5 +567,45 @@ func TestReadRejectsInvalidRange(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "end must") {
 		t.Fatalf("err = %v", err)
+	}
+}
+
+func TestReadRejectsAbsolutePathOutsideWorkingDir(t *testing.T) {
+	outside := t.TempDir()
+	path := filepath.Join(outside, "id_rsa")
+	if err := os.WriteFile(path, []byte("secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := (&Read{}).Execute(context.Background(), agent.ToolContext{WorkingDir: t.TempDir()}, map[string]any{
+		"path": path,
+	})
+	if err == nil {
+		t.Fatal("expected absolute path outside the working directory to be rejected")
+	}
+	if !strings.Contains(err.Error(), "path escapes working directory") {
+		t.Fatalf("err = %v, want path escape rejection", err)
+	}
+}
+
+func TestReadRejectsAbsolutePathTraversingOutOfWorkingDir(t *testing.T) {
+	root := t.TempDir()
+	wd := filepath.Join(root, "project")
+	if err := os.Mkdir(wd, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "id_rsa")
+	if err := os.WriteFile(path, []byte("secret\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := (&Read{}).Execute(context.Background(), agent.ToolContext{WorkingDir: wd}, map[string]any{
+		"path": filepath.Join(wd, "..", "id_rsa"),
+	})
+	if err == nil {
+		t.Fatal("expected traversal out of the working directory to be rejected")
+	}
+	if !strings.Contains(err.Error(), "path escapes working directory") {
+		t.Fatalf("err = %v, want path escape rejection", err)
 	}
 }


### PR DESCRIPTION
Fixes #18010

## Problem

`Read.Execute` calls `openRegularFile(toolCtx.WorkingDir, path, true)`. The
`allowAbsolute` branch cleaned the path, rejected symlinks and non-regular files, and
then opened it — without ever consulting `workingDir`.

That made the confinement the rest of the file enforces trivially bypassable. The
relative path goes through `os.Root` and rejects symlinks, with this comment explaining
why:

> Reject symlinks outright. `os.Root.Open` follows symlinks via openat without
> `O_NOFOLLOW`, so a symlink inside the working root that points outside it
> (e.g. `./notes -> ~/.ssh/id_rsa`) would otherwise be read transparently, bypassing the
> working-directory confinement that the bash denylist enforces for direct credential reads.

Blocking `./notes -> ~/.ssh/id_rsa` while allowing `/home/u/.ssh/id_rsa` does not raise
the bar for a model that has been prompt-injected by file content or a web result. Three
things disagreed with each other:

- the tool's schema says `path` is *"relative to the working directory"*, and its
  description says *"from the current working directory"*
- the symlink guard exists specifically to stop working-directory escapes
- the `bash` tool refuses `cat ~/.ssh/id_rsa` via `readsCredentialPath`, while `read`
  would return the same file

Approval still gates the call (`RequiresApproval` returns `true`), so this is
defense-in-depth rather than a direct exploit — but it left the approval prompt as the
only control, with the two layers behind it contradicting each other. A user approving
"read a file" in a session scoped to a project does not expect the path to be outside
that project.

## Change

Rewrite an absolute path to a working-directory-relative one and fall through to the
existing `os.Root` walk, instead of opening it directly. Absolute and relative paths now
get identical confinement, symlink rejection, and error messages — and the special-cased
absolute branch goes away, so it is a net deletion in `openRegularFile`.

- absolute paths **inside** the working directory keep working, which is the useful case
  (a model that just ran `pwd` and echoes a full path)
- absolute paths that escape now fail with the existing `path escapes working directory`
  error
- the schema description is updated to say what is actually enforced

The new `workingDirRelative` helper canonicalizes the *parent chain* before comparing, so
a symlinked working directory (`/tmp` on macOS, for example) still matches the
canonicalized base. The final component is deliberately left unresolved: resolving it
there would silently follow a symlink that the `os.Root` walk is supposed to reject.

`Edit` is unaffected — it already passes `allowAbsolute=false` and rejects every absolute
path.

## Testing

`TestReadAllowsAbsolutePath` asserted the old escaping behaviour (it read a file while
`WorkingDir` was a different temp dir), so it is renamed to
`TestReadAllowsAbsolutePathInsideWorkingDir` and now points the working directory at the
file's own directory — still covering absolute-path reads, just the confined ones.
`TestReadRejectsAbsoluteSymlink` is adjusted the same way so it keeps testing symlink
rejection rather than tripping the new escape check first.

Two new tests cover the fix, one for a plain outside-the-root absolute path and one for
`<wd>/../id_rsa` traversal. Both fail on `main` and pass here:

```
--- FAIL: TestReadRejectsAbsolutePathOutsideWorkingDir
    expected absolute path outside the working directory to be rejected
--- FAIL: TestReadRejectsAbsolutePathTraversingOutOfWorkingDir
    expected traversal out of the working directory to be rejected
```

```
$ go test ./agent/...
ok      github.com/ollama/ollama/agent
ok      github.com/ollama/ollama/agent/tools
```
