### PR TITLE
app/tools: allow web fetch of URLs that end in punctuation

### DIFF
--- a/app/tools/url_policy.go
+++ b/app/tools/url_policy.go
@@ -12,10 +12,17 @@ type directURLContextKey struct{}
 
 var directURLPattern = regexp.MustCompile("https?://[^\\s<>\"'`]+")
 
+// trailingPunctuation is punctuation a URL can pick up from the prose around it.
+const trailingPunctuation = ".,;:!?)]}"
+
 func WithAllowedDirectURLs(ctx context.Context, text string) context.Context {
 	allowed := make(map[string]struct{})
 	for _, match := range directURLPattern.FindAllString(text, -1) {
+		// A URL extracted from prose may have swallowed the punctuation that
+		// followed it, but it may also genuinely end in punctuation, as
+		// Wikipedia disambiguation URLs do. Allow both readings.
 		addAllowedDirectURLToMap(allowed, match)
+		addAllowedDirectURLToMap(allowed, strings.TrimRight(match, trailingPunctuation))
 	}
 	return context.WithValue(ctx, directURLContextKey{}, allowed)
 }
@@ -30,7 +37,7 @@ func addAllowedDirectURLToMap(allowed map[string]struct{}, raw string) {
 		return
 	}
 
-	raw = cleanDirectURL(raw)
+	raw = normalizeDirectURL(raw)
 	if raw == "" {
 		return
 	}
@@ -40,18 +47,17 @@ func addAllowedDirectURLToMap(allowed map[string]struct{}, raw string) {
 
 func allowedDirectURL(ctx context.Context, raw string) bool {
 	allowed, _ := ctx.Value(directURLContextKey{}).(map[string]struct{})
-	cleaned := cleanDirectURL(raw)
-	if cleaned == "" || cleaned != raw {
+	raw = normalizeDirectURL(raw)
+	if raw == "" {
 		return false
 	}
 
-	_, ok := allowed[cleaned]
+	_, ok := allowed[raw]
 	return ok
 }
 
-func cleanDirectURL(raw string) string {
+func normalizeDirectURL(raw string) string {
 	raw = strings.TrimSpace(raw)
-	raw = strings.TrimRight(raw, ".,;:!?)]}")
 
 	if !strings.HasPrefix(raw, "http://") && !strings.HasPrefix(raw, "https://") {
 		return ""

--- a/app/tools/url_policy_test.go
+++ b/app/tools/url_policy_test.go
@@ -19,3 +19,30 @@ func TestDirectURLsFromText_ExtractsMarkdownCodeSpanURL(t *testing.T) {
 		t.Fatal("expected URL wrapped in backticks to be allowed")
 	}
 }
+
+func TestDirectURLsFromText_AllowsURLEndingInPunctuation(t *testing.T) {
+	const u = "https://en.wikipedia.org/wiki/Go_(programming_language)"
+	ctx := WithAllowedDirectURLs(t.Context(), "please summarise "+u)
+
+	if !allowedDirectURL(ctx, u) {
+		t.Fatal("expected URL ending in a closing paren to be allowed")
+	}
+}
+
+func TestDirectURLsFromText_AllowsURLTrimmedFromProse(t *testing.T) {
+	ctx := WithAllowedDirectURLs(t.Context(), "summarize https://example.com/privacy.")
+
+	if !allowedDirectURL(ctx, "https://example.com/privacy") {
+		t.Fatal("expected URL without the sentence's trailing period to be allowed")
+	}
+}
+
+func TestAddAllowedDirectURL_KeepsTrailingPunctuation(t *testing.T) {
+	const u = "https://en.wikipedia.org/wiki/Go_(programming_language)"
+	ctx := WithAllowedDirectURLs(t.Context(), "no urls here")
+	addAllowedDirectURL(ctx, u)
+
+	if !allowedDirectURL(ctx, u) {
+		t.Fatal("expected discovered link to be allowed unmodified")
+	}
+}


### PR DESCRIPTION
Fixes #18012

`cleanDirectURL` trims trailing punctuation (`.,;:!?)]}`) so a URL can be pulled cleanly out of prose. The same function also gated the allowlist lookup, which additionally required `cleaned == raw`:

```go
cleaned := cleanDirectURL(raw)
if cleaned == "" || cleaned != raw {
	return false
}
```

So a URL whose real last character is one of those could never be fetched — it was stored truncated, and the exact string the user pasted was rejected by the equality check. No input satisfies both sides.

Pasting `https://en.wikipedia.org/wiki/Go_(programming_language)` and asking the model to summarise it fails with *"web fetch is only allowed for URLs provided by the user"* — for a URL provided in that very message. Anything ending in `)`, `]`, `}`, `!` or a trailing `.` is affected. Links discovered on a fetched page (`web_fetch.go:79`) and search results (`web_search.go:92`) were stored truncated too, so following them hit the same wall.

This separates extraction from matching:

- The punctuation trim now happens only in `WithAllowedDirectURLs`, where a URL is pulled out of free-form text. Both the regex match and the trimmed candidate are allowed, so a genuinely parenthesised URL survives and a URL followed by a sentence-ending period still works.
- `allowedDirectURL` and `addAllowedDirectURL` use the raw (whitespace-trimmed, scheme-checked) string — page links and search results are already well-formed URLs, not text scraped from prose.

The security property is unchanged: a tool argument that differs from what the user wrote still fails the set-membership check. `TestDirectURLsFromText_RejectsChangedToolArgument` covers that and still passes.

Three tests added; the two for the bug fail before this change and pass after.
