### PR TITLE
app: leave Claude closed when quitting Ollama

### DIFF
--- a/app/cmd/app/app_darwin.go
+++ b/app/cmd/app/app_darwin.go
@@ -71,7 +71,7 @@ type claudeDesktopController interface {
 	ConfigureAutodiscoveryWithAutoMode(autoMode bool) error
 	SetInstalledFromDesktopWithAutoMode(installed, restart, autoMode bool) error
 	ApplyProfileChange(change func() error, restartConfirmed bool) error
-	RestoreForShutdown(ctx context.Context) error
+	RestoreForShutdownWithConfirmation(ctx context.Context, quitConfirmed bool) error
 }
 
 var (
@@ -1669,7 +1669,7 @@ func quit() {
 	ctx, cancel := context.WithTimeout(context.Background(), claudeShutdownTimeout)
 	defer cancel()
 	handoff := bool(C.otherOllamaInstanceRunning())
-	if err := restoreClaudeAppForTermination(ctx, handoff); err != nil {
+	if err := restoreClaudeAppForTermination(ctx, handoff, true); err != nil {
 		slog.Warn("failed to restore Claude before quitting", "error", err)
 	}
 	C.quit()
@@ -1682,7 +1682,7 @@ func restoreClaudeBeforeQuit(ctx context.Context, handoff, configured bool, rest
 	return restore(ctx)
 }
 
-func restoreClaudeAppForTermination(ctx context.Context, handoff bool) error {
+func restoreClaudeAppForTermination(ctx context.Context, handoff, quitClaudeConfirmed bool) error {
 	claudeLifecycleMu.Lock()
 	defer claudeLifecycleMu.Unlock()
 
@@ -1691,7 +1691,9 @@ func restoreClaudeAppForTermination(ctx context.Context, handoff bool) error {
 		return nil
 	}
 	configured := claudeDesktop.UsesOllamaGateway()
-	err := restoreClaudeBeforeQuit(ctx, handoff, configured, claudeDesktop.RestoreForShutdown)
+	err := restoreClaudeBeforeQuit(ctx, handoff, configured, func(ctx context.Context) error {
+		return claudeDesktop.RestoreForShutdownWithConfirmation(ctx, quitClaudeConfirmed)
+	})
 	if !claudeDesktop.UsesOllamaGateway() {
 		stopClaudeAppProxy()
 	}
@@ -1699,14 +1701,18 @@ func restoreClaudeAppForTermination(ctx context.Context, handoff bool) error {
 }
 
 //export RestoreClaudeGatewayForShutdown
-func RestoreClaudeGatewayForShutdown() C.bool {
+func RestoreClaudeGatewayForShutdown(quitClaudeConfirmed C.bool) C.int {
 	ctx, cancel := context.WithTimeout(context.Background(), claudeShutdownTimeout)
 	defer cancel()
-	if err := restoreClaudeAppForTermination(ctx, false); err != nil {
-		slog.Warn("failed to restore Claude during system shutdown", "error", err)
-		return C._Bool(false)
+	err := restoreClaudeAppForTermination(ctx, false, quitClaudeConfirmed != C._Bool(false))
+	if errors.Is(err, launch.ErrClaudeDesktopQuitConfirmationRequired) {
+		return C.int(C.ClaudeRestoreConfirmationRequired)
 	}
-	return C._Bool(true)
+	if err != nil {
+		slog.Warn("failed to restore Claude before quitting Ollama", "error", err)
+		return C.int(C.ClaudeRestoreFailed)
+	}
+	return C.int(C.ClaudeRestoreSucceeded)
 }
 
 func LaunchNewApp() {

--- a/app/cmd/app/app_darwin.h
+++ b/app/cmd/app/app_darwin.h
@@ -46,7 +46,13 @@ void doubleClick(uintptr_t wndPtr);
 void handleConnectURL();
 bool SetClaudeGatewayInstalled(bool installed, bool restartClaude);
 bool HasUsedClaudeDesktopIntegration(void);
-bool RestoreClaudeGatewayForShutdown(void);
+enum ClaudeRestoreResult
+{
+    ClaudeRestoreSucceeded,
+    ClaudeRestoreConfirmationRequired,
+    ClaudeRestoreFailed,
+};
+int RestoreClaudeGatewayForShutdown(bool quitClaudeConfirmed);
 bool IsClaudeGatewayConfigured(void);
 bool IsClaudeDesktopInstalled(void);
 bool IsClaudeDesktopRunning(void);

--- a/app/cmd/app/app_darwin.m
+++ b/app/cmd/app/app_darwin.m
@@ -336,6 +336,7 @@ static NSImage *integrationAppIcon(NSString *appName,
 @property(assign, nonatomic) BOOL claudeDownloadCompleted;
 @property(assign, nonatomic) BOOL claudeDownloadModalRunning;
 @property(assign, nonatomic) BOOL quitInProgress;
+@property(assign, nonatomic) BOOL hiddenModalInProgress;
 @property(assign, nonatomic) BOOL systemTerminationReplyPending;
 @property(strong, nonatomic) NSApplication *systemTerminationApplication;
 - (void)openClaudeApp:(id)sender;
@@ -598,17 +599,31 @@ static NSImage *ollamaApplicationIcon(void) {
 }
 
 - (void)applicationDidBecomeActive:(NSNotification *)notification {
+    if (self.hiddenModalInProgress) {
+        return;
+    }
+
+    BOOL hasVisibleWindows = NO;
+    for (NSWindow *window in [NSApp windows]) {
+        if ([window isVisible]) {
+            hasVisibleWindows = YES;
+            break;
+        }
+    }
+
     NSRunningApplication *currentApp = [NSRunningApplication currentApplication];
     if (currentApp.activationPolicy == NSApplicationActivationPolicyAccessory) {
-        for (NSWindow *window in [NSApp windows]) {
-            if ([window isVisible]) {
-                // Switch to regular activation policy since we have a visible window
-                [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
-                return;
-            }
+        if (hasVisibleWindows) {
+            // Switch to regular activation policy since we have a visible window
+            [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+            return;
         }
         [NSApp hide:nil];
         return;
+    }
+
+    if (!hasVisibleWindows) {
+        ShowUI();
     }
 }
 
@@ -1133,8 +1148,8 @@ didCompleteWithError:(NSError *)error {
         }
         self.quitInProgress = YES;
         dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-            BOOL succeeded = RestoreClaudeGatewayForShutdown();
-            if (!succeeded) {
+            enum ClaudeRestoreResult result = RestoreClaudeGatewayForShutdown(true);
+            if (result != ClaudeRestoreSucceeded) {
                 appLogInfo(@"Unable to restore Claude during system shutdown");
             }
             dispatch_async(dispatch_get_main_queue(), ^{
@@ -1205,6 +1220,78 @@ didCompleteWithError:(NSError *)error {
     [NSApp setActivationPolicy:NSApplicationActivationPolicyAccessory];
 }
 
+- (NSModalResponse)runModalWithoutShowingHiddenWindows:(NSAlert *)alert {
+    BOOL appWasHidden = [NSApp isHidden];
+    NSApplicationActivationPolicy activationPolicy = [NSApp activationPolicy];
+    if (appWasHidden) {
+        self.hiddenModalInProgress = YES;
+        NSWindow *alertWindow = [alert window];
+        for (NSWindow *window in [NSApp windows]) {
+            if (window != alertWindow && [window delegate] == self) {
+                [window orderOut:nil];
+            }
+        }
+    }
+
+    NSModalResponse response = [alert runModal];
+    if (appWasHidden) {
+        [NSApp hide:nil];
+        [NSApp setActivationPolicy:activationPolicy];
+        self.hiddenModalInProgress = NO;
+    }
+    return response;
+}
+
+- (void)restoreClaudeAndQuit:(BOOL)quitClaudeConfirmed {
+    self.quitInProgress = YES;
+    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+        enum ClaudeRestoreResult result =
+            RestoreClaudeGatewayForShutdown(quitClaudeConfirmed);
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (self.systemTerminationReplyPending) {
+                if (result == ClaudeRestoreConfirmationRequired) {
+                    [self restoreClaudeAndQuit:YES];
+                    return;
+                }
+                if (result != ClaudeRestoreSucceeded) {
+                    appLogInfo(@"Unable to restore Claude during system shutdown");
+                }
+                [self completeSystemTermination];
+                return;
+            }
+            if (result == ClaudeRestoreSucceeded) {
+                [self quit];
+                return;
+            }
+
+            self.quitInProgress = NO;
+            if (result == ClaudeRestoreConfirmationRequired) {
+                NSAlert *alert = [[NSAlert alloc] init];
+                [alert setAlertStyle:NSAlertStyleWarning];
+                [alert setIcon:ollamaApplicationIcon()];
+                [alert setMessageText:@"Quit Claude and Ollama?"];
+                [alert setInformativeText:
+                    @"Claude must quit so Ollama can restore its settings. Any running task will stop."];
+                [alert addButtonWithTitle:@"Quit Claude and Ollama"];
+                [alert addButtonWithTitle:@"Cancel"];
+                if ([self runModalWithoutShowingHiddenWindows:alert] == NSAlertFirstButtonReturn) {
+                    [self restoreClaudeAndQuit:YES];
+                }
+                return;
+            }
+
+            [self refreshClaudeAppState];
+            NSAlert *alert = [[NSAlert alloc] init];
+            [alert setAlertStyle:NSAlertStyleWarning];
+            [alert setIcon:ollamaApplicationIcon()];
+            [alert setMessageText:@"Unable to quit Ollama"];
+            [alert setInformativeText:
+                @"Ollama couldn’t restore Claude’s settings, so Ollama is still running. Check the Ollama log and try again."];
+            [self runModalWithoutShowingHiddenWindows:alert];
+        });
+    });
+}
+
 - (void)requestQuit {
     if (self.quitInProgress) {
         return;
@@ -1214,48 +1301,7 @@ didCompleteWithError:(NSError *)error {
         return;
     }
 
-    BOOL restartClaude = IsClaudeDesktopRunning();
-    if (restartClaude) {
-        NSAlert *alert = [[NSAlert alloc] init];
-        [alert setAlertStyle:NSAlertStyleWarning];
-        [alert setIcon:ollamaApplicationIcon()];
-        [alert setMessageText:@"Restart Claude before quitting Ollama?"];
-        [alert setInformativeText:
-            @"Claude must restart before Ollama quits. Any running task will stop."];
-        [alert addButtonWithTitle:@"Restart Claude and Quit"];
-        [alert addButtonWithTitle:@"Cancel"];
-        if ([alert runModal] != NSAlertFirstButtonReturn) {
-            return;
-        }
-    }
-
-    self.quitInProgress = YES;
-    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
-        BOOL succeeded = SetClaudeGatewayInstalled(false, restartClaude);
-        dispatch_async(dispatch_get_main_queue(), ^{
-            if (self.systemTerminationReplyPending) {
-                if (!succeeded) {
-                    appLogInfo(@"Unable to restore Claude during system shutdown");
-                }
-                [self completeSystemTermination];
-                return;
-            }
-            if (succeeded) {
-                [self quit];
-                return;
-            }
-
-            self.quitInProgress = NO;
-            [self refreshClaudeAppState];
-            NSAlert *alert = [[NSAlert alloc] init];
-            [alert setAlertStyle:NSAlertStyleWarning];
-            [alert setIcon:ollamaApplicationIcon()];
-            [alert setMessageText:@"Unable to quit Ollama"];
-            [alert setInformativeText:
-                @"Ollama couldn’t update Claude, so it is still running. Check the Ollama log and try again."];
-            [alert runModal];
-        });
-    });
+    [self restoreClaudeAndQuit:NO];
 }
 
 - (void)quit {

--- a/app/cmd/app/app_darwin_test.go
+++ b/app/cmd/app/app_darwin_test.go
@@ -725,21 +725,22 @@ func TestClaudeDesktopDefaultsFollowAccountPlan(t *testing.T) {
 }
 
 type fakeClaudeDesktopController struct {
-	configured     bool
-	profileCurrent bool
-	configureCalls int
-	configureErr   error
-	running        bool
-	opened         bool
-	installed      bool
-	restart        bool
-	setErr         error
-	openErr        error
-	modelsAtSet    []string
-	configureOnSet bool
-	requireRestart bool
-	autoMode       bool
-	restoreCalls   int
+	configured       bool
+	profileCurrent   bool
+	configureCalls   int
+	configureErr     error
+	running          bool
+	opened           bool
+	installed        bool
+	restart          bool
+	setErr           error
+	openErr          error
+	modelsAtSet      []string
+	configureOnSet   bool
+	requireRestart   bool
+	autoMode         bool
+	restoreCalls     int
+	restoreConfirmed bool
 }
 
 func (f *fakeClaudeDesktopController) UsesOllamaGateway() bool { return f.configured }
@@ -818,8 +819,12 @@ func (f *fakeClaudeDesktopController) ApplyProfileChange(change func() error, re
 	return f.setErr
 }
 
-func (f *fakeClaudeDesktopController) RestoreForShutdown(context.Context) error {
+func (f *fakeClaudeDesktopController) RestoreForShutdownWithConfirmation(_ context.Context, quitConfirmed bool) error {
 	f.restoreCalls++
+	f.restoreConfirmed = quitConfirmed
+	if f.running && !quitConfirmed {
+		return launch.ErrClaudeDesktopQuitConfirmationRequired
+	}
 	f.configured = false
 	f.profileCurrent = false
 	f.installed = false
@@ -1384,7 +1389,7 @@ func TestResetClaudeDesktopMappingsSerializesDisconnectDuringCatalogRefresh(t *t
 
 func TestResetClaudeDesktopMappingsSerializesShutdownDuringCatalogRefresh(t *testing.T) {
 	testResetClaudeDesktopMappingsSerializesLifecycleChange(t, "shutdown", func() error {
-		return restoreClaudeAppForTermination(context.Background(), false)
+		return restoreClaudeAppForTermination(context.Background(), false, true)
 	})
 }
 
@@ -2445,6 +2450,36 @@ func TestRestoreClaudeBeforeQuit(t *testing.T) {
 	}
 	if called {
 		t.Fatal("restore called during an app replacement handoff")
+	}
+}
+
+func TestRestoreClaudeAppForTerminationRequiresQuitConfirmation(t *testing.T) {
+	previousDesktop := claudeDesktop
+	fake := &fakeClaudeDesktopController{configured: true, running: true}
+	claudeDesktop = fake
+	t.Cleanup(func() {
+		claudeDesktop = previousDesktop
+	})
+
+	err := restoreClaudeAppForTermination(context.Background(), false, false)
+	if !errors.Is(err, launch.ErrClaudeDesktopQuitConfirmationRequired) {
+		t.Fatalf("unconfirmed restore error = %v, want quit confirmation error", err)
+	}
+	if fake.restoreCalls != 1 || fake.restoreConfirmed {
+		t.Fatalf("unconfirmed restore = calls:%d confirmed:%v", fake.restoreCalls, fake.restoreConfirmed)
+	}
+	if !fake.configured {
+		t.Fatal("unconfirmed restore changed Claude's profile")
+	}
+
+	if err := restoreClaudeAppForTermination(context.Background(), false, true); err != nil {
+		t.Fatalf("confirmed restore error = %v", err)
+	}
+	if fake.restoreCalls != 2 || !fake.restoreConfirmed {
+		t.Fatalf("confirmed restore = calls:%d confirmed:%v", fake.restoreCalls, fake.restoreConfirmed)
+	}
+	if fake.configured {
+		t.Fatal("confirmed restore left Claude configured")
 	}
 }
 

--- a/cmd/launch/claude_desktop.go
+++ b/cmd/launch/claude_desktop.go
@@ -55,6 +55,10 @@ type ClaudeDesktop struct{}
 // change would interrupt a running Claude Desktop process.
 var ErrClaudeDesktopRestartConfirmationRequired = errors.New("Claude Desktop restart confirmation is required before changing its profile")
 
+// ErrClaudeDesktopQuitConfirmationRequired reports that restoring Claude's
+// profile for shutdown would interrupt a running Claude Desktop process.
+var ErrClaudeDesktopQuitConfirmationRequired = errors.New("Claude Desktop quit confirmation is required before restoring its profile for shutdown")
+
 func (c *ClaudeDesktop) String() string { return "Claude Desktop" }
 
 func (c *ClaudeDesktop) Supported() error { return claudeDesktopSupported() }
@@ -201,6 +205,13 @@ func (c *ClaudeDesktop) ApplyProfileChange(change func() error, restartConfirmed
 
 // RestoreForShutdown restores Claude's usual profile without reopening the app.
 func (c *ClaudeDesktop) RestoreForShutdown(ctx context.Context) error {
+	return c.RestoreForShutdownWithConfirmation(ctx, true)
+}
+
+// RestoreForShutdownWithConfirmation restores Claude's usual profile without
+// reopening the app. A running Claude is left unchanged until quitConfirmed is
+// true.
+func (c *ClaudeDesktop) RestoreForShutdownWithConfirmation(ctx context.Context, quitConfirmed bool) error {
 	if err := claudeDesktopSupported(); err != nil {
 		return err
 	}
@@ -210,6 +221,9 @@ func (c *ClaudeDesktop) RestoreForShutdown(ctx context.Context) error {
 	}
 	if !running {
 		return restoreClaudeDesktopProfile()
+	}
+	if !quitConfirmed {
+		return ErrClaudeDesktopQuitConfirmationRequired
 	}
 	if err := claudeDesktopQuitApp(ctx); err != nil {
 		return fmt.Errorf("quit Claude Desktop: %w", err)

--- a/cmd/launch/claude_desktop_test.go
+++ b/cmd/launch/claude_desktop_test.go
@@ -1495,6 +1495,40 @@ func TestClaudeDesktopRestoreForShutdownDoesNotReopenApp(t *testing.T) {
 	}
 }
 
+func TestClaudeDesktopRestoreForShutdownRequiresQuitConfirmation(t *testing.T) {
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	withClaudeDesktopPlatform(t, "darwin")
+	c := &ClaudeDesktop{}
+	if err := c.ConfigureAutodiscovery(); err != nil {
+		t.Fatal(err)
+	}
+
+	quitCalls := 0
+	withClaudeDesktopProcessHooks(t,
+		func() bool { return true },
+		func() error {
+			quitCalls++
+			return nil
+		},
+		func() error {
+			t.Fatal("Claude reopened during shutdown")
+			return nil
+		},
+	)
+
+	err := c.RestoreForShutdownWithConfirmation(context.Background(), false)
+	if !errors.Is(err, ErrClaudeDesktopQuitConfirmationRequired) {
+		t.Fatalf("RestoreForShutdown error = %v, want quit confirmation error", err)
+	}
+	if quitCalls != 0 {
+		t.Fatalf("quit calls = %d, want 0 before confirmation", quitCalls)
+	}
+	if !c.UsesOllamaGateway() {
+		t.Fatal("Claude profile changed before quit confirmation")
+	}
+}
+
 func TestClaudeDesktopRestoreForShutdownBoundsHungQuit(t *testing.T) {
 	withClaudeDesktopPlatform(t, "darwin")
 	oldRunning := claudeDesktopIsRunning


### PR DESCRIPTION
## Summary

When quitting Ollama while Claude Desktop is running:

- Ask for confirmation before interrupting Claude
- Quit Claude, restore its original configuration, and leave it closed
- Keep the full Ollama window hidden when quitting from the tray
- Preserve the current state if the user cancels
- Handle system shutdown without requiring an interactive confirmation

Previously, Ollama restarted Claude while quitting, which left Claude running after Ollama had exited.

## Testing

- `go test ./cmd/launch ./app/cmd/app`
- Verified in an isolated macOS sandbox:
  - Cancel keeps Claude running and its configuration unchanged
  - Confirm quits Claude once, restores its configuration, and exits Ollama
  - Quitting from the tray does not reveal the full Ollama window
  - Claude is not reopened after shutdown