### PR TITLE
app: prevent Claude model picker scroll jumps

### DIFF
--- a/app/ui/app/src/components/ClaudeDesktopModelsSettings.interaction.test.tsx
+++ b/app/ui/app/src/components/ClaudeDesktopModelsSettings.interaction.test.tsx
@@ -4,13 +4,95 @@ import {
   type ReactTestInstance,
   type ReactTestRenderer,
 } from "react-test-renderer";
-import { createRef } from "react";
+import {
+  createRef,
+  type ButtonHTMLAttributes,
+  type HTMLAttributes,
+  type MouseEvent as ReactMouseEvent,
+  type ReactNode,
+} from "react";
 import { describe, expect, it, vi } from "vitest";
 import { Switch } from "./ui/switch";
 import {
   ClaudeDesktopModelsSettings,
   type ClaudeDesktopModelsSettingsHandle,
 } from "./ClaudeDesktopModelsSettings";
+
+vi.mock("@headlessui/react", async (importOriginal) => {
+  const React = await import("react");
+  const original = await importOriginal<typeof import("@headlessui/react")>();
+  type PopoverContextValue = {
+    open: boolean;
+    close: () => void;
+    toggle: () => void;
+  };
+  const PopoverContext = React.createContext<PopoverContextValue | null>(null);
+  const usePopover = () => {
+    const context = React.useContext(PopoverContext);
+    if (!context) throw new Error("Popover components must be nested");
+    return context;
+  };
+
+  function TestPopover({
+    children,
+    className,
+  }: {
+    children: ReactNode;
+    className?: string;
+  }) {
+    const [open, setOpen] = React.useState(false);
+    const context = {
+      open,
+      close: () => setOpen(false),
+      toggle: () => setOpen((current) => !current),
+    };
+    return (
+      <PopoverContext.Provider value={context}>
+        <div className={className}>{children}</div>
+      </PopoverContext.Provider>
+    );
+  }
+
+  function TestPopoverButton({
+    onClick,
+    ...props
+  }: ButtonHTMLAttributes<HTMLButtonElement>) {
+    const { open, toggle } = usePopover();
+    return (
+      <button
+        {...props}
+        aria-expanded={open}
+        onClick={(event: ReactMouseEvent<HTMLButtonElement>) => {
+          onClick?.(event);
+          toggle();
+        }}
+      />
+    );
+  }
+
+  function TestPopoverPanel({
+    anchor,
+    children,
+    ...props
+  }: HTMLAttributes<HTMLDivElement> & {
+    anchor?: unknown;
+    children: ReactNode | ((props: { close: () => void }) => ReactNode);
+  }) {
+    const { open, close } = usePopover();
+    if (!open) return null;
+    return (
+      <div {...props} data-anchor={JSON.stringify(anchor)}>
+        {typeof children === "function" ? children({ close }) : children}
+      </div>
+    );
+  }
+
+  return Object.assign({}, original, {
+    Popover: TestPopover,
+    PopoverButton: TestPopoverButton,
+    PopoverPanel: TestPopoverPanel,
+  });
+});
 
 const fableRoute = {
   routeId: "claude-fable-5",
@@ -50,15 +132,24 @@ function testStatus(model = "glm-5.2:cloud", running = false) {
 
 async function selectKimi(renderer: ReactTestRenderer) {
   await act(async () => {
-    renderer.root
-      .findByProps({ "aria-label": "Ollama model for Fable 5" })
-      .props.onClick();
+    pickerButton(renderer).props.onClick();
     await Promise.resolve();
   });
   await act(async () => {
     renderer.root.findAllByProps({ role: "option" })[1].props.onClick();
     await Promise.resolve();
   });
+}
+
+function pickerButton(renderer: ReactTestRenderer) {
+  const button = renderer.root
+    .findAllByType("button")
+    .find(
+      (candidate) =>
+        candidate.props["aria-label"] === "Ollama model for Fable 5",
+    );
+  if (!button) throw new Error("Claude model picker button not found");
+  return button;
 }
 
 function actionButton(renderer: ReactTestRenderer) {
@@ -79,161 +170,12 @@ function textContent(node: ReactTestInstance): string {
     .join("");
 }
 
-async function openPickerAt({
-  top,
-  bottom,
-  innerHeight,
-}: {
-  top: number;
-  bottom: number;
-  innerHeight: number;
-}) {
-  let renderer!: ReactTestRenderer;
-  const menuClassesAtFocus: string[] = [];
-  const focus = vi.fn(() => {
-    const listbox = renderer.root.findByProps({ role: "listbox" });
-    menuClassesAtFocus.push(listbox.parent?.props.className ?? "");
-  });
-  class TestHTMLElement {
-    focus() {}
-  }
-  vi.stubGlobal("window", {
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    HTMLElement: TestHTMLElement,
-    innerHeight,
-    innerWidth: 1000,
-  });
-  vi.stubGlobal("document", {
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-  });
-  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
-
-  await act(async () => {
-    renderer = create(
-      <ClaudeDesktopModelsSettings
-        initialLocalModels={[]}
-        initialStatus={testStatus()}
-      />,
-      {
-        createNodeMock: (element) => {
-          if (element.type === "input") return { focus };
-          if (
-            element.type === "button" &&
-            element.props["aria-label"] === "Ollama model for Fable 5"
-          ) {
-            return {
-              getBoundingClientRect: () => ({
-                top,
-                bottom,
-                left: 400,
-                right: 600,
-                width: 200,
-              }),
-            };
-          }
-          return {
-            contains: vi.fn(() => true),
-            getBoundingClientRect: () => ({ height: 44 }),
-            scrollHeight: 256,
-          };
-        },
-      },
-    );
-    await Promise.resolve();
-  });
-
-  await act(async () => {
-    renderer.root
-      .findByProps({ "aria-label": "Ollama model for Fable 5" })
-      .props.onClick();
-    await Promise.resolve();
-  });
-
-  return { focus, menuClassesAtFocus, renderer };
-}
-
-async function cleanupPickerTest(renderer: ReactTestRenderer) {
-  await act(async () => {
-    renderer.unmount();
-    await Promise.resolve();
-  });
-  vi.unstubAllGlobals();
-}
-
 describe("ClaudeDesktopModelsSettings interactions", () => {
-  it("opens downward when the model menu does not fit above", async () => {
-    const { focus, menuClassesAtFocus, renderer } = await openPickerAt({
-      top: 24,
-      bottom: 60,
-      innerHeight: 600,
-    });
-    try {
-      const listbox = renderer.root.findByProps({ role: "listbox" });
-      expect(listbox.parent?.props["data-placement"]).toBe("down");
-      expect(listbox.parent?.props.style).toEqual({
-        left: 344,
-        top: 68,
-        width: 256,
-      });
-      expect(focus).toHaveBeenCalledWith({ preventScroll: true });
-      expect(menuClassesAtFocus[0]).toContain("visible");
-      expect(menuClassesAtFocus[0]).not.toContain("invisible");
-    } finally {
-      await cleanupPickerTest(renderer);
-    }
-  });
-
-  it("opens downward when the model menu fits on both sides", async () => {
-    const { renderer } = await openPickerAt({
-      top: 350,
-      bottom: 386,
-      innerHeight: 800,
-    });
-    try {
-      const listbox = renderer.root.findByProps({ role: "listbox" });
-      expect(listbox.parent?.props["data-placement"]).toBe("down");
-      expect(listbox.parent?.props.style.top).toBe(394);
-    } finally {
-      await cleanupPickerTest(renderer);
-    }
-  });
-
-  it("opens upward when the model menu only fits above", async () => {
-    const { renderer } = await openPickerAt({
-      top: 400,
-      bottom: 436,
-      innerHeight: 600,
-    });
-    try {
-      const listbox = renderer.root.findByProps({ role: "listbox" });
-      expect(listbox.parent?.props["data-placement"]).toBe("up");
-      expect(listbox.parent?.props.style.top).toBe(90);
-    } finally {
-      await cleanupPickerTest(renderer);
-    }
-  });
-
-  it("uses the larger side and constrains the list when neither side fits", async () => {
-    const { renderer } = await openPickerAt({
-      top: 180,
-      bottom: 216,
-      innerHeight: 400,
-    });
-    try {
-      const listbox = renderer.root.findByProps({ role: "listbox" });
-      expect(listbox.parent?.props["data-placement"]).toBe("down");
-      expect(listbox.props.style).toEqual({ maxHeight: 122 });
-    } finally {
-      await cleanupPickerTest(renderer);
-    }
-  });
-
-  it("disables auto mode while model changes are not applied", async () => {
+  it("opens below without scrolling and disables auto mode for draft changes", async () => {
     class TestHTMLElement {
       focus() {}
     }
+    const focus = vi.fn();
     vi.stubGlobal("window", {
       addEventListener: vi.fn(),
       removeEventListener: vi.fn(),
@@ -286,6 +228,10 @@ describe("ClaudeDesktopModelsSettings interactions", () => {
               ],
             }}
           />,
+          {
+            createNodeMock: (element) =>
+              element.type === "input" ? { focus } : null,
+          },
         );
         await Promise.resolve();
       });
@@ -296,11 +242,19 @@ describe("ClaudeDesktopModelsSettings interactions", () => {
       expect(autoModeSwitch().props["aria-checked"]).toBe(true);
 
       await act(async () => {
-        renderer!.root
-          .findByProps({ "aria-label": "Ollama model for Fable 5" })
-          .props.onClick();
+        pickerButton(renderer!).props.onClick();
         await Promise.resolve();
       });
+      expect(
+        renderer!.root.findByProps({
+          "data-anchor": JSON.stringify({
+            to: "bottom end",
+            gap: 8,
+            padding: 8,
+          }),
+        }),
+      ).toBeDefined();
+      expect(focus).toHaveBeenCalledWith({ preventScroll: true });
       await act(async () => {
         const options = renderer!.root.findAllByProps({ role: "option" });
         options[1].props.onClick();

--- a/app/ui/app/src/components/ClaudeDesktopModelsSettings.interaction.test.tsx
+++ b/app/ui/app/src/components/ClaudeDesktopModelsSettings.interaction.test.tsx
@@ -79,7 +79,157 @@ function textContent(node: ReactTestInstance): string {
     .join("");
 }
 
+async function openPickerAt({
+  top,
+  bottom,
+  innerHeight,
+}: {
+  top: number;
+  bottom: number;
+  innerHeight: number;
+}) {
+  let renderer!: ReactTestRenderer;
+  const menuClassesAtFocus: string[] = [];
+  const focus = vi.fn(() => {
+    const listbox = renderer.root.findByProps({ role: "listbox" });
+    menuClassesAtFocus.push(listbox.parent?.props.className ?? "");
+  });
+  class TestHTMLElement {
+    focus() {}
+  }
+  vi.stubGlobal("window", {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    HTMLElement: TestHTMLElement,
+    innerHeight,
+    innerWidth: 1000,
+  });
+  vi.stubGlobal("document", {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+
+  await act(async () => {
+    renderer = create(
+      <ClaudeDesktopModelsSettings
+        initialLocalModels={[]}
+        initialStatus={testStatus()}
+      />,
+      {
+        createNodeMock: (element) => {
+          if (element.type === "input") return { focus };
+          if (
+            element.type === "button" &&
+            element.props["aria-label"] === "Ollama model for Fable 5"
+          ) {
+            return {
+              getBoundingClientRect: () => ({
+                top,
+                bottom,
+                left: 400,
+                right: 600,
+                width: 200,
+              }),
+            };
+          }
+          return {
+            contains: vi.fn(() => true),
+            getBoundingClientRect: () => ({ height: 44 }),
+            scrollHeight: 256,
+          };
+        },
+      },
+    );
+    await Promise.resolve();
+  });
+
+  await act(async () => {
+    renderer.root
+      .findByProps({ "aria-label": "Ollama model for Fable 5" })
+      .props.onClick();
+    await Promise.resolve();
+  });
+
+  return { focus, menuClassesAtFocus, renderer };
+}
+
+async function cleanupPickerTest(renderer: ReactTestRenderer) {
+  await act(async () => {
+    renderer.unmount();
+    await Promise.resolve();
+  });
+  vi.unstubAllGlobals();
+}
+
 describe("ClaudeDesktopModelsSettings interactions", () => {
+  it("opens downward when the model menu does not fit above", async () => {
+    const { focus, menuClassesAtFocus, renderer } = await openPickerAt({
+      top: 24,
+      bottom: 60,
+      innerHeight: 600,
+    });
+    try {
+      const listbox = renderer.root.findByProps({ role: "listbox" });
+      expect(listbox.parent?.props["data-placement"]).toBe("down");
+      expect(listbox.parent?.props.style).toEqual({
+        left: 344,
+        top: 68,
+        width: 256,
+      });
+      expect(focus).toHaveBeenCalledWith({ preventScroll: true });
+      expect(menuClassesAtFocus[0]).toContain("visible");
+      expect(menuClassesAtFocus[0]).not.toContain("invisible");
+    } finally {
+      await cleanupPickerTest(renderer);
+    }
+  });
+
+  it("opens downward when the model menu fits on both sides", async () => {
+    const { renderer } = await openPickerAt({
+      top: 350,
+      bottom: 386,
+      innerHeight: 800,
+    });
+    try {
+      const listbox = renderer.root.findByProps({ role: "listbox" });
+      expect(listbox.parent?.props["data-placement"]).toBe("down");
+      expect(listbox.parent?.props.style.top).toBe(394);
+    } finally {
+      await cleanupPickerTest(renderer);
+    }
+  });
+
+  it("opens upward when the model menu only fits above", async () => {
+    const { renderer } = await openPickerAt({
+      top: 400,
+      bottom: 436,
+      innerHeight: 600,
+    });
+    try {
+      const listbox = renderer.root.findByProps({ role: "listbox" });
+      expect(listbox.parent?.props["data-placement"]).toBe("up");
+      expect(listbox.parent?.props.style.top).toBe(90);
+    } finally {
+      await cleanupPickerTest(renderer);
+    }
+  });
+
+  it("uses the larger side and constrains the list when neither side fits", async () => {
+    const { renderer } = await openPickerAt({
+      top: 180,
+      bottom: 216,
+      innerHeight: 400,
+    });
+    try {
+      const listbox = renderer.root.findByProps({ role: "listbox" });
+      expect(listbox.parent?.props["data-placement"]).toBe("down");
+      expect(listbox.props.style).toEqual({ maxHeight: 122 });
+    } finally {
+      await cleanupPickerTest(renderer);
+    }
+  });
+
   it("disables auto mode while model changes are not applied", async () => {
     class TestHTMLElement {
       focus() {}

--- a/app/ui/app/src/components/ClaudeDesktopModelsSettings.tsx
+++ b/app/ui/app/src/components/ClaudeDesktopModelsSettings.tsx
@@ -22,10 +22,12 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
+import { createPortal } from "react-dom";
 
 export interface ClaudeDesktopModelsSettingsHandle {
   resetToDefaults: () => Promise<boolean>;
@@ -147,22 +149,109 @@ function ClaudeModelPicker({
 }: ClaudeModelPickerProps) {
   const [open, setOpen] = useState(false);
   const [query, setQuery] = useState("");
+  const [placement, setPlacement] = useState<"up" | "down">("up");
+  const [listMaxHeight, setListMaxHeight] = useState(256);
+  const [layoutReady, setLayoutReady] = useState(false);
+  const [menuPosition, setMenuPosition] = useState({
+    left: 0,
+    top: 0,
+    width: 0,
+  });
   const pickerRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const menuRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
+  const searchHeaderRef = useRef<HTMLDivElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
   const normalizedQuery = query.trim().toLowerCase();
   const filteredModels = models.filter((model) =>
     model.displayName.toLowerCase().includes(normalizedQuery),
   );
+
+  useLayoutEffect(() => {
+    if (!open) return;
+
+    const updatePlacement = () => {
+      const trigger = triggerRef.current;
+      if (!trigger) return;
+
+      const viewportMargin = 8;
+      const menuGap = 8;
+      const triggerRect = trigger.getBoundingClientRect();
+      const roomAbove = Math.max(0, triggerRect.top - viewportMargin - menuGap);
+      const roomBelow = Math.max(
+        0,
+        window.innerHeight - triggerRect.bottom - viewportMargin - menuGap,
+      );
+      const headerHeight =
+        searchHeaderRef.current?.getBoundingClientRect().height ?? 0;
+      const preferredListHeight = Math.min(
+        listRef.current?.scrollHeight ?? 256,
+        256,
+      );
+      const preferredMenuHeight = headerHeight + preferredListHeight + 2;
+      const nextPlacement =
+        preferredMenuHeight <= roomBelow
+          ? "down"
+          : preferredMenuHeight <= roomAbove
+            ? "up"
+            : roomBelow >= roomAbove
+              ? "down"
+              : "up";
+      const availableHeight = nextPlacement === "up" ? roomAbove : roomBelow;
+      const nextListMaxHeight = Math.max(
+        0,
+        Math.min(256, Math.floor(availableHeight - headerHeight - 2)),
+      );
+      const menuHeight = headerHeight + nextListMaxHeight + 2;
+      const menuWidth = Math.min(
+        Math.max(triggerRect.width, 256),
+        window.innerWidth - viewportMargin * 2,
+      );
+      const menuLeft = Math.min(
+        Math.max(viewportMargin, triggerRect.right - menuWidth),
+        window.innerWidth - viewportMargin - menuWidth,
+      );
+
+      setPlacement(nextPlacement);
+      setListMaxHeight(nextListMaxHeight);
+      setMenuPosition({
+        left: menuLeft,
+        top:
+          nextPlacement === "up"
+            ? triggerRect.top - menuGap - menuHeight
+            : triggerRect.bottom + menuGap,
+        width: menuWidth,
+      });
+      setLayoutReady(true);
+    };
+
+    updatePlacement();
+    window.addEventListener("resize", updatePlacement);
+    window.addEventListener("scroll", updatePlacement, true);
+    return () => {
+      window.removeEventListener("resize", updatePlacement);
+      window.removeEventListener("scroll", updatePlacement, true);
+    };
+  }, [filteredModels.length, open]);
 
   useEffect(() => {
     if (!open) {
       setQuery("");
       return;
     }
-    searchRef.current?.focus();
+    if (!layoutReady) return;
+
+    searchRef.current?.focus({ preventScroll: true });
 
     const handlePointerDown = (event: MouseEvent) => {
-      if (!pickerRef.current?.contains(event.target as Node)) setOpen(false);
+      const target = event.target as Node;
+      if (
+        !pickerRef.current?.contains(target) &&
+        !menuRef.current?.contains(target)
+      ) {
+        setOpen(false);
+      }
     };
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
@@ -176,23 +265,100 @@ function ClaudeModelPicker({
       document.removeEventListener("mousedown", handlePointerDown);
       document.removeEventListener("keydown", handleKeyDown);
     };
-  }, [open]);
+  }, [layoutReady, open]);
+
+  const toggleOpen = () => {
+    if (open) {
+      setOpen(false);
+      return;
+    }
+    setLayoutReady(false);
+    setOpen(true);
+  };
 
   const choose = (model: string) => {
     onChange(model);
     setOpen(false);
   };
 
+  const menu = open ? (
+    <div
+      ref={menuRef}
+      className={`fixed z-50 overflow-hidden rounded-2xl border border-neutral-100 bg-white text-[15px] text-neutral-800 shadow-xl shadow-black/5 dark:border-neutral-600/40 dark:bg-neutral-800 dark:text-white ${
+        layoutReady ? "visible" : "invisible pointer-events-none"
+      }`}
+      data-placement={placement}
+      style={menuPosition}
+    >
+      <div
+        ref={searchHeaderRef}
+        className="flex items-center gap-2 border-b border-neutral-100 px-3 py-2 dark:border-neutral-700"
+      >
+        <MagnifyingGlassIcon className="h-4 w-4 flex-shrink-0 text-neutral-400" />
+        <input
+          ref={searchRef}
+          type="text"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Find model..."
+          aria-label={`Find model for ${routeName}`}
+          autoCorrect="off"
+          autoComplete="off"
+          className="min-w-0 flex-1 border-none bg-transparent py-0.5 outline-none"
+        />
+      </div>
+      <div
+        ref={listRef}
+        role="listbox"
+        className="overflow-y-auto py-1"
+        style={{ maxHeight: listMaxHeight }}
+      >
+        {filteredModels.map((model) => {
+          const available = modelIsAvailable(model);
+          const statusLabel = claudeDesktopModelStatusLabel(model);
+          const selected = value === model.name;
+          return (
+            <button
+              key={model.name}
+              type="button"
+              role="option"
+              aria-selected={selected}
+              disabled={!available}
+              onClick={() => choose(model.name)}
+              className="flex w-full cursor-pointer items-start gap-2 px-3 py-2 text-left hover:bg-neutral-100 focus:bg-neutral-100 focus:outline-none disabled:cursor-not-allowed disabled:opacity-45 dark:hover:bg-neutral-700/60 dark:focus:bg-neutral-700/60"
+            >
+              <span className="mt-0.5 h-4 w-4 flex-shrink-0">
+                {selected && <CheckIcon className="h-4 w-4" />}
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block truncate">{model.displayName}</span>
+                {statusLabel && (
+                  <span className="mt-0.5 block truncate text-xs text-neutral-400">
+                    {statusLabel}
+                  </span>
+                )}
+              </span>
+            </button>
+          );
+        })}
+        {filteredModels.length === 0 && (
+          <p className="px-3 py-2 text-neutral-400">No models found</p>
+        )}
+      </div>
+    </div>
+  ) : null;
+
   return (
     <div ref={pickerRef} className="relative min-w-0">
       <button
+        ref={triggerRef}
         id={id}
         type="button"
         aria-label={`Ollama model for ${routeName}`}
         aria-haspopup="listbox"
         aria-expanded={open}
         disabled={disabled}
-        onClick={() => setOpen((current) => !current)}
+        onClick={toggleOpen}
         className="flex min-h-9 w-full items-center gap-2 rounded-lg bg-neutral-50 px-3 py-1.5 text-left text-sm text-neutral-800 outline-none ring-1 ring-inset ring-neutral-200 hover:bg-neutral-100 focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-700 dark:text-neutral-100 dark:ring-neutral-600 dark:hover:bg-neutral-600"
       >
         <span
@@ -203,57 +369,9 @@ function ClaudeModelPicker({
         <ChevronUpDownIcon className="h-4 w-4 flex-shrink-0 text-neutral-400" />
       </button>
 
-      {open && (
-        <div className="absolute bottom-full right-0 z-50 mb-2 w-full min-w-64 overflow-hidden rounded-2xl border border-neutral-100 bg-white text-[15px] text-neutral-800 shadow-xl shadow-black/5 dark:border-neutral-600/40 dark:bg-neutral-800 dark:text-white">
-          <div className="flex items-center gap-2 border-b border-neutral-100 px-3 py-2 dark:border-neutral-700">
-            <MagnifyingGlassIcon className="h-4 w-4 flex-shrink-0 text-neutral-400" />
-            <input
-              ref={searchRef}
-              type="text"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Find model..."
-              aria-label={`Find model for ${routeName}`}
-              autoCorrect="off"
-              autoComplete="off"
-              className="min-w-0 flex-1 border-none bg-transparent py-0.5 outline-none"
-            />
-          </div>
-          <div role="listbox" className="max-h-64 overflow-y-auto py-1">
-            {filteredModels.map((model) => {
-              const available = modelIsAvailable(model);
-              const statusLabel = claudeDesktopModelStatusLabel(model);
-              const selected = value === model.name;
-              return (
-                <button
-                  key={model.name}
-                  type="button"
-                  role="option"
-                  aria-selected={selected}
-                  disabled={!available}
-                  onClick={() => choose(model.name)}
-                  className="flex w-full cursor-pointer items-start gap-2 px-3 py-2 text-left hover:bg-neutral-100 focus:bg-neutral-100 focus:outline-none disabled:cursor-not-allowed disabled:opacity-45 dark:hover:bg-neutral-700/60 dark:focus:bg-neutral-700/60"
-                >
-                  <span className="mt-0.5 h-4 w-4 flex-shrink-0">
-                    {selected && <CheckIcon className="h-4 w-4" />}
-                  </span>
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate">{model.displayName}</span>
-                    {statusLabel && (
-                      <span className="mt-0.5 block truncate text-xs text-neutral-400">
-                        {statusLabel}
-                      </span>
-                    )}
-                  </span>
-                </button>
-              );
-            })}
-            {filteredModels.length === 0 && (
-              <p className="px-3 py-2 text-neutral-400">No models found</p>
-            )}
-          </div>
-        </div>
-      )}
+      {menu && typeof document !== "undefined" && document.body
+        ? createPortal(menu, document.body)
+        : menu}
     </div>
   );
 }

--- a/app/ui/app/src/components/ClaudeDesktopModelsSettings.tsx
+++ b/app/ui/app/src/components/ClaudeDesktopModelsSettings.tsx
@@ -17,17 +17,16 @@ import {
   ChevronUpDownIcon,
   MagnifyingGlassIcon,
 } from "@heroicons/react/20/solid";
+import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import {
   forwardRef,
   useCallback,
   useEffect,
   useImperativeHandle,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
 } from "react";
-import { createPortal } from "react-dom";
 
 export interface ClaudeDesktopModelsSettingsHandle {
   resetToDefaults: () => Promise<boolean>;
@@ -147,153 +146,66 @@ function ClaudeModelPicker({
   disabled,
   onChange,
 }: ClaudeModelPickerProps) {
-  const [open, setOpen] = useState(false);
+  return (
+    <Popover className="relative min-w-0">
+      <PopoverButton
+        id={id}
+        aria-label={`Ollama model for ${routeName}`}
+        aria-haspopup="listbox"
+        disabled={disabled}
+        className="flex min-h-9 w-full items-center gap-2 rounded-lg bg-neutral-50 px-3 py-1.5 text-left text-sm text-neutral-800 outline-none ring-1 ring-inset ring-neutral-200 hover:bg-neutral-100 focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-700 dark:text-neutral-100 dark:ring-neutral-600 dark:hover:bg-neutral-600"
+      >
+        <span
+          className={`min-w-0 flex-1 truncate ${value ? "" : "text-neutral-400"}`}
+        >
+          {value || "Select a model"}
+        </span>
+        <ChevronUpDownIcon className="h-4 w-4 flex-shrink-0 text-neutral-400" />
+      </PopoverButton>
+
+      <PopoverPanel
+        anchor={{ to: "bottom end", gap: 8, padding: 8 }}
+        className="z-50 flex w-[var(--button-width)] min-w-64 flex-col overflow-hidden rounded-2xl border border-neutral-100 bg-white text-[15px] text-neutral-800 shadow-xl shadow-black/5 [--anchor-max-height:19rem] dark:border-neutral-600/40 dark:bg-neutral-800 dark:text-white"
+      >
+        {({ close }) => (
+          <ClaudeModelPickerOptions
+            routeName={routeName}
+            value={value}
+            models={models}
+            onChange={(model) => {
+              onChange(model);
+              close();
+            }}
+          />
+        )}
+      </PopoverPanel>
+    </Popover>
+  );
+}
+
+function ClaudeModelPickerOptions({
+  routeName,
+  value,
+  models,
+  onChange,
+}: Pick<
+  ClaudeModelPickerProps,
+  "routeName" | "value" | "models" | "onChange"
+>) {
   const [query, setQuery] = useState("");
-  const [placement, setPlacement] = useState<"up" | "down">("up");
-  const [listMaxHeight, setListMaxHeight] = useState(256);
-  const [layoutReady, setLayoutReady] = useState(false);
-  const [menuPosition, setMenuPosition] = useState({
-    left: 0,
-    top: 0,
-    width: 0,
-  });
-  const pickerRef = useRef<HTMLDivElement>(null);
-  const triggerRef = useRef<HTMLButtonElement>(null);
-  const menuRef = useRef<HTMLDivElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
-  const searchHeaderRef = useRef<HTMLDivElement>(null);
-  const listRef = useRef<HTMLDivElement>(null);
   const normalizedQuery = query.trim().toLowerCase();
   const filteredModels = models.filter((model) =>
     model.displayName.toLowerCase().includes(normalizedQuery),
   );
 
-  useLayoutEffect(() => {
-    if (!open) return;
-
-    const updatePlacement = () => {
-      const trigger = triggerRef.current;
-      if (!trigger) return;
-
-      const viewportMargin = 8;
-      const menuGap = 8;
-      const triggerRect = trigger.getBoundingClientRect();
-      const roomAbove = Math.max(0, triggerRect.top - viewportMargin - menuGap);
-      const roomBelow = Math.max(
-        0,
-        window.innerHeight - triggerRect.bottom - viewportMargin - menuGap,
-      );
-      const headerHeight =
-        searchHeaderRef.current?.getBoundingClientRect().height ?? 0;
-      const preferredListHeight = Math.min(
-        listRef.current?.scrollHeight ?? 256,
-        256,
-      );
-      const preferredMenuHeight = headerHeight + preferredListHeight + 2;
-      const nextPlacement =
-        preferredMenuHeight <= roomBelow
-          ? "down"
-          : preferredMenuHeight <= roomAbove
-            ? "up"
-            : roomBelow >= roomAbove
-              ? "down"
-              : "up";
-      const availableHeight = nextPlacement === "up" ? roomAbove : roomBelow;
-      const nextListMaxHeight = Math.max(
-        0,
-        Math.min(256, Math.floor(availableHeight - headerHeight - 2)),
-      );
-      const menuHeight = headerHeight + nextListMaxHeight + 2;
-      const menuWidth = Math.min(
-        Math.max(triggerRect.width, 256),
-        window.innerWidth - viewportMargin * 2,
-      );
-      const menuLeft = Math.min(
-        Math.max(viewportMargin, triggerRect.right - menuWidth),
-        window.innerWidth - viewportMargin - menuWidth,
-      );
-
-      setPlacement(nextPlacement);
-      setListMaxHeight(nextListMaxHeight);
-      setMenuPosition({
-        left: menuLeft,
-        top:
-          nextPlacement === "up"
-            ? triggerRect.top - menuGap - menuHeight
-            : triggerRect.bottom + menuGap,
-        width: menuWidth,
-      });
-      setLayoutReady(true);
-    };
-
-    updatePlacement();
-    window.addEventListener("resize", updatePlacement);
-    window.addEventListener("scroll", updatePlacement, true);
-    return () => {
-      window.removeEventListener("resize", updatePlacement);
-      window.removeEventListener("scroll", updatePlacement, true);
-    };
-  }, [filteredModels.length, open]);
-
   useEffect(() => {
-    if (!open) {
-      setQuery("");
-      return;
-    }
-    if (!layoutReady) return;
-
     searchRef.current?.focus({ preventScroll: true });
+  }, []);
 
-    const handlePointerDown = (event: MouseEvent) => {
-      const target = event.target as Node;
-      if (
-        !pickerRef.current?.contains(target) &&
-        !menuRef.current?.contains(target)
-      ) {
-        setOpen(false);
-      }
-    };
-    const handleKeyDown = (event: KeyboardEvent) => {
-      if (event.key === "Escape") {
-        event.preventDefault();
-        setOpen(false);
-      }
-    };
-    document.addEventListener("mousedown", handlePointerDown);
-    document.addEventListener("keydown", handleKeyDown);
-    return () => {
-      document.removeEventListener("mousedown", handlePointerDown);
-      document.removeEventListener("keydown", handleKeyDown);
-    };
-  }, [layoutReady, open]);
-
-  const toggleOpen = () => {
-    if (open) {
-      setOpen(false);
-      return;
-    }
-    setLayoutReady(false);
-    setOpen(true);
-  };
-
-  const choose = (model: string) => {
-    onChange(model);
-    setOpen(false);
-  };
-
-  const menu = open ? (
-    <div
-      ref={menuRef}
-      className={`fixed z-50 overflow-hidden rounded-2xl border border-neutral-100 bg-white text-[15px] text-neutral-800 shadow-xl shadow-black/5 dark:border-neutral-600/40 dark:bg-neutral-800 dark:text-white ${
-        layoutReady ? "visible" : "invisible pointer-events-none"
-      }`}
-      data-placement={placement}
-      style={menuPosition}
-    >
-      <div
-        ref={searchHeaderRef}
-        className="flex items-center gap-2 border-b border-neutral-100 px-3 py-2 dark:border-neutral-700"
-      >
+  return (
+    <>
+      <div className="flex flex-none items-center gap-2 border-b border-neutral-100 px-3 py-2 dark:border-neutral-700">
         <MagnifyingGlassIcon className="h-4 w-4 flex-shrink-0 text-neutral-400" />
         <input
           ref={searchRef}
@@ -307,12 +219,7 @@ function ClaudeModelPicker({
           className="min-w-0 flex-1 border-none bg-transparent py-0.5 outline-none"
         />
       </div>
-      <div
-        ref={listRef}
-        role="listbox"
-        className="overflow-y-auto py-1"
-        style={{ maxHeight: listMaxHeight }}
-      >
+      <div role="listbox" className="min-h-0 overflow-y-auto py-1">
         {filteredModels.map((model) => {
           const available = modelIsAvailable(model);
           const statusLabel = claudeDesktopModelStatusLabel(model);
@@ -324,7 +231,7 @@ function ClaudeModelPicker({
               role="option"
               aria-selected={selected}
               disabled={!available}
-              onClick={() => choose(model.name)}
+              onClick={() => onChange(model.name)}
               className="flex w-full cursor-pointer items-start gap-2 px-3 py-2 text-left hover:bg-neutral-100 focus:bg-neutral-100 focus:outline-none disabled:cursor-not-allowed disabled:opacity-45 dark:hover:bg-neutral-700/60 dark:focus:bg-neutral-700/60"
             >
               <span className="mt-0.5 h-4 w-4 flex-shrink-0">
@@ -345,34 +252,7 @@ function ClaudeModelPicker({
           <p className="px-3 py-2 text-neutral-400">No models found</p>
         )}
       </div>
-    </div>
-  ) : null;
-
-  return (
-    <div ref={pickerRef} className="relative min-w-0">
-      <button
-        ref={triggerRef}
-        id={id}
-        type="button"
-        aria-label={`Ollama model for ${routeName}`}
-        aria-haspopup="listbox"
-        aria-expanded={open}
-        disabled={disabled}
-        onClick={toggleOpen}
-        className="flex min-h-9 w-full items-center gap-2 rounded-lg bg-neutral-50 px-3 py-1.5 text-left text-sm text-neutral-800 outline-none ring-1 ring-inset ring-neutral-200 hover:bg-neutral-100 focus:ring-2 focus:ring-blue-500 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-neutral-700 dark:text-neutral-100 dark:ring-neutral-600 dark:hover:bg-neutral-600"
-      >
-        <span
-          className={`min-w-0 flex-1 truncate ${value ? "" : "text-neutral-400"}`}
-        >
-          {value || "Select a model"}
-        </span>
-        <ChevronUpDownIcon className="h-4 w-4 flex-shrink-0 text-neutral-400" />
-      </button>
-
-      {menu && typeof document !== "undefined" && document.body
-        ? createPortal(menu, document.body)
-        : menu}
-    </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary

- use the existing anchored popover to render the Claude model picker outside the Settings scroll container
- open below by default and automatically flip above when viewport space requires it
- preserve the existing menu height while constraining it to available viewport space
- focus search without scrolling the Settings page

## Test plan

- `npm test -- --run`
- `npx eslint src/components/ClaudeDesktopModelsSettings.tsx src/components/ClaudeDesktopModelsSettings.interaction.test.tsx`
- `npm run build`
- manually verify the picker opens down when both sides fit, flips up when there is not enough room below, and does not move the Settings scroll position