### PR TITLE
middleware: send anthropic ping events during silent tool-call composition

### DIFF
--- a/middleware/anthropic.go
+++ b/middleware/anthropic.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -20,12 +21,34 @@ import (
 	"github.com/ollama/ollama/logutil"
 )
 
+// anthropicPingInterval is how often a "ping" keepalive event is sent while a
+// streaming response is otherwise silent (e.g. while the model is composing
+// tool-call arguments, which produces no chat chunks at all until the call is
+// complete). Anthropic's own streaming API sends the same event as a
+// heartbeat; without it, a client can read-timeout and retry the whole
+// request during a long silent stretch. A var (not const) so tests can drive
+// it without a real multi-second sleep.
+var anthropicPingInterval = 15 * time.Second
+
 // AnthropicWriter wraps the response writer to transform Ollama responses to Anthropic format
 type AnthropicWriter struct {
 	BaseWriter
 	stream    bool
 	id        string
 	converter *anthropic.StreamConverter
+
+	// mu serializes writes to ResponseWriter between the normal write path
+	// and the keepalive ping ticker started in AnthropicMessagesMiddleware,
+	// which write concurrently from a separate goroutine.
+	mu sync.Mutex
+}
+
+// writePing sends a "ping" keepalive SSE event, guarded by mu so it can't
+// interleave with a concurrent Write call from the normal response path.
+func (w *AnthropicWriter) writePing() error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.writeEvent("ping", anthropic.PingEvent{Type: "ping"})
 }
 
 func (w *AnthropicWriter) writeError(data []byte) (int, error) {
@@ -77,6 +100,9 @@ func (w *AnthropicWriter) writeResponse(data []byte) (int, error) {
 }
 
 func (w *AnthropicWriter) Write(data []byte) (int, error) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
 	code := w.ResponseWriter.Status()
 	if code != http.StatusOK {
 		return w.writeError(data)
@@ -813,6 +839,33 @@ func AnthropicMessagesMiddleware() gin.HandlerFunc {
 			}
 		} else {
 			c.Writer = innerWriter
+
+			// Keep the connection alive while innerWriter is the sole writer.
+			// The web search path is excluded: WebSearchAnthropicWriter drives
+			// its own async follow-up calls and writes to the same underlying
+			// ResponseWriter without sharing innerWriter's write lock, so a
+			// concurrent ping there could interleave with its output.
+			if req.Stream {
+				stop := make(chan struct{})
+				done := make(chan struct{})
+				go func() {
+					defer close(done)
+					ticker := time.NewTicker(anthropicPingInterval)
+					defer ticker.Stop()
+					for {
+						select {
+						case <-stop:
+							return
+						case <-ticker.C:
+							_ = innerWriter.writePing()
+						}
+					}
+				}()
+				defer func() {
+					close(stop)
+					<-done
+				}()
+			}
 		}
 
 		c.Next()

--- a/middleware/anthropic_test.go
+++ b/middleware/anthropic_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/go-cmp/cmp"
@@ -603,6 +604,98 @@ func TestAnthropicMessagesMiddleware_SetsRelaxThinkingFlag(t *testing.T) {
 
 	if !flagSet {
 		t.Error("expected relax_thinking flag to be set in context")
+	}
+}
+
+func TestAnthropicMessagesMiddleware_StreamingKeepAlivePing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	original := anthropicPingInterval
+	anthropicPingInterval = 5 * time.Millisecond
+	t.Cleanup(func() { anthropicPingInterval = original })
+
+	router := gin.New()
+	router.Use(AnthropicMessagesMiddleware())
+	router.POST("/v1/messages", func(c *gin.Context) {
+		c.Writer.WriteHeader(http.StatusOK)
+		// Simulate the model silently composing tool-call arguments: no
+		// chunk is written for long enough that at least one ping should
+		// fire before the final chunk arrives.
+		time.Sleep(40 * time.Millisecond)
+		chunk := api.ChatResponse{
+			Model:      "test-model",
+			Message:    api.Message{Role: "assistant", Content: "done"},
+			Done:       true,
+			DoneReason: "stop",
+		}
+		data, _ := json.Marshal(chunk)
+		_, _ = c.Writer.Write(data)
+	})
+
+	body := `{"model":"test-model","max_tokens":100,"stream":true,"messages":[{"role":"user","content":"Hi"}]}`
+	req, _ := http.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", resp.Code, resp.Body.String())
+	}
+
+	events := parseSSEEvents(t, resp.Body.String())
+
+	pingCount := 0
+	hasMessageStop := false
+	for _, e := range events {
+		switch e.event {
+		case "ping":
+			pingCount++
+		case "message_stop":
+			hasMessageStop = true
+		}
+	}
+	if pingCount == 0 {
+		t.Fatalf("expected at least one ping event during the silent stretch, got none in %d events", len(events))
+	}
+	if !hasMessageStop {
+		t.Error("expected message_stop event after the silent stretch ends")
+	}
+}
+
+func TestAnthropicMessagesMiddleware_NoPingForFastStream(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	original := anthropicPingInterval
+	anthropicPingInterval = 500 * time.Millisecond
+	t.Cleanup(func() { anthropicPingInterval = original })
+
+	router := gin.New()
+	router.Use(AnthropicMessagesMiddleware())
+	router.POST("/v1/messages", func(c *gin.Context) {
+		c.Writer.WriteHeader(http.StatusOK)
+		chunk := api.ChatResponse{
+			Model:      "test-model",
+			Message:    api.Message{Role: "assistant", Content: "hi"},
+			Done:       true,
+			DoneReason: "stop",
+		}
+		data, _ := json.Marshal(chunk)
+		_, _ = c.Writer.Write(data)
+	})
+
+	body := `{"model":"test-model","max_tokens":100,"stream":true,"messages":[{"role":"user","content":"Hi"}]}`
+	req, _ := http.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp := httptest.NewRecorder()
+	router.ServeHTTP(resp, req)
+
+	events := parseSSEEvents(t, resp.Body.String())
+	for _, e := range events {
+		if e.event == "ping" {
+			t.Fatalf("did not expect a ping event for a stream that never stalls, got one among %d events", len(events))
+		}
 	}
 }
 


