### PR TITLE
app: list account cloud models for Claude

### DIFF
--- a/app/cmd/app/app_darwin.go
+++ b/app/cmd/app/app_darwin.go
@@ -662,12 +662,8 @@ func resolveClaudeDesktopStartupCatalog(ctx context.Context) (available, selecte
 		if err != nil {
 			slog.Debug("could not load account cloud models for Claude startup", "error", err)
 		} else {
-			available = mergeClaudeDesktopCloudInventory(available, cloudModels, false)
-			if hasExplicitCloudClaudeDesktopModelName(selectedNames) {
-				selectable = mergeClaudeDesktopCloudInventory(available, cloudModels, true)
-			} else {
-				selectable = available
-			}
+			available = mergeClaudeDesktopCloudInventory(available, cloudModels)
+			selectable = available
 		}
 	}
 	if len(savedMappings) > 0 {
@@ -764,7 +760,7 @@ func refreshClaudeDesktopCatalog(ctx context.Context, current []proxy.ClaudeDesk
 			} else {
 				cloudInventory = cloudModels
 				cloudInventoryKnown = true
-				available = mergeClaudeDesktopCloudInventory(available, cloudInventory, false)
+				available = mergeClaudeDesktopCloudInventory(available, cloudInventory)
 			}
 		}
 	}
