### PR TITLE
thinking: flush buffered tail at end of stream

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -696,6 +696,11 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 				}
 			} else if thinkingState != nil {
 				thinking, content := thinkingState.AddContent(cr.Content)
+				if cr.Done {
+					flushThinking, flushContent := thinkingState.Flush()
+					thinking += flushThinking
+					content += flushContent
+				}
 				res.Thinking = thinking
 				res.Response = content
 			}
@@ -2840,6 +2845,11 @@ func (s *Server) ChatHandler(c *gin.Context) {
 
 				if thinkingState != nil {
 					thinkingContent, remainingContent := thinkingState.AddContent(res.Message.Content)
+					if r.Done {
+						flushThinking, flushContent := thinkingState.Flush()
+						thinkingContent += flushThinking
+						remainingContent += flushContent
+					}
 					if thinkingContent == "" && remainingContent == "" && !r.Done {
 						// need to accumulate more to decide what to send
 						return

--- a/thinking/parser.go
+++ b/thinking/parser.go
@@ -161,6 +161,22 @@ func eat(s *Parser) (string, string, bool) {
 	}
 }
 
+// Flush drains any bytes AddContent is still holding back while it
+// disambiguates the opening or closing tag. Callers must invoke it once,
+// after the final AddContent call, when the stream ends (e.g. cr.Done):
+// AddContent has no other path to release those bytes, so without a Flush
+// call they are silently dropped.
+func (s *Parser) Flush() (thinking, content string) {
+	switch s.state {
+	case thinkingState_LookingForOpening:
+		content = s.acc.String()
+	case thinkingState_Thinking:
+		thinking = s.acc.String()
+	}
+	s.acc.Reset()
+	return thinking, content
+}
+
 // longest overlap between suffix of s and prefix of delim
 func overlap(s, delim string) int {
 	max := min(len(delim), len(s))

--- a/thinking/parser_test.go
+++ b/thinking/parser_test.go
@@ -285,3 +285,56 @@ func TestThinkingStreaming(t *testing.T) {
 		}
 	}
 }
+
+func TestParserFlush(t *testing.T) {
+	cases := []struct {
+		desc         string
+		input        string
+		wantThinking string
+		wantContent  string
+	}{
+		{
+			desc:        "stream ends mid partial opening tag",
+			input:       "<thi",
+			wantContent: "<thi",
+		},
+		{
+			desc:        "stream ends on whitespace-only prefix",
+			input:       "   ",
+			wantContent: "   ",
+		},
+		{
+			desc: "stream ends mid partial closing tag",
+			// "reasoning" is already emitted by AddContent itself; Flush only
+			// owes the ambiguous closing-tag candidate still held in acc.
+			input:        "<think>reasoning</",
+			wantThinking: "</",
+		},
+		{
+			desc:         "stream ends on a closing-tag fakeout",
+			input:        "<think>reasoning</thi",
+			wantThinking: "</thi",
+		},
+		{
+			desc:        "stream ends cleanly outside any buffering state",
+			input:       "<think>a</think>done",
+			wantContent: "",
+		},
+	}
+
+	for _, c := range cases {
+		parser := Parser{
+			OpeningTag: "<think>",
+			ClosingTag: "</think>",
+		}
+		parser.AddContent(c.input)
+		gotThinking, gotContent := parser.Flush()
+		if gotThinking != c.wantThinking || gotContent != c.wantContent {
+			t.Errorf("case %q: Flush() = (%q,%q), want (%q,%q)", c.desc, gotThinking, gotContent, c.wantThinking, c.wantContent)
+		}
+		// Flush must not resurrect the same bytes on a second call.
+		if again, again2 := parser.Flush(); again != "" || again2 != "" {
+			t.Errorf("case %q: second Flush() = (%q,%q), want (\"\",\"\")", c.desc, again, again2)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`thinking.Parser` buffers text while it's disambiguating a partial opening
tag or an overlapping closing-tag candidate. That buffer is only ever
drained by a *subsequent* `AddContent` call — there's no flush/finalize
API, and neither `/api/generate` nor `/api/chat` calls one when the runner
reports `Done`.

If generation ends while the parser is holding buffered text, that text is
silently discarded and never reaches the client. This is an asymmetry with
the builtin parser (`builtinParser.Add(cr.Content, cr.Done)`) and the tool
parser (explicitly flushed via `toolParser.Content()` on `r.Done`) — only
the generic thinking parser has no end-of-stream path.

Realistic triggers: `num_predict`/context limits cutting generation off
mid-tag, a stop sequence landing right after `<`, or a very short response
that's entirely a prefix of the opening tag (in which case the whole
response body can come back empty).

## Fix

Add `Parser.Flush() (thinking, content string)` that drains `s.acc`
according to the parser's current state at end-of-stream:
- buffered bytes while still looking for the opening tag are plain content
  (mirrors the "didn't see an opening tag" branch)
- buffered bytes while disambiguating the closing tag are thinking text

Call it from both `/api/generate` and `/api/chat` when `cr.Done` /
`r.Done` is set, merging the result into the final response chunk.

## Testing

- Added `TestParserFlush` covering: partial opening tag, whitespace-only
  prefix, partial closing tag, closing-tag fakeout, and the no-op case
  where nothing is buffered.
- Full `thinking` and `server` package test suites pass, no regressions.
- `gofmt` / `go vet` clean.