### PR TITLE
app: keep sign-in state across views

### DIFF
--- a/app/ui/app/src/components/DisplayLogin.tsx
+++ b/app/ui/app/src/components/DisplayLogin.tsx
@@ -1,7 +1,6 @@
 import type { ErrorEvent } from "@/gotypes";
 import { Display, type DisplayAction } from "@/components/ui/display";
 import { useUser } from "@/hooks/useUser";
-import { useEffect, useState } from "react";
 
 interface DisplayLoginProps {
   error: ErrorEvent | null;
@@ -16,56 +15,24 @@ export const DisplayLogin = ({
   onDismiss,
   message,
 }: DisplayLoginProps) => {
-  const { fetchConnectUrl, refetchUser, isAuthenticated } = useUser();
-  const [isAwaitingAuth, setIsAwaitingAuth] = useState(false);
-
-  useEffect(() => {
-    const handleFocus = () => {
-      if (isAwaitingAuth) {
-        setIsAwaitingAuth(false);
-        refetchUser();
-      }
-    };
-
-    window.addEventListener("focus", handleFocus);
-
-    return () => {
-      window.removeEventListener("focus", handleFocus);
-    };
-  }, [isAwaitingAuth, refetchUser]);
-
-  useEffect(() => {
-    if (isAuthenticated && isAwaitingAuth) {
-      setIsAwaitingAuth(false);
-      if (onDismiss) {
-        onDismiss();
-      }
-    }
-  }, [isAuthenticated, isAwaitingAuth, onDismiss]);
+  const { connectUser, connectionError, isAuthenticated, isConnecting } =
+    useUser();
 
   if (!error || error.code !== "cloud_unauthorized" || isAuthenticated)
     return null;
 
-  const handleSignIn = async () => {
-    try {
-      const { data: connectUrl } = await fetchConnectUrl();
-      if (connectUrl) {
-        window.open(connectUrl, "_blank");
-        setIsAwaitingAuth(true);
-      }
-    } catch (error) {
-      console.error("Error getting connect URL:", error);
-    }
-  };
-
   const action: DisplayAction = {
     label: "Sign In",
-    onClick: handleSignIn,
+    onClick: connectUser,
+    disabled: isConnecting,
+    loading: isConnecting,
   };
 
   return (
     <Display
-      message={message || "Cloud models require an Ollama account"}
+      message={
+        connectionError || message || "Cloud models require an Ollama account"
+      }
       action={action}
       className={className}
       onDismiss={onDismiss}

--- a/app/ui/app/src/components/Settings.tsx
+++ b/app/ui/app/src/components/Settings.tsx
@@ -149,16 +149,13 @@ export default function Settings() {
   const {
     user,
     isAuthenticated,
-    refreshUser,
-    isRefreshing,
     refetchUser,
-    fetchConnectUrl,
     isLoading,
     disconnectUser,
+    connectUser,
+    isConnecting,
+    connectionError,
   } = useUser();
-  const [isAwaitingConnection, setIsAwaitingConnection] = useState(false);
-  const [connectionError, setConnectionError] = useState<string | null>(null);
-  const [pollingInterval, setPollingInterval] = useState<number | null>(null);
   const {
     cloudDisabled,
     cloudStatus,
@@ -278,47 +275,6 @@ export default function Settings() {
       );
   }, []);
 
-  useEffect(() => {
-    const handleFocus = () => {
-      if (isAwaitingConnection && pollingInterval) {
-        // Stop polling when window gets focus
-        clearInterval(pollingInterval);
-        setPollingInterval(null);
-        // Reset awaiting connection state
-        setIsAwaitingConnection(false);
-        // Make one last refresh request
-        refreshUser();
-      }
-    };
-
-    window.addEventListener("focus", handleFocus);
-
-    return () => {
-      window.removeEventListener("focus", handleFocus);
-    };
-  }, [isAwaitingConnection, refreshUser, pollingInterval]);
-
-  // Check if user is authenticated after refresh
-  useEffect(() => {
-    if (isAwaitingConnection && isAuthenticated) {
-      setIsAwaitingConnection(false);
-      setConnectionError(null);
-      if (pollingInterval) {
-        clearInterval(pollingInterval);
-        setPollingInterval(null);
-      }
-    }
-  }, [isAuthenticated, isAwaitingConnection, pollingInterval]);
-
-  // Cleanup interval on unmount
-  useEffect(() => {
-    return () => {
-      if (pollingInterval) {
-        clearInterval(pollingInterval);
-      }
-    };
-  }, [pollingInterval]);
-
   const handleChange = useCallback(
     (field: keyof SettingsType, value: boolean | string | number) => {
       if (settings) {
@@ -411,41 +367,6 @@ export default function Settings() {
       );
     } finally {
       setResettingToDefaults(false);
-    }
-  };
-
-  const handleConnectOllamaAccount = async () => {
-    setConnectionError(null);
-
-    // If user is already authenticated, no need to connect
-    if (isAuthenticated) {
-      return;
-    }
-
-    try {
-      // If we don't have a user or user has no name, get connect URL
-      if (!user || !user?.name) {
-        const { data: connectUrl } = await fetchConnectUrl();
-        if (connectUrl) {
-          window.open(connectUrl, "_blank");
-          setIsAwaitingConnection(true);
-          // Start polling every 5 seconds
-          const interval = setInterval(() => {
-            refreshUser();
-          }, 5000);
-          setPollingInterval(interval);
-        } else {
-          setConnectionError("Failed to get connect URL");
-        }
-      }
-    } catch (error) {
-      console.error("Error connecting to Ollama account:", error);
-      setConnectionError(
-        error instanceof Error
-          ? error.message
-          : "Failed to connect to Ollama account",
-      );
-      setIsAwaitingConnection(false);
     }
   };
 
@@ -556,10 +477,10 @@ export default function Settings() {
                     <Button
                       type="button"
                       color="white"
-                      onClick={handleConnectOllamaAccount}
-                      disabled={isRefreshing || isAwaitingConnection}
+                      onClick={connectUser}
+                      disabled={isConnecting}
                     >
-                      {isRefreshing || isAwaitingConnection ? (
+                      {isConnecting ? (
                         <AnimatedDots />
                       ) : (
                         "Sign In"

--- a/app/ui/app/src/hooks/useUser.test.tsx
+++ b/app/ui/app/src/hooks/useUser.test.tsx
@@ -262,4 +262,73 @@ describe("useUser account connection", () => {
       queryClient.clear();
     }
   });
+
+  it("times out while the user check is still pending and ignores its late result", async () => {
+    const lateUser = {
+      id: "late-user-id",
+      name: "Late User",
+      email: "late@example.com",
+    };
+    const pendingUserResponse = deferred<typeof lateUser>();
+    apiMocks.fetchConnectUrl.mockResolvedValue(
+      "https://ollama.com/connect?name=MacBook&key=public-key&launch=true",
+    );
+    apiMocks.fetchUser.mockReturnValue(pendingUserResponse.promise);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+    });
+    queryClient.setQueryData(["user"], null);
+
+    let state!: UserState;
+    let renderer: ReactTestRenderer | undefined;
+
+    try {
+      await act(async () => {
+        renderer = create(
+          <QueryClientProvider client={queryClient}>
+            <UserProvider>
+              <UserStateHarness onRender={(nextState) => (state = nextState)} />
+            </UserProvider>
+          </QueryClientProvider>,
+        );
+        await flushUpdates();
+      });
+
+      await act(async () => {
+        await state.connectUser();
+        await flushUpdates();
+      });
+
+      expect(state.isConnecting).toBe(true);
+      expect(apiMocks.fetchUser).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(ACCOUNT_CONNECTION_TIMEOUT_MS);
+        await flushUpdates();
+      });
+
+      expect(state.isConnecting).toBe(false);
+      expect(state.connectionError).toBe(
+        "Connection is taking longer than expected. Please try again.",
+      );
+
+      await act(async () => {
+        pendingUserResponse.resolve(lateUser);
+        await flushUpdates();
+      });
+
+      expect(state.user).toBeNull();
+      expect(state.isAuthenticated).toBe(false);
+      expect(state.connectionError).toBe(
+        "Connection is taking longer than expected. Please try again.",
+      );
+    } finally {
+      await act(async () => {
+        renderer?.unmount();
+        await flushUpdates();
+      });
+      queryClient.clear();
+    }
+  });
 });

--- a/app/ui/app/src/hooks/useUser.test.tsx
+++ b/app/ui/app/src/hooks/useUser.test.tsx
@@ -1,0 +1,201 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const apiMocks = vi.hoisted(() => ({
+  disconnectUser: vi.fn(),
+  fetchConnectUrl: vi.fn(),
+  fetchUser: vi.fn(),
+}));
+
+vi.mock("@/api", () => apiMocks);
+
+import {
+  ACCOUNT_CONNECTION_POLL_INTERVAL_MS,
+  ACCOUNT_CONNECTION_TIMEOUT_MS,
+  UserProvider,
+  useUser,
+} from "./useUser";
+
+type UserState = ReturnType<typeof useUser>;
+
+function UserStateHarness({
+  onRender,
+}: {
+  onRender: (state: UserState) => void;
+}) {
+  onRender(useUser());
+  return null;
+}
+
+async function flushUpdates() {
+  await Promise.resolve();
+  await Promise.resolve();
+  await vi.advanceTimersByTimeAsync(0);
+}
+
+describe("useUser account connection", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+    vi.stubGlobal("window", {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      setInterval: globalThis.setInterval,
+      clearInterval: vi.fn(globalThis.clearInterval),
+      setTimeout: globalThis.setTimeout,
+      clearTimeout: vi.fn(globalThis.clearTimeout),
+      open: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("keeps polling after an early signed-out response and shares the authenticated user", async () => {
+    const authenticatedUser = {
+      id: "user-id",
+      name: "Test User",
+      email: "test@example.com",
+    };
+    apiMocks.fetchConnectUrl.mockResolvedValue(
+      "https://ollama.com/connect?name=MacBook&key=public-key&launch=true",
+    );
+    apiMocks.fetchUser
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue(authenticatedUser);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+    });
+    let initiatingState!: UserState;
+    let observingState!: UserState;
+    let renderer: ReactTestRenderer | undefined;
+    const renderHarness = (showInitiator: boolean) => (
+      <QueryClientProvider client={queryClient}>
+        <UserProvider>
+          {showInitiator && (
+            <UserStateHarness
+              key="initiator"
+              onRender={(nextState) => (initiatingState = nextState)}
+            />
+          )}
+          <UserStateHarness
+            key="observer"
+            onRender={(nextState) => (observingState = nextState)}
+          />
+        </UserProvider>
+      </QueryClientProvider>
+    );
+
+    try {
+      await act(async () => {
+        renderer = create(renderHarness(true));
+        await flushUpdates();
+      });
+
+      expect(initiatingState.isAuthenticated).toBe(false);
+      expect(observingState.isAuthenticated).toBe(false);
+
+      await act(async () => {
+        await initiatingState.connectUser();
+        await flushUpdates();
+      });
+
+      expect(window.open).toHaveBeenCalledWith(
+        "https://ollama.com/connect?name=MacBook&key=public-key&launch=true",
+        "_blank",
+      );
+      expect(initiatingState.isConnecting).toBe(true);
+      expect(observingState.isConnecting).toBe(true);
+      expect(apiMocks.fetchUser).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        renderer?.update(renderHarness(false));
+        await flushUpdates();
+      });
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(ACCOUNT_CONNECTION_POLL_INTERVAL_MS);
+        await flushUpdates();
+      });
+
+      expect(apiMocks.fetchUser).toHaveBeenCalledTimes(3);
+      expect(observingState.user).toEqual(authenticatedUser);
+      expect(observingState.isAuthenticated).toBe(true);
+      expect(observingState.isConnecting).toBe(false);
+      expect(observingState.connectionError).toBeNull();
+      expect(window.clearInterval).toHaveBeenCalled();
+      expect(window.removeEventListener).toHaveBeenCalledWith(
+        "focus",
+        expect.any(Function),
+      );
+    } finally {
+      await act(async () => {
+        renderer?.unmount();
+        await flushUpdates();
+      });
+      queryClient.clear();
+    }
+  });
+
+  it("stops a connection attempt after the bounded timeout", async () => {
+    apiMocks.fetchConnectUrl.mockResolvedValue(
+      "https://ollama.com/connect?name=MacBook&key=public-key&launch=true",
+    );
+    apiMocks.fetchUser.mockResolvedValue(null);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+    });
+    let state!: UserState;
+    let renderer: ReactTestRenderer | undefined;
+
+    try {
+      await act(async () => {
+        renderer = create(
+          <QueryClientProvider client={queryClient}>
+            <UserProvider>
+              <UserStateHarness onRender={(nextState) => (state = nextState)} />
+            </UserProvider>
+          </QueryClientProvider>,
+        );
+        await flushUpdates();
+      });
+
+      await act(async () => {
+        await state.connectUser();
+        await flushUpdates();
+      });
+
+      expect(state.isConnecting).toBe(true);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(ACCOUNT_CONNECTION_TIMEOUT_MS);
+        await flushUpdates();
+      });
+
+      expect(state.isConnecting).toBe(false);
+      expect(state.connectionError).toBe(
+        "Connection is taking longer than expected. Please try again.",
+      );
+
+      const fetchCountAtTimeout = apiMocks.fetchUser.mock.calls.length;
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(ACCOUNT_CONNECTION_POLL_INTERVAL_MS);
+        await flushUpdates();
+      });
+      expect(apiMocks.fetchUser).toHaveBeenCalledTimes(fetchCountAtTimeout);
+    } finally {
+      await act(async () => {
+        renderer?.unmount();
+        await flushUpdates();
+      });
+      queryClient.clear();
+    }
+  });
+});

