### PR TITLE
cmd/tui/chat: stop markdown tables at prose and honor escaped pipes

### DIFF
--- a/cmd/tui/chat/markdown.go
+++ b/cmd/tui/chat/markdown.go
@@ -228,13 +228,21 @@ func renderMarkdownCodeLine(line string, width int) []string {
 }
 
 func renderMarkdownTable(lines []string, width int) ([]string, int) {
-	if len(lines) < 2 || !looksLikeMarkdownTableRow(lines[0]) || !isMarkdownTableSeparator(lines[1]) {
+	if len(lines) < 2 || !isMarkdownTableSeparator(lines[1]) {
+		return nil, 0
+	}
+	headerLeading, headerTrailing, ok := markdownTableRowShape(lines[0])
+	if !ok {
 		return nil, 0
 	}
 
 	var rows [][]string
 	consumed := 0
-	for consumed < len(lines) && looksLikeMarkdownTableRow(lines[consumed]) {
+	for consumed < len(lines) {
+		leading, trailing, ok := markdownTableRowShape(lines[consumed])
+		if !ok || leading != headerLeading || trailing != headerTrailing {
+			break
+		}
 		if consumed == 1 && isMarkdownTableSeparator(lines[consumed]) {
 			consumed++
 			continue
@@ -376,9 +384,16 @@ func markdownInlineWidth(cell string) int {
 	return width
 }
 
-func looksLikeMarkdownTableRow(line string) bool {
-	line = strings.TrimSpace(line)
-	return strings.Contains(line, "|") && strings.Count(line, "|") >= 1
+// markdownTableRowShape reports whether line is delimited by a leading and/or
+// trailing pipe, and whether it holds an unescaped pipe at all. Prose has
+// neither delimiter, so requiring the same shape as the header row keeps an
+// ordinary sentence that merely mentions a pipe out of the table grid.
+func markdownTableRowShape(line string) (leading, trailing, ok bool) {
+	cells := splitMarkdownTableCells(strings.TrimSpace(line))
+	if len(cells) < 2 {
+		return false, false, false
+	}
+	return cells[0] == "", cells[len(cells)-1] == "", true
 }
 
 func isMarkdownTableSeparator(line string) bool {
@@ -398,15 +413,35 @@ func isMarkdownTableSeparator(line string) bool {
 }
 
 func parseMarkdownTableRow(line string) []string {
-	line = strings.TrimSpace(line)
-	line = strings.TrimPrefix(line, "|")
-	line = strings.TrimSuffix(line, "|")
-	raw := strings.Split(line, "|")
-	cells := make([]string, 0, len(raw))
-	for _, cell := range raw {
-		cells = append(cells, strings.TrimSpace(cell))
+	cells := splitMarkdownTableCells(strings.TrimSpace(line))
+	// Leading and trailing pipes delimit the row, they do not open an empty cell.
+	if len(cells) > 1 && cells[0] == "" {
+		cells = cells[1:]
+	}
+	if len(cells) > 1 && cells[len(cells)-1] == "" {
+		cells = cells[:len(cells)-1]
 	}
 	return cells
+}
+
+// splitMarkdownTableCells splits a table row on unescaped pipes, turning the
+// GFM escape \| into a literal pipe within a cell.
+func splitMarkdownTableCells(line string) []string {
+	var cells []string
+	var cell strings.Builder
+	for i := 0; i < len(line); i++ {
+		switch {
+		case line[i] == '\\' && i+1 < len(line) && line[i+1] == '|':
+			cell.WriteByte('|')
+			i++
+		case line[i] == '|':
+			cells = append(cells, strings.TrimSpace(cell.String()))
+			cell.Reset()
+		default:
+			cell.WriteByte(line[i])
+		}
+	}
+	return append(cells, strings.TrimSpace(cell.String()))
 }
 
 func padPlainLine(line string, width int) string {

--- a/cmd/tui/chat/render_test.go
+++ b/cmd/tui/chat/render_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -2260,5 +2261,27 @@ func TestRenderMarkdownTablePreservesValidSeparator(t *testing.T) {
 	}
 	if !strings.Contains(plain, "Name") || !strings.Contains(plain, "Ollama") {
 		t.Fatalf("valid Markdown table was not rendered:\n%s", plain)
+	}
+}
+
+func TestRenderMarkdownTableStopsBeforeProse(t *testing.T) {
+	markdown := strings.Join([]string{
+		"| col | val |",
+		"| --- | --- |",
+		"| x | 1 |",
+		"Note: the `a | b` syntax pipes output.",
+	}, "\n")
+
+	plain := stripANSI(renderMarkdownForView(markdown, 70))
+	if !strings.Contains(plain, "Note: the a | b syntax pipes output.") {
+		t.Fatalf("prose after the table was reflowed into the grid:\n%s", plain)
+	}
+}
+
+func TestRenderMarkdownTableEscapedPipe(t *testing.T) {
+	cells := parseMarkdownTableRow(`| a \| b | c |`)
+	want := []string{"a | b", "c"}
+	if !slices.Equal(cells, want) {
+		t.Fatalf("parseMarkdownTableRow = %q, want %q", cells, want)
 	}
 }


### PR DESCRIPTION
Fixes #18013

Two defects in the terminal chat's markdown table renderer.

**1. A line containing a single pipe was treated as a table row.** `looksLikeMarkdownTableRow` only required one `|`, so the row-consuming loop kept absorbing lines after the table ended. A sentence mentioning a shell pipe, a regex alternation or a TypeScript union type — which models routinely write immediately below a table — was chopped into cells and reflowed into the grid:

```
| col | val |
| --- | --- |
| x   | 1   |
Note: the `a | b` syntax pipes output.
```

rendered as

```
col          | val
x            | 1
Note: the    | b` syntax pipes
`a           | output.
```

**2. Escaped pipes were split as delimiters.** `parseMarkdownTableRow` did a plain `strings.Split(line, "|")`, so a cell using the GFM escape `\|` for a literal pipe became two cells — corrupting the text and giving the row more columns than the header, which misaligned the whole table.

The fix:

- `markdownTableRowShape` replaces `looksLikeMarkdownTableRow`. A row must carry the same leading/trailing pipe delimiters as the header row, which prose does not, so the table now ends at the first line that isn't shaped like one. Tables written without outer pipes still work, since the header sets the expected shape. This also collapses the redundant `Contains(line, "|") && Count(line, "|") >= 1`.
- `splitMarkdownTableCells` splits on unescaped pipes only and unescapes `\|` into the cell text. It backs both cell parsing and row detection, so a line whose only pipe is escaped is no longer mistaken for a row.

Two tests added; both fail before this change with exactly the output above and pass after. Existing table and pipe-prose tests are unaffected.
