### PR TITLE
docs/api: add missing 401 and 403 status codes to error documentation

### DIFF
--- a/docs/api/errors.mdx
+++ b/docs/api/errors.mdx
@@ -8,6 +8,8 @@ Endpoints return appropriate HTTP status codes based on the success or failure o
 
 - `200`: Success
 - `400`: Bad Request (missing parameters, invalid JSON, etc.)
+- `401`: Unauthorized (authentication required but not provided or invalid)
+- `403`: Forbidden (e.g. cloud model access is disabled or not available)
 - `404`: Not Found (model doesn't exist, etc.)
 - `429`: Too Many Requests (e.g. when a rate limit is exceeded)
 - `500`: Internal Server Error


### PR DESCRIPTION
The API server returns `401` for missing or invalid authentication (e.g. accessing a cloud model without signing in) and `403` when cloud model access is disabled, but the errors documentation only listed `200`, `400`, `404`, `429`, `500`, and `502`.

Without these entries, developers hitting auth-related errors have to dig through the source code to understand what the status code means. The `authentication.mdx` doc covers how to authenticate, but doesn't mention the error codes the API returns when authentication fails.

Added `401` and `403` to the status codes list in `docs/api/errors.mdx`, placed in order between `400` and `404`.
