### PR TITLE
app: synchronize macOS app handoff

### DIFF
--- a/app/cmd/app/app.go
+++ b/app/cmd/app/app.go
@@ -175,7 +175,10 @@ func main() {
 
 	// Check if another instance is already running
 	// On Windows, focus the existing instance; on other platforms, kill it
-	handleExistingInstance(startHidden)
+	if !handleExistingInstance(startHidden) {
+		slog.Error("Ollama instance handoff did not complete")
+		return
+	}
 
 	// on macOS, offer the user to create a symlink
 	// from /usr/local/bin/ollama to the app bundle

--- a/app/cmd/app/app.go
+++ b/app/cmd/app/app.go
@@ -176,7 +176,6 @@ func main() {
 	// Check if another instance is already running
 	// On Windows, focus the existing instance; on other platforms, kill it
 	if !handleExistingInstance(startHidden) {
-		slog.Error("Ollama instance handoff did not complete")
 		return
 	}
 

--- a/app/cmd/app/app_darwin.go
+++ b/app/cmd/app/app_darwin.go
@@ -213,9 +213,14 @@ func maybeMoveAndRestart() appMove {
 	return status
 }
 
-// handleExistingInstance handles existing instances on macOS
-func handleExistingInstance(_ bool) {
-	C.killOtherInstances()
+var killOtherInstances = func() bool { return bool(C.killOtherInstances()) }
+
+// handleExistingInstance handles existing instances on macOS.
+func handleExistingInstance(_ bool) bool {
+	if !isApp {
+		return true
+	}
+	return killOtherInstances()
 }
 
 func installSymlink() {
@@ -268,8 +273,7 @@ func osRun(_ func(), hasCompletedFirstRun, startHidden, showOnboarding bool, _ s
 		select {
 		case <-handoffSignal:
 			slog.Info("received app handoff signal, shutting down")
-			stopClaudeAppProxy()
-			C.quit()
+			quit()
 		case <-handoffDone:
 		}
 	}()

--- a/app/cmd/app/app_darwin.go
+++ b/app/cmd/app/app_darwin.go
@@ -21,7 +21,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -39,6 +38,7 @@ import (
 	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/internal/modelref"
 	"github.com/ollama/ollama/internal/proxy"
+	"golang.org/x/sys/unix"
 )
 
 var ollamaPath = func() string {
@@ -213,7 +213,211 @@ func maybeMoveAndRestart() appMove {
 	return status
 }
 
-var killOtherInstances = func() bool { return bool(C.killOtherInstances()) }
+type appProcessIdentity struct {
+	pid       int
+	startedAt int64
+}
+
+func (p appProcessIdentity) sameProcess(other appProcessIdentity) bool {
+	return p.pid == other.pid && p.startedAt == other.startedAt
+}
+
+func (p appProcessIdentity) startedAfter(other appProcessIdentity) bool {
+	if p.startedAt != other.startedAt {
+		return p.startedAt > other.startedAt
+	}
+	return p.pid > other.pid
+}
+
+type appProcessStopMode uint8
+
+const (
+	appProcessStopGracefully appProcessStopMode = iota
+	appProcessStopForcefully
+)
+
+type appProcessController struct {
+	discover func() ([]appProcessIdentity, error)
+	running  func(appProcessIdentity) (bool, error)
+	stop     func(appProcessIdentity, appProcessStopMode) error
+}
+
+type appSyncBarrierConfig struct {
+	gracePeriod  time.Duration
+	totalTimeout time.Duration
+	pollInterval time.Duration
+	settlePeriod time.Duration
+}
+
+// runAppSyncBarrier elects the newest launch, stops every older instance, and
+// returns only after no other instances remain.
+func runAppSyncBarrier(self appProcessIdentity, controller appProcessController, config appSyncBarrierConfig) error {
+	started := time.Now()
+	graceDeadline := started.Add(config.gracePeriod)
+	deadline := started.Add(config.totalTimeout)
+	sawEmpty := false
+
+	for {
+		processes, err := controller.discover()
+		if err != nil {
+			return err
+		}
+		for _, process := range processes {
+			if process.startedAfter(self) {
+				return fmt.Errorf("newer app instance %d owns the handoff", process.pid)
+			}
+		}
+
+		if len(processes) == 0 {
+			if sawEmpty {
+				return nil
+			}
+			sawEmpty = true
+			if !time.Now().Before(deadline) {
+				return fmt.Errorf("timed out waiting for app instances to exit")
+			}
+			time.Sleep(config.settlePeriod)
+			continue
+		}
+		sawEmpty = false
+
+		for _, process := range processes {
+			if err := controller.stop(process, appProcessStopGracefully); err != nil {
+				return err
+			}
+		}
+		exited, err := waitForAppProcesses(processes, controller, graceDeadline, config.pollInterval)
+		if err != nil {
+			return err
+		}
+		if !exited {
+			for _, process := range processes {
+				if err := controller.stop(process, appProcessStopForcefully); err != nil {
+					return err
+				}
+			}
+			exited, err = waitForAppProcesses(processes, controller, deadline, config.pollInterval)
+			if err != nil {
+				return err
+			}
+		}
+		if !exited {
+			return fmt.Errorf("timed out waiting for app instances to exit")
+		}
+	}
+}
+
+func waitForAppProcesses(processes []appProcessIdentity, controller appProcessController, deadline time.Time, pollInterval time.Duration) (bool, error) {
+	for {
+		running := false
+		for _, process := range processes {
+			alive, err := controller.running(process)
+			if err != nil {
+				return false, err
+			}
+			running = running || alive
+		}
+		if !running {
+			return true, nil
+		}
+		if !time.Now().Before(deadline) {
+			return false, nil
+		}
+		time.Sleep(pollInterval)
+	}
+}
+
+const (
+	appSyncBarrierGrace        = 35 * time.Second
+	appSyncBarrierTimeout      = 40 * time.Second
+	appSyncBarrierPollInterval = 50 * time.Millisecond
+	appSyncBarrierSettlePeriod = 100 * time.Millisecond
+)
+
+var killOtherInstances = runDarwinAppSyncBarrier
+
+func darwinProcessIdentityForPID(pid int) (appProcessIdentity, error) {
+	process, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
+	if err != nil {
+		if errors.Is(err, unix.EIO) && errors.Is(syscall.Kill(pid, 0), syscall.ESRCH) {
+			return appProcessIdentity{}, syscall.ESRCH
+		}
+		return appProcessIdentity{}, err
+	}
+	if int(process.Proc.P_pid) != pid {
+		return appProcessIdentity{}, syscall.ESRCH
+	}
+	return appProcessIdentity{
+		pid:       pid,
+		startedAt: process.Proc.P_starttime.Sec*1_000_000 + int64(process.Proc.P_starttime.Usec),
+	}, nil
+}
+
+func darwinOtherOllamaProcesses() ([]appProcessIdentity, error) {
+	var discovered *C.AppProcessIdentity
+	var count C.size_t
+	if !C.otherOllamaProcesses(&discovered, &count) {
+		return nil, errors.New("discover other Ollama app processes")
+	}
+	defer C.free(unsafe.Pointer(discovered))
+
+	identities := unsafe.Slice(discovered, int(count))
+	processes := make([]appProcessIdentity, len(identities))
+	for i, process := range identities {
+		processes[i] = appProcessIdentity{pid: int(process.pid), startedAt: int64(process.started_at)}
+	}
+	return processes, nil
+}
+
+func darwinAppProcessRunning(expected appProcessIdentity) (bool, error) {
+	actual, err := darwinProcessIdentityForPID(expected.pid)
+	if errors.Is(err, syscall.ESRCH) {
+		return false, nil
+	}
+	if err != nil {
+		return false, fmt.Errorf("inspect Ollama app process %d: %w", expected.pid, err)
+	}
+	return actual.sameProcess(expected), nil
+}
+
+func stopDarwinAppProcess(process appProcessIdentity, mode appProcessStopMode) error {
+	running, err := darwinAppProcessRunning(process)
+	if err != nil || !running {
+		return err
+	}
+	signal := syscall.SIGTERM
+	if mode == appProcessStopForcefully {
+		signal = syscall.SIGKILL
+	}
+	slog.Info("signaling Ollama app process", "pid", process.pid, "signal", signal)
+	if err := syscall.Kill(process.pid, signal); err != nil && !errors.Is(err, syscall.ESRCH) {
+		return fmt.Errorf("signal Ollama app process %d: %w", process.pid, err)
+	}
+	return nil
+}
+
+func runDarwinAppSyncBarrier() bool {
+	// NSWorkspace snapshots are not atomic, so two concurrent launches can both
+	// pass if neither is visible yet. This edge case is intentionally unhandled.
+	self, err := darwinProcessIdentityForPID(os.Getpid())
+	if err == nil {
+		err = runAppSyncBarrier(self, appProcessController{
+			discover: darwinOtherOllamaProcesses,
+			running:  darwinAppProcessRunning,
+			stop:     stopDarwinAppProcess,
+		}, appSyncBarrierConfig{
+			gracePeriod:  appSyncBarrierGrace,
+			totalTimeout: appSyncBarrierTimeout,
+			pollInterval: appSyncBarrierPollInterval,
+			settlePeriod: appSyncBarrierSettlePeriod,
+		})
+	}
+	if err != nil {
+		slog.Error("app instance sync barrier failed", "error", err)
+		return false
+	}
+	return true
+}
 
 // handleExistingInstance handles existing instances on macOS.
 func handleExistingInstance(_ bool) bool {
@@ -264,20 +468,6 @@ func UpdateAvailable(ver string) error {
 }
 
 func osRun(_ func(), hasCompletedFirstRun, startHidden, showOnboarding bool, _ string) {
-	handoffSignal := make(chan os.Signal, 1)
-	handoffDone := make(chan struct{})
-	signal.Notify(handoffSignal, syscall.SIGUSR1)
-	defer signal.Stop(handoffSignal)
-	defer close(handoffDone)
-	go func() {
-		select {
-		case <-handoffSignal:
-			slog.Info("received app handoff signal, shutting down")
-			quit()
-		case <-handoffDone:
-		}
-	}()
-
 	registerLaunchAgent(hasCompletedFirstRun)
 	if err := reconcileClaudeAppProxy(); err != nil {
 		slog.Warn("failed to start Claude gateway", "error", err)
@@ -1592,30 +1782,25 @@ func stopClaudeAppProxy() {
 func quit() {
 	ctx, cancel := context.WithTimeout(context.Background(), claudeShutdownTimeout)
 	defer cancel()
-	handoff := bool(C.otherOllamaInstanceRunning())
-	if err := restoreClaudeAppForTermination(ctx, handoff); err != nil {
+	if err := restoreClaudeAppForTermination(ctx); err != nil {
 		slog.Warn("failed to restore Claude before quitting", "error", err)
 	}
 	C.quit()
 }
 
-func restoreClaudeBeforeQuit(ctx context.Context, handoff, configured bool, restore func(context.Context) error) error {
-	if handoff || !configured {
+func restoreClaudeBeforeQuit(ctx context.Context, configured bool, restore func(context.Context) error) error {
+	if !configured {
 		return nil
 	}
 	return restore(ctx)
 }
 
-func restoreClaudeAppForTermination(ctx context.Context, handoff bool) error {
+func restoreClaudeAppForTermination(ctx context.Context) error {
 	claudeLifecycleMu.Lock()
 	defer claudeLifecycleMu.Unlock()
 
-	if handoff {
-		stopClaudeAppProxy()
-		return nil
-	}
 	configured := claudeDesktop.UsesOllamaGateway()
-	err := restoreClaudeBeforeQuit(ctx, handoff, configured, claudeDesktop.RestoreForShutdown)
+	err := restoreClaudeBeforeQuit(ctx, configured, claudeDesktop.RestoreForShutdown)
 	if !claudeDesktop.UsesOllamaGateway() {
 		stopClaudeAppProxy()
 	}
@@ -1626,7 +1811,7 @@ func restoreClaudeAppForTermination(ctx context.Context, handoff bool) error {
 func RestoreClaudeGatewayForShutdown() C.bool {
 	ctx, cancel := context.WithTimeout(context.Background(), claudeShutdownTimeout)
 	defer cancel()
-	if err := restoreClaudeAppForTermination(ctx, false); err != nil {
+	if err := restoreClaudeAppForTermination(ctx); err != nil {
 		slog.Warn("failed to restore Claude during system shutdown", "error", err)
 		return C._Bool(false)
 	}

--- a/app/cmd/app/app_darwin.go
+++ b/app/cmd/app/app_darwin.go
@@ -267,12 +267,16 @@ func runAppSyncBarrier(self appProcessIdentity, controller appProcessController,
 		if err != nil {
 			return err
 		}
+		// Overlapping launches are ordered by process age. Only the newest
+		// candidate may terminate existing instances.
 		for _, process := range processes {
 			if process.startedAfter(self) {
 				return fmt.Errorf("%w: pid %d", errNewerAppInstance, process.pid)
 			}
 		}
 
+		// Require two consecutive empty snapshots so a process that is still
+		// appearing in NSWorkspace cannot slip through the barrier.
 		if len(processes) == 0 {
 			if sawEmpty {
 				return nil
@@ -307,6 +311,8 @@ func runAppSyncBarrier(self appProcessIdentity, controller appProcessController,
 			}
 		}
 		if !exited {
+			// Graceful shutdown owns most of the deadline. Force only exact
+			// surviving identities so one stuck instance cannot block update.
 			for _, process := range processes {
 				if err := controller.stop(process, appProcessStopForcefully); err != nil {
 					return err
@@ -439,15 +445,21 @@ func runDarwinAppSyncBarrier() bool {
 			settlePeriod:     appSyncBarrierSettlePeriod,
 		})
 	}
-	if errors.Is(err, errNewerAppInstance) {
+	switch {
+	case errors.Is(err, errNewerAppInstance):
 		slog.Info("newer Ollama app instance owns the handoff")
-		return false
+	case err != nil:
+		slog.Warn("app instance sync barrier failed, continuing startup", "error", err)
 	}
-	if err != nil {
-		slog.Error("app instance sync barrier failed", "error", err)
-		return false
-	}
-	return true
+	return continueAfterBarrierError(err)
+}
+
+// continueAfterBarrierError reports whether startup may proceed after the sync
+// barrier. Losing the election to a newer instance is the only reason to block
+// launch; any other failure leaves at most a stale instance running, so the
+// app warns and continues rather than refusing to start.
+func continueAfterBarrierError(err error) bool {
+	return err == nil || !errors.Is(err, errNewerAppInstance)
 }
 
 // handleExistingInstance handles existing instances on macOS.

--- a/app/cmd/app/app_darwin.go
+++ b/app/cmd/app/app_darwin.go
@@ -21,10 +21,12 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 	"unsafe"
@@ -232,7 +234,8 @@ func (p appProcessIdentity) startedAfter(other appProcessIdentity) bool {
 type appProcessStopMode uint8
 
 const (
-	appProcessStopGracefully appProcessStopMode = iota
+	appProcessStopForHandoff appProcessStopMode = iota
+	appProcessStopGracefully
 	appProcessStopForcefully
 )
 
@@ -243,18 +246,20 @@ type appProcessController struct {
 }
 
 type appSyncBarrierConfig struct {
-	gracePeriod  time.Duration
-	totalTimeout time.Duration
-	pollInterval time.Duration
-	settlePeriod time.Duration
+	handoffTimeout   time.Duration
+	terminateTimeout time.Duration
+	killTimeout      time.Duration
+	pollInterval     time.Duration
+	settlePeriod     time.Duration
 }
 
 // runAppSyncBarrier elects the newest launch, stops every older instance, and
 // returns only after no other instances remain.
 func runAppSyncBarrier(self appProcessIdentity, controller appProcessController, config appSyncBarrierConfig) error {
 	started := time.Now()
-	graceDeadline := started.Add(config.gracePeriod)
-	deadline := started.Add(config.totalTimeout)
+	handoffDeadline := started.Add(config.handoffTimeout)
+	terminateDeadline := handoffDeadline.Add(config.terminateTimeout)
+	deadline := terminateDeadline.Add(config.killTimeout)
 	sawEmpty := false
 
 	for {
@@ -264,7 +269,7 @@ func runAppSyncBarrier(self appProcessIdentity, controller appProcessController,
 		}
 		for _, process := range processes {
 			if process.startedAfter(self) {
-				return fmt.Errorf("newer app instance %d owns the handoff", process.pid)
+				return fmt.Errorf("%w: pid %d", errNewerAppInstance, process.pid)
 			}
 		}
 
@@ -282,13 +287,24 @@ func runAppSyncBarrier(self appProcessIdentity, controller appProcessController,
 		sawEmpty = false
 
 		for _, process := range processes {
-			if err := controller.stop(process, appProcessStopGracefully); err != nil {
+			if err := controller.stop(process, appProcessStopForHandoff); err != nil {
 				return err
 			}
 		}
-		exited, err := waitForAppProcesses(processes, controller, graceDeadline, config.pollInterval)
+		exited, err := waitForAppProcesses(processes, controller, handoffDeadline, config.pollInterval)
 		if err != nil {
 			return err
+		}
+		if !exited {
+			for _, process := range processes {
+				if err := controller.stop(process, appProcessStopGracefully); err != nil {
+					return err
+				}
+			}
+			exited, err = waitForAppProcesses(processes, controller, terminateDeadline, config.pollInterval)
+			if err != nil {
+				return err
+			}
 		}
 		if !exited {
 			for _, process := range processes {
@@ -328,13 +344,20 @@ func waitForAppProcesses(processes []appProcessIdentity, controller appProcessCo
 }
 
 const (
-	appSyncBarrierGrace        = 35 * time.Second
-	appSyncBarrierTimeout      = 40 * time.Second
-	appSyncBarrierPollInterval = 50 * time.Millisecond
-	appSyncBarrierSettlePeriod = 100 * time.Millisecond
+	appSyncBarrierHandoffTimeout   = 5 * time.Second
+	appSyncBarrierTerminateTimeout = 30 * time.Second
+	appSyncBarrierKillTimeout      = 5 * time.Second
+	appSyncBarrierPollInterval     = 50 * time.Millisecond
+	appSyncBarrierSettlePeriod     = 100 * time.Millisecond
 )
 
+var errNewerAppInstance = errors.New("newer app instance owns the handoff")
+
 var killOtherInstances = runDarwinAppSyncBarrier
+
+// Once a replacement handoff starts, later shutdown signals must not restore
+// the Claude profile out from under the new app.
+var appHandoffInProgress atomic.Bool
 
 func darwinProcessIdentityForPID(pid int) (appProcessIdentity, error) {
 	process, err := unix.SysctlKinfoProc("kern.proc.pid", pid)
@@ -385,12 +408,15 @@ func stopDarwinAppProcess(process appProcessIdentity, mode appProcessStopMode) e
 	if err != nil || !running {
 		return err
 	}
-	signal := syscall.SIGTERM
-	if mode == appProcessStopForcefully {
-		signal = syscall.SIGKILL
+	processSignal := syscall.SIGUSR1
+	switch mode {
+	case appProcessStopGracefully:
+		processSignal = syscall.SIGTERM
+	case appProcessStopForcefully:
+		processSignal = syscall.SIGKILL
 	}
-	slog.Info("signaling Ollama app process", "pid", process.pid, "signal", signal)
-	if err := syscall.Kill(process.pid, signal); err != nil && !errors.Is(err, syscall.ESRCH) {
+	slog.Info("signaling Ollama app process", "pid", process.pid, "signal", processSignal)
+	if err := syscall.Kill(process.pid, processSignal); err != nil && !errors.Is(err, syscall.ESRCH) {
 		return fmt.Errorf("signal Ollama app process %d: %w", process.pid, err)
 	}
 	return nil
@@ -406,11 +432,16 @@ func runDarwinAppSyncBarrier() bool {
 			running:  darwinAppProcessRunning,
 			stop:     stopDarwinAppProcess,
 		}, appSyncBarrierConfig{
-			gracePeriod:  appSyncBarrierGrace,
-			totalTimeout: appSyncBarrierTimeout,
-			pollInterval: appSyncBarrierPollInterval,
-			settlePeriod: appSyncBarrierSettlePeriod,
+			handoffTimeout:   appSyncBarrierHandoffTimeout,
+			terminateTimeout: appSyncBarrierTerminateTimeout,
+			killTimeout:      appSyncBarrierKillTimeout,
+			pollInterval:     appSyncBarrierPollInterval,
+			settlePeriod:     appSyncBarrierSettlePeriod,
 		})
+	}
+	if errors.Is(err, errNewerAppInstance) {
+		slog.Info("newer Ollama app instance owns the handoff")
+		return false
 	}
 	if err != nil {
 		slog.Error("app instance sync barrier failed", "error", err)
@@ -468,6 +499,20 @@ func UpdateAvailable(ver string) error {
 }
 
 func osRun(_ func(), hasCompletedFirstRun, startHidden, showOnboarding bool, _ string) {
+	handoffSignal := make(chan os.Signal, 1)
+	handoffDone := make(chan struct{})
+	signal.Notify(handoffSignal, syscall.SIGUSR1)
+	defer signal.Stop(handoffSignal)
+	defer close(handoffDone)
+	go func() {
+		select {
+		case <-handoffSignal:
+			slog.Info("received app handoff signal, shutting down")
+			quitForHandoff()
+		case <-handoffDone:
+		}
+	}()
+
 	registerLaunchAgent(hasCompletedFirstRun)
 	if err := reconcileClaudeAppProxy(); err != nil {
 		slog.Warn("failed to start Claude gateway", "error", err)
@@ -1779,10 +1824,15 @@ func stopClaudeAppProxy() {
 	}
 }
 
+func quitForHandoff() {
+	appHandoffInProgress.Store(true)
+	quit()
+}
+
 func quit() {
 	ctx, cancel := context.WithTimeout(context.Background(), claudeShutdownTimeout)
 	defer cancel()
-	if err := restoreClaudeAppForTermination(ctx); err != nil {
+	if err := restoreClaudeAppForTermination(ctx, appHandoffInProgress.Load()); err != nil {
 		slog.Warn("failed to restore Claude before quitting", "error", err)
 	}
 	C.quit()
@@ -1795,10 +1845,14 @@ func restoreClaudeBeforeQuit(ctx context.Context, configured bool, restore func(
 	return restore(ctx)
 }
 
-func restoreClaudeAppForTermination(ctx context.Context) error {
+func restoreClaudeAppForTermination(ctx context.Context, handoff bool) error {
 	claudeLifecycleMu.Lock()
 	defer claudeLifecycleMu.Unlock()
 
+	if handoff {
+		stopClaudeAppProxy()
+		return nil
+	}
 	configured := claudeDesktop.UsesOllamaGateway()
 	err := restoreClaudeBeforeQuit(ctx, configured, claudeDesktop.RestoreForShutdown)
 	if !claudeDesktop.UsesOllamaGateway() {
@@ -1811,7 +1865,7 @@ func restoreClaudeAppForTermination(ctx context.Context) error {
 func RestoreClaudeGatewayForShutdown() C.bool {
 	ctx, cancel := context.WithTimeout(context.Background(), claudeShutdownTimeout)
 	defer cancel()
-	if err := restoreClaudeAppForTermination(ctx); err != nil {
+	if err := restoreClaudeAppForTermination(ctx, false); err != nil {
 		slog.Warn("failed to restore Claude during system shutdown", "error", err)
 		return C._Bool(false)
 	}

--- a/app/cmd/app/app_darwin.h
+++ b/app/cmd/app/app_darwin.h
@@ -1,5 +1,7 @@
 #import <Cocoa/Cocoa.h>
 #import <Security/Security.h>
+#include <stddef.h>
+#include <stdint.h>
 
 @interface AppDelegate : NSObject <NSApplicationDelegate>
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification;
@@ -17,8 +19,11 @@ enum AppMove
 };
 
 void run(bool showOnboarding, bool startHidden);
-bool killOtherInstances(void);
-bool otherOllamaInstanceRunning(void);
+typedef struct {
+    int pid;
+    int64_t started_at;
+} AppProcessIdentity;
+bool otherOllamaProcesses(AppProcessIdentity **processes, size_t *count);
 enum AppMove askToMoveToApplications();
 int createSymlinkWithAuthorization();
 int installSymlink(const char *cliPath);

--- a/app/cmd/app/app_darwin.h
+++ b/app/cmd/app/app_darwin.h
@@ -17,7 +17,7 @@ enum AppMove
 };
 
 void run(bool showOnboarding, bool startHidden);
-void killOtherInstances();
+bool killOtherInstances(void);
 bool otherOllamaInstanceRunning(void);
 enum AppMove askToMoveToApplications();
 int createSymlinkWithAuthorization();

--- a/app/cmd/app/app_darwin.m
+++ b/app/cmd/app/app_darwin.m
@@ -1582,6 +1582,8 @@ bool otherOllamaInstanceRunning(void) {
     return false;
 }
 
+// Pair each PID with its start time so PID reuse cannot redirect a signal or
+// keep the handoff waiting on an unrelated process.
 typedef struct {
     pid_t pid;
     uint64_t startSeconds;
@@ -1769,6 +1771,8 @@ bool killOtherInstances(void) {
         }
 
         for (size_t i = 0; i < count; i++) {
+            // Overlapping launches are ordered by process age. Only the newest
+            // candidate may terminate existing instances.
             if (processStartedAfter(processes[i], self)) {
                 appLogInfo([NSString stringWithFormat:
                     @"newer ollama instance %d owns the app handoff",
@@ -1784,6 +1788,8 @@ bool killOtherInstances(void) {
                 appLogInfo(@"ollama instance handoff complete");
                 return true;
             }
+            // Require two empty snapshots so a process that is still appearing
+            // in NSWorkspace cannot slip through the barrier.
             sawEmpty = true;
             now = monotonicNanos();
             if (now == 0 || now >= deadline) {
@@ -1802,6 +1808,8 @@ bool killOtherInstances(void) {
         OllamaWaitResult wait = waitForProcessesToExit(
             processes, count, terminateDeadline);
         if (wait == OllamaWaitTimedOut) {
+            // Graceful shutdown owns most of the deadline. Force only exact
+            // surviving identities so one stuck instance cannot block update.
             appLogInfo(@"graceful ollama instance handoff timed out; "
                         @"forcing remaining instances to exit");
             if (!signalProcesses(processes, count, SIGKILL, @"SIGKILL")) {

--- a/app/cmd/app/app_darwin.m
+++ b/app/cmd/app/app_darwin.m
@@ -8,12 +8,21 @@
 #import <ServiceManagement/ServiceManagement.h>
 #import <WebKit/WebKit.h>
 #import <objc/runtime.h>
+#include <errno.h>
+#include <libproc.h>
+#include <signal.h>
 #include <stdlib.h>
+#include <time.h>
+#include <unistd.h>
 
 extern NSString *SystemWidePath;
 
 static NSString *const ClaudeDownloadPageURL = @"https://claude.com/download";
 static NSString *const ShowAppsInMenuDefaultsKey = @"ShowAppsInMenu";
+static const uint64_t AppHandoffTerminateTimeoutNanos = 30 * NSEC_PER_SEC;
+static const uint64_t AppHandoffTimeoutNanos = 35 * NSEC_PER_SEC;
+static const useconds_t AppHandoffPollInterval = 50 * 1000;
+static const useconds_t AppHandoffSettleInterval = 100 * 1000;
 static NSBundle *OllamaResourceBundle(void);
 
 static BOOL shouldShowAppsInMenu(void) {
@@ -1573,24 +1582,238 @@ bool otherOllamaInstanceRunning(void) {
     return false;
 }
 
-// killOtherInstances kills all other instances of the app currently
-// running. This way we can ensure that only the most recently started
-// instance of Ollama is running
-void killOtherInstances() {
+typedef struct {
+    pid_t pid;
+    uint64_t startSeconds;
+    uint64_t startMicroseconds;
+} OllamaProcessIdentity;
+
+typedef enum {
+    OllamaProcessExited,
+    OllamaProcessRunning,
+    OllamaProcessUnknown,
+} OllamaProcessState;
+
+typedef enum {
+    OllamaWaitExited,
+    OllamaWaitTimedOut,
+    OllamaWaitFailed,
+} OllamaWaitResult;
+
+static uint64_t monotonicNanos(void) {
+    struct timespec now = {0};
+    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
+        return 0;
+    }
+    return (uint64_t)now.tv_sec * NSEC_PER_SEC + (uint64_t)now.tv_nsec;
+}
+
+static bool readProcessIdentity(pid_t pid, OllamaProcessIdentity *identity) {
+    struct proc_bsdinfo info = {0};
+    int size = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, sizeof(info));
+    if (size != sizeof(info)) {
+        return false;
+    }
+    identity->pid = pid;
+    identity->startSeconds = info.pbi_start_tvsec;
+    identity->startMicroseconds = info.pbi_start_tvusec;
+    return true;
+}
+
+static bool processStartedAfter(OllamaProcessIdentity process,
+                                OllamaProcessIdentity other) {
+    if (process.startSeconds != other.startSeconds) {
+        return process.startSeconds > other.startSeconds;
+    }
+    if (process.startMicroseconds != other.startMicroseconds) {
+        return process.startMicroseconds > other.startMicroseconds;
+    }
+    return process.pid > other.pid;
+}
+
+static OllamaProcessState processState(OllamaProcessIdentity expected) {
+    OllamaProcessIdentity actual = {0};
+    if (readProcessIdentity(expected.pid, &actual)) {
+        if (actual.startSeconds == expected.startSeconds &&
+            actual.startMicroseconds == expected.startMicroseconds) {
+            return OllamaProcessRunning;
+        }
+        return OllamaProcessExited;
+    }
+
+    if (kill(expected.pid, 0) == 0 || errno == EPERM) {
+        return OllamaProcessUnknown;
+    }
+    return errno == ESRCH ? OllamaProcessExited : OllamaProcessUnknown;
+}
+
+static bool otherOllamaProcesses(OllamaProcessIdentity **processes,
+                                 size_t *count) {
     pid_t myPid = getpid();
     NSArray *apps = [[NSWorkspace sharedWorkspace] runningApplications];
+    OllamaProcessIdentity *result = calloc(apps.count, sizeof(*result));
+    if (result == NULL && apps.count > 0) {
+        return false;
+    }
 
+    size_t resultCount = 0;
     for (NSRunningApplication *app in apps) {
-        if (isOllamaApplication(app)) {
-            pid_t pid = app.processIdentifier;
-            if (pid != myPid && pid > 0) {
-                appLogInfo([NSString stringWithFormat:@"terminating other ollama instance %d", pid]);
-                // Preserve the Claude profile while the replacement instance
-                // takes ownership of the local gateway.
-                kill(pid, SIGUSR1);
-            } else if (pid == -1) {
-                appLogInfo([NSString stringWithFormat:@"skipping app with invalid pid: %@", app.bundleIdentifier]);
+        pid_t pid = app.processIdentifier;
+        if (!isOllamaApplication(app) || pid == myPid) {
+            continue;
+        }
+        if (pid <= 0) {
+            appLogInfo([NSString stringWithFormat:
+                @"skipping app with invalid pid: %@", app.bundleIdentifier]);
+            continue;
+        }
+
+        OllamaProcessIdentity identity = {0};
+        if (readProcessIdentity(pid, &identity)) {
+            result[resultCount++] = identity;
+            continue;
+        }
+        if (kill(pid, 0) != 0 && errno == ESRCH) {
+            continue;
+        }
+        appLogInfo([NSString stringWithFormat:
+            @"unable to inspect ollama instance %d", pid]);
+        free(result);
+        return false;
+    }
+
+    *processes = result;
+    *count = resultCount;
+    return true;
+}
+
+static bool signalProcesses(OllamaProcessIdentity *processes, size_t count,
+                            int signal, NSString *signalName) {
+    bool signaled = true;
+    for (size_t i = 0; i < count; i++) {
+        pid_t pid = processes[i].pid;
+        OllamaProcessState state = processState(processes[i]);
+        if (state == OllamaProcessExited) {
+            continue;
+        }
+        if (state == OllamaProcessUnknown) {
+            appLogInfo([NSString stringWithFormat:
+                @"unable to inspect ollama instance %d before %@", pid,
+                signalName]);
+            signaled = false;
+            continue;
+        }
+
+        appLogInfo([NSString stringWithFormat:
+            @"sending %@ to ollama instance %d", signalName, pid]);
+        if (kill(pid, signal) != 0 && errno != ESRCH) {
+            appLogInfo([NSString stringWithFormat:
+                @"unable to send %@ to ollama instance %d", signalName, pid]);
+            signaled = false;
+        }
+    }
+    return signaled;
+}
+
+static OllamaWaitResult waitForProcessesToExit(
+    OllamaProcessIdentity *processes, size_t count, uint64_t deadline) {
+    while (true) {
+        bool running = false;
+        for (size_t i = 0; i < count; i++) {
+            OllamaProcessState state = processState(processes[i]);
+            if (state == OllamaProcessUnknown) {
+                appLogInfo([NSString stringWithFormat:
+                    @"unable to inspect ollama instance %d", processes[i].pid]);
+                return OllamaWaitFailed;
             }
+            running = running || state == OllamaProcessRunning;
+        }
+        if (!running) {
+            return OllamaWaitExited;
+        }
+        uint64_t now = monotonicNanos();
+        if (now == 0) {
+            appLogInfo(@"unable to read ollama instance handoff timer");
+            return OllamaWaitFailed;
+        }
+        if (now >= deadline) {
+            return OllamaWaitTimedOut;
+        }
+        usleep(AppHandoffPollInterval);
+    }
+}
+
+// killOtherInstances is a synchronous handoff barrier. It returns only after
+// every other packaged Ollama process has exited and the process list remains
+// empty, or after the handoff fails.
+bool killOtherInstances(void) {
+    uint64_t now = monotonicNanos();
+    if (now == 0) {
+        appLogInfo(@"unable to start ollama instance handoff timer");
+        return false;
+    }
+    OllamaProcessIdentity self = {0};
+    if (!readProcessIdentity(getpid(), &self)) {
+        appLogInfo(@"unable to inspect the current ollama instance");
+        return false;
+    }
+    uint64_t terminateDeadline = now + AppHandoffTerminateTimeoutNanos;
+    uint64_t deadline = now + AppHandoffTimeoutNanos;
+    bool sawEmpty = false;
+
+    while (true) {
+        OllamaProcessIdentity *processes = NULL;
+        size_t count = 0;
+        if (!otherOllamaProcesses(&processes, &count)) {
+            return false;
+        }
+
+        for (size_t i = 0; i < count; i++) {
+            if (processStartedAfter(processes[i], self)) {
+                appLogInfo([NSString stringWithFormat:
+                    @"newer ollama instance %d owns the app handoff",
+                    processes[i].pid]);
+                free(processes);
+                return false;
+            }
+        }
+
+        if (count == 0) {
+            free(processes);
+            if (sawEmpty) {
+                appLogInfo(@"ollama instance handoff complete");
+                return true;
+            }
+            sawEmpty = true;
+            now = monotonicNanos();
+            if (now == 0 || now >= deadline) {
+                return false;
+            }
+            usleep(AppHandoffSettleInterval);
+            continue;
+        }
+        sawEmpty = false;
+
+        if (!signalProcesses(processes, count, SIGTERM, @"SIGTERM")) {
+            free(processes);
+            return false;
+        }
+
+        OllamaWaitResult wait = waitForProcessesToExit(
+            processes, count, terminateDeadline);
+        if (wait == OllamaWaitTimedOut) {
+            appLogInfo(@"graceful ollama instance handoff timed out; "
+                        @"forcing remaining instances to exit");
+            if (!signalProcesses(processes, count, SIGKILL, @"SIGKILL")) {
+                free(processes);
+                return false;
+            }
+            wait = waitForProcessesToExit(processes, count, deadline);
+        }
+        free(processes);
+        if (wait != OllamaWaitExited) {
+            appLogInfo(@"ollama instance handoff failed");
+            return false;
         }
     }
 }

--- a/app/cmd/app/app_darwin.m
+++ b/app/cmd/app/app_darwin.m
@@ -10,19 +10,13 @@
 #import <objc/runtime.h>
 #include <errno.h>
 #include <libproc.h>
-#include <signal.h>
 #include <stdlib.h>
-#include <time.h>
 #include <unistd.h>
 
 extern NSString *SystemWidePath;
 
 static NSString *const ClaudeDownloadPageURL = @"https://claude.com/download";
 static NSString *const ShowAppsInMenuDefaultsKey = @"ShowAppsInMenu";
-static const uint64_t AppHandoffTerminateTimeoutNanos = 30 * NSEC_PER_SEC;
-static const uint64_t AppHandoffTimeoutNanos = 35 * NSEC_PER_SEC;
-static const useconds_t AppHandoffPollInterval = 50 * 1000;
-static const useconds_t AppHandoffSettleInterval = 100 * 1000;
 static NSBundle *OllamaResourceBundle(void);
 
 static BOOL shouldShowAppsInMenu(void) {
@@ -1570,90 +1564,10 @@ static BOOL isOllamaApplication(NSRunningApplication *app) {
         [bundleId isEqualToString:@"com.electron.ollama"];
 }
 
-bool otherOllamaInstanceRunning(void) {
-    pid_t myPid = getpid();
-    for (NSRunningApplication *app in
-         [[NSWorkspace sharedWorkspace] runningApplications]) {
-        if (isOllamaApplication(app) && app.processIdentifier > 0 &&
-            app.processIdentifier != myPid) {
-            return true;
-        }
-    }
-    return false;
-}
-
-// Pair each PID with its start time so PID reuse cannot redirect a signal or
-// keep the handoff waiting on an unrelated process.
-typedef struct {
-    pid_t pid;
-    uint64_t startSeconds;
-    uint64_t startMicroseconds;
-} OllamaProcessIdentity;
-
-typedef enum {
-    OllamaProcessExited,
-    OllamaProcessRunning,
-    OllamaProcessUnknown,
-} OllamaProcessState;
-
-typedef enum {
-    OllamaWaitExited,
-    OllamaWaitTimedOut,
-    OllamaWaitFailed,
-} OllamaWaitResult;
-
-static uint64_t monotonicNanos(void) {
-    struct timespec now = {0};
-    if (clock_gettime(CLOCK_MONOTONIC, &now) != 0) {
-        return 0;
-    }
-    return (uint64_t)now.tv_sec * NSEC_PER_SEC + (uint64_t)now.tv_nsec;
-}
-
-static bool readProcessIdentity(pid_t pid, OllamaProcessIdentity *identity) {
-    struct proc_bsdinfo info = {0};
-    int size = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &info, sizeof(info));
-    if (size != sizeof(info)) {
-        return false;
-    }
-    identity->pid = pid;
-    identity->startSeconds = info.pbi_start_tvsec;
-    identity->startMicroseconds = info.pbi_start_tvusec;
-    return true;
-}
-
-static bool processStartedAfter(OllamaProcessIdentity process,
-                                OllamaProcessIdentity other) {
-    if (process.startSeconds != other.startSeconds) {
-        return process.startSeconds > other.startSeconds;
-    }
-    if (process.startMicroseconds != other.startMicroseconds) {
-        return process.startMicroseconds > other.startMicroseconds;
-    }
-    return process.pid > other.pid;
-}
-
-static OllamaProcessState processState(OllamaProcessIdentity expected) {
-    OllamaProcessIdentity actual = {0};
-    if (readProcessIdentity(expected.pid, &actual)) {
-        if (actual.startSeconds == expected.startSeconds &&
-            actual.startMicroseconds == expected.startMicroseconds) {
-            return OllamaProcessRunning;
-        }
-        return OllamaProcessExited;
-    }
-
-    if (kill(expected.pid, 0) == 0 || errno == EPERM) {
-        return OllamaProcessUnknown;
-    }
-    return errno == ESRCH ? OllamaProcessExited : OllamaProcessUnknown;
-}
-
-static bool otherOllamaProcesses(OllamaProcessIdentity **processes,
-                                 size_t *count) {
+bool otherOllamaProcesses(AppProcessIdentity **processes, size_t *count) {
     pid_t myPid = getpid();
     NSArray *apps = [[NSWorkspace sharedWorkspace] runningApplications];
-    OllamaProcessIdentity *result = calloc(apps.count, sizeof(*result));
+    AppProcessIdentity *result = calloc(apps.count, sizeof(*result));
     if (result == NULL && apps.count > 0) {
         return false;
     }
@@ -1670,160 +1584,54 @@ static bool otherOllamaProcesses(OllamaProcessIdentity **processes,
             continue;
         }
 
-        OllamaProcessIdentity identity = {0};
-        if (readProcessIdentity(pid, &identity)) {
-            result[resultCount++] = identity;
+        // Tie the NSWorkspace match to the kernel process. Re-read the start
+        // time after confirming the current app so PID reuse is rejected.
+        struct proc_bsdinfo before = {0};
+        int size = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &before,
+                               sizeof(before));
+        if (size != sizeof(before)) {
+            if (kill(pid, 0) != 0 && errno == ESRCH) {
+                continue;
+            }
+            appLogInfo([NSString stringWithFormat:
+                @"unable to inspect ollama instance %d", pid]);
+            free(result);
+            return false;
+        }
+
+        NSRunningApplication *current =
+            [NSRunningApplication runningApplicationWithProcessIdentifier:pid];
+        if (current == nil || current.isTerminated ||
+            !isOllamaApplication(current)) {
             continue;
         }
-        if (kill(pid, 0) != 0 && errno == ESRCH) {
+
+        struct proc_bsdinfo after = {0};
+        size = proc_pidinfo(pid, PROC_PIDTBSDINFO, 0, &after, sizeof(after));
+        if (size != sizeof(after)) {
+            if (kill(pid, 0) != 0 && errno == ESRCH) {
+                continue;
+            }
+            appLogInfo([NSString stringWithFormat:
+                @"unable to confirm ollama instance %d", pid]);
+            free(result);
+            return false;
+        }
+        if (before.pbi_start_tvsec != after.pbi_start_tvsec ||
+            before.pbi_start_tvusec != after.pbi_start_tvusec) {
             continue;
         }
-        appLogInfo([NSString stringWithFormat:
-            @"unable to inspect ollama instance %d", pid]);
-        free(result);
-        return false;
+
+        result[resultCount++] = (AppProcessIdentity){
+            .pid = pid,
+            .started_at = (int64_t)after.pbi_start_tvsec * 1000000 +
+                after.pbi_start_tvusec,
+        };
     }
 
     *processes = result;
     *count = resultCount;
     return true;
-}
-
-static bool signalProcesses(OllamaProcessIdentity *processes, size_t count,
-                            int signal, NSString *signalName) {
-    bool signaled = true;
-    for (size_t i = 0; i < count; i++) {
-        pid_t pid = processes[i].pid;
-        OllamaProcessState state = processState(processes[i]);
-        if (state == OllamaProcessExited) {
-            continue;
-        }
-        if (state == OllamaProcessUnknown) {
-            appLogInfo([NSString stringWithFormat:
-                @"unable to inspect ollama instance %d before %@", pid,
-                signalName]);
-            signaled = false;
-            continue;
-        }
-
-        appLogInfo([NSString stringWithFormat:
-            @"sending %@ to ollama instance %d", signalName, pid]);
-        if (kill(pid, signal) != 0 && errno != ESRCH) {
-            appLogInfo([NSString stringWithFormat:
-                @"unable to send %@ to ollama instance %d", signalName, pid]);
-            signaled = false;
-        }
-    }
-    return signaled;
-}
-
-static OllamaWaitResult waitForProcessesToExit(
-    OllamaProcessIdentity *processes, size_t count, uint64_t deadline) {
-    while (true) {
-        bool running = false;
-        for (size_t i = 0; i < count; i++) {
-            OllamaProcessState state = processState(processes[i]);
-            if (state == OllamaProcessUnknown) {
-                appLogInfo([NSString stringWithFormat:
-                    @"unable to inspect ollama instance %d", processes[i].pid]);
-                return OllamaWaitFailed;
-            }
-            running = running || state == OllamaProcessRunning;
-        }
-        if (!running) {
-            return OllamaWaitExited;
-        }
-        uint64_t now = monotonicNanos();
-        if (now == 0) {
-            appLogInfo(@"unable to read ollama instance handoff timer");
-            return OllamaWaitFailed;
-        }
-        if (now >= deadline) {
-            return OllamaWaitTimedOut;
-        }
-        usleep(AppHandoffPollInterval);
-    }
-}
-
-// killOtherInstances is a synchronous handoff barrier. It returns only after
-// every other packaged Ollama process has exited and the process list remains
-// empty, or after the handoff fails.
-bool killOtherInstances(void) {
-    uint64_t now = monotonicNanos();
-    if (now == 0) {
-        appLogInfo(@"unable to start ollama instance handoff timer");
-        return false;
-    }
-    OllamaProcessIdentity self = {0};
-    if (!readProcessIdentity(getpid(), &self)) {
-        appLogInfo(@"unable to inspect the current ollama instance");
-        return false;
-    }
-    uint64_t terminateDeadline = now + AppHandoffTerminateTimeoutNanos;
-    uint64_t deadline = now + AppHandoffTimeoutNanos;
-    bool sawEmpty = false;
-
-    while (true) {
-        OllamaProcessIdentity *processes = NULL;
-        size_t count = 0;
-        if (!otherOllamaProcesses(&processes, &count)) {
-            return false;
-        }
-
-        for (size_t i = 0; i < count; i++) {
-            // Overlapping launches are ordered by process age. Only the newest
-            // candidate may terminate existing instances.
-            if (processStartedAfter(processes[i], self)) {
-                appLogInfo([NSString stringWithFormat:
-                    @"newer ollama instance %d owns the app handoff",
-                    processes[i].pid]);
-                free(processes);
-                return false;
-            }
-        }
-
-        if (count == 0) {
-            free(processes);
-            if (sawEmpty) {
-                appLogInfo(@"ollama instance handoff complete");
-                return true;
-            }
-            // Require two empty snapshots so a process that is still appearing
-            // in NSWorkspace cannot slip through the barrier.
-            sawEmpty = true;
-            now = monotonicNanos();
-            if (now == 0 || now >= deadline) {
-                return false;
-            }
-            usleep(AppHandoffSettleInterval);
-            continue;
-        }
-        sawEmpty = false;
-
-        if (!signalProcesses(processes, count, SIGTERM, @"SIGTERM")) {
-            free(processes);
-            return false;
-        }
-
-        OllamaWaitResult wait = waitForProcessesToExit(
-            processes, count, terminateDeadline);
-        if (wait == OllamaWaitTimedOut) {
-            // Graceful shutdown owns most of the deadline. Force only exact
-            // surviving identities so one stuck instance cannot block update.
-            appLogInfo(@"graceful ollama instance handoff timed out; "
-                        @"forcing remaining instances to exit");
-            if (!signalProcesses(processes, count, SIGKILL, @"SIGKILL")) {
-                free(processes);
-                return false;
-            }
-            wait = waitForProcessesToExit(processes, count, deadline);
-        }
-        free(processes);
-        if (wait != OllamaWaitExited) {
-            appLogInfo(@"ollama instance handoff failed");
-            return false;
-        }
-    }
 }
 
 // Move the source bundle to the system-wide applications location

--- a/app/cmd/app/app_darwin_test.go
+++ b/app/cmd/app/app_darwin_test.go
@@ -2703,6 +2703,46 @@ func TestRestoreClaudeBeforeQuit(t *testing.T) {
 	}
 }
 
+func TestHandleExistingInstanceSkipsDevelopmentBuild(t *testing.T) {
+	oldIsApp := isApp
+	oldKillOtherInstances := killOtherInstances
+	t.Cleanup(func() {
+		isApp = oldIsApp
+		killOtherInstances = oldKillOtherInstances
+	})
+
+	isApp = false
+	called := false
+	killOtherInstances = func() bool {
+		called = true
+		return false
+	}
+
+	if !handleExistingInstance(false) {
+		t.Fatal("development instance did not continue startup")
+	}
+	if called {
+		t.Fatal("development instance entered the packaged app handoff barrier")
+	}
+}
+
+func TestHandleExistingInstanceReturnsBarrierResult(t *testing.T) {
+	oldIsApp := isApp
+	oldKillOtherInstances := killOtherInstances
+	t.Cleanup(func() {
+		isApp = oldIsApp
+		killOtherInstances = oldKillOtherInstances
+	})
+
+	isApp = true
+	for _, want := range []bool{true, false} {
+		killOtherInstances = func() bool { return want }
+		if got := handleExistingInstance(false); got != want {
+			t.Fatalf("handleExistingInstance() = %v, want %v", got, want)
+		}
+	}
+}
+
 func TestSetClaudeGatewayInstalledRejectsMissingClaude(t *testing.T) {
 	previousInstalled := claudeDesktopInstalled
 	claudeDesktopInstalled = func() bool { return false }

--- a/app/cmd/app/app_darwin_test.go
+++ b/app/cmd/app/app_darwin_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"maps"
 	"net"
 	"net/http"
@@ -2811,6 +2812,27 @@ func TestRunAppSyncBarrierRequiresSettledEmptyList(t *testing.T) {
 	}
 	if queries != 2 {
 		t.Fatalf("discovery queries = %d, want 2", queries)
+	}
+}
+
+func TestContinueAfterBarrierErrorOnlyBlocksNewerInstance(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "success", err: nil, want: true},
+		{name: "discovery failure", err: errors.New("discover other Ollama app processes"), want: true},
+		{name: "handoff timeout", err: errors.New("timed out waiting for app instances to exit"), want: true},
+		{name: "newer instance", err: fmt.Errorf("%w: pid 2", errNewerAppInstance), want: false},
+		{name: "wrapped newer instance", err: fmt.Errorf("barrier: %w", fmt.Errorf("%w: pid 2", errNewerAppInstance)), want: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := continueAfterBarrierError(tt.err); got != tt.want {
+				t.Fatalf("continueAfterBarrierError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/app/cmd/app/app_darwin_test.go
+++ b/app/cmd/app/app_darwin_test.go
@@ -1590,7 +1590,7 @@ func TestResetClaudeDesktopMappingsSerializesDisconnectDuringCatalogRefresh(t *t
 
 func TestResetClaudeDesktopMappingsSerializesShutdownDuringCatalogRefresh(t *testing.T) {
 	testResetClaudeDesktopMappingsSerializesLifecycleChange(t, "shutdown", func() error {
-		return restoreClaudeAppForTermination(context.Background())
+		return restoreClaudeAppForTermination(context.Background(), false)
 	})
 }
 
@@ -2665,11 +2665,12 @@ func TestClaudeGatewayLocalSelectionCatalogPolicy(t *testing.T) {
 func TestRunAppSyncBarrierStopsOlderInstances(t *testing.T) {
 	for _, test := range []struct {
 		name      string
-		stubborn  bool
+		exitOn    appProcessStopMode
 		wantStops []appProcessStopMode
 	}{
-		{name: "graceful", wantStops: []appProcessStopMode{appProcessStopGracefully}},
-		{name: "forced", stubborn: true, wantStops: []appProcessStopMode{appProcessStopGracefully, appProcessStopForcefully}},
+		{name: "handoff", exitOn: appProcessStopForHandoff, wantStops: []appProcessStopMode{appProcessStopForHandoff}},
+		{name: "graceful", exitOn: appProcessStopGracefully, wantStops: []appProcessStopMode{appProcessStopForHandoff, appProcessStopGracefully}},
+		{name: "forced", exitOn: appProcessStopForcefully, wantStops: []appProcessStopMode{appProcessStopForHandoff, appProcessStopGracefully, appProcessStopForcefully}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			self := appProcessIdentity{pid: 20, startedAt: 20}
@@ -2691,7 +2692,7 @@ func TestRunAppSyncBarrierStopsOlderInstances(t *testing.T) {
 						t.Fatalf("stopped process %+v, want %+v", process, older)
 					}
 					stops = append(stops, mode)
-					if !test.stubborn || mode == appProcessStopForcefully {
+					if mode == test.exitOn {
 						alive = false
 					}
 					return nil
@@ -2699,8 +2700,7 @@ func TestRunAppSyncBarrierStopsOlderInstances(t *testing.T) {
 			}
 
 			err := runAppSyncBarrier(self, controller, appSyncBarrierConfig{
-				gracePeriod:  time.Millisecond,
-				totalTimeout: time.Second,
+				killTimeout:  time.Second,
 				pollInterval: time.Millisecond,
 			})
 			if err != nil {
@@ -2758,18 +2758,18 @@ func TestRunAppSyncBarrierStopsEveryOlderInstance(t *testing.T) {
 	}
 
 	err := runAppSyncBarrier(self, controller, appSyncBarrierConfig{
-		gracePeriod:  time.Millisecond,
-		totalTimeout: time.Second,
+		killTimeout:  time.Second,
 		pollInterval: time.Millisecond,
 	})
 	if err != nil {
 		t.Fatal(err)
 	}
 	want := []stoppedProcess{
-		{process: graceful, mode: appProcessStopGracefully},
+		{process: graceful, mode: appProcessStopForHandoff},
+		{process: stubborn, mode: appProcessStopForHandoff},
 		{process: stubborn, mode: appProcessStopGracefully},
 		{process: stubborn, mode: appProcessStopForcefully},
-		{process: late, mode: appProcessStopGracefully},
+		{process: late, mode: appProcessStopForHandoff},
 	}
 	if !slices.Equal(stops, want) {
 		t.Fatalf("stops = %+v, want %+v", stops, want)
@@ -2789,8 +2789,8 @@ func TestRunAppSyncBarrierDefersToNewerInstance(t *testing.T) {
 			stopped = true
 			return nil
 		},
-	}, appSyncBarrierConfig{totalTimeout: time.Second})
-	if err == nil || !strings.Contains(err.Error(), "newer app instance") {
+	}, appSyncBarrierConfig{killTimeout: time.Second})
+	if !errors.Is(err, errNewerAppInstance) {
 		t.Fatalf("barrier error = %v, want newer-instance error", err)
 	}
 	if stopped {
@@ -2805,7 +2805,7 @@ func TestRunAppSyncBarrierRequiresSettledEmptyList(t *testing.T) {
 			queries++
 			return nil, nil
 		},
-	}, appSyncBarrierConfig{totalTimeout: time.Second})
+	}, appSyncBarrierConfig{killTimeout: time.Second})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -2841,6 +2841,20 @@ func TestRestoreClaudeBeforeQuit(t *testing.T) {
 		return wantErr
 	}); !errors.Is(err, wantErr) {
 		t.Fatalf("restore error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestRestoreClaudeAppForTerminationPreservesHandoffProfile(t *testing.T) {
+	previousDesktop := claudeDesktop
+	fake := &fakeClaudeDesktopController{configured: true}
+	claudeDesktop = fake
+	t.Cleanup(func() { claudeDesktop = previousDesktop })
+
+	if err := restoreClaudeAppForTermination(context.Background(), true); err != nil {
+		t.Fatal(err)
+	}
+	if fake.restoreCalls != 0 || !fake.configured {
+		t.Fatalf("handoff restore calls/configured = %d/%v, want 0/true", fake.restoreCalls, fake.configured)
 	}
 }
 

--- a/app/cmd/app/app_darwin_test.go
+++ b/app/cmd/app/app_darwin_test.go
@@ -1590,7 +1590,7 @@ func TestResetClaudeDesktopMappingsSerializesDisconnectDuringCatalogRefresh(t *t
 
 func TestResetClaudeDesktopMappingsSerializesShutdownDuringCatalogRefresh(t *testing.T) {
 	testResetClaudeDesktopMappingsSerializesLifecycleChange(t, "shutdown", func() error {
-		return restoreClaudeAppForTermination(context.Background(), false)
+		return restoreClaudeAppForTermination(context.Background())
 	})
 }
 
@@ -2662,9 +2662,161 @@ func TestClaudeGatewayLocalSelectionCatalogPolicy(t *testing.T) {
 	}
 }
 
+func TestRunAppSyncBarrierStopsOlderInstances(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		stubborn  bool
+		wantStops []appProcessStopMode
+	}{
+		{name: "graceful", wantStops: []appProcessStopMode{appProcessStopGracefully}},
+		{name: "forced", stubborn: true, wantStops: []appProcessStopMode{appProcessStopGracefully, appProcessStopForcefully}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			self := appProcessIdentity{pid: 20, startedAt: 20}
+			older := appProcessIdentity{pid: 10, startedAt: 10}
+			alive := true
+			var stops []appProcessStopMode
+			controller := appProcessController{
+				discover: func() ([]appProcessIdentity, error) {
+					if alive {
+						return []appProcessIdentity{older}, nil
+					}
+					return nil, nil
+				},
+				running: func(process appProcessIdentity) (bool, error) {
+					return alive && process.sameProcess(older), nil
+				},
+				stop: func(process appProcessIdentity, mode appProcessStopMode) error {
+					if !process.sameProcess(older) {
+						t.Fatalf("stopped process %+v, want %+v", process, older)
+					}
+					stops = append(stops, mode)
+					if !test.stubborn || mode == appProcessStopForcefully {
+						alive = false
+					}
+					return nil
+				},
+			}
+
+			err := runAppSyncBarrier(self, controller, appSyncBarrierConfig{
+				gracePeriod:  time.Millisecond,
+				totalTimeout: time.Second,
+				pollInterval: time.Millisecond,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Equal(stops, test.wantStops) {
+				t.Fatalf("stop modes = %v, want %v", stops, test.wantStops)
+			}
+		})
+	}
+}
+
+func TestRunAppSyncBarrierStopsEveryOlderInstance(t *testing.T) {
+	self := appProcessIdentity{pid: 30, startedAt: 30}
+	graceful := appProcessIdentity{pid: 10, startedAt: 10}
+	stubborn := appProcessIdentity{pid: 20, startedAt: 20}
+	late := appProcessIdentity{pid: 25, startedAt: 25}
+	alive := map[appProcessIdentity]bool{
+		graceful: true,
+		stubborn: true,
+	}
+	type stoppedProcess struct {
+		process appProcessIdentity
+		mode    appProcessStopMode
+	}
+	var stops []stoppedProcess
+	lateDiscovered := false
+	controller := appProcessController{
+		discover: func() ([]appProcessIdentity, error) {
+			if !alive[graceful] && !alive[stubborn] && !lateDiscovered {
+				alive[late] = true
+				lateDiscovered = true
+			}
+			var processes []appProcessIdentity
+			for _, process := range []appProcessIdentity{graceful, stubborn, late} {
+				if alive[process] {
+					processes = append(processes, process)
+				}
+			}
+			return processes, nil
+		},
+		running: func(process appProcessIdentity) (bool, error) {
+			return alive[process], nil
+		},
+		stop: func(process appProcessIdentity, mode appProcessStopMode) error {
+			if !alive[process] {
+				return nil
+			}
+			stops = append(stops, stoppedProcess{process: process, mode: mode})
+			if !process.sameProcess(stubborn) || mode == appProcessStopForcefully {
+				alive[process] = false
+			}
+			return nil
+		},
+	}
+
+	err := runAppSyncBarrier(self, controller, appSyncBarrierConfig{
+		gracePeriod:  time.Millisecond,
+		totalTimeout: time.Second,
+		pollInterval: time.Millisecond,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []stoppedProcess{
+		{process: graceful, mode: appProcessStopGracefully},
+		{process: stubborn, mode: appProcessStopGracefully},
+		{process: stubborn, mode: appProcessStopForcefully},
+		{process: late, mode: appProcessStopGracefully},
+	}
+	if !slices.Equal(stops, want) {
+		t.Fatalf("stops = %+v, want %+v", stops, want)
+	}
+}
+
+func TestRunAppSyncBarrierDefersToNewerInstance(t *testing.T) {
+	self := appProcessIdentity{pid: 10, startedAt: 10}
+	newer := appProcessIdentity{pid: 20, startedAt: 20}
+	stopped := false
+	err := runAppSyncBarrier(self, appProcessController{
+		discover: func() ([]appProcessIdentity, error) {
+			return []appProcessIdentity{newer}, nil
+		},
+		running: func(appProcessIdentity) (bool, error) { return true, nil },
+		stop: func(appProcessIdentity, appProcessStopMode) error {
+			stopped = true
+			return nil
+		},
+	}, appSyncBarrierConfig{totalTimeout: time.Second})
+	if err == nil || !strings.Contains(err.Error(), "newer app instance") {
+		t.Fatalf("barrier error = %v, want newer-instance error", err)
+	}
+	if stopped {
+		t.Fatal("older launch stopped the newer instance")
+	}
+}
+
+func TestRunAppSyncBarrierRequiresSettledEmptyList(t *testing.T) {
+	queries := 0
+	err := runAppSyncBarrier(appProcessIdentity{pid: 1, startedAt: 1}, appProcessController{
+		discover: func() ([]appProcessIdentity, error) {
+			queries++
+			return nil, nil
+		},
+	}, appSyncBarrierConfig{totalTimeout: time.Second})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if queries != 2 {
+		t.Fatalf("discovery queries = %d, want 2", queries)
+	}
+}
+
 func TestRestoreClaudeBeforeQuit(t *testing.T) {
 	called := false
-	if err := restoreClaudeBeforeQuit(context.Background(), false, false, func(context.Context) error {
+	if err := restoreClaudeBeforeQuit(context.Background(), false, func(context.Context) error {
 		called = true
 		return nil
 	}); err != nil {
@@ -2674,7 +2826,7 @@ func TestRestoreClaudeBeforeQuit(t *testing.T) {
 		t.Fatal("restore called while Claude was not configured")
 	}
 
-	if err := restoreClaudeBeforeQuit(context.Background(), false, true, func(context.Context) error {
+	if err := restoreClaudeBeforeQuit(context.Background(), true, func(context.Context) error {
 		called = true
 		return nil
 	}); err != nil {
@@ -2685,21 +2837,10 @@ func TestRestoreClaudeBeforeQuit(t *testing.T) {
 	}
 
 	wantErr := errors.New("restore failed")
-	if err := restoreClaudeBeforeQuit(context.Background(), false, true, func(context.Context) error {
+	if err := restoreClaudeBeforeQuit(context.Background(), true, func(context.Context) error {
 		return wantErr
 	}); !errors.Is(err, wantErr) {
 		t.Fatalf("restore error = %v, want %v", err, wantErr)
-	}
-
-	called = false
-	if err := restoreClaudeBeforeQuit(context.Background(), true, true, func(context.Context) error {
-		called = true
-		return nil
-	}); err != nil {
-		t.Fatal(err)
-	}
-	if called {
-		t.Fatal("restore called during an app replacement handoff")
 	}
 }
 
@@ -2740,6 +2881,16 @@ func TestHandleExistingInstanceReturnsBarrierResult(t *testing.T) {
 		if got := handleExistingInstance(false); got != want {
 			t.Fatalf("handleExistingInstance() = %v, want %v", got, want)
 		}
+	}
+}
+
+func TestDarwinAppProcessRunningReportsExitedProcess(t *testing.T) {
+	running, err := darwinAppProcessRunning(appProcessIdentity{pid: 1 << 30, startedAt: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if running {
+		t.Fatal("nonexistent process reported as running")
 	}
 }
 

--- a/app/cmd/app/app_windows.go
+++ b/app/cmd/app/app_windows.go
@@ -74,11 +74,12 @@ func maybeMoveAndRestart() appMove {
 }
 
 // handleExistingInstance checks for existing instances and optionally focuses them
-func handleExistingInstance(startHidden bool) {
+func handleExistingInstance(startHidden bool) bool {
 	if wintray.CheckAndFocusExistingInstance(!startHidden) {
 		slog.Info("existing instance found, exiting")
 		os.Exit(0)
 	}
+	return true
 }
 
 func installSymlink() {}


### PR DESCRIPTION
macOS updates can leave more than one Ollama app process running. 

- The newest visible app instance wins. An older launch exits when it sees a newer one.
- The barrier fails open unless the app definitively loses that election. Discovery, inspection, signaling, and timeout failures warn and allow startup. This favors app availability, even if a stale instance remains.
- Handoff uses SIGUSR1 first because it preserves the Claude configuration. SIGTERM remains the compatibility fallback for older releases. SIGKILL is the final fallback for a process that does not exit.
- Once an instance receives SIGUSR1, handoff intent stays set. A later SIGTERM cannot trigger normal Claude restoration.
- Processes are tracked by PID and start time. Identity is checked again before signaling to avoid killing a process that reused the PID.
- The barrier requires two consecutive empty snapshots before startup continues. This accounts for delayed process visibility.
- We are not adding a lease. Two launches can still race if neither is visible to the other. We accept and document that narrow edge case.
- This does not change Squirrel or the updater. It only controls when the replacement app can continue through the existing update path.