### PR TITLE
model/parsers: preserve the cohere end-of-turn token

### DIFF
--- a/model/parsers/cohere.go
+++ b/model/parsers/cohere.go
@@ -60,6 +60,7 @@ func (p *CohereParser) PreservedTokens() []string {
 		cohereStartText, cohereEndText,
 		cohereStartAction, cohereEndAction,
 		cohereStartResponse, cohereEndResponse,
+		cohereEndOfTurn,
 	}
 }
 

--- a/model/parsers/cohere_test.go
+++ b/model/parsers/cohere_test.go
@@ -1,6 +1,7 @@
 package parsers
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/ollama/ollama/api"
@@ -264,5 +265,37 @@ func TestCohereParseBareContentBeforeEndOfTurn(t *testing.T) {
 	})
 	if content != "plain answer" {
 		t.Errorf("content = %q, want %q", content, "plain answer")
+	}
+}
+
+func TestCoherePreservesEndOfTurn(t *testing.T) {
+	// The parser treats <|END_OF_TURN_TOKEN|> as a block boundary, so it has
+	// to survive detokenization. llama-server drops special tokens that are
+	// not listed in PreservedTokens, which would make that boundary invisible.
+	p := &CohereParser{}
+	if !slices.Contains(p.PreservedTokens(), cohereEndOfTurn) {
+		t.Errorf("PreservedTokens() = %v, missing %q", p.PreservedTokens(), cohereEndOfTurn)
+	}
+}
+
+func TestCohereParseTextThenActionSeparatedByEndOfTurn(t *testing.T) {
+	// A model that closes a text block with the end-of-turn marker instead of
+	// <|END_TEXT|> must still have the following action block parsed as a tool
+	// call rather than streamed to the user as literal text.
+	p := &CohereParser{}
+	p.Init(nil, nil, nil)
+
+	content, _, calls := cohereAddAll(t, p, []string{
+		`t<|END_THINKING|><|START_TEXT|>hi<|END_OF_TURN_TOKEN|>` +
+			`<|START_ACTION|>[{"tool_call_id":"1","tool_name":"get_weather","parameters":{"city":"SF"}}]<|END_ACTION|><|END_OF_TURN_TOKEN|>`,
+	})
+	if content != "hi" {
+		t.Errorf("content = %q, want %q", content, "hi")
+	}
+	if len(calls) != 1 {
+		t.Fatalf("calls = %v, want 1 tool call", calls)
+	}
+	if calls[0].Function.Name != "get_weather" {
+		t.Errorf("tool name = %q, want %q", calls[0].Function.Name, "get_weather")
 	}
 }


### PR DESCRIPTION
Fixes #18053.

The cohere parser uses `<|END_OF_TURN_TOKEN|>` as a block boundary but does not list it in `PreservedTokens()`. llama-server only renders special tokens that appear in `preserved_tokens`, so the parser never receives it, and the fallback at `cohere.go:174` that closes a content block on the end-of-turn marker is unreachable there.

The visible effect: a turn that closes its text block with the end-of-turn marker instead of `<|END_TEXT|>` and then opens an action block stays in the content-collecting state, so the whole tool call is streamed to the user as literal text and no tool call is emitted. `llm/server.go:214` notes that `PreservedTokens` is ignored by non-llama-server runners, so the MLX runner passes the token through and parses the same turn correctly.

Running the parser on that turn, once with the token present and once stripped the way llama-server strips it:

| Input | content | tool calls |
| --- | --- | --- |
| token preserved | `"hi"` | 1 (`get_weather`) |
| token stripped | `"hi<\|START_ACTION\|>[{...}]<\|END_ACTION\|>"` | 0 |

**Tests**

Two tests are added. `TestCohereParseTextThenActionSeparatedByEndOfTurn` covers the behavior above. `TestCoherePreservesEndOfTurn` asserts the token stays in `PreservedTokens()`, since the existing cohere tests all feed the token to the parser literally and so cannot catch it going missing. The guard test fails without the one-line change.

`go test ./model/... ./server/... ./llm/... ./api/...` passes, `gofmt` and `go vet` are clean.

**No new dependencies.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
