### PR TITLE
llm: force fp32 cuBLAS accumulation for qwen2.5-vl runners

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -926,6 +926,7 @@ func NewLlamaServerRunner(
 		serverEnvs[k] = v
 	}
 	serverEnvs["LLAMA_MEDIA_MARKER"] = mediaMarker
+	applyArchServerEnvs(serverEnvs, arch)
 
 	launch := llamaServerLaunchConfig{
 		modelPath:    modelPath,
@@ -1027,6 +1028,41 @@ func (s *llamaServerRunner) startProcess() error {
 	}(s.cmd, s.done)
 
 	return nil
+}
+
+// ggmlCublasComputeTypeEnv is stock ggml's process-wide cuBLAS compute-type
+// override (ggml-cuda.cu, honored at pin b10488 for CUDA and HIP). Without
+// it, f16-weight mul_mats run with compute_type = src0->type, i.e. fp16
+// accumulation.
+const ggmlCublasComputeTypeEnv = "GGML_CUDA_CUBLAS_COMPUTE_TYPE"
+
+// applyArchServerEnvs adds per-architecture environment overrides for the
+// llama-server subprocess. Each runner serves one model, so a process-wide
+// ggml knob is effectively model-scoped here.
+//
+// qwen25vl: the mtmd/clip vision tower/merger runs its f16-weight matmuls as
+// fp16-accumulate cuBLAS GEMMs on CUDA/HIP, and the partial sums overflow on
+// specific images — qwen2.5vl:3b returns '?'x31 garbage and poisons the
+// runner slot — while the CPU backend always accumulates in fp32 and serves
+// the same image correctly. Forcing f32 compute keeps every cuBLAS GEMM in
+// fp32 accumulation, matching CPU numerics. Text-side cost is negligible for
+// quantized tags (MMQ/MMVQ carry the quantized matmuls and the f16 decode
+// vector kernels already accumulate in fp32); -fp16 text tags pay an
+// fp32-GEMM prefill cost. qwen2vl shares the clip graph builder but has no
+// measured trigger; add it here if one shows up. Diagnosis:
+// docs/maxusai/qwen25vl-3b-poison-image-garbage-decode.md (PR #214); knob
+// details: docs/maxusai/qwen25vl-cublas-f32-env.md.
+//
+// An operator-set GGML_CUDA_CUBLAS_COMPUTE_TYPE always wins: without this
+// guard SetupLlamaServerCommandEnv would overwrite the inherited value with
+// ours, and =f16 is the documented way to reproduce stock behavior.
+func applyArchServerEnvs(serverEnvs map[string]string, modelArch string) {
+	switch modelArch {
+	case "qwen25vl":
+		if _, ok := os.LookupEnv(ggmlCublasComputeTypeEnv); !ok {
+			serverEnvs[ggmlCublasComputeTypeEnv] = "f32"
+		}
+	}
 }
 
 func qwenVLServerArgs(modelArch string) []string {

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"maps"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -3736,4 +3737,57 @@ func fakeRunningCmd() *exec.Cmd {
 	// pass *testing.T here without changing all call sites. The OS will
 	// SIGKILL children when the test process exits.
 	return cmd
+}
+
+func TestApplyArchServerEnvs(t *testing.T) {
+	tests := []struct {
+		name     string
+		arch     string
+		operator string // pre-set GGML_CUDA_CUBLAS_COMPUTE_TYPE; "" = ensure unset
+		want     map[string]string
+	}{
+		{
+			name: "qwen25vl forces f32 cublas compute",
+			arch: "qwen25vl",
+			want: map[string]string{ggmlCublasComputeTypeEnv: "f32"},
+		},
+		{
+			// =f16 reproduces stock fp16-accumulate behavior for A/B; the
+			// arch default must not clobber an operator value.
+			name:     "operator override wins",
+			arch:     "qwen25vl",
+			operator: "f16",
+			want:     map[string]string{},
+		},
+		{
+			// qwen2vl shares the clip graph but has no measured poison
+			// trigger; it stays on stock behavior deliberately.
+			name: "qwen2vl untouched",
+			arch: "qwen2vl",
+			want: map[string]string{},
+		},
+		{
+			name: "other arch untouched",
+			arch: "llama",
+			want: map[string]string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.operator != "" {
+				t.Setenv(ggmlCublasComputeTypeEnv, tt.operator)
+			} else {
+				// t.Setenv registers restoration, then unset so a value
+				// inherited from the dev environment cannot leak in.
+				t.Setenv(ggmlCublasComputeTypeEnv, "")
+				os.Unsetenv(ggmlCublasComputeTypeEnv)
+			}
+			got := map[string]string{}
+			applyArchServerEnvs(got, tt.arch)
+			if !maps.Equal(got, tt.want) {
+				t.Fatalf("applyArchServerEnvs(%q) = %v, want %v", tt.arch, got, tt.want)
+			}
+		})
+	}
 }