### PR DESCRIPTION
Addresses #14902

## Problem

While a model is composing tool-call arguments, `/api/chat` produces no
content/thinking/tool-call chunks at all until the call is complete — the
existing `if res.Message.Content != "" || res.Message.Thinking != "" ||
len(res.Message.ToolCalls) > 0 || r.Done || ...` gate in `ChatHandler`
means nothing gets written to the client for however long that takes.

Over a long enough stretch (a slow model, a large context, a CPU-only
box), clients hit their read timeout, tear the connection down, and
retry the whole request. The original report: running Claude Code through
`ollama launch claude` against a local model, a single long tool-call
composition caused roughly an hour of repeated timeout/retry cycles with
no file ever getting written, purely because the Claude Code client had
no bytes to reset its read-timeout clock with.

`anthropic/anthropic.go` already defines a `PingEvent` type for exactly
this ("keepalive event") but nothing ever constructed one.

## Approach

The issue's own proposed fix — have `ChatHandler` forward empty chunks
and have `StreamConverter.Process` turn them into pings — touches the
shared, protocol-agnostic gate in `server/routes.go` that every protocol
(native `/api/chat`, OpenAI compat) routes through. The issue reporter
flagged this themselves: that gate was a deliberate choice to avoid
triggering bad behavior in some client, and they weren't sure it was safe
to loosen for everyone.

This PR takes a different approach that doesn't touch that shared code at
all: a plain interval ticker inside `AnthropicMessagesMiddleware`, entirely
on the Anthropic-compat side, writing a `ping` SSE event directly to the
response writer for the life of a streaming request — the same heartbeat
mechanism Anthropic's own API uses. No other protocol is touched, so
there's no shared-behavior risk to reason about.

Since the ticker goroutine and the normal write path both write to the
same underlying `http.ResponseWriter`, `AnthropicWriter` gets a `sync.Mutex`
guarding every write, and the ticker is started/stopped/joined (via
stop+done channels) tightly around the `c.Next()` call so it can never fire
after the handler has finished.

**Scope**: only the plain streaming path (`c.Writer = innerWriter`, no
`web_search` tool). `WebSearchAnthropicWriter` drives its own async
follow-up `/api/chat` calls and writes to the same underlying
`ResponseWriter` without sharing `AnthropicWriter`'s new lock — layering a
concurrent ticker on top of that would need its own writer-coordination
work. Left as a natural follow-up rather than risking a second,
uncoordinated writer in one PR.

## Testing

- `TestAnthropicMessagesMiddleware_StreamingKeepAlivePing`: a fake
  downstream handler sleeps past an (overridden, short) ping interval
  before writing its only chunk; asserts at least one `ping` event appears
  and the stream still completes correctly (`message_stop` present).
- `TestAnthropicMessagesMiddleware_NoPingForFastStream`: a stream that
  never stalls gets zero `ping` events — no noise added to the common case.
- `anthropicPingInterval` is a package var (not a const) specifically so
  tests can drive it without a real multi-second sleep.
- Full `middleware` package suite passes under `go test -race`, including
  10x repeats of the two new tests, with no data races — the mutex is
  actually exercised, not just present.
- `gofmt` / `go vet` clean.

Happy to adjust the interval, extend coverage to the web-search path in
this PR instead of as follow-up, or take a different approach entirely —
posting this as a concrete starting point per CONTRIBUTING.md's guidance
to discuss non-trivial changes.