### PR TITLE
openai: support max_completion_tokens in chat completions

### DIFF
--- a/openai/openai.go
+++ b/openai/openai.go
@@ -103,24 +103,25 @@ type Reasoning struct {
 }
 
 type ChatCompletionRequest struct {
-	Model            string          `json:"model"`
-	Messages         []Message       `json:"messages"`
-	Stream           bool            `json:"stream"`
-	StreamOptions    *StreamOptions  `json:"stream_options"`
-	MaxTokens        *int            `json:"max_tokens"`
-	Seed             *int            `json:"seed"`
-	Stop             any             `json:"stop"`
-	Temperature      *float64        `json:"temperature"`
-	FrequencyPenalty *float64        `json:"frequency_penalty"`
-	PresencePenalty  *float64        `json:"presence_penalty"`
-	TopP             *float64        `json:"top_p"`
-	ResponseFormat   *ResponseFormat `json:"response_format"`
-	Tools            []api.Tool      `json:"tools"`
-	Reasoning        *Reasoning      `json:"reasoning,omitempty"`
-	ReasoningEffort  *string         `json:"reasoning_effort,omitempty"`
-	Logprobs         *bool           `json:"logprobs"`
-	TopLogprobs      int             `json:"top_logprobs"`
-	DebugRenderOnly  bool            `json:"_debug_render_only"`
+	Model               string          `json:"model"`
+	Messages            []Message       `json:"messages"`
+	Stream              bool            `json:"stream"`
+	StreamOptions       *StreamOptions  `json:"stream_options"`
+	MaxTokens           *int            `json:"max_tokens"`
+	MaxCompletionTokens *int            `json:"max_completion_tokens"`
+	Seed                *int            `json:"seed"`
+	Stop                any             `json:"stop"`
+	Temperature         *float64        `json:"temperature"`
+	FrequencyPenalty    *float64        `json:"frequency_penalty"`
+	PresencePenalty     *float64        `json:"presence_penalty"`
+	TopP                *float64        `json:"top_p"`
+	ResponseFormat      *ResponseFormat `json:"response_format"`
+	Tools               []api.Tool      `json:"tools"`
+	Reasoning           *Reasoning      `json:"reasoning,omitempty"`
+	ReasoningEffort     *string         `json:"reasoning_effort,omitempty"`
+	Logprobs            *bool           `json:"logprobs"`
+	TopLogprobs         int             `json:"top_logprobs"`
+	DebugRenderOnly     bool            `json:"_debug_render_only"`
 }
 
 type ChatCompletion struct {
@@ -653,7 +654,11 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 		options["stop"] = stops
 	}
 
-	if r.MaxTokens != nil {
+	// max_completion_tokens is the successor to the deprecated max_tokens
+	// field for chat completions; prefer it when a client sends both.
+	if r.MaxCompletionTokens != nil {
+		options["num_predict"] = *r.MaxCompletionTokens
+	} else if r.MaxTokens != nil {
 		options["num_predict"] = *r.MaxTokens
 	}
 

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -110,6 +110,50 @@ func TestFromChatRequest_ReasoningEffort(t *testing.T) {
 	}
 }
 
+func TestFromChatRequest_MaxCompletionTokens(t *testing.T) {
+	intPtr := func(n int) *int { return &n }
+
+	cases := []struct {
+		name                string
+		maxTokens           *int
+		maxCompletionTokens *int
+		want                any // expected options["num_predict"]; nil means absent
+	}{
+		{name: "neither set", want: nil},
+		{name: "max_tokens only", maxTokens: intPtr(10), want: 10},
+		{name: "max_completion_tokens only", maxCompletionTokens: intPtr(20), want: 20},
+		{name: "both set prefers max_completion_tokens", maxTokens: intPtr(10), maxCompletionTokens: intPtr(20), want: 20},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := ChatCompletionRequest{
+				Model:               "test-model",
+				Messages:            []Message{{Role: "user", Content: "hi"}},
+				MaxTokens:           tc.maxTokens,
+				MaxCompletionTokens: tc.maxCompletionTokens,
+			}
+			result, err := FromChatRequest(req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			got, ok := result.Options["num_predict"]
+			if tc.want == nil {
+				if ok {
+					t.Fatalf("expected no num_predict, got %v", got)
+				}
+				return
+			}
+			if !ok {
+				t.Fatalf("expected num_predict=%v, got none", tc.want)
+			}
+			if got != tc.want {
+				t.Fatalf("got num_predict=%v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestFromChatRequest_WithImage(t *testing.T) {
 	imgData, _ := base64.StdEncoding.DecodeString(image)
 


### PR DESCRIPTION
## Problem

OpenAI deprecated `max_tokens` for `/v1/chat/completions` in favor of
`max_completion_tokens`, and clients (including vLLM-compatible tooling)
send it accordingly. `ChatCompletionRequest` had no field for
`max_completion_tokens`, so it was silently dropped by JSON decoding: a
request that set only `max_completion_tokens` got unbounded generation
with an HTTP 200 and no indication the limit was ignored.

Reported reproduction: `max_completion_tokens: 10` on `/v1/chat/completions`
was silently accepted but had no effect (`completion_tokens=422`), while
the identical request with `max_tokens: 10` correctly limited output
(`completion_tokens=10`, `finish_reason=length`). In a real application
this let generation consume the full context window unexpectedly.

## Fix

Add `MaxCompletionTokens *int \`json:"max_completion_tokens"\`` to
`ChatCompletionRequest`, and prefer it over the legacy `MaxTokens` when a
client sends both (matching the deprecation direction). This only touches
`FromChatRequest` (the chat-completions path) — `FromCompleteRequest`
(legacy `/v1/completions`) is untouched since `max_completion_tokens` was
never part of that API.

## Testing

- Added `TestFromChatRequest_MaxCompletionTokens` covering: neither set,
  `max_tokens` only, `max_completion_tokens` only, and both set (asserts
  `max_completion_tokens` wins).
- Full `openai` package test suite passes, no regressions.
- `gofmt` / `go vet` clean.