### PR DESCRIPTION
Fixes deterministic `'?'×31` garbage decode from qwen2.5-vl on CUDA by forcing fp32 cuBLAS accumulation in that family's runner. 90 lines, Go-only, no behavior change for any other model. Related: #14170, #17687.

## The bug, in one minute on stock ollama

```python
import numpy as np
from PIL import Image
ys, xs = np.mgrid[0:1800, 0:1350]
cells = ((xs // 56) + (ys // 56)) % 2
Image.fromarray(np.where(cells[..., None], 255, 0).astype(np.uint8).repeat(3, axis=2)).save("trigger.png")
```

The identical prebuilt PNG (12 KB, md5 `afc8ff7e84ee8958878b44675565d5b0`, 1350×1800) is here if you would rather not run the snippet — **[trigger_checker56_1350x1800.png](https://github.com/MaxusAI/ollama/raw/da39f04969eacf0c09cda376192c966871fd1584/docs/maxusai/vision-suite/synthetic-triggers/trigger_checker56_1350x1800.png)**:

<img src="https://github.com/MaxusAI/ollama/raw/da39f04969eacf0c09cda376192c966871fd1584/docs/maxusai/vision-suite/synthetic-triggers/trigger_checker56_1350x1800.png" width="220" alt="56px black/white checkerboard, 1350x1800">

Being exactly specified integer pixels it carries no decoder ambiguity — the generator and the file reproduce bit-identically, unlike a photo, whose trigger can depend on which JPEG decoder reads it.

Send `trigger.png` to stock `qwen2.5vl:3b-q4_K_M` (`/api/chat` or `/api/generate`, `temperature 0`), fully GPU-resident (measured on stock 0.32.9; the same clip vision path with the same fp16-accumulate GEMMs serves every release since 0.30):

| serving | result |
|---|---|
| default | `'?'×31`, `done_reason: null` — every call, every quantization (q4_K_M / q8_0 / fp16) — verified with this exact file on stock **0.30.0** and **0.33.0** |
| `GGML_CUDA_CUBLAS_COMPUTE_TYPE=f32` (or `bf16`) | correct description of the checkerboard |
| CPU-only | correct |

Ordinary photos trigger it too — a corpus of insurance photos surfaced the class, and those corpus triggers reproduce on stock **0.30.0, 0.32.9, 0.32.15 and 0.33.0**. Large high-contrast images are the worst case, so 1800–2048 px OCR-style pipelines are maximally exposed. On 0.32.10–0.32.15 the first poisoned request additionally leaves the runner slot returning garbage for **every subsequent request** until reload (other releases recover on the next request).

Releases before 0.30 served this family through the since-removed Go vision engine. That implementation is **not** clean either — it carries the same fp16-accumulate defect with its own *disjoint* trigger set, because fp16 overflow depends on GEMM summation order, so each implementation picks different victims. Measured on a 768-image production fold: 0.7.1 fails at row 8 (a different corpus image garbles it on request #1 and poisons its slot) and 0.24.0 — which passes both spot-probe images — fails at row ~172 on a member of its own set. Passing a spot check is not passing a corpus; no engine is clean.

The 0.30 boundary is about *fixability*, not the defect: `GGML_CUDA_CUBLAS_COMPUTE_TYPE` does not exist in the pre-0.30 engines' ggml (binary grep: 0 matches in 0.7.1/0.24.0 with `GGML_CUDA_FORCE_MMQ` as a positive control; 2 matches in current builds), so llama-server-era releases are runtime-fixable and the removed engines never were. This checkerboard targets the clip path those releases share; the fix direction — ≥fp32 accumulation for this tower's matmuls — applies to any fp16-accumulate implementation of it.

## Mechanism (measured, not inferred)

Hooking every stage of the HF `Qwen2.5-VL-3B-Instruct` vision tower in bf16 shows the final block (`blocks.31.mlp`) emits massive-activation outliers at **0.57× fp16's 65,504 ceiling for ordinary images** — every input walks the cliff edge. Trigger images push those channels to 0.77–1.07×. The stored tensors still fit in fp16; the **partial sums inside the next fp16-accumulate GEMM** transiently exceed the ceiling before cancellation → inf → NaN cascade → degenerate decode. The generated checkerboard above measures 1.06×.

On the CUDA backend, the vision tower/merger's f16-weight matmuls run through `ggml_cuda_mul_mat_cublas` with `compute_type = src0->type`, i.e. `CUBLAS_COMPUTE_16F`; the small-batch `mmf`/`mmvf` kernels already accumulate fp32, so cuBLAS is the only fp16-accumulate stage — which is why the failure is CUDA-specific, quant-independent (mmproj weights are f16 in every quant), and immune to `f32`/`bf16` compute and to CPU. Flash-attention on/off, KV cache f32/bf16, and `GGML_CUDA_FORCE_MMQ` were all swept and change nothing: the overflow is in the weight GEMMs those paths share. The margin (~40% between ordinary and triggering images, on a tower idling at 0.57×) is structurally too thin for fp16 accumulation to be safe for this family.

## The change

ggml already exposes `GGML_CUDA_CUBLAS_COMPUTE_TYPE`, and each llama-server runner serves exactly one model — so setting `=f32` in the qwen25vl runner's subprocess environment scopes fp32 accumulation to the affected family:

- `applyArchServerEnvs()` in `llm/llama_server.go` (+36, beside the existing arch-keyed `qwenVLServerArgs`), called from the runner-env assembly.
- An operator-set `GGML_CUDA_CUBLAS_COMPUTE_TYPE` always wins: `=f16` restores stock behavior for A/B; `=bf16` also heals (cuBLAS bf16 GEMMs accumulate in fp32) at timing parity with f32, measured on both Turing (sm_75, no native bf16 tensor cores — cuBLAS still takes the path) and Blackwell.
- Table test (+54) covering the default, the override, and untouched arches.

Cost: vision-encode GEMMs for this family run f32 (weights dequantized + `cublasSgemm`); warm trigger-image encode measured 676 ms (Blackwell) / 1059 ms (Turing) under f32 versus a garbage result under f16. Text-side cost is ~nil for quantized tags (MMQ/MMVQ carry those matmuls; the f16 decode-vector kernels already accumulate fp32); f16 text weights pay an fp32-GEMM prefill cost — scoped to the qwen25vl family only.

`qwen2vl` shares the graph builder but has no measured trigger and is deliberately left stock; the switch extends trivially if one shows up.

## Validation

- Causal three-way A/B on stock 0.33.0: default garbles, `f32`/`bf16` heal, forcing `f16` reproduces — same matrix on Turing and Blackwell with this patch's gate active (default heals; `=f16` override brings the garbage back; `=bf16` override heals).
- Slot follow-ups stay clean after a healed trigger request.
- `go test ./llm/` green; `gofumpt` clean.

## Blast radius — is any other clip model affected?

Checked, so the arch scoping is evidenced rather than assumed. Every vision model we serve was screened statically against its GGUF (which F16 vision matmuls could overflow at the measured activation ceiling), then probed with all six corpus triggers plus the synthetic at full image budget — once at stock precision, once with `GGML_CUDA_CUBLAS_COMPUTE_TYPE=f16` forcing fp16 on *everything* (which strips even the existing flash-attn `GGML_PREC_F32`).

| model | F16 vision matmuls | unsafe | fails at stock | fails under forced fp16 |
|---|---|---|---|---|
| **qwen2.5vl:3b** | 194 | 2 | **3 / 7** | **7 / 7** |
| qwen2.5vl:7b | 194 | 2 | 0 / 7 | **0 / 7** |
| nemotron3:33b | 195 | **20** | 0 / 7 | **0 / 7** (at 3.3 k tokens) |
| qwen3.6:35b-a3b | 165 | 2 | 0 / 7 | — |
| gemma4:12b | **0** | 0 | 0 / 7 | — |
| granite3.2-vision | **0** | 0 | 0 / 7 | — |

- **gemma4 and granite cannot have this bug** — their vision weights contain no F16 matmuls at all, so there is no fp16-accumulate GEMM to overflow.
- **The 3B has essentially no margin.** Under forced fp16 *every* image fails, including four corpus photos it serves correctly at stock — so the existing per-op protections are doing real work, and widening them (rather than removing precision) is the right direction.
- **The nearest candidates have genuine margin, not luck.** nemotron3 carries ten times the exposed weights and still survives maximum fp16 pressure on every known trigger at a 3.3 k-token budget.

That is why this PR gates only `qwen25vl`: no other model is triggered by any image we have, at any budget, even when pushed harder than any real configuration.

## Prior art

The model-level fragility is documented: [huggingface/transformers#33294](https://github.com/huggingface/transformers/issues/33294) reports Qwen2-VL in fp16 producing *"gibberish output (repeated exclamation marks)"* alongside `probability tensor contains either inf, nan or element < 0`, with fp32 clean — the same fingerprint we see. It was fixed by PR #33312 (replace inf with zeros in attention weights), then corrected in [#35151](https://github.com/huggingface/transformers/issues/35151) because that fix also zeroed the `-inf` causal mask. Qwen's own guidance is that these models are trained in bf16 and fp16's range overflows, which matches our measurement that `bf16` heals as well as `f32`.

We found no report of this class in llama.cpp's clip/mtmd path. The closest is [ggml-org/llama.cpp#20081](https://github.com/ggml-org/llama.cpp/issues/20081) — Qwen3.5-27B mmproj giving drastically wrong vision output on Vulkan versus CUDA, reliably and only for *specific images*, with no precision cause identified and still unresolved. That is the same phenomenon shape on a different backend and may well be the same root cause.

## Scope notes for review

- **Why not fix clip.cpp?** It should also be fixed there, and we have localised it precisely. Instrumenting the clip graph with a non-finite eval callback names the failing node on pin `b10488`:

  ```
  node #1106  name='ffn_down-31'  op=MUL_MAT  type=f32
  shape=[1280,12288]   bad=3/15728640   nan=0  inf=3
  src[0]: v.blk.31.ffn_down.weight  f16 [3420,1280]
  src[1]: ffn_swiglu-31             f32 [3420,12288]
  ```

  **Three elements out of 15.7 million** overflow to `inf` — enough to NaN the image embeddings (`MTMD_DEBUG_EMBEDDINGS` reports `mean=nan, sum=nan` on GPU and clean stats on CPU) and produce the degenerate decode. So the minimal llama.cpp fix is a single call in `clip_graph::build_ffn`:

  ```c
  if (down) {
      cur = build_mm(down, cur);
      if (cur->op == GGML_OP_MUL_MAT) {
          ggml_mul_mat_set_prec(cur, GGML_PREC_F32);   // FFN down-proj consumes the activation peak
      }
  }
  ```

  Validated end to end with no global precision forcing on either side: stock `libmtmd` garbles the checkerboard, this one call yields a correct description and zero non-finite nodes. We are happy to file that as a separate llama.cpp PR. This ollama-side PR is still worth taking on its own: it protects users on every currently released llama.cpp pin, needs no native-code change, and reverts in one line once an upstream fix lands.

  *A/B caveat for reviewers:* `GGML_CUDA_CUBLAS_COMPUTE_TYPE=f16` **overrides** per-op `GGML_PREC_F32` (the env check runs after the `op_params` check in `ggml_cuda_mul_mat_cublas`), so testing the per-op fix with `=f16` produces a false negative. Use `=auto`.
- **Why f32 and not bf16 as the default?** Both heal; f32 is closest to CPU numerics and measured at parity. bf16 remains one env var away for any deployment that prefers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
