### PR TITLE
app: fix macOS update process handoff

### DIFF
--- a/app/cmd/app/app.go
+++ b/app/cmd/app/app.go
@@ -415,12 +415,23 @@ func startHiddenTasks() {
 				UpdateAvailable("")
 			} else {
 				slog.Debug("launching new version...")
-				// TODO - consider a timer that aborts if this takes too long and we haven't been killed yet...
-				LaunchNewApp()
-				os.Exit(0)
+				if !launchUpdateAndShutdown(LaunchNewApp, func() { os.Exit(0) }) {
+					slog.Error("failed to launch new version")
+				}
 			}
 		}
 	}
+}
+
+// launchUpdateAndShutdown keeps the current process alive if relaunch is rejected.
+// Once the replacement launch is accepted, this process owns its side of the
+// handoff and shuts down instead of relying on the new process to terminate it.
+func launchUpdateAndShutdown(launch func() bool, shutdown func()) bool {
+	if !launch() {
+		return false
+	}
+	shutdown()
+	return true
 }
 
 func checkUserLoggedIn(uiServerPort int) bool {

--- a/app/cmd/app/app.go
+++ b/app/cmd/app/app.go
@@ -415,23 +415,15 @@ func startHiddenTasks() {
 				UpdateAvailable("")
 			} else {
 				slog.Debug("launching new version...")
-				if !launchUpdateAndShutdown(LaunchNewApp, func() { os.Exit(0) }) {
+				// The replacement signals this process after it reaches the
+				// existing-instance handoff. Keep serving until then so an early
+				// replacement failure does not leave the user without a running app.
+				if !LaunchNewApp() {
 					slog.Error("failed to launch new version")
 				}
 			}
 		}
 	}
