### PR TITLE
mlxrunner: check every fallible mlx-c call in the MLX bindings

### DIFF
--- a/x/mlxrunner/mlx/array.go
+++ b/x/mlxrunner/mlx/array.go
@@ -53,15 +53,15 @@ func FromValue[T scalarTypes](t T) *Array {
 	tt := New("")
 	switch v := any(t).(type) {
 	case bool:
-		tt.ctx = C.mlx_array_new_bool(C.bool(v))
+		tt.ctx = mlxCheck(C.mlx_array_new_bool(C.bool(v)))
 	case int:
-		tt.ctx = C.mlx_array_new_int(C.int(v))
+		tt.ctx = mlxCheck(C.mlx_array_new_int(C.int(v)))
 	case float32:
-		tt.ctx = C.mlx_array_new_float32(C.float(v))
+		tt.ctx = mlxCheck(C.mlx_array_new_float32(C.float(v)))
 	case float64:
-		tt.ctx = C.mlx_array_new_float64(C.double(v))
+		tt.ctx = mlxCheck(C.mlx_array_new_float64(C.double(v)))
 	case complex64:
-		tt.ctx = C.mlx_array_new_complex(C.float(real(v)), C.float(imag(v)))
+		tt.ctx = mlxCheck(C.mlx_array_new_complex(C.float(real(v)), C.float(imag(v))))
 	default:
 		panic("unsupported type")
 	}
@@ -121,17 +121,17 @@ func FromValues[S ~[]E, E arrayTypes](s S, shape ...int) *Array {
 	}
 
 	tt := New("")
-	tt.ctx = C.mlx_array_new_data(unsafe.Pointer(&bts[0]), unsafe.SliceData(cShape), C.int(len(cShape)), C.mlx_dtype(dtype))
+	tt.ctx = mlxCheck(C.mlx_array_new_data(unsafe.Pointer(&bts[0]), unsafe.SliceData(cShape), C.int(len(cShape)), C.mlx_dtype(dtype)))
 	return tt
 }
 
 func (t *Array) Set(other *Array) {
-	C.mlx_array_set(&t.ctx, other.ctx)
+	mlxCheck(C.mlx_array_set(&t.ctx, other.ctx))
 }
 
 func (t *Array) Clone() *Array {
 	tt := New(t.name)
-	C.mlx_array_set(&tt.ctx, t.ctx)
+	mlxCheck(C.mlx_array_set(&tt.ctx, t.ctx))
 	return tt
 }
 
@@ -168,7 +168,7 @@ func Sweep() {
 			arrays[n] = t
 			n++
 		} else if t.Valid() {
-			C.mlx_array_free(t.ctx)
+			mlxCheck(C.mlx_array_free(t.ctx))
 			t.ctx.ctx = nil
 		}
 	}
@@ -182,10 +182,10 @@ func (t *Array) Valid() bool {
 }
 
 func (t *Array) String() string {
-	str := C.mlx_string_new()
-	defer C.mlx_string_free(str)
-	C.mlx_array_tostring(&str, t.ctx)
-	return strings.TrimSpace(C.GoString(C.mlx_string_data(str)))
+	str := mlxCheck(C.mlx_string_new())
+	mlxCheck(C.mlx_array_tostring(&str, t.ctx))
+	defer freeString(str)
+	return strings.TrimSpace(C.GoString(mlxCheck(C.mlx_string_data(str))))
 }
 
 func (t *Array) LogValue() slog.Value {
@@ -206,15 +206,15 @@ func (t *Array) LogValue() slog.Value {
 // shape utilities
 
 func (t *Array) Size() int {
-	return int(C.mlx_array_size(t.ctx))
+	return int(mlxCheck(C.mlx_array_size(t.ctx)))
 }
 
 func (t *Array) NumBytes() int {
-	return int(C.mlx_array_nbytes(t.ctx))
+	return int(mlxCheck(C.mlx_array_nbytes(t.ctx)))
 }
 
 func (t *Array) NumDims() int {
-	return int(C.mlx_array_ndim(t.ctx))
+	return int(mlxCheck(C.mlx_array_ndim(t.ctx)))
 }
 
 func (t *Array) Dims() []int {
@@ -227,11 +227,15 @@ func (t *Array) Dims() []int {
 }
 
 func (t *Array) Dim(dim int) int {
-	return int(C.mlx_array_dim(t.ctx, C.int(dim)))
+	n := C.mlx_array_dim(t.ctx, C.int(dim))
+	if err := lastError(); err != nil {
+		panic(err)
+	}
+	return int(n)
 }
 
 func (t *Array) DType() DType {
-	return DType(C.mlx_array_dtype(t.ctx))
+	return DType(mlxCheck(C.mlx_array_dtype(t.ctx)))
 }
 
 // data utilities
@@ -241,7 +245,7 @@ func (t *Array) Int() int32 {
 		panic(fmt.Sprintf("mlx: Int requires a DTypeInt32 array, got %v", dt))
 	}
 	var item C.int32_t
-	C.mlx_array_item_int32(&item, t.ctx)
+	mlxCheck(C.mlx_array_item_int32(&item, t.ctx))
 	return int32(item)
 }
 
@@ -250,7 +254,7 @@ func (t *Array) Float() float32 {
 		panic(fmt.Sprintf("mlx: Float requires a DTypeFloat32 array, got %v", dt))
 	}
 	var item C.float
-	C.mlx_array_item_float32(&item, t.ctx)
+	mlxCheck(C.mlx_array_item_float32(&item, t.ctx))
 	return float32(item)
 }
 
@@ -259,8 +263,9 @@ func (t *Array) Ints() []int32 {
 		panic(fmt.Sprintf("mlx: Ints requires DTypeInt32, got %v", dt))
 	}
 	Eval(t)
+	data := mlxCheck(C.mlx_array_data_int32(t.ctx))
 	ints := make([]int32, t.Size())
-	copy(ints, unsafe.Slice((*int32)(unsafe.Pointer(C.mlx_array_data_int32(t.ctx))), len(ints)))
+	copy(ints, unsafe.Slice((*int32)(unsafe.Pointer(data)), len(ints)))
 	return ints
 }
 
@@ -269,15 +274,18 @@ func (t *Array) Floats() []float32 {
 		panic(fmt.Sprintf("mlx: Floats requires DTypeFloat32, got %v", dt))
 	}
 	Eval(t)
+	data := mlxCheck(C.mlx_array_data_float32(t.ctx))
 	floats := make([]float32, t.Size())
-	copy(floats, unsafe.Slice((*float32)(unsafe.Pointer(C.mlx_array_data_float32(t.ctx))), len(floats)))
+	copy(floats, unsafe.Slice((*float32)(unsafe.Pointer(data)), len(floats)))
 	return floats
 }
 
 func (t *Array) Save(name string) error {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
-	C.mlx_save(cName, t.ctx)
+	if err := mlxError(C.mlx_save(cName, t.ctx)); err != nil {
+		return fmt.Errorf("failed to save array to %s: %w", name, err)
+	}
 	return nil
 }
 

--- a/x/mlxrunner/mlx/array_test.go
+++ b/x/mlxrunner/mlx/array_test.go
@@ -86,3 +86,15 @@ func TestComparisonOpsAndBernoulli(t *testing.T) {
 		})
 	}
 }
+
+// An empty array has no buffer, so its data pointer is null without an error.
+func TestEmptyArrayData(t *testing.T) {
+	withMLXThread(t, func(t *mlxthreadtest.T) {
+		if got := Zeros(DTypeFloat32, 0).Floats(); len(got) != 0 {
+			t.Fatalf("Floats() = %v, want empty", got)
+		}
+		if got := Zeros(DTypeInt32, 0).Ints(); len(got) != 0 {
+			t.Fatalf("Ints() = %v, want empty", got)
+		}
+	})
+}

--- a/x/mlxrunner/mlx/compile.go
+++ b/x/mlxrunner/mlx/compile.go
@@ -63,9 +63,7 @@ func Compile(name string, fn CompileFunc, opts ...CompileOption) CompileFunc {
 			defer C.mlx_closure_free(src)
 
 			closure = C.mlx_closure_new()
-			mlxCheck(name+": compile failed", func() C.int {
-				return C.mlx_compile(&closure, src, C.bool(cfg.shapeless))
-			})
+			mlxCheck(C.mlx_compile(&closure, src, C.bool(cfg.shapeless)))
 		})
 
 		inVec := C.mlx_vector_array_new()
@@ -76,9 +74,7 @@ func Compile(name string, fn CompileFunc, opts ...CompileOption) CompileFunc {
 
 		outVec := C.mlx_vector_array_new()
 		defer C.mlx_vector_array_free(outVec)
-		mlxCheck(name+": closure apply failed", func() C.int {
-			return C.mlx_closure_apply(&outVec, closure, inVec)
-		})
+		mlxCheck(C.mlx_closure_apply(&outVec, closure, inVec))
 
 		n := int(C.mlx_vector_array_size(outVec))
 		outputs := make([]*Array, n)

--- a/x/mlxrunner/mlx/compile.go
+++ b/x/mlxrunner/mlx/compile.go
@@ -55,32 +55,32 @@ func Compile(name string, fn CompileFunc, opts ...CompileOption) CompileFunc {
 		once.Do(func() {
 			payload := (*cgo.Handle)(C.malloc(C.size_t(unsafe.Sizeof(cgo.Handle(0)))))
 			*payload = cgo.NewHandle(fn)
-			src := C.mlx_closure_new_func_payload(
+			src := mlxCheck(C.mlx_closure_new_func_payload(
 				(*[0]byte)(C.closureCallback),
 				unsafe.Pointer(payload),
 				(*[0]byte)(C.closureDestructor),
-			)
-			defer C.mlx_closure_free(src)
+			))
+			defer freeClosure(src)
 
-			closure = C.mlx_closure_new()
+			closure = mlxCheck(C.mlx_closure_new())
 			mlxCheck(C.mlx_compile(&closure, src, C.bool(cfg.shapeless)))
 		})
 
-		inVec := C.mlx_vector_array_new()
-		defer C.mlx_vector_array_free(inVec)
+		inVec := mlxCheck(C.mlx_vector_array_new())
+		defer freeVectorArray(inVec)
 		for _, in := range inputs {
-			C.mlx_vector_array_append_value(inVec, in.ctx)
+			mlxCheck(C.mlx_vector_array_append_value(inVec, in.ctx))
 		}
 
-		outVec := C.mlx_vector_array_new()
-		defer C.mlx_vector_array_free(outVec)
+		outVec := mlxCheck(C.mlx_vector_array_new())
+		defer freeVectorArray(outVec)
 		mlxCheck(C.mlx_closure_apply(&outVec, closure, inVec))
 
-		n := int(C.mlx_vector_array_size(outVec))
+		n := int(mlxCheck(C.mlx_vector_array_size(outVec)))
 		outputs := make([]*Array, n)
 		for i := range n {
 			outputs[i] = New(name)
-			C.mlx_vector_array_get(&outputs[i].ctx, outVec, C.size_t(i))
+			mlxCheck(C.mlx_vector_array_get(&outputs[i].ctx, outVec, C.size_t(i)))
 		}
 		return outputs
 	}
@@ -150,7 +150,7 @@ func closureCallback(res *C.mlx_vector_array, input C.mlx_vector_array, payload 
 				panic("mlx: traced array was pinned during compilation")
 			}
 			if a.Valid() {
-				C.mlx_array_free(a.ctx)
+				mlxCheck(C.mlx_array_free(a.ctx))
 				a.ctx.ctx = nil
 			}
 		}
@@ -158,11 +158,11 @@ func closureCallback(res *C.mlx_vector_array, input C.mlx_vector_array, payload 
 		traceScratch = nil
 	}()
 
-	n := int(C.mlx_vector_array_size(input))
+	n := int(mlxCheck(C.mlx_vector_array_size(input)))
 	inputs := make([]*Array, n)
 	for i := range n {
 		a := New("")
-		C.mlx_vector_array_get(&a.ctx, input, C.size_t(i))
+		mlxCheck(C.mlx_vector_array_get(&a.ctx, input, C.size_t(i)))
 		inputs[i] = a
 	}
 
