### PR TITLE
server: parse thinking out of /api/generate response even when think is false

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -635,7 +635,12 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	var thinkingState *thinking.Parser
 	if builtinParser == nil {
 		openingTag, closingTag := thinking.InferTags(m.Template.Template)
-		if req.Think != nil && req.Think.Bool() && openingTag != "" && closingTag != "" {
+		// Parse thinking out of the response even when think is false. The option
+		// only disables thinking generation hints, but a model may still emit
+		// thinking traces; always separating them keeps `response` clean and
+		// matches the behavior of /api/chat. (If no thinking tags exist in the
+		// template, nothing is parsed and this is a no-op.)
+		if openingTag != "" && closingTag != "" {
 			thinkingState = &thinking.Parser{
 				OpeningTag: openingTag,
 				ClosingTag: closingTag,


### PR DESCRIPTION
## Summary

Fixes #18044

`/api/generate` with `think: false` leaks raw `  thinking… response` markup into `response` and leaves `thinking` null, while `/api/chat` handles the same request correctly.

## Root cause

For models with no builtin parser (e.g. `deepseek-r1`/`qwen3`, where thinking is handled by the go template), `GenerateHandler` builds a `thinking.Parser` (`thinkingState`) only when `req.Think != nil && req.Think.Bool()`:

```go
if req.Think != nil && req.Think.Bool() && openingTag != "" && closingTag != "" {
    thinkingState = &thinking.Parser{...}
}
```

`think: false` disables *server-side parsing* but does not stop the model from emitting a thinking trace (the prompt/template is unchanged — `eval_count` is identical whether `think` is set, omitted, or false). With `thinkingState == nil` the raw `  thinking… response` block is copied straight into `response`.

Native `/api/chat` always runs the thinking parser (in the runner), so it separates the trace into `message.thinking` even when `think: false` — which is the behavior this change brings `/api/generate` in line with.

## Fix

Always build `thinkingState` when the template has thinking tags, regardless of the `think` option. `thinking.Parser` is a no-op when no thinking tags are present, so non-thinking models are unaffected.

Verified with the existing `thinking` package tests plus a standalone reproduction: feeding the stream `  thinking\n<trace>\n  response\nOK` through `thinking.Parser{OpeningTag:"thinking", ClosingTag:"response"}` yields `thinking="<trace>"` and `content="OK"`.
