### PR TITLE
api: connect to loopback when OLLAMA_HOST is an unspecified address

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -73,7 +73,7 @@ func checkError(resp *http.Response, body []byte) error {
 // used.
 func ClientFromEnvironment() (*Client, error) {
 	return &Client{
-		base: envconfig.Host(),
+		base: envconfig.ConnectableHost(),
 		http: http.DefaultClient,
 	}, nil
 }

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -34,6 +34,13 @@ func TestClientFromEnvironment(t *testing.T) {
 		"scheme, hostname, and port": {value: "https://example.com:1234", expect: "https://example.com:1234"},
 		"trailing slash":             {value: "example.com/", expect: "http://example.com:11434"},
 		"trailing slash port":        {value: "example.com:1234/", expect: "http://example.com:1234"},
+		// A client cannot connect to an unspecified bind address: on Windows it
+		// fails outright, and where it does resolve it may reach a different
+		// server than the one OLLAMA_HOST was meant to select.
+		"unspecified ipv4":        {value: "0.0.0.0", expect: "http://127.0.0.1:11434"},
+		"unspecified ipv4 + port": {value: "0.0.0.0:8200", expect: "http://127.0.0.1:8200"},
+		"unspecified ipv6":        {value: "[::]", expect: "http://[::1]:11434"},
+		"unspecified ipv6 + port": {value: "[::]:8200", expect: "http://[::1]:8200"},
 	}
 
 	for k, v := range testCases {


### PR DESCRIPTION
`ClientFromEnvironment` builds its base URL from `envconfig.Host()`, which returns the address the server *binds* to. Wildcard addresses such as `0.0.0.0` and `::` are meant for binding a listening socket, not for connecting as a client.

When more than one server listens on the port, the connection can land on a different server than the one `OLLAMA_HOST` selected. With one server bound to `[::]` and another to `127.0.0.1` on the same port:

| `OLLAMA_HOST` | before | after |
| --- | --- | --- |
| `[::]:PORT` | reaches the **IPv4** server | reaches the **IPv6** server |

That is how a correctly configured server comes to look unreachable: the CLI talks to the wrong instance, the user runs `ollama serve` again, and a second server is left running unnoticed — the behaviour reported in #17831, where a server configured with `OLLAMA_HOST=0.0.0.0:8200` is reported as not running and a second instance appears on the default port.

`envconfig.ConnectableHost()` already maps unspecified addresses to the matching loopback address, and several launchers (`cmd/launch/codex.go`, `kimi.go`, `muse.go`, `cline.go`, and the macOS app) use it for exactly this reason. This change uses it for the environment client as well, so the CLI benefits from the same handling.

The two remaining uses of `envconfig.Host()` in `cmd/cmd.go` are left untouched on purpose: `RunServer` must bind to the configured address, and `isLocalhost` deliberately treats unspecified addresses as local.

### Testing

Four cases added to `TestClientFromEnvironment`, covering `0.0.0.0`, `0.0.0.0:8200`, `[::]` and `[::]:8200`. They fail on `main`:

```
--- FAIL: TestClientFromEnvironment/unspecified_ipv4
    expected http://127.0.0.1:11434, got http://0.0.0.0:11434
--- FAIL: TestClientFromEnvironment/unspecified_ipv6
    expected http://[::1]:11434, got http://[::]:11434
```

and pass with the change. `go test ./api/... ./envconfig/...` is green, `gofmt` and `go vet` are clean.

One caveat: I could not run the `cmd` package tests, as it does not build on Windows due to the MLX code under `x/mlxrunner/mlx` (the cgo files are excluded without `CGO_ENABLED`, leaving `Array`, `Compile1` and `Shapeless` undefined). I verified this failure is pre-existing on a clean tree and unrelated to this change.

Fixes #17831