-}
-
-// launchUpdateAndShutdown keeps the current process alive if relaunch is rejected.
-// Once the replacement launch is accepted, this process owns its side of the
-// handoff and shuts down instead of relying on the new process to terminate it.
-func launchUpdateAndShutdown(launch func() bool, shutdown func()) bool {
-	if !launch() {
-		return false
-	}
-	shutdown()
-	return true
 }
 
 func checkUserLoggedIn(uiServerPort int) bool {

--- a/app/cmd/app/app_darwin.go
+++ b/app/cmd/app/app_darwin.go
@@ -157,14 +157,31 @@ func StopUI() {
 
 //export StartUpdate
 func StartUpdate() {
-	if err := updater.DoUpgrade(true); err != nil {
+	err := installAndLaunchUpdate(
+		func() bool {
+			_, err := os.Stat(updater.UpgradeMarkerFile)
+			return err == nil
+		},
+		func() error { return updater.DoUpgrade(true) },
+		LaunchNewApp,
+	)
+	if err != nil {
 		slog.Error("upgrade failed", "error", err)
-		return
 	}
+}
+
+func installAndLaunchUpdate(installed func() bool, install func() error, launch func() bool) error {
+	if !installed() {
+		if err := install(); err != nil {
+			return err
+		}
+	}
+
 	slog.Debug("launching new version...")
-	if !launchUpdateAndShutdown(LaunchNewApp, func() { C.quit() }) {
-		slog.Error("failed to launch new version")
+	if !launch() {
+		return errors.New("failed to launch new version")
 	}
+	return nil
 }
 
 //export darwinStartHiddenTasks

--- a/app/cmd/app/app_darwin.go
+++ b/app/cmd/app/app_darwin.go
@@ -162,9 +162,9 @@ func StartUpdate() {
 		return
 	}
 	slog.Debug("launching new version...")
-	// TODO - consider a timer that aborts if this takes too long and we haven't been killed yet...
-	LaunchNewApp()
-	// not reached if upgrade works, the new app will kill this process
+	if !launchUpdateAndShutdown(LaunchNewApp, func() { C.quit() }) {
+		slog.Error("failed to launch new version")
+	}
 }
 
 //export darwinStartHiddenTasks
@@ -216,6 +216,14 @@ func maybeMoveAndRestart() appMove {
 // handleExistingInstance handles existing instances on macOS
 func handleExistingInstance(_ bool) {
 	C.killOtherInstances()
+}
+
+func handoffNeedsForcedTermination(terminated bool, expectedPID, actualPID int) bool {
+	return bool(C.shouldForceTerminateHandoff(
+		C.bool(terminated),
+		C.int(expectedPID),
+		C.int(actualPID),
+	))
 }
 
 func installSymlink() {
@@ -1709,10 +1717,10 @@ func RestoreClaudeGatewayForShutdown() C.bool {
 	return C._Bool(true)
 }
 
-func LaunchNewApp() {
+func LaunchNewApp() bool {
 	appName := C.CString(updater.BundlePath)
 	defer C.free(unsafe.Pointer(appName))
-	C.launchApp(appName)
+	return bool(C.launchApp(appName))
 }
 
 func registerLaunchAgent(hasCompletedFirstRun bool) {

--- a/app/cmd/app/app_darwin.h
+++ b/app/cmd/app/app_darwin.h
@@ -18,6 +18,7 @@ enum AppMove
 
 void run(bool showOnboarding, bool startHidden);
 void killOtherInstances();
+bool shouldForceTerminateHandoff(bool terminated, int expectedPID, int actualPID);
 bool otherOllamaInstanceRunning(void);
 enum AppMove askToMoveToApplications();
 int createSymlinkWithAuthorization();
@@ -30,7 +31,7 @@ bool IsOnboardingActive(void);
 void StopUI();
 void StartUpdate();
 void darwinStartHiddenTasks();
-void launchApp(const char *appPath);
+bool launchApp(const char *appPath);
 void updateAvailable();
 void quit();
 void uiRequest(char *path);

--- a/app/cmd/app/app_darwin.m
+++ b/app/cmd/app/app_darwin.m
@@ -14,6 +14,7 @@ extern NSString *SystemWidePath;
 
 static NSString *const ClaudeDownloadPageURL = @"https://claude.com/download";
 static NSString *const ShowAppsInMenuDefaultsKey = @"ShowAppsInMenu";
+static const int64_t AppHandoffGracePeriod = 5 * NSEC_PER_SEC;
 static NSBundle *OllamaResourceBundle(void);
 
 static BOOL shouldShowAppsInMenu(void) {
@@ -1574,6 +1575,11 @@ bool otherOllamaInstanceRunning(void) {
     return false;
 }
 
+bool shouldForceTerminateHandoff(bool terminated, int expectedPID,
+                                 int actualPID) {
+    return !terminated && expectedPID > 0 && actualPID == expectedPID;
+}
+
 // killOtherInstances kills all other instances of the app currently
 // running. This way we can ensure that only the most recently started
 // instance of Ollama is running
@@ -1585,10 +1591,37 @@ void killOtherInstances() {
         if (isOllamaApplication(app)) {
             pid_t pid = app.processIdentifier;
             if (pid != myPid && pid > 0) {
-                appLogInfo([NSString stringWithFormat:@"terminating other ollama instance %d", pid]);
+                appLogInfo([NSString
+                    stringWithFormat:@"requesting handoff from ollama instance %d",
+                                     pid]);
                 // Preserve the Claude profile while the replacement instance
                 // takes ownership of the local gateway.
-                kill(pid, SIGUSR1);
+                if (kill(pid, SIGUSR1) != 0) {
+                    appLogInfo([NSString
+                        stringWithFormat:@"unable to signal ollama instance %d",
+                                         pid]);
+                }
+
+                // Older or unhealthy instances may not complete the graceful
+                // handoff. Give them time to clean up, then enforce the
+                // single-instance invariant if this exact process is still
+                // running.
+                dispatch_after(
+                    dispatch_time(DISPATCH_TIME_NOW, AppHandoffGracePeriod),
+                    dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+                      pid_t actualPID = app.processIdentifier;
+                      if (!shouldForceTerminateHandoff(
+                              [app isTerminated], pid, actualPID)) {
+                          return;
+                      }
+                      appLogInfo([NSString stringWithFormat:
+                          @"forcing stale ollama instance %d to terminate", pid]);
+                      if (kill(pid, SIGTERM) != 0) {
+                          appLogInfo([NSString stringWithFormat:
+                              @"unable to terminate stale ollama instance %d",
+                              pid]);
+                      }
+                    });
             } else if (pid == -1) {
                 appLogInfo([NSString stringWithFormat:@"skipping app with invalid pid: %@", app.bundleIdentifier]);
             }
@@ -1839,18 +1872,25 @@ enum AppMove askToMoveToApplications() {
     return MoveCompleted;
 }
 
-void launchApp(const char *appPath) {
+bool launchApp(const char *appPath) {
     pid_t pid = getpid();
     appLogInfo([NSString
         stringWithFormat:@"Launching %@ from PID=%d", @(appPath), pid]);
     NSError *error = nil;
     NSWorkspace *workspace = [NSWorkspace sharedWorkspace];
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-    [workspace launchApplicationAtURL:[NSURL fileURLWithPath:@(appPath)]
-                              options:NSWorkspaceLaunchNewInstance |
-                                      NSWorkspaceLaunchDefault
-                        configuration:@{}
-                                error:&error];
+    NSRunningApplication *application =
+        [workspace launchApplicationAtURL:[NSURL fileURLWithPath:@(appPath)]
+                                  options:NSWorkspaceLaunchNewInstance |
+                                          NSWorkspaceLaunchDefault
+                            configuration:@{}
+                                    error:&error];
+    if (application == nil || error != nil) {
+        appLogInfo([NSString stringWithFormat:@"Unable to launch %@: %@",
+                                              @(appPath), error]);
+        return false;
+    }
+    return true;
 }
 
 int installSymlink(const char *cliPath) {

--- a/app/cmd/app/app_darwin.m
+++ b/app/cmd/app/app_darwin.m
@@ -1621,6 +1621,30 @@ void killOtherInstances() {
                               @"unable to terminate stale ollama instance %d",
                               pid]);
                       }
+
+                      // Ollama handles SIGTERM gracefully. If that shutdown
+                      // path is also stuck, check the same application after
+                      // one final bounded grace period and force it to
+                      // terminate.
+                      dispatch_after(
+                          dispatch_time(DISPATCH_TIME_NOW,
+                                        AppHandoffGracePeriod),
+                          dispatch_get_global_queue(QOS_CLASS_UTILITY, 0), ^{
+                            pid_t finalPID = app.processIdentifier;
+                            if (!shouldForceTerminateHandoff(
+                                    [app isTerminated], pid, finalPID)) {
+                                return;
+                            }
+                            appLogInfo([NSString stringWithFormat:
+                                @"force terminating stale ollama instance %d",
+                                pid]);
+                            if (![app forceTerminate]) {
+                                appLogInfo([NSString stringWithFormat:
+                                    @"unable to force terminate stale ollama "
+                                     "instance %d",
+                                    pid]);
+                            }
+                          });
                     });
             } else if (pid == -1) {
                 appLogInfo([NSString stringWithFormat:@"skipping app with invalid pid: %@", app.bundleIdentifier]);

--- a/app/cmd/app/app_darwin_test.go
+++ b/app/cmd/app/app_darwin_test.go
@@ -2448,6 +2448,47 @@ func TestRestoreClaudeBeforeQuit(t *testing.T) {
 	}
 }
 
+func TestHandoffNeedsForcedTermination(t *testing.T) {
+	tests := []struct {
+		name        string
+		terminated  bool
+		expectedPID int
+		actualPID   int
+		want        bool
+	}{
+		{
+			name:        "same process still running",
+			expectedPID: 123,
+			actualPID:   123,
+			want:        true,
+		},
+		{
+			name:        "graceful handoff completed",
+			terminated:  true,
+			expectedPID: 123,
+			actualPID:   123,
+		},
+		{
+			name:        "process identifier was reused",
+			expectedPID: 123,
+			actualPID:   456,
+		},
+		{
+			name:        "invalid expected process",
+			expectedPID: -1,
+			actualPID:   -1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := handoffNeedsForcedTermination(tt.terminated, tt.expectedPID, tt.actualPID); got != tt.want {
+				t.Fatalf("handoffNeedsForcedTermination() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSetClaudeGatewayInstalledRejectsMissingClaude(t *testing.T) {
 	previousInstalled := claudeDesktopInstalled
 	claudeDesktopInstalled = func() bool { return false }

--- a/app/cmd/app/app_darwin_test.go
+++ b/app/cmd/app/app_darwin_test.go
@@ -2489,6 +2489,34 @@ func TestHandoffNeedsForcedTermination(t *testing.T) {
 	}
 }
 
+func TestInstallAndLaunchUpdateRetriesInstalledUpdate(t *testing.T) {
+	installed := false
+	installCalls := 0
+	launchCalls := 0
+	install := func() error {
+		installCalls++
+		installed = true
+		return nil
+	}
+	launch := func() bool {
+		launchCalls++
+		return launchCalls > 1
+	}
+
+	if err := installAndLaunchUpdate(func() bool { return installed }, install, launch); err == nil {
+		t.Fatal("first launch unexpectedly succeeded")
+	}
+	if err := installAndLaunchUpdate(func() bool { return installed }, install, launch); err != nil {
+		t.Fatalf("second launch failed: %v", err)
+	}
+	if installCalls != 1 {
+		t.Fatalf("install called %d times, want 1", installCalls)
+	}
+	if launchCalls != 2 {
+		t.Fatalf("launch called %d times, want 2", launchCalls)
+	}
+}
+
 func TestSetClaudeGatewayInstalledRejectsMissingClaude(t *testing.T) {
 	previousInstalled := claudeDesktopInstalled
 	claudeDesktopInstalled = func() bool { return false }

--- a/app/cmd/app/app_test.go
+++ b/app/cmd/app/app_test.go
@@ -42,6 +42,42 @@ func TestShouldShowOnboarding(t *testing.T) {
 	}
 }
 
+func TestLaunchUpdateAndShutdown(t *testing.T) {
+	t.Run("successful launch shuts down current instance", func(t *testing.T) {
+		launched := false
+		shutdown := false
+		if !launchUpdateAndShutdown(func() bool {
+			launched = true
+			return true
+		}, func() {
+			if !launched {
+				t.Fatal("current instance shut down before updated app launched")
+			}
+			shutdown = true
+		}) {
+			t.Fatal("launchUpdateAndShutdown() = false, want true")
+		}
+		if !launched {
+			t.Fatal("updated app was not launched")
+		}
+		if !shutdown {
+			t.Fatal("current instance was not shut down")
+		}
+	})
+
+	t.Run("failed launch keeps current instance running", func(t *testing.T) {
+		shutdown := false
+		if launchUpdateAndShutdown(func() bool { return false }, func() {
+			shutdown = true
+		}) {
+			t.Fatal("launchUpdateAndShutdown() = true, want false")
+		}
+		if shutdown {
+			t.Fatal("current instance shut down after failed launch")
+		}
+	})
+}
+
 func TestDispatchURLSchemeRequest(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/app/cmd/app/app_test.go
+++ b/app/cmd/app/app_test.go
@@ -42,42 +42,6 @@ func TestShouldShowOnboarding(t *testing.T) {
 	}
 }
 
-func TestLaunchUpdateAndShutdown(t *testing.T) {
-	t.Run("successful launch shuts down current instance", func(t *testing.T) {
-		launched := false
-		shutdown := false
-		if !launchUpdateAndShutdown(func() bool {
-			launched = true
-			return true
-		}, func() {
-			if !launched {
-				t.Fatal("current instance shut down before updated app launched")
-			}
-			shutdown = true
-		}) {
-			t.Fatal("launchUpdateAndShutdown() = false, want true")
-		}
-		if !launched {
-			t.Fatal("updated app was not launched")
-		}
-		if !shutdown {
-			t.Fatal("current instance was not shut down")
-		}
-	})
-
-	t.Run("failed launch keeps current instance running", func(t *testing.T) {
-		shutdown := false
-		if launchUpdateAndShutdown(func() bool { return false }, func() {
-			shutdown = true
-		}) {
-			t.Fatal("launchUpdateAndShutdown() = true, want false")
-		}
-		if shutdown {
-			t.Fatal("current instance shut down after failed launch")
-		}
-	})
-}
-
 func TestDispatchURLSchemeRequest(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/app/cmd/app/app_windows.go
+++ b/app/cmd/app/app_windows.go
@@ -269,7 +269,8 @@ func createLoginShortcut() error {
 	return nil
 }
 
-func LaunchNewApp() {
+func LaunchNewApp() bool {
+	return false
 }
 
 func logStartup() {


### PR DESCRIPTION
## Summary
- make macOS relaunch report success and shut down the outgoing app after a successful manual or background update
- give existing instances five seconds to complete the graceful Claude handoff, then terminate the exact stale process if it is still running
- keep the current app running when macOS rejects the replacement launch

## Testing
- go test ./app/cmd/app ./app/updater -count=1
- isolated macOS update rehearsal: 9.9.1 ignored SIGUSR1, 9.9.2 replaced the bundle and terminated the stale PID through the fallback
- isolated follow-up update: 9.9.2 replaced itself with 9.9.3 and the outgoing PID shut down immediately, leaving exactly one instance