### PR TITLE
docs: fix double spaces in development guide

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,7 @@ go run . serve
 ```
 
 > [!NOTE]
-> Ollama includes native code compiled with CGO.  From time to time these data structures can change and CGO can get out of sync resulting in unexpected crashes.  You can force a full build of the native code by running `go clean -cache` first. 
+> Ollama includes native code compiled with CGO. From time to time these data structures can change and CGO can get out of sync resulting in unexpected crashes. You can force a full build of the native code by running `go clean -cache` first.
 
 ## Native build model
 


### PR DESCRIPTION
docs(development): fix double spaces after period in CGO note.