### PR TITLE
model/parsers: accept = as a key/value separator in gemma4 tool args

### DIFF
--- a/model/parsers/gemma4.go
+++ b/model/parsers/gemma4.go
@@ -472,7 +472,7 @@ func quoteGemma4BareKeys(s string) string {
 		sb.WriteString(s[spaceStart:i])
 
 		keyEnd := gemma4BareKeyEnd(s, i)
-		if keyEnd > i && keyEnd < len(s) && s[keyEnd] == ':' {
+		if keyEnd > i && keyEnd < len(s) && (s[keyEnd] == ':' || s[keyEnd] == '=') {
 			sb.WriteByte('"')
 			sb.WriteString(s[i:keyEnd])
 			sb.WriteByte('"')
@@ -617,7 +617,7 @@ func repairGemma4SingleQuotedValues(s string) string {
 			}
 		}
 
-		if s[i] != ':' {
+		if s[i] != ':' && s[i] != '=' {
 			sb.WriteByte(s[i])
 			i++
 			continue

--- a/model/parsers/gemma4_test.go
+++ b/model/parsers/gemma4_test.go
@@ -857,6 +857,16 @@ func TestGemma4ArgsToJSON(t *testing.T) {
 			expected: `{"name":"test","count":5,"active":true,"tags":["a"]}`,
 		},
 		{
+			name:     "bare_key_with_equals_separator",
+			input:    `{save_as=<|"|>report.docx<|"|>}`,
+			expected: `{"save_as":"report.docx"}`,
+		},
+		{
+			name:     "mixed_colon_and_equals_separators",
+			input:    `{save_as=<|"|>report.docx<|"|>,format:<|"|>docx<|"|>}`,
+			expected: `{"save_as":"report.docx","format":"docx"}`,
+		},
+		{
 			name:     "null_value",
 			input:    `{value:null}`,
 			expected: `{"value":null}`,
@@ -1070,6 +1080,11 @@ func TestRepairGemma4SingleQuotedValues(t *testing.T) {
 			name:     "preserves_unterminated_single_quote",
 			input:    `{pattern:'abc}`,
 			expected: `{pattern:'abc}`,
+		},
+		{
+			name:     "converts_single_quoted_value_with_equals_separator",
+			input:    `{save_as='report.docx'}`,
+			expected: `{save_as=<|"|>report.docx<|"|>}`,
 		},
 	}
 


### PR DESCRIPTION
Fixes #17882

## Problem

Gemma4 (tested: `gemma4:26b-a4b-it-q4_K_M`) renders tool-call arguments with
a bare key followed by `:` (`save_as:<|"|>report.docx<|"|>`), but the model
sometimes drifts to `key=value` instead (`save_as='report.docx'` or
`save_as="report.docx"`) — most often, per the issue's data (68% vs ~95%
parse success, n=22/20), when the user prompt itself contains quoted
`key='value'` assignments.

Both `quoteGemma4BareKeys` and `repairGemma4SingleQuotedValues` are
anchored solely on `:`:
- `quoteGemma4BareKeys` only quotes a bare key when the byte right after it
  is `:`, so a `key=` key is left completely unquoted.
- `repairGemma4SingleQuotedValues` only attempts to convert a following
  single-quoted value into a Gemma-delimited string when it just consumed
  a `:`, so a `'value'` sitting after `=` is never touched either.

Neither the key nor the value gets repaired, `json.Unmarshal` fails, and
the API returns `tool_calls: []` with empty content — the generated
arguments only survive in the server's warning log
(`gemma4 tool call parsing failed: invalid character 's' looking for
beginning of object key string`), with no way for the client to recover.

## Fix

Accept `=` wherever `:` is accepted, in both functions:

- `quoteGemma4BareKeys`: widen the separator check to `s[keyEnd] == ':' ||
  s[keyEnd] == '='`. It already emits a literal `:` regardless of which
  separator it consumed, so a `=`-separated key is normalized to canonical
  JSON with no other change needed.
- `repairGemma4SingleQuotedValues`: widen the same check so a single-quoted
  value following `=` gets converted into a Gemma-delimited value exactly
  like one following `:` does. The `=` byte itself is written through
  unchanged at this stage — `quoteGemma4BareKeys` normalizes it to `:` in
  the pass right after, since the repair pipeline calls
  `gemma4ArgsToJSON` → `quoteGemma4BareKeys` on the result.

## Testing

- Added `bare_key_with_equals_separator` and
  `mixed_colon_and_equals_separators` cases to `TestGemma4ArgsToJSON`.
- Added `converts_single_quoted_value_with_equals_separator` to
  `TestRepairGemma4SingleQuotedValues`.
- Full `model/parsers` package test suite passes, no regressions.
- `gofmt` / `go vet` clean.