### PR TITLE
docs: add Cursor to Community Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ console.log(response.message.content);
 ### Code Editors & Development
 
 - [Cline](https://github.com/cline/cline) - VS Code extension for multi-file/whole-repo coding
+- [Cursor](https://cursor.com) - AI code editor with local Ollama model support via extension
 - [Continue](https://github.com/continuedev/continue) - Open-source AI code assistant for any IDE
 - [Void](https://github.com/voideditor/void) - Open source AI code editor, Cursor alternative
 - [Copilot for Obsidian](https://github.com/logancyang/obsidian-copilot) - AI assistant for Obsidian


### PR DESCRIPTION
Add Cursor AI editor to Code Editors & Development section. Cursor supports Ollama local models via extension.