### PR TITLE
openai, anthropic: honor tool_choice: none by dropping tools

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -377,6 +377,13 @@ func FromMessagesRequest(r MessagesRequest) (*api.ChatRequest, error) {
 		tools = append(tools, tool)
 	}
 
+	// tool_choice: {"type": "none"} means the model must not call any tool
+	// this turn. The model has no mechanism of its own to honor that, so the
+	// only reliable way to enforce it is to not give it any tools to call.
+	if r.ToolChoice != nil && r.ToolChoice.Type == "none" {
+		tools = nil
+	}
+
 	var think *api.ThinkValue
 	normalizedEffort := ""
 	if r.OutputConfig != nil {

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -654,6 +654,70 @@ func TestFromMessagesRequest_WithTools(t *testing.T) {
 	}
 }
 
+func TestFromMessagesRequest_ToolChoiceNoneDropsTools(t *testing.T) {
+	req := MessagesRequest{
+		Model:     "test-model",
+		MaxTokens: 1024,
+		Messages:  []MessageParam{{Role: "user", Content: textContent("Hello")}},
+		Tools: []Tool{
+			{
+				Name:        "get_weather",
+				Description: "Get current weather",
+				InputSchema: json.RawMessage(`{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}`),
+			},
+		},
+		ToolChoice: &ToolChoice{Type: "none"},
+	}
+
+	result, err := FromMessagesRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Tools) != 0 {
+		t.Fatalf("expected tool_choice: none to drop all tools, got %d", len(result.Tools))
+	}
+}
+
+func TestFromMessagesRequest_ToolChoiceOtherKeepsTools(t *testing.T) {
+	cases := []struct {
+		name       string
+		toolChoice *ToolChoice
+	}{
+		{name: "nil", toolChoice: nil},
+		{name: "auto", toolChoice: &ToolChoice{Type: "auto"}},
+		{name: "any", toolChoice: &ToolChoice{Type: "any"}},
+		{name: "specific tool", toolChoice: &ToolChoice{Type: "tool", Name: "get_weather"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := MessagesRequest{
+				Model:     "test-model",
+				MaxTokens: 1024,
+				Messages:  []MessageParam{{Role: "user", Content: textContent("Hello")}},
+				Tools: []Tool{
+					{
+						Name:        "get_weather",
+						Description: "Get current weather",
+						InputSchema: json.RawMessage(`{"type":"object","properties":{"location":{"type":"string"}},"required":["location"]}`),
+					},
+				},
+				ToolChoice: tc.toolChoice,
+			}
+
+			result, err := FromMessagesRequest(req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(result.Tools) != 1 {
+				t.Fatalf("expected tool_choice %q to keep tools unchanged, got %d tools", tc.name, len(result.Tools))
+			}
+		})
+	}
+}
+
 func TestFromMessagesRequest_DropsCustomWebSearchWhenBuiltinPresent(t *testing.T) {
 	req := MessagesRequest{
 		Model:     "test-model",

--- a/openai/openai.go
+++ b/openai/openai.go
@@ -116,11 +116,14 @@ type ChatCompletionRequest struct {
 	TopP             *float64        `json:"top_p"`
 	ResponseFormat   *ResponseFormat `json:"response_format"`
 	Tools            []api.Tool      `json:"tools"`
-	Reasoning        *Reasoning      `json:"reasoning,omitempty"`
-	ReasoningEffort  *string         `json:"reasoning_effort,omitempty"`
-	Logprobs         *bool           `json:"logprobs"`
-	TopLogprobs      int             `json:"top_logprobs"`
-	DebugRenderOnly  bool            `json:"_debug_render_only"`
+	// ToolChoice is either the string "none"/"auto"/"required" or an object
+	// forcing a specific function; only "none" is currently honored.
+	ToolChoice      any        `json:"tool_choice,omitempty"`
+	Reasoning       *Reasoning `json:"reasoning,omitempty"`
+	ReasoningEffort *string    `json:"reasoning_effort,omitempty"`
+	Logprobs        *bool      `json:"logprobs"`
+	TopLogprobs     int        `json:"top_logprobs"`
+	DebugRenderOnly bool       `json:"_debug_render_only"`
 }
 
 type ChatCompletion struct {
@@ -707,13 +710,21 @@ func FromChatRequest(r ChatCompletionRequest) (*api.ChatRequest, error) {
 		return nil, err
 	}
 
+	tools := r.Tools
+	// tool_choice: "none" means the model must not call any tool this turn.
+	// The model has no mechanism of its own to honor that, so the only
+	// reliable way to enforce it is to not give it any tools to call.
+	if choice, ok := r.ToolChoice.(string); ok && choice == "none" {
+		tools = nil
+	}
+
 	return &api.ChatRequest{
 		Model:           r.Model,
 		Messages:        messages,
 		Format:          format,
 		Options:         options,
 		Stream:          &r.Stream,
-		Tools:           r.Tools,
+		Tools:           tools,
 		Think:           think,
 		Logprobs:        r.Logprobs != nil && *r.Logprobs,
 		TopLogprobs:     r.TopLogprobs,

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -110,6 +110,79 @@ func TestFromChatRequest_ReasoningEffort(t *testing.T) {
 	}
 }
 
+func TestFromChatRequest_ToolChoiceNoneDropsTools(t *testing.T) {
+	tools := []api.Tool{
+		{
+			Type: "function",
+			Function: api.ToolFunction{
+				Name:        "get_weather",
+				Description: "Get current weather",
+			},
+		},
+	}
+
+	req := ChatCompletionRequest{
+		Model:      "test-model",
+		Messages:   []Message{{Role: "user", Content: "Hello"}},
+		Tools:      tools,
+		ToolChoice: "none",
+	}
+
+	result, err := FromChatRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Tools) != 0 {
+		t.Fatalf("expected tool_choice: \"none\" to drop all tools, got %d", len(result.Tools))
+	}
+}
+
+func TestFromChatRequest_ToolChoiceOtherKeepsTools(t *testing.T) {
+	tools := []api.Tool{
+		{
+			Type: "function",
+			Function: api.ToolFunction{
+				Name:        "get_weather",
+				Description: "Get current weather",
+			},
+		},
+	}
+
+	cases := []struct {
+		name       string
+		toolChoice any
+	}{
+		{name: "unset", toolChoice: nil},
+		{name: "auto", toolChoice: "auto"},
+		{name: "required", toolChoice: "required"},
+		{name: "specific function object", toolChoice: map[string]any{
+			"type":     "function",
+			"function": map[string]any{"name": "get_weather"},
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := ChatCompletionRequest{
+				Model:      "test-model",
+				Messages:   []Message{{Role: "user", Content: "Hello"}},
+				Tools:      tools,
+				ToolChoice: tc.toolChoice,
+			}
+
+			result, err := FromChatRequest(req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(result.Tools) != 1 {
+				t.Fatalf("expected tool_choice %q to keep tools unchanged, got %d tools", tc.name, len(result.Tools))
+			}
+		})
+	}
+}
+
 func TestFromChatRequest_WithImage(t *testing.T) {
 	imgData, _ := base64.StdEncoding.DecodeString(image)
 


### PR DESCRIPTION
Addresses the "none" half of #17921 (tool_choice still ignored in OpenAI
and Anthropic compat).

## Problem

Neither compat layer acts on `tool_choice`:

- **OpenAI** (`/v1/chat/completions`): `ChatCompletionRequest` has no
  field for `tool_choice` at all — it's silently dropped by JSON decoding.
- **Anthropic** (`/v1/messages`): `ToolChoice` *is* parsed into a struct
  (`MessagesRequest.ToolChoice`), and it even shows up in trace logging
  (`anthropic/trace.go:112`), but nothing in `FromMessagesRequest` ever
  reads it.

A client sending `tool_choice: "none"` (OpenAI) or `{"type": "none"}`
(Anthropic) to stop a tool-calling loop gets no such guarantee: the model
still calls a tool if it wants to, with no error to detect the mismatch by.
Agent frameworks that rely on `"none"` to terminate tool loops get an
unsafe no-op instead.

## Fix

The model has no mechanism of its own to honor "don't call a tool this
turn" — so the only reliable way to enforce it is to not give the model
any tools to call. When `tool_choice` is `"none"` in either layer, drop
`tools` from the outgoing `api.ChatRequest` entirely. Every other value
(`auto`, `required`, a specific forced tool, or `tool_choice` unset) is
completely unchanged — this only touches the `"none"` case.

## Scope: forced tool_choice is NOT addressed here

The other half of #17921 — `tool_choice` forcing one specific named tool
— is a materially different, larger problem: reliably making a model call
one named tool needs a grammar constraint expressed in that model
family's own tool-call syntax, and that syntax differs per parser
(`model/parsers/gemma4.go`'s `key:value` format, qwen's format, harmony's
`<|channel>` format, etc. are all different). That's cross-cutting,
per-parser-family work I don't think is safe to bundle into one PR
without maintainer design input on the right architecture for it. This
PR intentionally only ships the `"none"` fix, which is fully self-contained
and needed no new grammar machinery.

## Testing

- `TestFromChatRequest_ToolChoiceNoneDropsTools` / `TestFromMessagesRequest_ToolChoiceNoneDropsTools`:
  `tool_choice: "none"` drops all tools from the converted request.
- `TestFromChatRequest_ToolChoiceOtherKeepsTools` / `TestFromMessagesRequest_ToolChoiceOtherKeepsTools`:
  table tests confirming `auto`, `required`/`any`, a specific forced-tool
  object, and an unset/nil `tool_choice` all leave tools completely
  unchanged — this is the regression guard that the fix is scoped to
  exactly the `"none"` case.
- Full `openai` and `anthropic` package suites pass, plus the downstream
  `server` and `middleware` suites (both consume these conversion
  functions) — no regressions.
- `gofmt` / `go vet` clean.