### PR TITLE
agent: name the searched directories when a skill is not found

### DIFF
--- a/agent/skills.go
+++ b/agent/skills.go
@@ -146,7 +146,8 @@ func (s Skill) resources() []string {
 // SkillCatalog contains valid skills and diagnostics for ignored invalid
 // entries, so one malformed skill cannot hide the rest.
 type SkillCatalog struct {
-	dir         string
+	// roots are the directories that were scanned, lowest-precedence first.
+	roots       []string
 	skills      map[string]Skill
 	diagnostics []error
 }
@@ -156,7 +157,7 @@ func DiscoverSkills(dir string) (*SkillCatalog, error) {
 	if err != nil {
 		return nil, err
 	}
-	catalog := &SkillCatalog{dir: dir, skills: make(map[string]Skill)}
+	catalog := &SkillCatalog{roots: []string{dir}, skills: make(map[string]Skill)}
 	entries, err := os.ReadDir(dir)
 	if errors.Is(err, fs.ErrNotExist) {
 		return catalog, nil
@@ -214,6 +215,9 @@ func LoadDefaultSkills(projectDir string) (*SkillCatalog, error) {
 		return nil, err
 	}
 	catalog := &SkillCatalog{skills: make(map[string]Skill)}
+	for _, root := range roots {
+		catalog.roots = append(catalog.roots, root.path)
+	}
 	bundled, err := bundledSkillCreator()
 	if err != nil {
 		return nil, err
@@ -649,11 +653,13 @@ func defaultSkillRoots(projectDir string) ([]skillRoot, error) {
 	return roots, nil
 }
 
+// Dir returns the single directory the catalog was built from, or "" when it
+// merges several roots and no one directory represents it.
 func (c *SkillCatalog) Dir() string {
-	if c == nil {
+	if c == nil || len(c.roots) != 1 {
 		return ""
 	}
-	return c.dir
+	return c.roots[0]
 }
 
 func (c *SkillCatalog) List() []Skill {
@@ -701,16 +707,19 @@ func (c *SkillCatalog) ExcludeNames(names []string) []string {
 }
 
 func (c *SkillCatalog) Load(name string) (Skill, error) {
+	if c == nil {
+		return Skill{}, errors.New("skills are unavailable")
+	}
 	name = strings.TrimSpace(name)
 	if !skillName.MatchString(name) {
 		return Skill{}, fmt.Errorf("invalid skill name %q", name)
 	}
-	if c == nil {
-		return Skill{}, errors.New("skills are unavailable")
-	}
 	skill, ok := c.skills[name]
 	if !ok {
-		return Skill{}, fmt.Errorf("skill %q not found in %s", name, c.dir)
+		if len(c.roots) == 0 {
+			return Skill{}, fmt.Errorf("skill %q not found", name)
+		}
+		return Skill{}, fmt.Errorf("skill %q not found in %s", name, strings.Join(c.roots, ", "))
 	}
 	return skill, nil
 }

--- a/agent/skills_test.go
+++ b/agent/skills_test.go
@@ -514,3 +514,31 @@ func TestImportSkillsRejectsUnreadableManifest(t *testing.T) {
 		t.Fatalf("failures = %#v", result.Failures)
 	}
 }
+
+func TestLoadNotFoundNamesSearchedRoots(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	skillsDir := t.TempDir()
+	t.Setenv(SkillsDirEnv, skillsDir)
+	project := t.TempDir()
+
+	catalog, err := LoadDefaultSkills(project)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = catalog.Load("does-not-exist")
+	if err == nil {
+		t.Fatal("expected an error for a missing skill")
+	}
+	for _, want := range []string{
+		filepath.Join(home, ".agents", "skills"),
+		skillsDir,
+		filepath.Join(project, ".agents", "skills"),
+		filepath.Join(project, ".ollama", "skills"),
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Load error = %q, want it to name %q", err, want)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #18014

`SkillCatalog.Load` formats its error with `c.dir`:

```go
return Skill{}, fmt.Errorf("skill %q not found in %s", name, c.dir)
```

but `dir` was only ever set by `DiscoverSkills`. Both production callers (`cmd/agent_tui.go:80`, `cmd/tui/chat/input.go:230`) go through `LoadDefaultSkills`, which builds the catalog literal without it, so the message always ended in a dangling `not found in ` and `Dir()` always returned `""`. The user sees this whenever the model calls the `skill` tool with an unknown name, or `--skill <name>` names a skill that didn't load.

`LoadDefaultSkills` merges four roots (`~/.agents/skills`, the user Ollama skills dir, `<project>/.agents/skills`, `<project>/.ollama/skills`), so a single `dir` is the wrong shape for it. The catalog now records the roots it scanned and the error lists them — knowing *which* directories were searched is the point of the message:

```
skill "does-not-exist" not found in /home/u/.agents/skills, /home/u/.ollama/skills, /proj/.agents/skills, /proj/.ollama/skills
```

`Dir()` now reports the directory only when exactly one root backs the catalog. That keeps what `DiscoverSkills` callers saw, and keeps the empty value that `skillsDirForDisplay` (`cmd/tui/chat/input.go:270`) already falls back on for merged catalogs — that call site wants the Ollama-owned skills directory, not the lowest-precedence root, so its fallback stays correct.

Also swapped the two guards in `Load` so a nil catalog is reported as "skills are unavailable" rather than as a name problem, as the issue notes.

One test added; it fails before this change with `skill "does-not-exist" not found in ` and passes after.
