### PR TITLE
docs: add Remuda to desktop community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ console.log(response.message.content);
 - [Reins](https://github.com/ibrahimcetin/reins) - Parameter tuning and reasoning model support
 - [ConfiChat](https://github.com/1runeberg/confichat) - Privacy-focused with optional encryption
 - [LLocal.in](https://github.com/kartikm7/llocal) - Electron desktop client
+- [Remuda](https://github.com/magna-nz/remuda) - macOS app for testing and tuning models with a built-in Modelfile editor
 - [MindMac](https://mindmac.app) - AI chat client for Mac
 - [Msty](https://msty.app) - Multi-model desktop client
 - [BoltAI for Mac](https://boltai.com) - AI chat client for Mac

--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ console.log(response.message.content);
 - [Reins](https://github.com/ibrahimcetin/reins) - Parameter tuning and reasoning model support
 - [ConfiChat](https://github.com/1runeberg/confichat) - Privacy-focused with optional encryption
 - [LLocal.in](https://github.com/kartikm7/llocal) - Electron desktop client
-- [Remuda](https://github.com/magna-nz/remuda) - macOS app for testing and tuning models with a built-in Modelfile editor
+- [Remuda](https://github.com/magna-nz/remuda) - Desktop app for testing and tuning models with a built-in Modelfile editor
 - [MindMac](https://mindmac.app) - AI chat client for Mac
 - [Msty](https://msty.app) - Multi-model desktop client
 - [BoltAI for Mac](https://boltai.com) - AI chat client for Mac


### PR DESCRIPTION
Adds [Remuda](https://github.com/magna-nz/remuda) to the Desktop chat interfaces list.

Remuda is an open-source (MIT) macOS desktop app for running, testing and tuning local Ollama models. It pairs a chat pane with a Modelfile editor, so you can test a model and edit its Modelfile side by side — saving rebuilds the model through Ollama and reloads it. It also surfaces the VRAM/RAM split, the runner's context size and a live `keep_alive` countdown.

It's a client only — no bundled models, no inference, talks to the Ollama you already run on `127.0.0.1`.

Placed after the last open-source entry, before the hosted/commercial ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)