--- a/app/ui/app/src/hooks/useUser.test.tsx
+++ b/app/ui/app/src/hooks/useUser.test.tsx
@@ -34,6 +34,14 @@ async function flushUpdates() {
   await vi.advanceTimersByTimeAsync(0);
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
 describe("useUser account connection", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -134,6 +142,62 @@ describe("useUser account connection", () => {
         "focus",
         expect.any(Function),
       );
+    } finally {
+      await act(async () => {
+        renderer?.unmount();
+        await flushUpdates();
+      });
+      queryClient.clear();
+    }
+  });
+
+  it("keeps the user signed out when an older user request completes", async () => {
+    const oldUser = {
+      id: "old-user-id",
+      name: "Old User",
+      email: "old@example.com",
+    };
+    const staleUserResponse = deferred<typeof oldUser>();
+    apiMocks.fetchUser.mockReturnValue(staleUserResponse.promise);
+    apiMocks.disconnectUser.mockResolvedValue(undefined);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: Infinity } },
+    });
+    queryClient.setQueryData(["user"], oldUser, { updatedAt: 0 });
+
+    let state!: UserState;
+    let renderer: ReactTestRenderer | undefined;
+
+    try {
+      await act(async () => {
+        renderer = create(
+          <QueryClientProvider client={queryClient}>
+            <UserProvider>
+              <UserStateHarness onRender={(nextState) => (state = nextState)} />
+            </UserProvider>
+          </QueryClientProvider>,
+        );
+        await flushUpdates();
+      });
+
+      expect(state.user).toEqual(oldUser);
+      expect(apiMocks.fetchUser).toHaveBeenCalledTimes(1);
+
+      await act(async () => {
+        state.disconnectUser();
+        await flushUpdates();
+      });
+
+      expect(state.user).toBeNull();
+
+      await act(async () => {
+        staleUserResponse.resolve(oldUser);
+        await flushUpdates();
+      });
+
+      expect(state.user).toBeNull();
+      expect(state.isAuthenticated).toBe(false);
     } finally {
       await act(async () => {
         renderer?.unmount();

--- a/app/ui/app/src/hooks/useUser.ts
+++ b/app/ui/app/src/hooks/useUser.ts
@@ -58,9 +58,6 @@ function useUserValue() {
     },
   });
 
-  // Background authentication checks should not replace account UI with its
-  // initial-loading state. In Chat, doing so would unmount the sign-in banner
-  // and cancel the connection attempt after its first check.
   const isLoading = userQuery.isLoading;
   const isAuthenticated = Boolean(userQuery.data?.name);
   const isConnecting = connectUrlQuery.isFetching || isAwaitingConnection;

--- a/app/ui/app/src/hooks/useUser.ts
+++ b/app/ui/app/src/hooks/useUser.ts
@@ -1,8 +1,26 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { fetchUser, fetchConnectUrl, disconnectUser } from "@/api";
+import {
+  createContext,
+  createElement,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
-export function useUser() {
+export const ACCOUNT_CONNECTION_POLL_INTERVAL_MS = 1000;
+export const ACCOUNT_CONNECTION_TIMEOUT_MS = 5 * 60 * 1000;
+const accountConnectionTimeoutMessage =
+  "Connection is taking longer than expected. Please try again.";
+
+function useUserValue() {
   const queryClient = useQueryClient();
+  const [isAwaitingConnection, setIsAwaitingConnection] = useState(false);
+  const [connectionError, setConnectionError] = useState<string | null>(null);
+  const connectionAttemptRef = useRef(0);
 
   const userQuery = useQuery({
     queryKey: ["user"],
@@ -40,8 +58,107 @@ export function useUser() {
     },
   });
 
-  const isLoading = userQuery.isLoading || userQuery.isFetching;
+  // Background authentication checks should not replace account UI with its
+  // initial-loading state. In Chat, doing so would unmount the sign-in banner
+  // and cancel the connection attempt after its first check.
+  const isLoading = userQuery.isLoading;
   const isAuthenticated = Boolean(userQuery.data?.name);
+  const isConnecting = connectUrlQuery.isFetching || isAwaitingConnection;
+  const refetchConnectUrl = connectUrlQuery.refetch;
+  const refetchUser = userQuery.refetch;
+
+  const connectUser = useCallback(async () => {
+    if (isAuthenticated || isConnecting) return;
+
+    const connectionAttempt = ++connectionAttemptRef.current;
+    setConnectionError(null);
+
+    try {
+      const { data: connectUrl } = await refetchConnectUrl();
+      if (connectionAttempt !== connectionAttemptRef.current) return;
+      if (!connectUrl) throw new Error("No sign-in URL was returned");
+
+      window.open(connectUrl, "_blank");
+      setIsAwaitingConnection(true);
+    } catch (error) {
+      if (connectionAttempt !== connectionAttemptRef.current) return;
+      console.error("Failed to start sign in:", error);
+      setConnectionError("Unable to start sign in. Please try again.");
+    }
+  }, [isAuthenticated, isConnecting, refetchConnectUrl]);
+
+  useEffect(() => {
+    if (!isAwaitingConnection) return;
+
+    const connectionAttempt = connectionAttemptRef.current;
+    let checking = false;
+    let settled = false;
+    let timeoutPending = false;
+
+    const finishConnection = (error: string | null) => {
+      if (settled || connectionAttempt !== connectionAttemptRef.current) return;
+      settled = true;
+      setIsAwaitingConnection(false);
+      setConnectionError(error);
+    };
+
+    const checkConnection = async () => {
+      if (
+        checking ||
+        settled ||
+        connectionAttempt !== connectionAttemptRef.current
+      ) {
+        return;
+      }
+      checking = true;
+
+      try {
+        const result = await refetchUser();
+        if (result.data?.name) finishConnection(null);
+      } catch (error) {
+        console.error("Failed to check sign-in status:", error);
+      } finally {
+        checking = false;
+        if (timeoutPending) {
+          finishConnection(accountConnectionTimeoutMessage);
+        }
+      }
+    };
+
+    void checkConnection();
+    const pollingInterval = window.setInterval(
+      checkConnection,
+      ACCOUNT_CONNECTION_POLL_INTERVAL_MS,
+    );
+    const timeout = window.setTimeout(() => {
+      if (checking) {
+        timeoutPending = true;
+        return;
+      }
+      finishConnection(accountConnectionTimeoutMessage);
+    }, ACCOUNT_CONNECTION_TIMEOUT_MS);
+
+    window.addEventListener("focus", checkConnection);
+    return () => {
+      settled = true;
+      window.clearInterval(pollingInterval);
+      window.clearTimeout(timeout);
+      window.removeEventListener("focus", checkConnection);
+    };
+  }, [isAwaitingConnection, refetchUser]);
+
+  useEffect(() => {
+    if (!isAuthenticated) return;
+    setIsAwaitingConnection(false);
+    setConnectionError(null);
+  }, [isAuthenticated]);
+
+  useEffect(
+    () => () => {
+      connectionAttemptRef.current += 1;
+    },
+    [],
+  );
 
   return {
     user: userQuery.data,
@@ -49,11 +166,31 @@ export function useUser() {
     isError: userQuery.isError,
     error: userQuery.error,
     isAuthenticated,
+    connectUser,
+    isConnecting,
+    connectionError,
     refreshUser: refreshUser.mutate,
     isRefreshing: refreshUser.isPending,
-    refetchUser: userQuery.refetch,
+    refetchUser,
     fetchConnectUrl: connectUrlQuery.refetch,
     connectUrl: connectUrlQuery.data,
     disconnectUser: disconnectMutation.mutate,
   };
+}
+
+type UserContextValue = ReturnType<typeof useUserValue>;
+
+const UserContext = createContext<UserContextValue | null>(null);
+
+export function UserProvider({ children }: { children: ReactNode }) {
+  const value = useUserValue();
+  return createElement(UserContext.Provider, { value }, children);
+}
+
+export function useUser(): UserContextValue {
+  const value = useContext(UserContext);
+  if (!value) {
+    throw new Error("useUser must be used within a UserProvider");
+  }
+  return value;
 }

--- a/app/ui/app/src/hooks/useUser.ts
+++ b/app/ui/app/src/hooks/useUser.ts
@@ -92,13 +92,15 @@ function useUserValue() {
     const connectionAttempt = connectionAttemptRef.current;
     let checking = false;
     let settled = false;
-    let timeoutPending = false;
 
     const finishConnection = (error: string | null) => {
-      if (settled || connectionAttempt !== connectionAttemptRef.current) return;
+      if (settled || connectionAttempt !== connectionAttemptRef.current) {
+        return false;
+      }
       settled = true;
       setIsAwaitingConnection(false);
       setConnectionError(error);
+      return true;
     };
 
     const checkConnection = async () => {
@@ -118,9 +120,6 @@ function useUserValue() {
         console.error("Failed to check sign-in status:", error);
       } finally {
         checking = false;
-        if (timeoutPending) {
-          finishConnection(accountConnectionTimeoutMessage);
-        }
       }
     };
 
@@ -130,11 +129,9 @@ function useUserValue() {
       ACCOUNT_CONNECTION_POLL_INTERVAL_MS,
     );
     const timeout = window.setTimeout(() => {
-      if (checking) {
-        timeoutPending = true;
-        return;
+      if (finishConnection(accountConnectionTimeoutMessage)) {
+        void queryClient.cancelQueries({ queryKey: ["user"], exact: true });
       }
-      finishConnection(accountConnectionTimeoutMessage);
     }, ACCOUNT_CONNECTION_TIMEOUT_MS);
 
     window.addEventListener("focus", checkConnection);
@@ -144,7 +141,7 @@ function useUserValue() {
       window.clearTimeout(timeout);
       window.removeEventListener("focus", checkConnection);
     };
-  }, [isAwaitingConnection, refetchUser]);
+  }, [isAwaitingConnection, queryClient, refetchUser]);
 
   useEffect(() => {
     if (!isAuthenticated) return;

--- a/app/ui/app/src/hooks/useUser.ts
+++ b/app/ui/app/src/hooks/useUser.ts
@@ -53,6 +53,8 @@ function useUserValue() {
 
   const disconnectMutation = useMutation({
     mutationFn: disconnectUser,
+    onMutate: () =>
+      queryClient.cancelQueries({ queryKey: ["user"], exact: true }),
     onSuccess: () => {
       queryClient.setQueryData(["user"], null);
     },

--- a/app/ui/app/src/main.tsx
+++ b/app/ui/app/src/main.tsx
@@ -3,7 +3,6 @@ import ReactDOM from "react-dom/client";
 import { RouterProvider, createRouter } from "@tanstack/react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { routeTree } from "./routeTree.gen";
-import { fetchUser } from "./api";
 import { StreamingProvider } from "./contexts/StreamingContext";
 import { UserProvider } from "./hooks/useUser";
 
@@ -16,12 +15,6 @@ const queryClient = new QueryClient({
       networkMode: "always", // Allow queries even when offline (local server)
     },
   },
-});
-
-fetchUser().then((userData) => {
-  if (userData) {
-    queryClient.setQueryData(["user"], userData);
-  }
 });
 
 const router = createRouter({

--- a/app/ui/app/src/main.tsx
+++ b/app/ui/app/src/main.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { routeTree } from "./routeTree.gen";
 import { fetchUser } from "./api";
 import { StreamingProvider } from "./contexts/StreamingContext";
+import { UserProvider } from "./hooks/useUser";
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -41,9 +42,11 @@ if (!rootElement.innerHTML) {
   root.render(
     <StrictMode>
       <QueryClientProvider client={queryClient}>
-        <StreamingProvider>
-          <RouterProvider router={router} />
-        </StreamingProvider>
+        <UserProvider>
+          <StreamingProvider>
+            <RouterProvider router={router} />
+          </StreamingProvider>
+        </UserProvider>
       </QueryClientProvider>
     </StrictMode>,
   );


### PR DESCRIPTION
## Summary

- move account sign-in polling into a shared app-level user provider
- keep the connection attempt alive when navigating between Settings and Chat
- update every view from the same authenticated user state
- retain automatic browser-to-app return without navigating an already-open app away from its current page
- stop polling after success or a five-minute timeout and surface connection errors

When the app window is no longer running, the existing callback behavior still opens the default Chat page.

## Testing

- npm test -- --run (108 tests)
- npm run build
- npx eslint on changed files
- git diff --check
- manual sandbox sign-in flow using an isolated app bundle