@@ -778,7 +774,7 @@ func refreshClaudeDesktopCatalog(ctx context.Context, current []proxy.ClaudeDesk
 		if cloudInventoryKnown {
 			for _, accountModel := range cloudInventory {
 				if accountModel.Name == model.Name || accountModel.OllamaModel == model.OllamaModel {
-					available = mergeClaudeDesktopCloudInventory(available, []proxy.ClaudeDesktopModel{accountModel}, true)
+					available = mergeClaudeDesktopCloudInventory(available, []proxy.ClaudeDesktopModel{accountModel})
 					break
 				}
 			}
@@ -923,14 +919,11 @@ func includeSelectedClaudeDesktopModels(available, selected []proxy.ClaudeDeskto
 	return models
 }
 
-func mergeClaudeDesktopCloudInventory(available, cloudModels []proxy.ClaudeDesktopModel, appendMissing bool) []proxy.ClaudeDesktopModel {
+func mergeClaudeDesktopCloudInventory(available, cloudModels []proxy.ClaudeDesktopModel) []proxy.ClaudeDesktopModel {
 	models := proxy.VerifyClaudeDesktopModelsWithCloudInventory(available, cloudModels)
 	seen := make(map[string]struct{}, len(models))
 	for _, model := range models {
 		seen[model.OllamaModel] = struct{}{}
-	}
-	if !appendMissing {
-		return models
 	}
 	for _, model := range cloudModels {
 		if _, ok := seen[model.OllamaModel]; ok {
@@ -1570,14 +1563,14 @@ func applyClaudeDesktopMappingsWithOpen(mappings map[string]string, restartConfi
 		if err != nil {
 			slog.Debug("could not load account cloud models for Claude selection", "error", err)
 		} else {
-			selectable = mergeClaudeDesktopCloudInventory(available, cloudModels, true)
+			selectable = mergeClaudeDesktopCloudInventory(available, cloudModels)
 		}
 	}
 	selected, err := mapKnownClaudeDesktopModels(selectable, current, localNames, mappings)
 	if err != nil {
 		return false, err
 	}
-	if err := validateClaudeDesktopModels(selected, accessState, localNames, localErr == nil); err != nil {
+	if err := ensureClaudeDesktopModelsAvailable(context.Background(), selected); err != nil {
 		return false, err
 	}
 

--- a/app/cmd/app/app_darwin_test.go
+++ b/app/cmd/app/app_darwin_test.go
@@ -357,6 +357,85 @@ func TestResolveClaudeDesktopStartupCatalogMarksDefaultAccountModelsAutoEligible
 	}
 }
 
+func TestClaudeDesktopCatalogListsAccountModelsWithoutChangingDefaults(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	mappings := api.ModelRecommendationMappings{
+		"claude-sonnet-5": {Model: "glm-5.3-flash:cloud", RequiredPlan: "pro"},
+	}
+	recommendations := claudeDesktopRecommendationModelsForTest(t, []api.ModelRecommendation{
+		{Model: "glm-5.3-flash:cloud", RequiredPlan: "pro"},
+	}, &mappings)
+
+	previousLoader := claudeModelsLoader
+	previousAccess := claudeAccessStateResolver
+	previousCloud := claudeCloudModelsResolver
+	claudeProxyMu.Lock()
+	previousAvailable := claudeAvailableModels
+	previousSource := claudeModelSource
+	previousUpdated := claudeCatalogUpdated
+	claudeProxyMu.Unlock()
+	claudeModelsLoader = func(context.Context) ([]proxy.ClaudeDesktopModel, string) {
+		return recommendations, "endpoint"
+	}
+	claudeAccessStateResolver = func(context.Context) (proxy.ClaudeDesktopAccessState, error) {
+		return proxy.ClaudeDesktopAccessState{
+			Cloud:   proxy.ClaudeDesktopCloudOn,
+			Account: proxy.ClaudeDesktopAccountSignedIn,
+			Plan:    "pro",
+		}, nil
+	}
+	claudeCloudModelsResolver = func(context.Context) ([]proxy.ClaudeDesktopModel, error) {
+		return proxy.ClaudeDesktopModelsFromCloudInventory([]string{
+			"glm-5.3-flash:cloud",
+			"deepseek-v4-flash:cloud",
+		}), nil
+	}
+	t.Cleanup(func() {
+		claudeModelsLoader = previousLoader
+		claudeAccessStateResolver = previousAccess
+		claudeCloudModelsResolver = previousCloud
+		claudeProxyMu.Lock()
+		claudeAvailableModels = previousAvailable
+		claudeModelSource = previousSource
+		claudeCatalogUpdated = previousUpdated
+		claudeProxyMu.Unlock()
+	})
+
+	assertCatalog := func(t *testing.T, available, selected []proxy.ClaudeDesktopModel) {
+		t.Helper()
+		if got := proxy.ClaudeDesktopMappings(selected); !maps.Equal(got, map[string]string{
+			"claude-sonnet-5": "glm-5.3-flash:cloud",
+		}) {
+			t.Fatalf("default mappings = %v, want GLM Flash for Sonnet 5", got)
+		}
+		for _, model := range available {
+			if model.OllamaModel != "deepseek-v4-flash:cloud" {
+				continue
+			}
+			if model.Recommended {
+				t.Fatal("account DeepSeek model was marked as recommended")
+			}
+			if !model.AccountCloud {
+				t.Fatal("account DeepSeek model is missing cloud inventory membership")
+			}
+			return
+		}
+		t.Fatal("account DeepSeek model is missing from the selectable catalog")
+	}
+
+	available, selected, source := resolveClaudeDesktopStartupCatalog(context.Background())
+	if source != "endpoint" {
+		t.Fatalf("source = %q, want endpoint", source)
+	}
+	assertCatalog(t, available, selected)
+
+	available, selected, source = refreshClaudeDesktopCatalog(context.Background(), selected, true)
+	if source != "endpoint" {
+		t.Fatalf("refreshed source = %q, want endpoint", source)
+	}
+	assertCatalog(t, available, selected)
+}
+
 func TestResolveClaudeDesktopStartupCatalogUsesSafeFallback(t *testing.T) {
 	states := []struct {
 		name  string
@@ -1079,7 +1158,6 @@ func TestSetClaudeDesktopAutoModeAvoidsUnnecessaryRestart(t *testing.T) {
 	claudeAvailableModels = mergeClaudeDesktopCloudInventory(
 		proxy.ClaudeDesktopModelsFromRecommendations([]api.ModelRecommendation{{Model: "glm-5.2:cloud"}}),
 		proxy.ClaudeDesktopModelsFromCloudInventory([]string{"glm-5.2:cloud"}),
-		false,
 	)
 	previousDesktop := claudeDesktop
 	previousRunning := claudeDesktopRunning
@@ -1186,7 +1264,7 @@ func TestClaudeDesktopAutoModeModelEligibility(t *testing.T) {
 		"glm-5.2:cloud",
 		"gemma4:31b-cloud",
 	})
-	recommended = mergeClaudeDesktopCloudInventory(recommended, accountCloud, false)
+	recommended = mergeClaudeDesktopCloudInventory(recommended, accountCloud)
 	custom := proxy.SelectClaudeDesktopModels(nil, []string{"qwen3:8b"})
 	tagOnly := proxy.SelectClaudeDesktopModels(nil, []string{"made-up:cloud"})
 


### PR DESCRIPTION
## Summary

- include signed-in account cloud models in the Claude Desktop picker even when they are not recommendations
- continue using recommendation mappings for new and reset defaults, while preserving saved mappings
- retry model validation while the local Ollama server comes back after a Settings reset

## Why

The recommendation endpoint should determine Claude's defaults, not limit the selectable catalog. This keeps models such as `deepseek-v4-flash:cloud` selectable for users who have access while allowing `glm-5.3-flash:cloud` to remain the Sonnet 5 default supplied by the recommendation mapping.

Resetting all settings can also restart the local Ollama server. Claude mapping validation previously ran before that server was ready, leaving every model marked unavailable and causing the reset to fail.

## Test plan

- `go test ./app/cmd/app -count=1`
- `go test ./internal/proxy -count=1`

