### PR TITLE
docs: fix spacing in README get started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The official [Ollama Docker image](https://hub.docker.com/r/ollama/ollama) `olla
 ollama
 ```
 
-You'll be prompted to run a model or connect Ollama to your existing agents or applications such as `Claude Code`, `OpenClaw`, `OpenCode` , `Codex`, `Copilot`,  and more.
+You'll be prompted to run a model or connect Ollama to your existing agents or applications such as `Claude Code`, `OpenClaw`, `OpenCode`, `Codex`, `Copilot`, and more.
 
 ### Coding
 


### PR DESCRIPTION
docs: OpenCode , Codex, Copilot,  and -> OpenCode, Codex, Copilot, and (remove extra spaces before comma and after comma).