@@ -176,7 +176,7 @@ func closureCallback(res *C.mlx_vector_array, input C.mlx_vector_array, payload 
 		}
 		arrPtr = &handles[0]
 	}
-	C.mlx_vector_array_set_data(res, arrPtr, C.size_t(len(outputs)))
+	mlxCheck(C.mlx_vector_array_set_data(res, arrPtr, C.size_t(len(outputs))))
 	return 0
 }
 

--- a/x/mlxrunner/mlx/compile_test.go
+++ b/x/mlxrunner/mlx/compile_test.go
@@ -124,8 +124,8 @@ func testCompileCallbackPanicRecovers(t *mlxthreadtest.T) {
 		if r == nil {
 			t.Fatal("expected panic from Call, got none")
 		}
-		if _, ok := r.(string); !ok {
-			t.Fatalf("expected string panic, got %T: %v", r, r)
+		if _, ok := r.(error); !ok {
+			t.Fatalf("expected error panic, got %T: %v", r, r)
 		}
 	}()
 	boom(x)

--- a/x/mlxrunner/mlx/fast.go
+++ b/x/mlxrunner/mlx/fast.go
@@ -21,7 +21,7 @@ func FastScaledDotProductAttention(q, k, v *Array, scale float32, mode string, m
 	}
 
 	out := New("FAST_SDPA")
-	C.mlx_fast_scaled_dot_product_attention(&out.ctx, q.ctx, k.ctx, v.ctx, C.float(scale), cMode, maskCtx, sinks.ctx, C.bool(false), DefaultStream().ctx)
+	mlxCheck(C.mlx_fast_scaled_dot_product_attention(&out.ctx, q.ctx, k.ctx, v.ctx, C.float(scale), cMode, maskCtx, sinks.ctx, C.bool(false), DefaultStream().ctx))
 	return out
 }
 
