### PR TITLE
Update Msty link from .app to .ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ console.log(response.message.content);
 - [ConfiChat](https://github.com/1runeberg/confichat) - Privacy-focused with optional encryption
 - [LLocal.in](https://github.com/kartikm7/llocal) - Electron desktop client
 - [MindMac](https://mindmac.app) - AI chat client for Mac
-- [Msty](https://msty.app) - Multi-model desktop client
+- [Msty](https://msty.ai) - Multi-model desktop client
 - [BoltAI for Mac](https://boltai.com) - AI chat client for Mac
 - [IntelliBar](https://intellibar.app/) - AI-powered assistant for macOS
 - [Kerlig AI](https://www.kerlig.com/) - AI writing assistant for macOS


### PR DESCRIPTION
## Problem
The README contains an outdated link to the Msty community integration. The domain has changed from `msty.app` to `msty.ai`.

## Solution
Updated the Msty community integration link in the README from `msty.app` to `msty.ai`.

## Verification
- Confirmed `https://msty.ai` returns HTTP 200
- Verified no stale msty.app references remain in the documentation