### PR TITLE
server: log inference requests before handling

### DIFF
--- a/server/inference_request_log.go
+++ b/server/inference_request_log.go
@@ -79,8 +79,8 @@ func (l *inferenceRequestLogger) middleware(route string) gin.HandlerFunc {
 			}
 		}
 
-		c.Next()
 		l.log(route, method, scheme, host, contentType, body)
+		c.Next()
 	}
 }
 

--- a/server/routes_request_log_test.go
+++ b/server/routes_request_log_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-func TestInferenceRequestLoggerMiddlewareWritesReplayArtifacts(t *testing.T) {
+func TestInferenceRequestLoggerMiddlewareWritesReplayArtifactsBeforeHandler(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	logDir := t.TempDir()
@@ -25,6 +25,14 @@ func TestInferenceRequestLoggerMiddlewareWritesReplayArtifacts(t *testing.T) {
 
 	r := gin.New()
 	r.POST(route, requestLogger.middleware(route), func(c *gin.Context) {
+		entries, err := os.ReadDir(logDir)
+		if err != nil {
+			t.Fatalf("failed to read request log directory in handler: %v", err)
+		}
+		if len(entries) != 2 {
+			t.Fatalf("expected request logs before handler runs, got %d files (%v)", len(entries), entries)
+		}
+
 		body, err := io.ReadAll(c.Request.Body)
 		if err != nil {
 			t.Fatalf("failed to read body in handler: %v", err)


### PR DESCRIPTION
## Summary

- write OLLAMA_DEBUG_LOG_REQUESTS replay artifacts before invoking inference handlers
- preserve the request body for downstream handlers
- add regression coverage proving both artifacts exist while the handler is running

This makes request logs available while a slow or hung inference request is still in progress.

Fixes #17437

## Testing

- go test ./server -count=1
- npm ci && npm run build in app/ui/app
- go test ./...
- gofmt -d server/inference_request_log.go server/routes_request_log_test.go
- git diff --check