### PR TITLE
agent/tools: confine absolute read paths to the working directory

### DIFF
--- a/agent/tools/file.go
+++ b/agent/tools/file.go
@@ -386,35 +386,8 @@ func openRegularFile(workingDir, path string, allowAbsolute bool) (*os.File, os.
 	if path == "" {
 		return nil, nil, fmt.Errorf("path parameter is required")
 	}
-	if allowAbsolute && filepath.IsAbs(path) {
-		cleaned := filepath.Clean(path)
-		info, err := os.Lstat(cleaned)
-		if err != nil {
-			return nil, nil, err
-		}
-		if info.Mode()&os.ModeSymlink != 0 {
-			return nil, nil, fmt.Errorf("%s is a symlink; read the target file directly", path)
-		}
-		if err := rejectNonRegularFile(path, info); err != nil {
-			return nil, nil, err
-		}
-		file, err := os.Open(cleaned)
-		if err != nil {
-			return nil, nil, err
-		}
-		info, err = file.Stat()
-		if err != nil {
-			file.Close()
-			return nil, nil, err
-		}
-		if err := rejectNonRegularFile(path, info); err != nil {
-			file.Close()
-			return nil, nil, err
-		}
-		return file, info, nil
-	}
 
-	rel, err := cleanRelativePath(path)
+	rel, err := resolveWorkingDirPath(workingDir, path, allowAbsolute)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -441,6 +414,42 @@ func openRegularFile(workingDir, path string, allowAbsolute bool) (*os.File, os.
 		return nil, nil, err
 	}
 	return file, info, nil
+}
+
+// resolveWorkingDirPath turns a tool-supplied path into one relative to
+// workingDir, suitable for opening through the confined os.Root below. An
+// absolute path is only considered when allowAbsolute is set, and even then
+// must resolve inside workingDir: the tool's schema documents paths as
+// relative to the working directory, and the caller (e.g. the bash tool's
+// credential-path denylist) relies on that confinement holding for every
+// tool, not just the ones that only ever see relative paths.
+func resolveWorkingDirPath(workingDir, path string, allowAbsolute bool) (string, error) {
+	if !filepath.IsAbs(path) {
+		return cleanRelativePath(path)
+	}
+	if !allowAbsolute {
+		return "", fmt.Errorf("absolute paths are not allowed")
+	}
+	base, err := workingDirAbs(workingDir)
+	if err != nil {
+		return "", err
+	}
+	// Resolve symlinks in the parent directory chain, the same way
+	// workingDirAbs resolved base above, but leave the final path
+	// component untouched so a symlink there is still caught by the
+	// os.Root-confined Lstat below rather than silently followed here.
+	cleaned := filepath.Clean(path)
+	dir, err := canonicalPath(filepath.Dir(cleaned))
+	if err != nil {
+		return "", err
+	}
+	resolved := filepath.Join(dir, filepath.Base(cleaned))
+
+	rel, err := filepath.Rel(base, resolved)
+	if err != nil {
+		return "", fmt.Errorf("path escapes working directory")
+	}
+	return cleanRelativePath(rel)
 }
 
 func regularRootFileInfo(root *os.Root, rel, path string) (os.FileInfo, error) {

--- a/agent/tools/file_test.go
+++ b/agent/tools/file_test.go
@@ -429,7 +429,9 @@ func TestReadAllowsAbsolutePath(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	result, err := (&Read{}).Execute(context.Background(), agent.ToolContext{WorkingDir: t.TempDir()}, map[string]any{
+	// The absolute path resolves inside WorkingDir, so it's allowed even
+	// though it wasn't given relative to it.
+	result, err := (&Read{}).Execute(context.Background(), agent.ToolContext{WorkingDir: dir}, map[string]any{
 		"path": path,
 	})
 	if err != nil {
@@ -437,6 +439,24 @@ func TestReadAllowsAbsolutePath(t *testing.T) {
 	}
 	if result.Content != content {
 		t.Fatalf("content = %q", result.Content)
+	}
+}
+
+func TestReadRejectsAbsolutePathOutsideWorkingDir(t *testing.T) {
+	outside := t.TempDir()
+	secret := filepath.Join(outside, "id_rsa")
+	if err := os.WriteFile(secret, []byte("-----BEGIN OPENSSH PRIVATE KEY-----"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := (&Read{}).Execute(context.Background(), agent.ToolContext{WorkingDir: t.TempDir()}, map[string]any{
+		"path": secret,
+	})
+	if err == nil {
+		t.Fatalf("expected absolute path outside WorkingDir to be rejected, got content %q", result.Content)
+	}
+	if !strings.Contains(err.Error(), "path escapes working directory") {
+		t.Fatalf("err = %v", err)
 	}
 }
 
@@ -451,11 +471,39 @@ func TestReadRejectsAbsoluteSymlink(t *testing.T) {
 		t.Skipf("symlinks unavailable: %v", err)
 	}
 
-	_, err := (&Read{}).Execute(context.Background(), agent.ToolContext{WorkingDir: t.TempDir()}, map[string]any{
+	// link resolves inside WorkingDir, so this isolates the symlink check
+	// from the working-directory confinement check.
+	_, err := (&Read{}).Execute(context.Background(), agent.ToolContext{WorkingDir: dir}, map[string]any{
 		"path": link,
 	})
 	if err == nil {
 		t.Fatal("expected absolute symlink to be rejected")
+	}
+	if !strings.Contains(err.Error(), "symlink") {
+		t.Fatalf("err = %v, want symlink rejection", err)
+	}
+}
+
+func TestReadRejectsAbsoluteSymlinkEscapingWorkingDir(t *testing.T) {
+	outside := t.TempDir()
+	target := filepath.Join(outside, "target.txt")
+	if err := os.WriteFile(target, []byte("hello\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	link := filepath.Join(dir, "alias")
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	// The symlink itself resolves inside WorkingDir (so it passes the
+	// escape check), but it must still be rejected because it isn't a
+	// regular file, and this repo's os.Root confinement never follows it.
+	_, err := (&Read{}).Execute(context.Background(), agent.ToolContext{WorkingDir: dir}, map[string]any{
+		"path": link,
+	})
+	if err == nil {
+		t.Fatal("expected symlink escaping WorkingDir to be rejected")
 	}
 	if !strings.Contains(err.Error(), "symlink") {
 		t.Fatalf("err = %v, want symlink rejection", err)


### PR DESCRIPTION
## Problem

The agent's `read` tool documents itself as working-directory-scoped
(`Description()`/`Schema()` both say paths are relative to the working
directory), and it explicitly rejects a relative symlink that resolves
outside the working root for exactly that reason. But `Read.Execute` calls
`openRegularFile(toolCtx.WorkingDir, path, true)` with `allowAbsolute =
true`, and the absolute-path branch performed **no confinement check at
all** — it just `os.Open`'d whatever was asked for.

The guard the code documents was trivially bypassed by not using a
symlink: just ask for the absolute path directly. This also created a
denylist asymmetry with the `bash` tool, which refuses to `cat
~/.ssh/id_rsa` / `~/.aws/credentials` / etc — the same file was blocked
through `bash` but readable through `read`, in the same agent session.

Approval is still required (`Read.RequiresApproval` returns `true`), so
this was defense-in-depth rather than a direct exploit, but the approval
prompt is the *only* remaining control, and the two layers behind it
disagreed with each other.

## Fix

Route absolute paths through the same `os.Root`-confined open already used
for relative paths, instead of a separate unguarded `os.Open` branch:

- Resolve symlinks in the *parent directory chain* of the absolute path
  (the same way `workingDir` itself is already canonicalized), but leave
  the final path component untouched so a symlink there is still caught by
  the existing `os.Root` Lstat-based check rather than being silently
  followed here.
- Require the resolved path to land inside `workingDir` via
  `filepath.Rel`, reusing `cleanRelativePath`'s existing escape check.

An absolute path that already resolves inside the working directory keeps
working unchanged. Anything outside it — symlink or not — now hits the
same `"path escapes working directory"` rejection a relative escape
already gets.

## Testing

- `TestReadAllowsAbsolutePath` updated to reflect the real invariant (an
  absolute path *inside* `WorkingDir` is allowed), since it previously
  asserted the vulnerable behavior (absolute path in a completely
  different temp dir succeeding).
- Added `TestReadRejectsAbsolutePathOutsideWorkingDir` — the issue's exact
  repro (reading an absolute path to a file outside `WorkingDir`) now
  fails with `"path escapes working directory"` instead of returning the
  file's contents.
- `TestReadRejectsAbsoluteSymlink` adjusted so it isolates the symlink
  check from the new confinement check (symlink now lives inside
  `WorkingDir`).
- Added `TestReadRejectsAbsoluteSymlinkEscapingWorkingDir` — a symlink that
  itself resolves inside `WorkingDir` but points outside it is still
  rejected.
- Full `agent` and `agent/tools` package test suites pass, no regressions.
- `gofmt` / `go vet` clean.