### PR TITLE
envconfig: trim whitespace and drop empty OLLAMA_ORIGINS entries

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -85,7 +85,11 @@ func ConnectableHost() *url.URL {
 // AllowedOrigins returns a list of allowed origins. AllowedOrigins can be configured via the OLLAMA_ORIGINS environment variable.
 func AllowedOrigins() (origins []string) {
 	if s := Var("OLLAMA_ORIGINS"); s != "" {
-		origins = strings.Split(s, ",")
+		for o := range strings.SplitSeq(s, ",") {
+			if o = strings.TrimSpace(o); o != "" {
+				origins = append(origins, o)
+			}
+		}
 	}
 
 	for _, origin := range []string{"localhost", "127.0.0.1", "0.0.0.0"} {

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -169,6 +169,28 @@ func TestOrigins(t *testing.T) {
 			"vscode-webview://*",
 			"vscode-file://*",
 		}},
+		{"http://a.example, http://b.example ,,\thttp://c.example\t", []string{
+			"http://a.example",
+			"http://b.example",
+			"http://c.example",
+			"http://localhost",
+			"https://localhost",
+			"http://localhost:*",
+			"https://localhost:*",
+			"http://127.0.0.1",
+			"https://127.0.0.1",
+			"http://127.0.0.1:*",
+			"https://127.0.0.1:*",
+			"http://0.0.0.0",
+			"https://0.0.0.0",
+			"http://0.0.0.0:*",
+			"https://0.0.0.0:*",
+			"app://*",
+			"file://*",
+			"tauri://*",
+			"vscode-webview://*",
+			"vscode-file://*",
+		}},
 	}
 	for _, tt := range cases {
 		t.Run(tt.value, func(t *testing.T) {


### PR DESCRIPTION
Fixes #18011

`AllowedOrigins()` splits `OLLAMA_ORIGINS` on `,` and hands the raw fragments to the CORS middleware. Fragments are never trimmed and empty ones are never dropped, so writing the variable the way a comma-separated list is normally written:

```sh
OLLAMA_ORIGINS="https://a.example, https://b.example" ollama serve
```

yields the allowed origin `" https://b.example"`. No `Origin` header ever equals that, so `b.example` is silently blocked — no warning, no log line, just a CORS error in the browser for an origin the user believes they allowed. Doubled or trailing commas similarly add a useless `""` entry.

`Var()` already trims the whole value and strips surrounding quotes, so the outer-whitespace case was handled; the missing per-entry trim looks like an oversight.

This trims each entry and skips the empty ones. Behavior for values with no whitespace is unchanged.

Covered by a new case in `TestOrigins` (`"http://a.example, http://b.example ,,\thttp://c.example\t"`), which fails before the change and passes after.