@@ -32,7 +32,7 @@ type LayerNorm struct {
 
 func (r *LayerNorm) Forward(x *Array, eps float32) *Array {
 	out := New("FAST_LAYERNORM")
-	C.mlx_fast_layer_norm(&out.ctx, x.ctx, r.Weight.ctx, r.Bias.ctx, C.float(eps), DefaultStream().ctx)
+	mlxCheck(C.mlx_fast_layer_norm(&out.ctx, x.ctx, r.Weight.ctx, r.Bias.ctx, C.float(eps), DefaultStream().ctx))
 	return out
 }
 
@@ -42,6 +42,6 @@ type RMSNorm struct {
 
 func (r *RMSNorm) Forward(x *Array, eps float32) *Array {
 	out := New("FAST_RMSNORM")
-	C.mlx_fast_rms_norm(&out.ctx, x.ctx, r.Weight.ctx, C.float(eps), DefaultStream().ctx)
+	mlxCheck(C.mlx_fast_rms_norm(&out.ctx, x.ctx, r.Weight.ctx, C.float(eps), DefaultStream().ctx))
 	return out
 }

--- a/x/mlxrunner/mlx/gpu_kernel.go
+++ b/x/mlxrunner/mlx/gpu_kernel.go
@@ -69,23 +69,24 @@ type gpuLaunch struct {
 	inputs      []*Array
 }
 
-func cStringVector(values []string) (C.mlx_vector_string, func(), bool) {
+func cStringVector(values []string) (C.mlx_vector_string, func(), error) {
 	vec := C.mlx_vector_string_new()
-	ok := true
+	if err := mlxError(vec); err != nil {
+		return C.mlx_vector_string{}, nil, err
+	}
 	for _, s := range values {
 		cs := C.CString(s)
-		if C.mlx_vector_string_append_value(vec, cs) != 0 {
-			ok = false
-		}
+		err := mlxError(C.mlx_vector_string_append_value(vec, cs))
 		C.free(unsafe.Pointer(cs))
-		if !ok {
-			break
+		if err != nil {
+			mlxCheck(C.mlx_vector_string_free(vec))
+			return C.mlx_vector_string{}, nil, err
 		}
 	}
 	cleanup := func() {
-		C.mlx_vector_string_free(vec)
+		mlxCheck(C.mlx_vector_string_free(vec))
 	}
-	return vec, cleanup, ok
+	return vec, cleanup, nil
 }
 
 // run executes the kernel with the first backend that works, in CUDA,
@@ -107,14 +108,22 @@ func (k *gpuKernel) run(launch gpuLaunch) []*Array {
 	return outs
 }
 
-func (k *gpuKernel) disableMetal(reason string) {
+func (k *gpuKernel) disableMetal(reason string, err error) {
 	k.metalDisabled = true
-	slog.Warn("custom GPU kernel backend disabled", "kernel", k.name, "backend", "metal", "reason", reason)
+	args := []any{"kernel", k.name, "backend", "metal", "reason", reason}
+	if err != nil {
+		args = append(args, "error", err)
+	}
+	slog.Warn("custom GPU kernel backend disabled", args...)
 }
 
-func (k *gpuKernel) disableCUDA(reason string) {
+func (k *gpuKernel) disableCUDA(reason string, err error) {
 	k.cudaDisabled = true
-	slog.Warn("custom GPU kernel backend disabled", "kernel", k.name, "backend", "cuda", "reason", reason)
+	args := []any{"kernel", k.name, "backend", "cuda", "reason", reason}
+	if err != nil {
+		args = append(args, "error", err)
+	}
+	slog.Warn("custom GPU kernel backend disabled", args...)
 }
 
 func (k *gpuKernel) getMetal() (C.mlx_fast_metal_kernel, bool) {
@@ -125,22 +134,20 @@ func (k *gpuKernel) getMetal() (C.mlx_fast_metal_kernel, bool) {
 		}
 
 		if k.metal.source == "" {
-			k.disableMetal("no source")
+			k.disableMetal("no source", nil)
 			return
 		}
 
-		inputs, freeInputs, ok := cStringVector(k.inputs)
-		if !ok {
-			freeInputs()
-			k.disableMetal("creating input names failed")
+		inputs, freeInputs, err := cStringVector(k.inputs)
+		if err != nil {
+			k.disableMetal("creating input names failed", err)
 			return
 		}
 		defer freeInputs()
 
-		outputs, freeOutputs, ok := cStringVector(k.outputs)
-		if !ok {
-			freeOutputs()
-			k.disableMetal("creating output names failed")
+		outputs, freeOutputs, err := cStringVector(k.outputs)
+		if err != nil {
+			k.disableMetal("creating output names failed", err)
 			return
 		}
 		defer freeOutputs()
@@ -162,8 +169,8 @@ func (k *gpuKernel) getMetal() (C.mlx_fast_metal_kernel, bool) {
 			C.bool(true),
 			C.bool(false),
 		)
-		if k.metalKernel.ctx == nil {
-			k.disableMetal("creating kernel failed")
+		if err := mlxError(k.metalKernel); err != nil {
+			k.disableMetal("creating kernel failed", err)
 		}
 	})
 	return k.metalKernel, !k.metalDisabled
@@ -180,21 +187,25 @@ func (k *gpuKernel) applyMetal(launch gpuLaunch) ([]*Array, bool) {
 
 	cfg := C.mlx_fast_metal_kernel_config_new()
 	defer C.mlx_fast_metal_kernel_config_free(cfg)
+	if err := mlxError(cfg); err != nil {
+		k.disableMetal("creating config failed", err)
+		return nil, false
+	}
 	for _, arg := range launch.dtypes {
 		name := C.CString(arg.name)
-		rc := C.mlx_fast_metal_kernel_config_add_template_arg_dtype(cfg, name, C.mlx_dtype(arg.dtype))
+		err := mlxError(C.mlx_fast_metal_kernel_config_add_template_arg_dtype(cfg, name, C.mlx_dtype(arg.dtype)))
 		C.free(unsafe.Pointer(name))
-		if rc != 0 {
-			k.disableMetal("setting dtype template arg failed")
+		if err != nil {
+			k.disableMetal("setting dtype template arg failed", err)
 			return nil, false
 		}
 	}
 	for _, arg := range launch.ints {
 		name := C.CString(arg.name)
-		rc := C.mlx_fast_metal_kernel_config_add_template_arg_int(cfg, name, C.int(arg.value))
+		err := mlxError(C.mlx_fast_metal_kernel_config_add_template_arg_int(cfg, name, C.int(arg.value)))
 		C.free(unsafe.Pointer(name))
-		if rc != 0 {
-			k.disableMetal("setting int template arg failed")
+		if err != nil {
+			k.disableMetal("setting int template arg failed", err)
 			return nil, false
 		}
 	}
@@ -203,14 +214,17 @@ func (k *gpuKernel) applyMetal(launch gpuLaunch) ([]*Array, bool) {
 		for i, d := range out.shape {
 			shape[i] = C.int(d)
 		}
-		if C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(shape), C.size_t(len(shape)), C.mlx_dtype(out.dtype)) != 0 {
-			k.disableMetal("adding output failed")
+		if err := mlxError(C.mlx_fast_metal_kernel_config_add_output_arg(cfg, unsafe.SliceData(shape), C.size_t(len(shape)), C.mlx_dtype(out.dtype))); err != nil {
+			k.disableMetal("adding output failed", err)
 			return nil, false
 		}
 	}
-	if C.mlx_fast_metal_kernel_config_set_grid(cfg, C.int(launch.grid[0]), C.int(launch.grid[1]), C.int(launch.grid[2])) != 0 ||
-		C.mlx_fast_metal_kernel_config_set_thread_group(cfg, C.int(launch.threadGroup[0]), C.int(launch.threadGroup[1]), C.int(launch.threadGroup[2])) != 0 {
-		k.disableMetal("setting grid failed")
+	if err := mlxError(C.mlx_fast_metal_kernel_config_set_grid(cfg, C.int(launch.grid[0]), C.int(launch.grid[1]), C.int(launch.grid[2]))); err != nil {
+		k.disableMetal("setting grid failed", err)
+		return nil, false
+	}
+	if err := mlxError(C.mlx_fast_metal_kernel_config_set_thread_group(cfg, C.int(launch.threadGroup[0]), C.int(launch.threadGroup[1]), C.int(launch.threadGroup[2]))); err != nil {
+		k.disableMetal("setting thread group failed", err)
 		return nil, false
 	}
 
@@ -219,21 +233,29 @@ func (k *gpuKernel) applyMetal(launch gpuLaunch) ([]*Array, bool) {
 		inputs[i] = in.ctx
 	}
 	inVec := C.mlx_vector_array_new_data(unsafe.SliceData(inputs), C.size_t(len(inputs)))
-	defer C.mlx_vector_array_free(inVec)
-	outVec := C.mlx_vector_array_new()
-	defer C.mlx_vector_array_free(outVec)
-	if C.mlx_fast_metal_kernel_apply(&outVec, kernel, inVec, cfg, DefaultStream().ctx) != 0 {
-		k.disableMetal("launching failed")
+	if err := mlxError(inVec); err != nil {
+		k.disableMetal("creating input vector failed", err)
 		return nil, false
 	}
-	if int(C.mlx_vector_array_size(outVec)) < len(launch.outputs) {
+	defer freeVectorArray(inVec)
+	outVec := C.mlx_vector_array_new()
+	if err := mlxError(outVec); err != nil {
+		k.disableMetal("creating output vector failed", err)
+		return nil, false
+	}
+	defer freeVectorArray(outVec)
+	if err := mlxError(C.mlx_fast_metal_kernel_apply(&outVec, kernel, inVec, cfg, DefaultStream().ctx)); err != nil {
+		k.disableMetal("launching failed", err)
+		return nil, false
+	}
+	if int(mlxCheck(C.mlx_vector_array_size(outVec))) < len(launch.outputs) {
 		return nil, false
 	}
 
 	outs := make([]*Array, len(launch.outputs))
 	for i, out := range launch.outputs {
 		outs[i] = New(out.name)
-		C.mlx_vector_array_get(&outs[i].ctx, outVec, C.size_t(i))
+		mlxCheck(C.mlx_vector_array_get(&outs[i].ctx, outVec, C.size_t(i)))
 	}
 	return outs, true
 }
@@ -246,22 +268,20 @@ func (k *gpuKernel) getCUDA() (C.mlx_fast_cuda_kernel, bool) {
 		}
 
 		if k.cuda.source == "" {
-			k.disableCUDA("no source")
+			k.disableCUDA("no source", nil)
 			return
 		}
 
-		inputs, freeInputs, ok := cStringVector(k.inputs)
-		if !ok {
-			freeInputs()
-			k.disableCUDA("creating input names failed")
+		inputs, freeInputs, err := cStringVector(k.inputs)
+		if err != nil {
+			k.disableCUDA("creating input names failed", err)
 			return
 		}
 		defer freeInputs()
 
-		outputs, freeOutputs, ok := cStringVector(k.outputs)
-		if !ok {
-			freeOutputs()
-			k.disableCUDA("creating output names failed")
+		outputs, freeOutputs, err := cStringVector(k.outputs)
+		if err != nil {
+			k.disableCUDA("creating output names failed", err)
 			return
 		}
 		defer freeOutputs()
@@ -282,8 +302,8 @@ func (k *gpuKernel) getCUDA() (C.mlx_fast_cuda_kernel, bool) {
 			C.bool(true),
 			C.int(0),
 		)
-		if k.cudaKernel.ctx == nil {
-			k.disableCUDA("creating kernel failed")
+		if err := mlxError(k.cudaKernel); err != nil {
+			k.disableCUDA("creating kernel failed", err)
 		}
 	})
 	return k.cudaKernel, !k.cudaDisabled
@@ -300,21 +320,25 @@ func (k *gpuKernel) applyCUDA(launch gpuLaunch) ([]*Array, bool) {
 
 	cfg := C.mlx_fast_cuda_kernel_config_new()
 	defer C.mlx_fast_cuda_kernel_config_free(cfg)
+	if err := mlxError(cfg); err != nil {
+		k.disableCUDA("creating config failed", err)
+		return nil, false
+	}
 	for _, arg := range launch.dtypes {
 		name := C.CString(arg.name)
-		rc := C.mlx_fast_cuda_kernel_config_add_template_arg_dtype(cfg, name, C.mlx_dtype(arg.dtype))
+		err := mlxError(C.mlx_fast_cuda_kernel_config_add_template_arg_dtype(cfg, name, C.mlx_dtype(arg.dtype)))
 		C.free(unsafe.Pointer(name))
-		if rc != 0 {
-			k.disableCUDA("setting dtype template arg failed")
+		if err != nil {
+			k.disableCUDA("setting dtype template arg failed", err)
 			return nil, false
 		}
 	}
 	for _, arg := range launch.ints {
 		name := C.CString(arg.name)
-		rc := C.mlx_fast_cuda_kernel_config_add_template_arg_int(cfg, name, C.int(arg.value))
+		err := mlxError(C.mlx_fast_cuda_kernel_config_add_template_arg_int(cfg, name, C.int(arg.value)))
 		C.free(unsafe.Pointer(name))
-		if rc != 0 {
-			k.disableCUDA("setting int template arg failed")
+		if err != nil {
+			k.disableCUDA("setting int template arg failed", err)
 			return nil, false
 		}
 	}
@@ -323,14 +347,17 @@ func (k *gpuKernel) applyCUDA(launch gpuLaunch) ([]*Array, bool) {
 		for i, d := range out.shape {
 			shape[i] = C.int(d)
 		}
-		if C.mlx_fast_cuda_kernel_config_add_output_arg(cfg, unsafe.SliceData(shape), C.size_t(len(shape)), C.mlx_dtype(out.dtype)) != 0 {
-			k.disableCUDA("adding output failed")
+		if err := mlxError(C.mlx_fast_cuda_kernel_config_add_output_arg(cfg, unsafe.SliceData(shape), C.size_t(len(shape)), C.mlx_dtype(out.dtype))); err != nil {
+			k.disableCUDA("adding output failed", err)
 			return nil, false
 		}
 	}
-	if C.mlx_fast_cuda_kernel_config_set_grid(cfg, C.int(launch.grid[0]), C.int(launch.grid[1]), C.int(launch.grid[2])) != 0 ||
-		C.mlx_fast_cuda_kernel_config_set_thread_group(cfg, C.int(launch.threadGroup[0]), C.int(launch.threadGroup[1]), C.int(launch.threadGroup[2])) != 0 {
-		k.disableCUDA("setting grid failed")
+	if err := mlxError(C.mlx_fast_cuda_kernel_config_set_grid(cfg, C.int(launch.grid[0]), C.int(launch.grid[1]), C.int(launch.grid[2]))); err != nil {
+		k.disableCUDA("setting grid failed", err)
+		return nil, false
+	}
+	if err := mlxError(C.mlx_fast_cuda_kernel_config_set_thread_group(cfg, C.int(launch.threadGroup[0]), C.int(launch.threadGroup[1]), C.int(launch.threadGroup[2]))); err != nil {
+		k.disableCUDA("setting thread group failed", err)
 		return nil, false
 	}
 
@@ -339,21 +366,29 @@ func (k *gpuKernel) applyCUDA(launch gpuLaunch) ([]*Array, bool) {
 		inputs[i] = in.ctx
 	}
 	inVec := C.mlx_vector_array_new_data(unsafe.SliceData(inputs), C.size_t(len(inputs)))
-	defer C.mlx_vector_array_free(inVec)
-	outVec := C.mlx_vector_array_new()
-	defer C.mlx_vector_array_free(outVec)
-	if C.mlx_fast_cuda_kernel_apply(&outVec, kernel, inVec, cfg, DefaultStream().ctx) != 0 {
-		k.disableCUDA("launching failed")
+	if err := mlxError(inVec); err != nil {
+		k.disableCUDA("creating input vector failed", err)
 		return nil, false
 	}
-	if int(C.mlx_vector_array_size(outVec)) < len(launch.outputs) {
+	defer freeVectorArray(inVec)
+	outVec := C.mlx_vector_array_new()
+	if err := mlxError(outVec); err != nil {
+		k.disableCUDA("creating output vector failed", err)
+		return nil, false
+	}
+	defer freeVectorArray(outVec)
+	if err := mlxError(C.mlx_fast_cuda_kernel_apply(&outVec, kernel, inVec, cfg, DefaultStream().ctx)); err != nil {
+		k.disableCUDA("launching failed", err)
+		return nil, false
+	}
+	if int(mlxCheck(C.mlx_vector_array_size(outVec))) < len(launch.outputs) {
 		return nil, false
 	}
 
 	outs := make([]*Array, len(launch.outputs))
 	for i, out := range launch.outputs {
 		outs[i] = New(out.name)
-		C.mlx_vector_array_get(&outs[i].ctx, outVec, C.size_t(i))
+		mlxCheck(C.mlx_vector_array_get(&outs[i].ctx, outVec, C.size_t(i)))
 	}
 	return outs, true
 }

--- a/x/mlxrunner/mlx/io.go
+++ b/x/mlxrunner/mlx/io.go
@@ -33,10 +33,13 @@ func LoadSafetensorsNative(path string) (*SafetensorsFile, error) {
 	defer C.free(unsafe.Pointer(cPath))
 
 	stream := loadSafetensorsStream()
-	defer C.mlx_stream_free(stream)
+	if err := mlxError(stream); err != nil {
+		return nil, err
+	}
+	defer freeStream(stream)
 
-	if C.mlx_load_safetensors(&arrays, &metadata, cPath, stream) != 0 {
-		return nil, fmt.Errorf("failed to load safetensors: %s", path)
+	if err := mlxError(C.mlx_load_safetensors(&arrays, &metadata, cPath, stream)); err != nil {
+		return nil, fmt.Errorf("failed to load safetensors %s: %w", path, err)
 	}
 
 	return &SafetensorsFile{arrays: arrays, metadata: metadata}, nil
@@ -47,8 +50,12 @@ func (s *SafetensorsFile) Get(name string) *Array {
 	cName := C.CString(name)
 	defer C.free(unsafe.Pointer(cName))
 
-	value := C.mlx_array_new()
-	if C.mlx_map_string_to_array_get(&value, s.arrays, cName) != 0 {
+	value := mlxCheck(C.mlx_array_new())
+	rc := C.mlx_map_string_to_array_get(&value, s.arrays, cName)
+	if err := lastError(); err != nil {
+		panic(err)
+	}
+	if rc != 0 {
 		return nil
 	}
 	if value.ctx == nil {
@@ -66,7 +73,11 @@ func (s *SafetensorsFile) GetMetadata(key string) string {
 	defer C.free(unsafe.Pointer(cKey))
 
 	var cValue *C.char
-	if C.mlx_map_string_to_string_get(&cValue, s.metadata, cKey) != 0 {
+	rc := C.mlx_map_string_to_string_get(&cValue, s.metadata, cKey)
+	if err := lastError(); err != nil {
+		panic(err)
+	}
+	if rc != 0 {
 		return ""
 	}
 	return C.GoString(cValue)
@@ -77,8 +88,8 @@ func (s *SafetensorsFile) Free() {
 	if s == nil {
 		return
 	}
-	C.mlx_map_string_to_array_free(s.arrays)
-	C.mlx_map_string_to_string_free(s.metadata)
+	freeArrayMap(s.arrays)
+	freeStringMap(s.metadata)
 }
 
 func Load(path string) iter.Seq2[string, *Array] {
@@ -89,13 +100,17 @@ func Load(path string) iter.Seq2[string, *Array] {
 		}
 		defer sf.Free()
 
-		it := C.mlx_map_string_to_array_iterator_new(sf.arrays)
-		defer C.mlx_map_string_to_array_iterator_free(it)
+		it := mlxCheck(C.mlx_map_string_to_array_iterator_new(sf.arrays))
+		defer freeArrayMapIterator(it)
 
 		for {
 			var key *C.char
-			value := C.mlx_array_new()
-			if C.mlx_map_string_to_array_iterator_next(&key, &value, it) != 0 {
+			value := mlxCheck(C.mlx_array_new())
+			rc := C.mlx_map_string_to_array_iterator_next(&key, &value, it)
+			if err := lastError(); err != nil {
+				panic(err)
+			}
+			if rc != 0 {
 				break
 			}
 
@@ -120,7 +135,10 @@ func SaveSafetensorsWithMetadata(path string, arrays map[string]*Array, metadata
 	defer C.free(unsafe.Pointer(cPath))
 
 	cArrays := C.mlx_map_string_to_array_new()
-	defer C.mlx_map_string_to_array_free(cArrays)
+	if err := mlxError(cArrays); err != nil {
+		return err
+	}
+	defer freeArrayMap(cArrays)
 
 	arrayNames := make([]string, 0, len(arrays))
 	for name, arr := range arrays {
@@ -134,12 +152,18 @@ func SaveSafetensorsWithMetadata(path string, arrays map[string]*Array, metadata
 	for _, name := range arrayNames {
 		arr := arrays[name]
 		cName := C.CString(name)
-		C.mlx_map_string_to_array_insert(cArrays, cName, arr.ctx)
+		err := mlxError(C.mlx_map_string_to_array_insert(cArrays, cName, arr.ctx))
 		C.free(unsafe.Pointer(cName))
+		if err != nil {
+			return err
+		}
 	}
 
 	cMetadata := C.mlx_map_string_to_string_new()
-	defer C.mlx_map_string_to_string_free(cMetadata)
+	if err := mlxError(cMetadata); err != nil {
+		return err
+	}
+	defer freeStringMap(cMetadata)
 
 	metadataKeys := make([]string, 0, len(metadata))
 	for key := range metadata {
@@ -151,13 +175,16 @@ func SaveSafetensorsWithMetadata(path string, arrays map[string]*Array, metadata
 		value := metadata[key]
 		cKey := C.CString(key)
 		cValue := C.CString(value)
-		C.mlx_map_string_to_string_insert(cMetadata, cKey, cValue)
+		err := mlxError(C.mlx_map_string_to_string_insert(cMetadata, cKey, cValue))
 		C.free(unsafe.Pointer(cKey))
 		C.free(unsafe.Pointer(cValue))
+		if err != nil {
+			return err
+		}
 	}
 
-	if C.mlx_save_safetensors(cPath, cArrays, cMetadata) != 0 {
-		return fmt.Errorf("failed to save safetensors: %s", path)
+	if err := mlxError(C.mlx_save_safetensors(cPath, cArrays, cMetadata)); err != nil {
+		return fmt.Errorf("failed to save safetensors %s: %w", path, err)
 	}
 
 	return nil

--- a/x/mlxrunner/mlx/memory.go
+++ b/x/mlxrunner/mlx/memory.go
@@ -72,22 +72,22 @@ func ResetPeakMemory() {
 // for resident Metal allocations.
 func MaxRecommendedWorkingSetSize() (int, error) {
 	info := C.mlx_device_info_new()
-	if err := mlxCall("get device info failed", func() C.int {
-		return C.mlx_device_info_get(&info, DefaultDevice().ctx)
-	}); err != nil {
-		C.mlx_device_info_free(info)
+	defer C.mlx_device_info_free(info)
+	if err := mlxError(C.mlx_device_info_get(&info, DefaultDevice().ctx)); err != nil {
 		return 0, err
 	}
-	defer C.mlx_device_info_free(info)
 
 	key := C.CString("max_recommended_working_set_size")
 	defer C.free(unsafe.Pointer(key))
 
 	var size C.size_t
-	if err := mlxCall("max recommended working set size unavailable", func() C.int {
-		return C.mlx_device_info_get_size(&size, info, key)
-	}); err != nil {
+	rc := C.mlx_device_info_get_size(&size, info, key)
+	if err := lastError(); err != nil {
 		return 0, err
+	}
+	if rc != 0 {
+		// mlx-c reports a missing key with a non-zero return and no message.
+		return 0, fmt.Errorf("mlx: no max_recommended_working_set_size in device info")
 	}
 	return int(size), nil
 }
@@ -100,9 +100,7 @@ func SetWiredLimit(limit int) (int, error) {
 	}
 
 	var previous C.size_t
-	if err := mlxCall("set wired limit failed", func() C.int {
-		return C.mlx_set_wired_limit(&previous, C.size_t(limit))
-	}); err != nil {
+	if err := mlxError(C.mlx_set_wired_limit(&previous, C.size_t(limit))); err != nil {
 		return 0, err
 	}
 	return int(previous), nil

--- a/x/mlxrunner/mlx/memory.go
+++ b/x/mlxrunner/mlx/memory.go
@@ -48,34 +48,34 @@ func PrettyBytes(n int) fmt.Stringer {
 
 func ActiveMemory() int {
 	var active C.size_t
-	C.mlx_get_active_memory(&active)
+	mlxCheck(C.mlx_get_active_memory(&active))
 	return int(active)
 }
 
 func CacheMemory() int {
 	var cache C.size_t
-	C.mlx_get_cache_memory(&cache)
+	mlxCheck(C.mlx_get_cache_memory(&cache))
 	return int(cache)
 }
 
 func PeakMemory() int {
 	var peak C.size_t
-	C.mlx_get_peak_memory(&peak)
+	mlxCheck(C.mlx_get_peak_memory(&peak))
 	return int(peak)
 }
 
 func ResetPeakMemory() {
-	C.mlx_reset_peak_memory()
+	mlxCheck(C.mlx_reset_peak_memory())
 }
 
 // MaxRecommendedWorkingSetSize returns the device's recommended upper bound
 // for resident Metal allocations.
 func MaxRecommendedWorkingSetSize() (int, error) {
-	info := C.mlx_device_info_new()
-	defer C.mlx_device_info_free(info)
+	info := mlxCheck(C.mlx_device_info_new())
 	if err := mlxError(C.mlx_device_info_get(&info, DefaultDevice().ctx)); err != nil {
 		return 0, err
 	}
+	defer freeDeviceInfo(info)
 
 	key := C.CString("max_recommended_working_set_size")
 	defer C.free(unsafe.Pointer(key))
@@ -125,5 +125,5 @@ type (
 )
 
 func ClearCache() {
-	C.mlx_clear_cache()
+	mlxCheck(C.mlx_clear_cache())
 }

--- a/x/mlxrunner/mlx/mlx.go
+++ b/x/mlxrunner/mlx/mlx.go
@@ -93,12 +93,35 @@ func mlxCheck[T comparable](v T) T {
 	return v
 }
 
+// Deferred frees go through these helpers: defer evaluates a call's
+// arguments immediately, so defer mlxCheck(C.mlx_..._free(v)) would
+// free v on the spot and defer only the check.
+func freeArray(a C.mlx_array)              { mlxCheck(C.mlx_array_free(a)) }
+func freeString(s C.mlx_string)            { mlxCheck(C.mlx_string_free(s)) }
+func freeVectorArray(v C.mlx_vector_array) { mlxCheck(C.mlx_vector_array_free(v)) }
+func freeClosure(c C.mlx_closure)          { mlxCheck(C.mlx_closure_free(c)) }
+func freeStream(s C.mlx_stream)            { mlxCheck(C.mlx_stream_free(s)) }
+func freeDevice(d C.mlx_device)            { mlxCheck(C.mlx_device_free(d)) }
+func freeDeviceInfo(i C.mlx_device_info)   { mlxCheck(C.mlx_device_info_free(i)) }
+
+func freeArrayMap(m C.mlx_map_string_to_array) {
+	mlxCheck(C.mlx_map_string_to_array_free(m))
+}
+
+func freeStringMap(m C.mlx_map_string_to_string) {
+	mlxCheck(C.mlx_map_string_to_string_free(m))
+}
+
+func freeArrayMapIterator(it C.mlx_map_string_to_array_iterator) {
+	mlxCheck(C.mlx_map_string_to_array_iterator_free(it))
+}
+
 // Version returns the MLX core library version string.
 func Version() string {
-	str := C.mlx_string_new()
-	defer C.mlx_string_free(str)
-	C.mlx_version(&str)
-	return C.GoString(C.mlx_string_data(str))
+	str := mlxCheck(C.mlx_string_new())
+	mlxCheck(C.mlx_version(&str))
+	defer freeString(str)
+	return C.GoString(mlxCheck(C.mlx_string_data(str)))
 }
 
 func doEval(outputs []*Array, async bool) {
@@ -106,12 +129,12 @@ func doEval(outputs []*Array, async bool) {
 		return
 	}
 
-	vector := C.mlx_vector_array_new()
-	defer C.mlx_vector_array_free(vector)
+	vector := mlxCheck(C.mlx_vector_array_new())
+	defer freeVectorArray(vector)
 
 	for _, output := range outputs {
 		if output != nil && output.Valid() {
-			C.mlx_vector_array_append_value(vector, output.ctx)
+			mlxCheck(C.mlx_vector_array_append_value(vector, output.ctx))
 		}
 	}
 
@@ -133,13 +156,13 @@ func Eval(outputs ...*Array) {
 // MetalIsAvailable returns true if a Metal GPU is available.
 func MetalIsAvailable() bool {
 	var available C._Bool
-	C.mlx_metal_is_available(&available)
+	mlxCheck(C.mlx_metal_is_available(&available))
 	return bool(available)
 }
 
 // CUDAIsAvailable returns true if a CUDA GPU is available.
 func CUDAIsAvailable() bool {
 	var available C._Bool
-	C.mlx_cuda_is_available(&available)
+	mlxCheck(C.mlx_cuda_is_available(&available))
 	return bool(available)
 }

--- a/x/mlxrunner/mlx/mlx.go
+++ b/x/mlxrunner/mlx/mlx.go
@@ -1,3 +1,8 @@
+// Package mlx wraps the MLX C API.
+//
+// MLX keeps stream and backend state in thread-locals, so all calls into this
+// package must come from a single goroutine locked to its OS thread (see
+// x/internal/mlxthread).
 package mlx
 
 //go:generate go run generator/main.go -output=. ./include/mlx/c/*.h
@@ -9,35 +14,27 @@ package mlx
 // #include "generated.h"
 // #include <string.h>
 //
-// static __thread char _mlx_last_error_msg[1024] = {0};
-// static __thread int  _mlx_last_error_flag = 0;
+// static char _mlx_last_error[1024];
 //
-// static void _mlx_capture_error_handler(const char* msg, void* data) {
+// static void _mlx_capture_error(const char* msg, void* data) {
 //     (void)data;
-//     strncpy(_mlx_last_error_msg, msg, sizeof(_mlx_last_error_msg) - 1);
-//     _mlx_last_error_msg[sizeof(_mlx_last_error_msg) - 1] = '\0';
-//     _mlx_last_error_flag = 1;
+//     strncpy(_mlx_last_error, msg, sizeof(_mlx_last_error) - 1);
 // }
 //
 // static void mlx_install_capture_handler(void) {
 //     if (mlx_set_error_handler_) {
-//         mlx_set_error_handler_(_mlx_capture_error_handler, NULL, NULL);
+//         mlx_set_error_handler_(_mlx_capture_error, NULL, NULL);
 //     }
 // }
 //
-// static void mlx_clear_last_error(void) {
-//     _mlx_last_error_flag = 0;
-//     _mlx_last_error_msg[0] = '\0';
-// }
-//
-// static const char* mlx_get_last_error(void) {
-//     return _mlx_last_error_flag ? _mlx_last_error_msg : "";
+// static char* mlx_last_error(void) {
+//     return _mlx_last_error;
 // }
 import "C"
 
 import (
+	"errors"
 	"fmt"
-	"runtime"
 )
 
 func init() {
@@ -46,37 +43,62 @@ func init() {
 	C.mlx_install_capture_handler()
 }
 
+var errBuf = C.mlx_last_error()
+
+// lastError consumes the captured MLX error, or returns nil when none is
+// pending.
+func lastError() error {
+	if *errBuf == 0 {
+		return nil
+	}
+	err := fmt.Errorf("mlx: %s", C.GoString(errBuf))
+	*errBuf = 0
+	return err
+}
+
+// mlxError returns the MLX error captured by the call that produced v. mlx-c
+// signals failure with a non-zero int status; a message next to a zero
+// status came from an earlier unchecked call.
+func mlxError[T comparable](v T) error {
+	var zero T
+	var failed, signaled bool
+	switch any(zero).(type) {
+	case C.int:
+		failed, signaled = v != zero, true
+	default:
+		// Only an int status signals failure. Handles, pointers, sizes, and
+		// dtypes are all valid at zero: a null handle is what the out-param
+		// constructors return, and an empty array has no data.
+	}
+	if *errBuf != 0 {
+		err := lastError()
+		if signaled && !failed {
+			return fmt.Errorf("mlx: unchecked error from an earlier call: %w", err)
+		}
+		return err
+	}
+	if failed {
+		return errors.New("mlx: call failed without an error message")
+	}
+	return nil
+}
+
+// mlxCheck panics on a failed call and otherwise passes its result through.
+// Most array operations cannot recover from a failed graph construction or
+// evaluation.
+func mlxCheck[T comparable](v T) T {
+	if err := mlxError(v); err != nil {
+		panic(err)
+	}
+	return v
+}
+
 // Version returns the MLX core library version string.
 func Version() string {
 	str := C.mlx_string_new()
 	defer C.mlx_string_free(str)
 	C.mlx_version(&str)
 	return C.GoString(C.mlx_string_data(str))
-}
-
-// mlxCall locks the goroutine to its OS thread so the thread-local error state
-// is read from the same thread that executed fn.
-func mlxCall(fallback string, fn func() C.int) error {
-	runtime.LockOSThread()
-	defer runtime.UnlockOSThread()
-
-	C.mlx_clear_last_error()
-	if fn() != 0 {
-		msg := C.GoString(C.mlx_get_last_error())
-		if msg == "" {
-			msg = fallback
-		}
-		return fmt.Errorf("mlx: %s", msg)
-	}
-	return nil
-}
-
-// mlxCheck panics with the captured MLX error. Most array operations cannot
-// recover from a failed graph construction or evaluation.
-func mlxCheck(fallback string, fn func() C.int) {
-	if err := mlxCall(fallback, fn); err != nil {
-		panic(err.Error())
-	}
 }
 
 func doEval(outputs []*Array, async bool) {
@@ -93,12 +115,11 @@ func doEval(outputs []*Array, async bool) {
 		}
 	}
 
-	mlxCheck("eval failed", func() C.int {
-		if async {
-			return C.mlx_async_eval(vector)
-		}
-		return C.mlx_eval(vector)
-	})
+	if async {
+		mlxCheck(C.mlx_async_eval(vector))
+	} else {
+		mlxCheck(C.mlx_eval(vector))
+	}
 }
 
 func AsyncEval(outputs ...*Array) {

--- a/x/mlxrunner/mlx/ops.go
+++ b/x/mlxrunner/mlx/ops.go
@@ -9,49 +9,49 @@ import (
 
 func (t *Array) Abs() *Array {
 	out := New("ABS")
-	C.mlx_abs(&out.ctx, t.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_abs(&out.ctx, t.ctx, DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Add(other *Array) *Array {
 	out := New("ADD")
-	C.mlx_add(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_add(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Addmm(a, b *Array, alpha, beta float32) *Array {
 	out := New("ADDMM")
-	C.mlx_addmm(&out.ctx, t.ctx, a.ctx, b.ctx, C.float(alpha), C.float(beta), DefaultStream().ctx)
+	mlxCheck(C.mlx_addmm(&out.ctx, t.ctx, a.ctx, b.ctx, C.float(alpha), C.float(beta), DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Argmax(axis int, keepDims bool) *Array {
 	out := New("ARGMAX")
-	C.mlx_argmax_axis(&out.ctx, t.ctx, C.int(axis), C.bool(keepDims), DefaultStream().ctx)
+	mlxCheck(C.mlx_argmax_axis(&out.ctx, t.ctx, C.int(axis), C.bool(keepDims), DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) ArgpartitionAxis(kth int, axis int) *Array {
 	out := New("ARGPARTITION")
-	C.mlx_argpartition_axis(&out.ctx, t.ctx, C.int(kth), C.int(axis), DefaultStream().ctx)
+	mlxCheck(C.mlx_argpartition_axis(&out.ctx, t.ctx, C.int(kth), C.int(axis), DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) ArgsortAxis(axis int) *Array {
 	out := New("ARGSORT_AXIS")
-	C.mlx_argsort_axis(&out.ctx, t.ctx, C.int(axis), DefaultStream().ctx)
+	mlxCheck(C.mlx_argsort_axis(&out.ctx, t.ctx, C.int(axis), DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) AsType(dtype DType) *Array {
 	out := New("AS_TYPE")
-	C.mlx_astype(&out.ctx, t.ctx, C.mlx_dtype(dtype), DefaultStream().ctx)
+	mlxCheck(C.mlx_astype(&out.ctx, t.ctx, C.mlx_dtype(dtype), DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) BitwiseXor(other *Array) *Array {
 	out := New("BITWISE_XOR")
-	C.mlx_bitwise_xor(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_bitwise_xor(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx))
 	return out
 }
 
@@ -67,19 +67,19 @@ func (t *Array) AsStrided(shape []int, strides []int, offset int) *Array {
 	}
 
 	out := New("AS_STRIDED")
-	C.mlx_as_strided(
+	mlxCheck(C.mlx_as_strided(
 		&out.ctx, t.ctx,
 		unsafe.SliceData(cShape), C.size_t(len(shape)),
 		unsafe.SliceData(cStrides), C.size_t(len(strides)),
 		C.size_t(offset),
 		DefaultStream().ctx,
-	)
+	))
 	return out
 }
 
 func (t *Array) BitwiseAnd(other *Array) *Array {
 	out := New("BITWISE_AND")
-	C.mlx_bitwise_and(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_bitwise_and(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx))
 	return out
 }
 
@@ -88,47 +88,47 @@ func (t *Array) Concatenate(axis int, others ...*Array) *Array {
 		return t.Clone()
 	}
 
-	vector := C.mlx_vector_array_new()
-	defer C.mlx_vector_array_free(vector)
+	vector := mlxCheck(C.mlx_vector_array_new())
+	defer freeVectorArray(vector)
 
 	s := append([]*Array{t}, others...)
 	for _, other := range s {
-		C.mlx_vector_array_append_value(vector, other.ctx)
+		mlxCheck(C.mlx_vector_array_append_value(vector, other.ctx))
 	}
 
 	out := New("CONCATENATE")
-	C.mlx_concatenate_axis(&out.ctx, vector, C.int(axis), DefaultStream().ctx)
+	mlxCheck(C.mlx_concatenate_axis(&out.ctx, vector, C.int(axis), DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Cumsum(axis int, reverse, inclusive bool) *Array {
 	out := New("CUMSUM")
 	optDtype := C.mlx_optional_dtype{has_value: false}
-	C.mlx_cumsum_axis(&out.ctx, t.ctx, C.int(axis), C.bool(reverse), C.bool(inclusive), optDtype, DefaultStream().ctx)
+	mlxCheck(C.mlx_cumsum_axis(&out.ctx, t.ctx, C.int(axis), C.bool(reverse), C.bool(inclusive), optDtype, DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Divide(other *Array) *Array {
 	out := New("DIVIDE")
-	C.mlx_divide(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_divide(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) ExpandDims(axis int) *Array {
 	out := New("EXPAND_DIMS")
-	C.mlx_expand_dims(&out.ctx, t.ctx, C.int(axis), DefaultStream().ctx)
+	mlxCheck(C.mlx_expand_dims(&out.ctx, t.ctx, C.int(axis), DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Flatten(startAxis, endAxis int) *Array {
 	out := New("FLATTEN")
-	C.mlx_flatten(&out.ctx, t.ctx, C.int(startAxis), C.int(endAxis), DefaultStream().ctx)
+	mlxCheck(C.mlx_flatten(&out.ctx, t.ctx, C.int(startAxis), C.int(endAxis), DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) FloorDivide(other *Array) *Array {
 	out := New("FLOOR_DIVIDE")
-	C.mlx_floor_divide(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_floor_divide(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx))
 	return out
 }
 
@@ -140,79 +140,79 @@ func (t *Array) GatherMM(other, lhs, rhs *Array, sorted bool) *Array {
 		rhs = New("")
 	}
 	out := New("GATHER_MM")
-	C.mlx_gather_mm(&out.ctx, t.ctx, other.ctx, lhs.ctx, rhs.ctx, C.bool(sorted), DefaultStream().ctx)
+	mlxCheck(C.mlx_gather_mm(&out.ctx, t.ctx, other.ctx, lhs.ctx, rhs.ctx, C.bool(sorted), DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) LogsumexpAxis(axis int, keepDims bool) *Array {
 	out := New("LOGSUMEXP_AXIS")
-	C.mlx_logsumexp_axis(&out.ctx, t.ctx, C.int(axis), C.bool(keepDims), DefaultStream().ctx)
+	mlxCheck(C.mlx_logsumexp_axis(&out.ctx, t.ctx, C.int(axis), C.bool(keepDims), DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Equal(other *Array) *Array {
 	out := New("EQUAL")
-	C.mlx_equal(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_equal(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Greater(other *Array) *Array {
 	out := New("GREATER")
-	C.mlx_greater(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_greater(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Less(other *Array) *Array {
 	out := New("LESS")
-	C.mlx_less(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_less(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) LessEqual(other *Array) *Array {
 	out := New("LESS_EQUAL")
-	C.mlx_less_equal(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_less_equal(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) MaxAxis(axis int, keepDims bool) *Array {
 	out := New("MAX_AXIS")
-	C.mlx_max_axis(&out.ctx, t.ctx, C.int(axis), C.bool(keepDims), DefaultStream().ctx)
+	mlxCheck(C.mlx_max_axis(&out.ctx, t.ctx, C.int(axis), C.bool(keepDims), DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Matmul(other *Array) *Array {
 	out := New("MATMUL")
-	C.mlx_matmul(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_matmul(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Multiply(other *Array) *Array {
 	out := New("MULTIPLY")
-	C.mlx_multiply(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_multiply(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Negative() *Array {
 	out := New("NEGATIVE")
-	C.mlx_negative(&out.ctx, t.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_negative(&out.ctx, t.ctx, DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Power(exponent *Array) *Array {
 	out := New("POWER")
-	C.mlx_power(&out.ctx, t.ctx, exponent.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_power(&out.ctx, t.ctx, exponent.ctx, DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) PutAlongAxis(indices, values *Array, axis int) *Array {
 	out := New("PUT_ALONG_AXIS")
-	C.mlx_put_along_axis(&out.ctx, t.ctx, indices.ctx, values.ctx, C.int(axis), DefaultStream().ctx)
+	mlxCheck(C.mlx_put_along_axis(&out.ctx, t.ctx, indices.ctx, values.ctx, C.int(axis), DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) ScatterAddAxis(indices, values *Array, axis int) *Array {
 	out := New("SCATTER_ADD_AXIS")
-	C.mlx_scatter_add_axis(&out.ctx, t.ctx, indices.ctx, values.ctx, C.int(axis), DefaultStream().ctx)
+	mlxCheck(C.mlx_scatter_add_axis(&out.ctx, t.ctx, indices.ctx, values.ctx, C.int(axis), DefaultStream().ctx))
 	return out
 }
 
@@ -223,43 +223,43 @@ func (t *Array) Reshape(axes ...int) *Array {
 	}
 
 	out := New("RESHAPE")
-	C.mlx_reshape(&out.ctx, t.ctx, unsafe.SliceData(cAxes), C.size_t(len(cAxes)), DefaultStream().ctx)
+	mlxCheck(C.mlx_reshape(&out.ctx, t.ctx, unsafe.SliceData(cAxes), C.size_t(len(cAxes)), DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) RightShift(other *Array) *Array {
 	out := New("RIGHT_SHIFT")
-	C.mlx_right_shift(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_right_shift(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Remainder(other *Array) *Array {
 	out := New("REMAINDER")
-	C.mlx_remainder(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_remainder(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Sigmoid() *Array {
 	out := New("SIGMOID")
-	C.mlx_sigmoid(&out.ctx, t.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_sigmoid(&out.ctx, t.ctx, DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Sign() *Array {
 	out := New("SIGN")
-	C.mlx_sign(&out.ctx, t.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_sign(&out.ctx, t.ctx, DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Sqrt() *Array {
 	out := New("SQRT")
-	C.mlx_sqrt(&out.ctx, t.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_sqrt(&out.ctx, t.ctx, DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Squeeze(axis int) *Array {
 	out := New("SQUEEZE")
-	C.mlx_squeeze_axis(&out.ctx, t.ctx, C.int(axis), DefaultStream().ctx)
+	mlxCheck(C.mlx_squeeze_axis(&out.ctx, t.ctx, C.int(axis), DefaultStream().ctx))
 	return out
 }
 
@@ -270,41 +270,41 @@ func (t *Array) StackAxis(axis int, others ...*Array) *Array {
 		vectorData[i+1] = others[i].ctx
 	}
 
-	vector := C.mlx_vector_array_new_data(unsafe.SliceData(vectorData), C.size_t(len(vectorData)))
-	defer C.mlx_vector_array_free(vector)
+	vector := mlxCheck(C.mlx_vector_array_new_data(unsafe.SliceData(vectorData), C.size_t(len(vectorData))))
+	defer freeVectorArray(vector)
 
 	out := New("STACK_AXIS")
-	C.mlx_stack_axis(&out.ctx, vector, C.int(axis), DefaultStream().ctx)
+	mlxCheck(C.mlx_stack_axis(&out.ctx, vector, C.int(axis), DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Subtract(other *Array) *Array {
 	out := New("SUBTRACT")
-	C.mlx_subtract(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_subtract(&out.ctx, t.ctx, other.ctx, DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) SumAxis(axis int, keepDims bool) *Array {
 	out := New("SUM_AXIS")
-	C.mlx_sum_axis(&out.ctx, t.ctx, C.int(axis), C.bool(keepDims), DefaultStream().ctx)
+	mlxCheck(C.mlx_sum_axis(&out.ctx, t.ctx, C.int(axis), C.bool(keepDims), DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) TakeAxis(indices *Array, axis int) *Array {
 	out := New("TAKE_AXIS")
-	C.mlx_take_axis(&out.ctx, t.ctx, indices.ctx, C.int(axis), DefaultStream().ctx)
+	mlxCheck(C.mlx_take_axis(&out.ctx, t.ctx, indices.ctx, C.int(axis), DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) TakeAlongAxis(indices *Array, axis int) *Array {
 	out := New("TAKE_ALONG_AXIS")
-	C.mlx_take_along_axis(&out.ctx, t.ctx, indices.ctx, C.int(axis), DefaultStream().ctx)
+	mlxCheck(C.mlx_take_along_axis(&out.ctx, t.ctx, indices.ctx, C.int(axis), DefaultStream().ctx))
 	return out
 }
 
 func (t *Array) Tanh() *Array {
 	out := New("TANH")
-	C.mlx_tanh(&out.ctx, t.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_tanh(&out.ctx, t.ctx, DefaultStream().ctx))
 	return out
 }
 
@@ -315,7 +315,7 @@ func (t *Array) Transpose(axes ...int) *Array {
 	}
 
 	out := New("TRANSPOSE")
-	C.mlx_transpose_axes(&out.ctx, t.ctx, unsafe.SliceData(cAxes), C.size_t(len(cAxes)), DefaultStream().ctx)
+	mlxCheck(C.mlx_transpose_axes(&out.ctx, t.ctx, unsafe.SliceData(cAxes), C.size_t(len(cAxes)), DefaultStream().ctx))
 	return out
 }
 
@@ -326,6 +326,6 @@ func Zeros(dtype DType, shape ...int) *Array {
 	}
 
 	t := New("ZEROS")
-	C.mlx_zeros(&t.ctx, unsafe.SliceData(cAxes), C.size_t(len(cAxes)), C.mlx_dtype(dtype), DefaultStream().ctx)
+	mlxCheck(C.mlx_zeros(&t.ctx, unsafe.SliceData(cAxes), C.size_t(len(cAxes)), C.mlx_dtype(dtype), DefaultStream().ctx))
 	return t
 }

--- a/x/mlxrunner/mlx/ops_extra.go
+++ b/x/mlxrunner/mlx/ops_extra.go
@@ -15,19 +15,19 @@ func Quantize(w *Array, groupSize, bits int, mode string) (weights, scales, bias
 	defer C.free(unsafe.Pointer(cMode))
 	optGroupSize := C.mlx_optional_int{value: C.int(groupSize), has_value: true}
 	optBits := C.mlx_optional_int{value: C.int(bits), has_value: true}
-	res := C.mlx_vector_array_new()
-	defer C.mlx_vector_array_free(res)
+	res := mlxCheck(C.mlx_vector_array_new())
+	defer freeVectorArray(res)
 	var globalScale C.mlx_array
-	C.mlx_quantize(&res, w.ctx, optGroupSize, optBits, cMode, globalScale, DefaultStream().ctx)
+	mlxCheck(C.mlx_quantize(&res, w.ctx, optGroupSize, optBits, cMode, globalScale, DefaultStream().ctx))
 
-	vecSize := int(C.mlx_vector_array_size(res))
+	vecSize := int(mlxCheck(C.mlx_vector_array_size(res)))
 	w0 := New("QUANTIZE_W")
-	C.mlx_vector_array_get(&w0.ctx, res, 0)
+	mlxCheck(C.mlx_vector_array_get(&w0.ctx, res, 0))
 	w1 := New("QUANTIZE_S")
-	C.mlx_vector_array_get(&w1.ctx, res, 1)
+	mlxCheck(C.mlx_vector_array_get(&w1.ctx, res, 1))
 	if vecSize >= 3 {
 		w2 := New("QUANTIZE_B")
-		C.mlx_vector_array_get(&w2.ctx, res, 2)
+		mlxCheck(C.mlx_vector_array_get(&w2.ctx, res, 2))
 		return w0, w1, w2
 	}
 	return w0, w1, nil
@@ -35,13 +35,13 @@ func Quantize(w *Array, groupSize, bits int, mode string) (weights, scales, bias
 
 func FromFP8(x *Array, dtype DType) *Array {
 	out := New("FROM_FP8")
-	C.mlx_from_fp8(&out.ctx, x.ctx, C.mlx_dtype(dtype), DefaultStream().ctx)
+	mlxCheck(C.mlx_from_fp8(&out.ctx, x.ctx, C.mlx_dtype(dtype), DefaultStream().ctx))
 	return out
 }
 
 func ToFP8(x *Array) *Array {
 	out := New("TO_FP8")
-	C.mlx_to_fp8(&out.ctx, x.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_to_fp8(&out.ctx, x.ctx, DefaultStream().ctx))
 	return out
 }
 
@@ -59,7 +59,7 @@ func Dequantize(w, scales, biases *Array, groupSize, bits int, mode string, glob
 
 	out := New("DEQUANTIZE")
 	var noGlobalScale C.mlx_array
-	C.mlx_dequantize(&out.ctx, w.ctx, scales.ctx, b, optGroupSize, optBits, cMode, noGlobalScale, optDtype, DefaultStream().ctx)
+	mlxCheck(C.mlx_dequantize(&out.ctx, w.ctx, scales.ctx, b, optGroupSize, optBits, cMode, noGlobalScale, optDtype, DefaultStream().ctx))
 	if globalScale != nil {
 		// The C-level global_scale argument is rejected on Metal; apply it on top.
 		gs := globalScale
@@ -85,7 +85,7 @@ func QuantizedMatmul(x, w, scales, biases *Array, transpose bool, groupSize, bit
 	}
 
 	out := New("QUANTIZED_MATMUL")
-	C.mlx_quantized_matmul(&out.ctx, x.ctx, w.ctx, scales.ctx, b, C.bool(transpose), optGroupSize, optBits, cMode, DefaultStream().ctx)
+	mlxCheck(C.mlx_quantized_matmul(&out.ctx, x.ctx, w.ctx, scales.ctx, b, C.bool(transpose), optGroupSize, optBits, cMode, DefaultStream().ctx))
 	return out
 }
 
@@ -107,7 +107,7 @@ func GatherQMM(x, w, scales *Array, biases, lhsIndices, rhsIndices *Array, trans
 	}
 
 	out := New("GATHER_QMM")
-	C.mlx_gather_qmm(&out.ctx, x.ctx, w.ctx, scales.ctx, b, lhs, rhs, C.bool(transpose), optGroupSize, optBits, cMode, C.bool(sortedIndices), DefaultStream().ctx)
+	mlxCheck(C.mlx_gather_qmm(&out.ctx, x.ctx, w.ctx, scales.ctx, b, lhs, rhs, C.bool(transpose), optGroupSize, optBits, cMode, C.bool(sortedIndices), DefaultStream().ctx))
 	return out
 }
 
@@ -115,7 +115,7 @@ func GatherQMM(x, w, scales *Array, biases, lhsIndices, rhsIndices *Array, trans
 
 func Arange(start, stop, step float64, dtype DType) *Array {
 	out := New("ARANGE")
-	C.mlx_arange(&out.ctx, C.double(start), C.double(stop), C.double(step), C.mlx_dtype(dtype), DefaultStream().ctx)
+	mlxCheck(C.mlx_arange(&out.ctx, C.double(start), C.double(stop), C.double(step), C.mlx_dtype(dtype), DefaultStream().ctx))
 	return out
 }
 
@@ -125,25 +125,25 @@ func Tile(a *Array, reps []int32) *Array {
 		cReps[i] = C.int(r)
 	}
 	out := New("TILE")
-	C.mlx_tile(&out.ctx, a.ctx, unsafe.SliceData(cReps), C.size_t(len(reps)), DefaultStream().ctx)
+	mlxCheck(C.mlx_tile(&out.ctx, a.ctx, unsafe.SliceData(cReps), C.size_t(len(reps)), DefaultStream().ctx))
 	return out
 }
 
 func Tri(n, m int32, k int) *Array {
 	out := New("TRI")
-	C.mlx_tri(&out.ctx, C.int(n), C.int(m), C.int(k), C.mlx_dtype(DTypeFloat32), DefaultStream().ctx)
+	mlxCheck(C.mlx_tri(&out.ctx, C.int(n), C.int(m), C.int(k), C.mlx_dtype(DTypeFloat32), DefaultStream().ctx))
 	return out
 }
 
 func Where(condition, a, b *Array) *Array {
 	out := New("WHERE")
-	C.mlx_where(&out.ctx, condition.ctx, a.ctx, b.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_where(&out.ctx, condition.ctx, a.ctx, b.ctx, DefaultStream().ctx))
 	return out
 }
 
 func Conv1d(x, weight *Array, bias *Array, stride, padding, dilation, groups int32) *Array {
 	out := New("CONV1D")
-	C.mlx_conv1d(
+	mlxCheck(C.mlx_conv1d(
 		&out.ctx,
 		x.ctx,
 		weight.ctx,
@@ -152,7 +152,7 @@ func Conv1d(x, weight *Array, bias *Array, stride, padding, dilation, groups int
 		C.int(dilation),
 		C.int(groups),
 		DefaultStream().ctx,
-	)
+	))
 	if bias != nil && bias.Valid() {
 		out = Add(out, bias)
 	}
@@ -161,7 +161,7 @@ func Conv1d(x, weight *Array, bias *Array, stride, padding, dilation, groups int
 
 func Contiguous(a *Array, allowColMajor bool) *Array {
 	out := New("CONTIGUOUS")
-	C.mlx_contiguous(&out.ctx, a.ctx, C.bool(allowColMajor), DefaultStream().ctx)
+	mlxCheck(C.mlx_contiguous(&out.ctx, a.ctx, C.bool(allowColMajor), DefaultStream().ctx))
 	return out
 }
 
@@ -169,7 +169,7 @@ func Contiguous(a *Array, allowColMajor bool) *Array {
 // MLX uses NHWC layout.
 func Conv2d(x, weight *Array, strideH, strideW, padH, padW, dilationH, dilationW, groups int32) *Array {
 	out := New("CONV2D")
-	C.mlx_conv2d(
+	mlxCheck(C.mlx_conv2d(
 		&out.ctx,
 		x.ctx,
 		weight.ctx,
@@ -178,7 +178,7 @@ func Conv2d(x, weight *Array, strideH, strideW, padH, padW, dilationH, dilationW
 		C.int(dilationH), C.int(dilationW),
 		C.int(groups),
 		DefaultStream().ctx,
-	)
+	))
 	return out
 }
 
@@ -196,7 +196,7 @@ func Pad(a *Array, axes []int, lowPad, highPad []int, padValue *Array, mode stri
 	cMode := C.CString(mode)
 	defer C.free(unsafe.Pointer(cMode))
 	out := New("PAD")
-	C.mlx_pad(
+	mlxCheck(C.mlx_pad(
 		&out.ctx,
 		a.ctx,
 		unsafe.SliceData(cAxes), C.size_t(len(cAxes)),
@@ -205,7 +205,7 @@ func Pad(a *Array, axes []int, lowPad, highPad []int, padValue *Array, mode stri
 		padValue.ctx,
 		cMode,
 		DefaultStream().ctx,
-	)
+	))
 	return out
 }
 
@@ -223,14 +223,14 @@ func DepthwiseConv1d(x, weight *Array, bias *Array) *Array {
 // Maximum returns element-wise maximum of two arrays.
 func Maximum(a, b *Array) *Array {
 	out := New("MAXIMUM")
-	C.mlx_maximum(&out.ctx, a.ctx, b.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_maximum(&out.ctx, a.ctx, b.ctx, DefaultStream().ctx))
 	return out
 }
 
 // Minimum returns element-wise minimum of two arrays.
 func Minimum(a, b *Array) *Array {
 	out := New("MINIMUM")
-	C.mlx_minimum(&out.ctx, a.ctx, b.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_minimum(&out.ctx, a.ctx, b.ctx, DefaultStream().ctx))
 	return out
 }
 
@@ -298,11 +298,11 @@ func Stack(arrays []*Array, axis int) *Array {
 	for i := range arrays {
 		vectorData[i] = arrays[i].ctx
 	}
-	vector := C.mlx_vector_array_new_data(unsafe.SliceData(vectorData), C.size_t(len(vectorData)))
-	defer C.mlx_vector_array_free(vector)
+	vector := mlxCheck(C.mlx_vector_array_new_data(unsafe.SliceData(vectorData), C.size_t(len(vectorData))))
+	defer freeVectorArray(vector)
 
 	out := New("STACK")
-	C.mlx_stack_axis(&out.ctx, vector, C.int(axis), DefaultStream().ctx)
+	mlxCheck(C.mlx_stack_axis(&out.ctx, vector, C.int(axis), DefaultStream().ctx))
 	return out
 }
 
@@ -324,13 +324,13 @@ func Take(a *Array, indices *Array, axis int) *Array {
 
 func RSqrt(a *Array) *Array {
 	out := New("RSQRT")
-	C.mlx_rsqrt(&out.ctx, a.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_rsqrt(&out.ctx, a.ctx, DefaultStream().ctx))
 	return out
 }
 
 func Mean(a *Array, axis int, keepDims bool) *Array {
 	out := New("MEAN_AXIS")
-	C.mlx_mean_axis(&out.ctx, a.ctx, C.int(axis), C.bool(keepDims), DefaultStream().ctx)
+	mlxCheck(C.mlx_mean_axis(&out.ctx, a.ctx, C.int(axis), C.bool(keepDims), DefaultStream().ctx))
 	return out
 }
 
@@ -409,7 +409,7 @@ func SliceStartStop(a *Array, start, stop []int32) *Array {
 		cStrides[i] = 1
 	}
 	out := New("SLICE")
-	C.mlx_slice(&out.ctx, a.ctx, unsafe.SliceData(cStart), C.size_t(n), unsafe.SliceData(cStop), C.size_t(n), unsafe.SliceData(cStrides), C.size_t(n), DefaultStream().ctx)
+	mlxCheck(C.mlx_slice(&out.ctx, a.ctx, unsafe.SliceData(cStart), C.size_t(n), unsafe.SliceData(cStop), C.size_t(n), unsafe.SliceData(cStrides), C.size_t(n), DefaultStream().ctx))
 	return out
 }
 
@@ -449,7 +449,7 @@ func RoPEWithFreqs(x *Array, dims int, traditional bool, base, scale float32, of
 		}
 	}
 	out := New("FAST_ROPE")
-	C.mlx_fast_rope_dynamic(
+	mlxCheck(C.mlx_fast_rope_dynamic(
 		&out.ctx,
 		x.ctx,
 		C.int(dims),
@@ -459,7 +459,7 @@ func RoPEWithFreqs(x *Array, dims int, traditional bool, base, scale float32, of
 		offsets.ctx,
 		freqsCtx,
 		DefaultStream().ctx,
-	)
+	))
 	return out
 }
 
@@ -469,55 +469,55 @@ func Sigmoid(a *Array) *Array {
 
 func Erf(a *Array) *Array {
 	out := New("ERF")
-	C.mlx_erf(&out.ctx, a.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_erf(&out.ctx, a.ctx, DefaultStream().ctx))
 	return out
 }
 
 func Exp(a *Array) *Array {
 	out := New("EXP")
-	C.mlx_exp(&out.ctx, a.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_exp(&out.ctx, a.ctx, DefaultStream().ctx))
 	return out
 }
 
 func Log(a *Array) *Array {
 	out := New("LOG")
-	C.mlx_log(&out.ctx, a.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_log(&out.ctx, a.ctx, DefaultStream().ctx))
 	return out
 }
 
 func Sin(a *Array) *Array {
 	out := New("SIN")
-	C.mlx_sin(&out.ctx, a.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_sin(&out.ctx, a.ctx, DefaultStream().ctx))
 	return out
 }
 
 func Cos(a *Array) *Array {
 	out := New("COS")
-	C.mlx_cos(&out.ctx, a.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_cos(&out.ctx, a.ctx, DefaultStream().ctx))
 	return out
 }
 
 func erf(a *Array) *Array {
 	out := New("ERF")
-	C.mlx_erf(&out.ctx, a.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_erf(&out.ctx, a.ctx, DefaultStream().ctx))
 	return out
 }
 
 func Clip(a, aMin, aMax *Array) *Array {
 	out := New("CLIP")
-	C.mlx_clip(&out.ctx, a.ctx, aMin.ctx, aMax.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_clip(&out.ctx, a.ctx, aMin.ctx, aMax.ctx, DefaultStream().ctx))
 	return out
 }
 
 func Logaddexp(a, b *Array) *Array {
 	out := New("LOGADDEXP")
-	C.mlx_logaddexp(&out.ctx, a.ctx, b.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_logaddexp(&out.ctx, a.ctx, b.ctx, DefaultStream().ctx))
 	return out
 }
 
 func SoftmaxAxis(a *Array, axis int, precise bool) *Array {
 	out := New("SOFTMAX_AXIS")
-	C.mlx_softmax_axis(&out.ctx, a.ctx, C.int(axis), C.bool(precise), DefaultStream().ctx)
+	mlxCheck(C.mlx_softmax_axis(&out.ctx, a.ctx, C.int(axis), C.bool(precise), DefaultStream().ctx))
 	return out
 }
 
@@ -530,7 +530,7 @@ func LayerNormFn(x, weight, bias *Array, eps float32) *Array {
 	if bias != nil {
 		b = bias.ctx
 	}
-	C.mlx_fast_layer_norm(&out.ctx, x.ctx, w, b, C.float(eps), DefaultStream().ctx)
+	mlxCheck(C.mlx_fast_layer_norm(&out.ctx, x.ctx, w, b, C.float(eps), DefaultStream().ctx))
 	return out
 }
 
@@ -540,7 +540,7 @@ func RMSNormFn(x, weight *Array, eps float32) *Array {
 	if weight != nil {
 		w = weight.ctx
 	}
-	C.mlx_fast_rms_norm(&out.ctx, x.ctx, w, C.float(eps), DefaultStream().ctx)
+	mlxCheck(C.mlx_fast_rms_norm(&out.ctx, x.ctx, w, C.float(eps), DefaultStream().ctx))
 	return out
 }
 
@@ -553,38 +553,38 @@ func AddMM(c, a, b *Array, alpha, beta float32) *Array {
 // scalarWithDtype creates a scalar array matching the dtype of a.
 // Matching dtype is important for graph fusion and avoiding implicit casts.
 func scalarWithDtype(s float32, a *Array) C.mlx_array {
-	f32 := C.mlx_array_new_float(C.float(s))
 	dtype := a.DType()
+	f32 := mlxCheck(C.mlx_array_new_float(C.float(s)))
 	if dtype == DTypeFloat32 {
 		return f32
 	}
-	casted := C.mlx_array_new()
-	C.mlx_astype(&casted, f32, C.mlx_dtype(dtype), DefaultStream().ctx)
-	C.mlx_array_free(f32)
+	defer freeArray(f32)
+	casted := mlxCheck(C.mlx_array_new())
+	mlxCheck(C.mlx_astype(&casted, f32, C.mlx_dtype(dtype), DefaultStream().ctx))
 	return casted
 }
 
 func AddScalar(a *Array, s float32) *Array {
 	scalar := scalarWithDtype(s, a)
+	defer freeArray(scalar)
 	out := New("ADD_SCALAR")
-	C.mlx_add(&out.ctx, a.ctx, scalar, DefaultStream().ctx)
-	C.mlx_array_free(scalar)
+	mlxCheck(C.mlx_add(&out.ctx, a.ctx, scalar, DefaultStream().ctx))
 	return out
 }
 
 func MulScalar(a *Array, s float32) *Array {
 	scalar := scalarWithDtype(s, a)
+	defer freeArray(scalar)
 	out := New("MUL_SCALAR")
-	C.mlx_multiply(&out.ctx, a.ctx, scalar, DefaultStream().ctx)
-	C.mlx_array_free(scalar)
+	mlxCheck(C.mlx_multiply(&out.ctx, a.ctx, scalar, DefaultStream().ctx))
 	return out
 }
 
 func DivScalar(a *Array, s float32) *Array {
 	scalar := scalarWithDtype(s, a)
+	defer freeArray(scalar)
 	out := New("DIV_SCALAR")
-	C.mlx_divide(&out.ctx, a.ctx, scalar, DefaultStream().ctx)
-	C.mlx_array_free(scalar)
+	mlxCheck(C.mlx_divide(&out.ctx, a.ctx, scalar, DefaultStream().ctx))
 	return out
 }
 
@@ -601,13 +601,13 @@ func NewArrayInt32(data []int32, shape []int32) *Array {
 		cShape[i] = C.int(s)
 	}
 	out := New("NEW_ARRAY_INT32")
-	out.ctx = C.mlx_array_new_data(unsafe.Pointer(&data[0]), unsafe.SliceData(cShape), C.int(len(shape)), C.mlx_dtype(DTypeInt32))
+	out.ctx = mlxCheck(C.mlx_array_new_data(unsafe.Pointer(&data[0]), unsafe.SliceData(cShape), C.int(len(shape)), C.mlx_dtype(DTypeInt32)))
 	return out
 }
 
 func NewScalarArray(value float32) *Array {
 	out := New("SCALAR")
-	out.ctx = C.mlx_array_new_float32(C.float(value))
+	out.ctx = mlxCheck(C.mlx_array_new_float32(C.float(value)))
 	return out
 }
 
@@ -686,9 +686,9 @@ func collect(v reflect.Value, arrays *[]*Array, seen map[uintptr]bool) {
 }
 
 func EnableCompile() {
-	C.mlx_enable_compile()
+	mlxCheck(C.mlx_enable_compile())
 }
 
 func DisableCompile() {
-	C.mlx_disable_compile()
+	mlxCheck(C.mlx_disable_compile())
 }

--- a/x/mlxrunner/mlx/random.go
+++ b/x/mlxrunner/mlx/random.go
@@ -7,7 +7,7 @@ import "unsafe"
 
 func RandomKey(seed uint64) *Array {
 	out := New("RANDOM_KEY")
-	C.mlx_random_key(&out.ctx, C.uint64_t(seed))
+	mlxCheck(C.mlx_random_key(&out.ctx, C.uint64_t(seed)))
 	return out
 }
 
@@ -20,7 +20,7 @@ func (t *Array) CategoricalWithKey(axis int, key *Array) *Array {
 		key = New("")
 	}
 	out := New("")
-	C.mlx_random_categorical(&out.ctx, t.ctx, C.int(axis), key.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_random_categorical(&out.ctx, t.ctx, C.int(axis), key.ctx, DefaultStream().ctx))
 	return out
 }
 
@@ -39,6 +39,6 @@ func BernoulliWithKey(p *Array, key *Array) *Array {
 		key = New("")
 	}
 	out := New("BERNOULLI")
-	C.mlx_random_bernoulli(&out.ctx, p.ctx, unsafe.SliceData(shape), C.size_t(len(shape)), key.ctx, DefaultStream().ctx)
+	mlxCheck(C.mlx_random_bernoulli(&out.ctx, p.ctx, unsafe.SliceData(shape), C.size_t(len(shape)), key.ctx, DefaultStream().ctx))
 	return out
 }

--- a/x/mlxrunner/mlx/slice.go
+++ b/x/mlxrunner/mlx/slice.go
@@ -76,25 +76,25 @@ func makeSlices(dims []int, slices ...slice) (starts, stops, strides []C.int) {
 func (t *Array) Slice(slices ...slice) *Array {
 	starts, stops, strides := makeSlices(t.Dims(), slices...)
 	out := New("SLICE")
-	C.mlx_slice(
+	mlxCheck(C.mlx_slice(
 		&out.ctx, t.ctx,
 		unsafe.SliceData(starts), C.size_t(len(starts)),
 		unsafe.SliceData(stops), C.size_t(len(stops)),
 		unsafe.SliceData(strides), C.size_t(len(strides)),
 		DefaultStream().ctx,
-	)
+	))
 	return out
 }
 
 func (t *Array) SliceUpdate(other *Array, slices ...slice) *Array {
 	starts, stops, strides := makeSlices(t.Dims(), slices...)
 	out := New("SLICE_UPDATE")
-	C.mlx_slice_update(
+	mlxCheck(C.mlx_slice_update(
 		&out.ctx, t.ctx, other.ctx,
 		unsafe.SliceData(starts), C.size_t(len(starts)),
 		unsafe.SliceData(stops), C.size_t(len(stops)),
 		unsafe.SliceData(strides), C.size_t(len(strides)),
 		DefaultStream().ctx,
-	)
+	))
 	return out
 }

--- a/x/mlxrunner/mlx/stream.go
+++ b/x/mlxrunner/mlx/stream.go
@@ -10,10 +10,10 @@ type Device struct {
 }
 
 func (d Device) LogValue() slog.Value {
-	str := C.mlx_string_new()
-	defer C.mlx_string_free(str)
-	C.mlx_device_tostring(&str, d.ctx)
-	return slog.StringValue(C.GoString(C.mlx_string_data(str)))
+	str := mlxCheck(C.mlx_string_new())
+	mlxCheck(C.mlx_device_tostring(&str, d.ctx))
+	defer freeString(str)
+	return slog.StringValue(C.GoString(mlxCheck(C.mlx_string_data(str))))
 }
 
 var (
@@ -30,8 +30,8 @@ func resetDefaultStreamCache() {
 
 func DefaultDevice() Device {
 	if !defaultDeviceSet {
-		d := C.mlx_device_new()
-		C.mlx_get_default_device(&d)
+		d := mlxCheck(C.mlx_device_new())
+		mlxCheck(C.mlx_get_default_device(&d))
 		defaultDevice = Device{d}
 		defaultDeviceSet = true
 	}
@@ -41,18 +41,18 @@ func DefaultDevice() Device {
 
 // GPUIsAvailable returns true if a GPU device is available.
 func GPUIsAvailable() bool {
-	dev := C.mlx_device_new_type(C.MLX_GPU, 0)
-	defer C.mlx_device_free(dev)
+	dev := mlxCheck(C.mlx_device_new_type(C.MLX_GPU, 0))
+	defer freeDevice(dev)
 	var avail C.bool
-	C.mlx_device_is_available(&avail, dev)
+	mlxCheck(C.mlx_device_is_available(&avail, dev))
 	return bool(avail)
 }
 
 // SetDefaultDeviceGPU sets the default MLX device to GPU.
 func SetDefaultDeviceGPU() {
-	dev := C.mlx_device_new_type(C.MLX_GPU, 0)
-	C.mlx_set_default_device(dev)
-	C.mlx_device_free(dev)
+	dev := mlxCheck(C.mlx_device_new_type(C.MLX_GPU, 0))
+	mlxCheck(C.mlx_set_default_device(dev))
+	freeDevice(dev)
 	resetDefaultStreamCache()
 }
 
@@ -61,16 +61,16 @@ type Stream struct {
 }
 
 func (s Stream) LogValue() slog.Value {
-	str := C.mlx_string_new()
-	defer C.mlx_string_free(str)
-	C.mlx_stream_tostring(&str, s.ctx)
-	return slog.StringValue(C.GoString(C.mlx_string_data(str)))
+	str := mlxCheck(C.mlx_string_new())
+	mlxCheck(C.mlx_stream_tostring(&str, s.ctx))
+	defer freeString(str)
+	return slog.StringValue(C.GoString(mlxCheck(C.mlx_string_data(str))))
 }
 
 func DefaultStream() Stream {
 	if !defaultStreamSet {
-		s := C.mlx_stream_new()
-		C.mlx_get_default_stream(&s, DefaultDevice().ctx)
+		s := mlxCheck(C.mlx_stream_new())
+		mlxCheck(C.mlx_get_default_stream(&s, DefaultDevice().ctx))
 		defaultStream = Stream{s}
 		defaultStreamSet = true
 	}

--- a/x/models/laguna/laguna_test.go
+++ b/x/models/laguna/laguna_test.go
@@ -197,7 +197,7 @@ func TestTinyLagunaLoadAndForward(t *testing.T) {
 	mlxtest.Run(t, func(t *mlxtest.T) {
 		cfg, err := parseConfig([]byte(`{
 		"model_type": "laguna",
-		"hidden_size": 8,
+		"hidden_size": 32,
 		"intermediate_size": 12,
 		"moe_intermediate_size": 4,
 		"shared_expert_intermediate_size": 4,
@@ -264,8 +264,8 @@ func TestTinyLagunaLoadAndForward(t *testing.T) {
 			SeqQueryLens: []int32{int32(tokens.Dim(1))},
 		}, caches)
 		mlx.Eval(hidden)
-		if got := hidden.Dims(); len(got) != 3 || got[0] != 1 || got[1] != 3 || got[2] != 8 {
-			t.Fatalf("hidden shape = %v, want [1 3 8]", got)
+		if got := hidden.Dims(); len(got) != 3 || got[0] != 1 || got[1] != 3 || got[2] != 32 {
+			t.Fatalf("hidden shape = %v, want [1 3 32]", got)
 		}
 
 		logits := m.Unembed(hidden)
@@ -285,7 +285,7 @@ func TestTinyLagunaLoadWeightsFusesDenseGateUp(t *testing.T) {
 	mlxtest.Run(t, func(t *mlxtest.T) {
 		cfg, err := parseConfig([]byte(`{
 		"model_type": "laguna",
-		"hidden_size": 8,
+		"hidden_size": 32,
 		"intermediate_size": 12,
 		"moe_intermediate_size": 4,
 		"shared_expert_intermediate_size": 4,
@@ -329,7 +329,7 @@ func TestTinyLagunaLoadWeightsFusesDenseGateUp(t *testing.T) {
 		if moe.SwitchMLP.GateUpWeight == nil {
 			t.Fatal("expected fused GateUpWeight to be populated")
 		}
-		if got, want := moe.SwitchMLP.GateUpWeight.Dims(), []int{2, 8, 8}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		if got, want := moe.SwitchMLP.GateUpWeight.Dims(), []int{2, 32, 8}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
 			t.Fatalf("GateUpWeight dims = %v, want %v", got, want)
 		}
 	})
@@ -339,7 +339,7 @@ func TestTinyLagunaLoadWeightsKeepsBF16SourceLayout(t *testing.T) {
 	mlxtest.Run(t, func(t *mlxtest.T) {
 		cfg, err := parseConfig([]byte(`{
 		"model_type": "laguna",
-		"hidden_size": 8,
+		"hidden_size": 32,
 		"intermediate_size": 12,
 		"moe_intermediate_size": 4,
 		"shared_expert_intermediate_size": 4,
@@ -392,7 +392,7 @@ func TestTinyLagunaLoadWeightsKeepsBF16SourceLayout(t *testing.T) {
 		if moe.SwitchMLP.GateUpWeight != nil {
 			t.Fatal("expected BF16 source-layout SwitchMLP to avoid pre-fused gate/up weights")
 		}
-		if got, want := moe.SwitchMLP.GateWeight.Dims(), []int{2, 4, 8}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
+		if got, want := moe.SwitchMLP.GateWeight.Dims(), []int{2, 4, 32}; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] || got[2] != want[2] {
 			t.Fatalf("GateWeight dims = %v, want %v", got, want)
 		}
 	})
@@ -401,7 +401,7 @@ func TestTinyLagunaLoadWeightsKeepsBF16SourceLayout(t *testing.T) {
 func TestTinyLagunaLoadWeightsKeepsMixedExpertPrecision(t *testing.T) {
 	mlxtest.Run(t, func(t *mlxtest.T) {
 		cfg := &Config{
-			HiddenSize:                8,
+			HiddenSize:                32,
 			IntermediateSize:          12,
 			MoeIntermediateSize:       4,
 			SharedExpertIntermediate:  4,
@@ -418,7 +418,7 @@ func TestTinyLagunaLoadWeightsKeepsMixedExpertPrecision(t *testing.T) {
 			NumExpertsPerTok:          1,
 			MoeRoutedScalingFactor:    2.5,
 			RMSNormEps:                1e-5,
-			QuantGroupSize:            4,
+			QuantGroupSize:            32,
 			QuantBits:                 4,
 			QuantMode:                 "affine",
 		}
@@ -739,38 +739,38 @@ func TestCombinedTensorGlobalScaleIgnoresInputGlobalScale(t *testing.T) {
 
 func tinyLagunaTensors() map[string]*mlx.Array {
 	tensors := map[string]*mlx.Array{
-		"model.embed_tokens.weight": weights(16, 8),
-		"model.norm.weight":         ones(8),
-		"lm_head.weight":            weights(16, 8),
+		"model.embed_tokens.weight": weights(16, 32),
+		"model.norm.weight":         ones(32),
+		"lm_head.weight":            weights(16, 32),
 	}
 	for layer := range 2 {
 		prefix := "model.layers." + string(rune('0'+layer))
-		tensors[prefix+".input_layernorm.weight"] = ones(8)
-		tensors[prefix+".post_attention_layernorm.weight"] = ones(8)
-		tensors[prefix+".self_attn.q_proj.weight"] = weights(8, 8)
-		tensors[prefix+".self_attn.k_proj.weight"] = weights(4, 8)
-		tensors[prefix+".self_attn.v_proj.weight"] = weights(4, 8)
-		tensors[prefix+".self_attn.o_proj.weight"] = weights(8, 8)
-		tensors[prefix+".self_attn.g_proj.weight"] = weights(2, 8)
+		tensors[prefix+".input_layernorm.weight"] = ones(32)
+		tensors[prefix+".post_attention_layernorm.weight"] = ones(32)
+		tensors[prefix+".self_attn.q_proj.weight"] = weights(8, 32)
+		tensors[prefix+".self_attn.k_proj.weight"] = weights(4, 32)
+		tensors[prefix+".self_attn.v_proj.weight"] = weights(4, 32)
+		tensors[prefix+".self_attn.o_proj.weight"] = weights(32, 8)
+		tensors[prefix+".self_attn.g_proj.weight"] = weights(2, 32)
 		tensors[prefix+".self_attn.q_norm.weight"] = ones(4)
 		tensors[prefix+".self_attn.k_norm.weight"] = ones(4)
 	}
 
-	tensors["model.layers.0.mlp.gate_proj.weight"] = weights(12, 8)
-	tensors["model.layers.0.mlp.up_proj.weight"] = weights(12, 8)
-	tensors["model.layers.0.mlp.down_proj.weight"] = weights(8, 12)
+	tensors["model.layers.0.mlp.gate_proj.weight"] = weights(12, 32)
+	tensors["model.layers.0.mlp.up_proj.weight"] = weights(12, 32)
+	tensors["model.layers.0.mlp.down_proj.weight"] = weights(32, 12)
 
-	tensors["model.layers.1.mlp.gate.weight"] = weights(2, 8)
+	tensors["model.layers.1.mlp.gate.weight"] = weights(2, 32)
 	tensors["model.layers.1.mlp.experts.e_score_correction_bias"] = mlx.FromValues([]float32{0.1, -0.1}, 2)
 	for expert := range 2 {
 		prefix := "model.layers.1.mlp.experts." + string(rune('0'+expert))
-		tensors[prefix+".gate_proj.weight"] = weights(4, 8)
-		tensors[prefix+".up_proj.weight"] = weights(4, 8)
-		tensors[prefix+".down_proj.weight"] = weights(8, 4)
+		tensors[prefix+".gate_proj.weight"] = weights(4, 32)
+		tensors[prefix+".up_proj.weight"] = weights(4, 32)
+		tensors[prefix+".down_proj.weight"] = weights(32, 4)
 	}
-	tensors["model.layers.1.mlp.shared_expert.gate_proj.weight"] = weights(4, 8)
-	tensors["model.layers.1.mlp.shared_expert.up_proj.weight"] = weights(4, 8)
-	tensors["model.layers.1.mlp.shared_expert.down_proj.weight"] = weights(8, 4)
+	tensors["model.layers.1.mlp.shared_expert.gate_proj.weight"] = weights(4, 32)
+	tensors["model.layers.1.mlp.shared_expert.up_proj.weight"] = weights(4, 32)
+	tensors["model.layers.1.mlp.shared_expert.down_proj.weight"] = weights(32, 4)
 	return tensors
 }
 


### PR DESCRIPTION
MLX reports errors through a callback plus a return code on each call. We install a handler to capture the message (instead of the default, which exits the process) but then ignored almost all of the return codes. So a failed operation kept going with a null array — the message was lost and the failure showed up later as zeros, skipped evals, or a crash somewhere unrelated.

Now every fallible call is checked: operations panic with the captured MLX message and load/save return it as an error. Since all MLX calls happen on a single pinned thread anyway, the error capture also no longer needs thread-local buffers or per-call locking.

This caught a test that had been passing on null arrays — it quantized with a group size MLX doesn't support.