### PR TITLE
Add Talos as an `ollama launch` integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The official [Ollama Docker image](https://hub.docker.com/r/ollama/ollama) `olla
 ollama
 ```
 
-You'll be prompted to run a model or connect Ollama to your existing agents or applications such as `Claude Code`, `OpenClaw`, `OpenCode` , `Codex`, `Copilot`,  and more.
+You'll be prompted to run a model or connect Ollama to your existing agents or applications such as `Claude Code`, `OpenClaw`, `OpenCode` , `Codex`, `Copilot`, `Talos`,  and more.
 
 ### Coding
 
@@ -73,6 +73,12 @@ Use [OpenClaw](https://docs.ollama.com/integrations/openclaw) to turn Ollama int
 
 ```
 ollama launch openclaw
+```
+
+For a permission-gated agent that asks for approval before anything risky runs and records its actions in a checkable audit log, use [Talos](https://docs.ollama.com/integrations/talos):
+
+```
+ollama launch talos
 ```
 
 ### Chat with a model

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -303,6 +303,7 @@ Supported integrations:
   pool            Pool
   cline           Cline
   qwen            Qwen Code
+  talos           Talos
   vscode          VS Code (aliases: code)
 
 Examples:

--- a/cmd/launch/registry.go
+++ b/cmd/launch/registry.go
@@ -33,7 +33,7 @@ type IntegrationInfo struct {
 	Description string
 }
 
-var launcherIntegrationOrder = []string{"claude", "chatgpt", "hermes", "openclaw", "opencode", "hermes-desktop", "codex", "copilot", "omp", "cline", "droid", "dsh", "pi", "pool", "qwen"}
+var launcherIntegrationOrder = []string{"claude", "chatgpt", "hermes", "openclaw", "opencode", "hermes-desktop", "codex", "copilot", "omp", "cline", "droid", "dsh", "pi", "pool", "qwen", "talos"}
 
 var integrationSpecs = []*IntegrationSpec{
 	{
@@ -288,6 +288,20 @@ var integrationSpecs = []*IntegrationSpec{
 				return (&Hermes{}).ensureInstalledFor("hermes-desktop")
 			},
 			URL: "https://hermes-agent.nousresearch.com/docs/getting-started/installation/",
+		},
+	},
+	{
+		Name:        "talos",
+		Runner:      &Talos{},
+		Description: "Permission-gated agent with a provable audit log",
+		Install: IntegrationInstallSpec{
+			CheckInstalled: func() bool {
+				return (&Talos{}).installed()
+			},
+			EnsureInstalled: func() error {
+				return (&Talos{}).ensureInstalled()
+			},
+			URL: "https://talos-agent.ch",
 		},
 	},
 	{

--- a/cmd/launch/talos.go
+++ b/cmd/launch/talos.go
@@ -87,6 +87,19 @@ func (t *Talos) Configure(model string) error {
 		configModel = base
 	}
 
+	// An exported TALOS_MODEL_* variable outranks talos.env in Talos's own
+	// loader, so a stale export would make launch save and report the
+	// requested model while the launched process runs another. Refuse before
+	// writing anything instead of silently configuring a lie.
+	for _, kv := range []struct{ key, want string }{
+		{talosProviderKey, provider},
+		{talosModelKey, configModel},
+	} {
+		if value, ok := os.LookupEnv(kv.key); ok && strings.TrimSpace(value) != "" && value != kv.want {
+			return fmt.Errorf("%s is set to %q in your environment and overrides Talos's config file\n\nUnset it or set it to %q, then re-run:\n  ollama launch talos", kv.key, value, kv.want)
+		}
+	}
+
 	if err := talosConfigSet(argv, talosProviderKey, provider); err != nil {
 		return err
 	}

--- a/cmd/launch/talos.go
+++ b/cmd/launch/talos.go
@@ -1,0 +1,320 @@
+package launch
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/ollama/ollama/cmd/config"
+	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/internal/modelref"
+)
+
+const (
+	// The Talos installer proves the download before it unpacks anything: it
+	// fetches the published sha256 and an Ed25519 release signature and refuses
+	// on mismatch, so piping it into a shell is the vendor-supported install
+	// path, not a shortcut around verification.
+	talosInstallScript = "curl -fsSL https://talos-agent.ch/install.sh | sh"
+	// Provider slugs from Talos's own model catalog (talos/catalog.py). The
+	// local entry defaults to http://localhost:11434/v1 and needs no key.
+	talosProviderLocal = "ollama"
+	talosProviderCloud = "ollama-cloud"
+	// Writable SETTING keys in Talos's config schema (talos/schema.py).
+	talosProviderKey = "TALOS_MODEL_PROVIDER"
+	talosModelKey    = "TALOS_MODEL"
+)
+
+var (
+	talosGOOS     = runtime.GOOS
+	talosLookPath = exec.LookPath
+	talosCommand  = exec.Command
+	talosUserHome = os.UserHomeDir
+)
+
+// Talos is intentionally not an Editor integration: Talos guards its config
+// behind a schema that decides per key what a command may write, so launch
+// goes through `talos config set` — the same validated surface Talos offers
+// scripts — instead of rewriting the env file itself.
+type Talos struct{}
+
+func (t *Talos) String() string { return "Talos" }
+
+func (t *Talos) Run(_ string, _ []LaunchModel, args []string) error {
+	argv, err := t.command()
+	if err != nil {
+		return err
+	}
+	return talosAttachedCommand(argv, append([]string{"chat"}, args...)...).Run()
+}
+
+// Supported reports platform support separately from installation: Talos's
+// installer requires a POSIX shell and Python 3.11+, and ships no Windows path.
+func (t *Talos) Supported() error {
+	if talosGOOS == "windows" {
+		return fmt.Errorf("talos currently supports macOS and Linux")
+	}
+	return nil
+}
+
+func (t *Talos) Paths() []string {
+	configPath, err := talosConfigPath()
+	if err != nil {
+		return nil
+	}
+	return []string{configPath}
+}
+
+// Configure points Talos at Ollama through Talos's own CLI. `config set`
+// validates against the schema and writes atomically with mode 600 — a file
+// rewrite from the outside would bypass both.
+func (t *Talos) Configure(model string) error {
+	argv, err := t.command()
+	if err != nil {
+		return err
+	}
+
+	provider := talosProviderLocal
+	configModel := model
+	// A `:cloud` model cannot run against the local daemon from Talos's side
+	// without Ollama in the middle, so it goes to Talos's ollama-cloud provider,
+	// whose endpoint expects the plain upstream model name.
+	if base, ok := modelref.StripCloudSourceTag(model); ok {
+		provider = talosProviderCloud
+		configModel = base
+	}
+
+	if err := talosConfigSet(argv, talosProviderKey, provider); err != nil {
+		return err
+	}
+	if err := talosConfigSet(argv, talosModelKey, configModel); err != nil {
+		return err
+	}
+
+	if provider == talosProviderCloud && !talosCloudKeyPresent() {
+		// Talos refuses secrets on its command line by design (a key there lands
+		// in shell history and process listings), so launch cannot write
+		// OLLAMA_API_KEY — the user has to take Talos's secret-safe path.
+		fmt.Fprintf(os.Stderr, "%sCloud models need an Ollama API key in Talos. Talos does not accept keys on the command line; run `talos setup model` once, or add OLLAMA_API_KEY to your Talos env file.%s\n", ansiGray, ansiReset)
+	}
+
+	if warn := talosNonDefaultHostWarning(); warn != "" && provider == talosProviderLocal {
+		fmt.Fprintf(os.Stderr, "%s%s%s\n", ansiGray, warn, ansiReset)
+	}
+	return nil
+}
+
+func (t *Talos) CurrentModel() string {
+	values := talosConfigValues()
+	provider := strings.TrimSpace(values[talosProviderKey])
+	current := strings.TrimSpace(values[talosModelKey])
+	if current == "" {
+		return ""
+	}
+	switch provider {
+	case talosProviderLocal:
+		return current
+	case talosProviderCloud:
+		// Report cloud models the way launch names them so the launcher sees a
+		// match instead of reconfiguring on every run.
+		return current + ":cloud"
+	default:
+		return ""
+	}
+}
+
+func (t *Talos) Onboard() error {
+	return config.MarkIntegrationOnboarded("talos")
+}
+
+func (t *Talos) RequiresInteractiveOnboarding() bool {
+	return false
+}
+
+func (t *Talos) installed() bool {
+	_, err := t.command()
+	return err == nil
+}
+
+func (t *Talos) ensureInstalled() error {
+	if t.installed() {
+		return nil
+	}
+
+	var missing []string
+	for _, dep := range []string{"curl", "sh"} {
+		if _, err := talosLookPath(dep); err != nil {
+			missing = append(missing, dep)
+		}
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("Talos is not installed and required dependencies are missing\n\nInstall the following first:\n  %s\n\nThen re-run:\n  ollama launch talos", strings.Join(missing, "\n  "))
+	}
+
+	ok, err := ConfirmPrompt("Talos is not installed. Install now?")
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("talos installation cancelled")
+	}
+
+	// The installer runs Talos's full test suite and its adversarial suite in
+	// front of the user before it finishes, so this takes a few minutes.
+	fmt.Fprintf(os.Stderr, "\nInstalling Talos...\n")
+	if err := talosAttachedCommand([]string{"sh"}, "-c", talosInstallScript).Run(); err != nil {
+		return fmt.Errorf("failed to install talos: %w", err)
+	}
+
+	if !t.installed() {
+		return fmt.Errorf("talos was installed but was not found\n\nYou may need to restart your shell")
+	}
+
+	fmt.Fprintf(os.Stderr, "%sTalos installed successfully%s\n\n", ansiGreen, ansiReset)
+	return nil
+}
+
+// command resolves how to invoke Talos. The installer puts everything under
+// ~/talos (or $TALOS_PREFIX) and deliberately adds nothing to PATH, so the
+// venv interpreter plus `-m talos` is the canonical invocation; a `talos`
+// shim on PATH still wins when the user made one.
+func (t *Talos) command() ([]string, error) {
+	if path, err := talosLookPath("talos"); err == nil {
+		return []string{path}, nil
+	}
+
+	prefix, err := talosPrefix()
+	if err != nil {
+		return nil, err
+	}
+	python := filepath.Join(prefix, ".venv", "bin", "python")
+	if _, err := os.Stat(python); err == nil {
+		return []string{python, "-m", "talos"}, nil
+	}
+
+	return nil, fmt.Errorf("talos is not installed")
+}
+
+func talosPrefix() (string, error) {
+	if prefix := strings.TrimSpace(os.Getenv("TALOS_PREFIX")); prefix != "" {
+		return filepath.Clean(prefix), nil
+	}
+	home, err := talosUserHome()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "talos"), nil
+}
+
+func talosConfigPath() (string, error) {
+	prefix, err := talosPrefix()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(prefix, "talos.env"), nil
+}
+
+// talosSecretsEnvPath mirrors Talos's SECRETS_ENV: $TALOS_SECRETS_ENV, or the
+// default location next to the other operator secrets.
+func talosSecretsEnvPath() (string, error) {
+	if path := strings.TrimSpace(os.Getenv("TALOS_SECRETS_ENV")); path != "" {
+		return filepath.Clean(path), nil
+	}
+	home, err := talosUserHome()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".secrets", "talos-telegram.env"), nil
+}
+
+// talosConfigValues reads the model settings the way Talos does: talos.env
+// first, the secrets file on top, and the process environment last.
+func talosConfigValues() map[string]string {
+	values := make(map[string]string)
+	if configPath, err := talosConfigPath(); err == nil {
+		if data, err := os.ReadFile(configPath); err == nil {
+			for key, value := range talosParseEnvFile(data) {
+				values[key] = value
+			}
+		}
+	}
+	if secretsPath, err := talosSecretsEnvPath(); err == nil {
+		if data, err := os.ReadFile(secretsPath); err == nil {
+			for key, value := range talosParseEnvFile(data) {
+				values[key] = value
+			}
+		}
+	}
+	for _, key := range []string{talosProviderKey, talosModelKey, "OLLAMA_API_KEY"} {
+		// An empty variable is no override — Talos's own loader treats it as unset.
+		if value, ok := os.LookupEnv(key); ok && strings.TrimSpace(value) != "" {
+			values[key] = value
+		}
+	}
+	return values
+}
+
+func talosCloudKeyPresent() bool {
+	return strings.TrimSpace(talosConfigValues()["OLLAMA_API_KEY"]) != ""
+}
+
+// talosNonDefaultHostWarning flags the one gap launch cannot close: Talos's
+// local provider defaults to http://localhost:11434/v1, and the per-provider
+// base URL key is POLICY in Talos's schema, which `config set` refuses — even
+// with a confirmation. A custom OLLAMA_HOST therefore needs a manual edit.
+func talosNonDefaultHostWarning() string {
+	host := strings.TrimRight(envconfig.Host().String(), "/")
+	if host == "http://127.0.0.1:11434" || host == "http://localhost:11434" {
+		return ""
+	}
+	return fmt.Sprintf("Note: Ollama is at %s, but Talos's local provider defaults to http://localhost:11434/v1 and its base URL is a policy key launch may not write. Set TALOS_BASE_URL_OLLAMA in your Talos env file to %s/v1.", host, host)
+}
+
+func talosConfigSet(argv []string, key, value string) error {
+	args := append(append([]string(nil), argv[1:]...), "config", "set", key, value)
+	out, err := talosCommand(argv[0], args...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("talos config set %s: %w\n%s", key, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// talosParseEnvFile mirrors Talos's own flat KEY=VALUE parser: comments and
+// blank lines are dropped, and matching quotes around the value are stripped.
+func talosParseEnvFile(data []byte) map[string]string {
+	out := make(map[string]string)
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if len(value) >= 2 {
+			if (value[0] == '"' && value[len(value)-1] == '"') || (value[0] == '\'' && value[len(value)-1] == '\'') {
+				value = value[1 : len(value)-1]
+			}
+		}
+		out[key] = value
+	}
+	return out
+}
+
+func talosAttachedCommand(argv []string, args ...string) *exec.Cmd {
+	all := append(append([]string(nil), argv...), args...)
+	cmd := talosCommand(all[0], all[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd
+}

--- a/cmd/launch/talos.go
+++ b/cmd/launch/talos.go
@@ -18,7 +18,7 @@ const (
 	// fetches the published sha256 and an Ed25519 release signature and refuses
 	// on mismatch, so piping it into a shell is the vendor-supported install
 	// path, not a shortcut around verification.
-	talosInstallScript = "curl -fsSL https://talos-agent.ch/install.sh | sh"
+	talosInstallScript = "curl -fsSL https://talos-agent.ch/install.sh | bash"
 	// Provider slugs from Talos's own model catalog (talos/catalog.py). The
 	// local entry defaults to http://localhost:11434/v1 and needs no key.
 	talosProviderLocal = "ollama"
@@ -52,7 +52,7 @@ func (t *Talos) Run(_ string, _ []LaunchModel, args []string) error {
 }
 
 // Supported reports platform support separately from installation: Talos's
-// installer requires a POSIX shell and Python 3.11+, and ships no Windows path.
+// installer requires Bash and Python 3.11+, and ships no Windows path.
 func (t *Talos) Supported() error {
 	if talosGOOS == "windows" {
 		return fmt.Errorf("talos currently supports macOS and Linux")
@@ -158,7 +158,7 @@ func (t *Talos) ensureInstalled() error {
 	}
 
 	var missing []string
-	for _, dep := range []string{"curl", "sh"} {
+	for _, dep := range []string{"curl", "bash"} {
 		if _, err := talosLookPath(dep); err != nil {
 			missing = append(missing, dep)
 		}
@@ -178,7 +178,7 @@ func (t *Talos) ensureInstalled() error {
 	// The installer runs Talos's full test suite and its adversarial suite in
 	// front of the user before it finishes, so this takes a few minutes.
 	fmt.Fprintf(os.Stderr, "\nInstalling Talos...\n")
-	if err := talosAttachedCommand([]string{"sh"}, "-c", talosInstallScript).Run(); err != nil {
+	if err := talosAttachedCommand([]string{"bash"}, "-o", "pipefail", "-c", talosInstallScript).Run(); err != nil {
 		return fmt.Errorf("failed to install talos: %w", err)
 	}
 
@@ -190,10 +190,8 @@ func (t *Talos) ensureInstalled() error {
 	return nil
 }
 
-// command resolves how to invoke Talos. The installer puts everything under
-// ~/talos (or $TALOS_PREFIX) and deliberately adds nothing to PATH, so the
-// venv interpreter plus `-m talos` is the canonical invocation; a `talos`
-// shim on PATH still wins when the user made one.
+// command prefers PATH, then the installer's bin/talos wrapper under
+// $TALOS_PREFIX or ~/talos. Older installations can use their venv directly.
 func (t *Talos) command() ([]string, error) {
 	if path, err := talosLookPath("talos"); err == nil {
 		return []string{path}, nil
@@ -202,6 +200,9 @@ func (t *Talos) command() ([]string, error) {
 	prefix, err := talosPrefix()
 	if err != nil {
 		return nil, err
+	}
+	if wrapper, err := talosLookPath(filepath.Join(prefix, "bin", "talos")); err == nil {
+		return []string{wrapper}, nil
 	}
 	python := filepath.Join(prefix, ".venv", "bin", "python")
 	if _, err := os.Stat(python); err == nil {
@@ -223,11 +224,33 @@ func talosPrefix() (string, error) {
 }
 
 func talosConfigPath() (string, error) {
+	// A PATH entry can select a different installation than TALOS_PREFIX.
+	// Recognize the official layout through symlinks so CurrentModel and Paths
+	// inspect the same configuration that the selected command will write.
+	if path, err := talosLookPath("talos"); err == nil {
+		if prefix, ok := talosWrapperPrefix(path); ok {
+			return filepath.Join(prefix, "talos.env"), nil
+		}
+	}
 	prefix, err := talosPrefix()
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(prefix, "talos.env"), nil
+}
+
+func talosWrapperPrefix(path string) (string, bool) {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil || filepath.Base(resolved) != "talos" || filepath.Base(filepath.Dir(resolved)) != "bin" {
+		return "", false
+	}
+	prefix := filepath.Dir(filepath.Dir(resolved))
+	for _, name := range []string{filepath.Join(".venv", "bin", "python"), filepath.Join("talos", "__main__.py")} {
+		if info, err := os.Stat(filepath.Join(prefix, name)); err != nil || !info.Mode().IsRegular() {
+			return "", false
+		}
+	}
+	return prefix, true
 }
 
 // talosSecretsEnvPath mirrors Talos's SECRETS_ENV: $TALOS_SECRETS_ENV, or the
@@ -287,8 +310,7 @@ func talosNonDefaultHostWarning() string {
 }
 
 func talosConfigSet(argv []string, key, value string) error {
-	args := append(append([]string(nil), argv[1:]...), "config", "set", key, value)
-	out, err := talosCommand(argv[0], args...).CombinedOutput()
+	out, err := talosExecCommand(argv, "config", "set", key, value).CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("talos config set %s: %w\n%s", key, err, strings.TrimSpace(string(out)))
 	}
@@ -323,9 +345,24 @@ func talosParseEnvFile(data []byte) map[string]string {
 	return out
 }
 
-func talosAttachedCommand(argv []string, args ...string) *exec.Cmd {
+func talosExecCommand(argv []string, args ...string) *exec.Cmd {
 	all := append(append([]string(nil), argv...), args...)
 	cmd := talosCommand(all[0], all[1:]...)
+	if len(argv) == 3 && argv[1] == "-m" && argv[2] == "talos" {
+		// Match bin/talos for a legacy venv: make the module importable without
+		// changing the caller's directory or its relative workspace settings.
+		prefix := filepath.Dir(filepath.Dir(filepath.Dir(argv[0])))
+		pythonPath := prefix
+		if current := os.Getenv("PYTHONPATH"); current != "" {
+			pythonPath += string(os.PathListSeparator) + current
+		}
+		cmd.Env = append(os.Environ(), "PYTHONPATH="+pythonPath)
+	}
+	return cmd
+}
+
+func talosAttachedCommand(argv []string, args ...string) *exec.Cmd {
+	cmd := talosExecCommand(argv, args...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/cmd/launch/talos_e2e_test.go
+++ b/cmd/launch/talos_e2e_test.go
@@ -1,0 +1,146 @@
+package launch
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+
+// This opt-in test downloads and executes the public, signature-verifying Talos
+// installer in a temporary prefix. Only the model server is a fixture; the
+// installer, config CLI, Python runtime, chat and event log are real.
+// Run with TALOS_TEST_INSTALLER=1 go test ./cmd/launch -run TestTalosReleasedInstaller -v.
+func TestTalosReleasedInstaller(t *testing.T) {
+	if os.Getenv("TALOS_TEST_INSTALLER") != "1" {
+		t.Skip("set TALOS_TEST_INSTALLER=1 to test the published installer")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("Talos installer supports macOS and Linux")
+	}
+	for _, name := range []string{"bash", "curl", "python3"} {
+		if _, err := exec.LookPath(name); err != nil {
+			t.Fatalf("installer prerequisite %s: %v", name, err)
+		}
+	}
+	tmp := t.TempDir()
+	clearTalosEnvVars(t)
+	withLauncherHooks(t)
+	prefix := filepath.Join(tmp, "installed-talos")
+	t.Setenv("TALOS_PREFIX", prefix)
+	t.Setenv("TALOS_BIN_DIR", filepath.Join(tmp, "commands"))
+	t.Setenv("TALOS_SECRETS_ENV", filepath.Join(tmp, "empty-secrets.env"))
+	t.Setenv("NO_COLOR", "1")
+	oldLookPath := talosLookPath
+	talosLookPath = func(name string) (string, error) {
+		if name == "talos" {
+			return "", exec.ErrNotFound
+		}
+		return exec.LookPath(name)
+	}
+	t.Cleanup(func() { talosLookPath = oldLookPath })
+	DefaultConfirmPrompt = func(_ string, _ ConfirmOptions) (bool, error) { return true, nil }
+	if err := (&Talos{}).ensureInstalled(); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls, invalid atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			invalid.Add(1)
+		}
+		switch {
+		case r.Method == "GET" && r.URL.Path == "/v1/models":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"data":[{"id":"fixture-model"}]}`)
+		case r.Method == "POST" && r.URL.Path == "/v1/chat/completions":
+			var body struct {
+				Model string `json:"model"`
+			}
+			if err := json.NewDecoder(r.Body).Decode(&body); err != nil || body.Model != "fixture-model" {
+				invalid.Add(1)
+				http.Error(w, "unexpected model request", http.StatusBadRequest)
+				return
+			}
+			calls.Add(1)
+			w.Header().Set("Content-Type", "text/event-stream")
+			fmt.Fprint(w, "data: {\"choices\":[{\"delta\":{\"content\":\"LAUNCHER_E2E_OK\"}}]}\n\ndata: [DONE]\n\n")
+		default:
+			invalid.Add(1)
+			http.Error(w, "unexpected endpoint", http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(server.Close)
+	t.Setenv("TALOS_BASE_URL_OLLAMA", server.URL+"/v1")
+	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:11434")
+	caller := filepath.Join(tmp, "caller")
+	if err := os.Mkdir(caller, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(caller)
+	wrapper := filepath.Join(prefix, "bin", "talos")
+
+	for _, mode := range []string{"prefix-wrapper", "path-symlink", "legacy-venv"} {
+		t.Run(mode, func(t *testing.T) {
+			if mode == "path-symlink" {
+				before := talosLookPath
+				talosLookPath = func(name string) (string, error) {
+					if name == "talos" {
+						return filepath.Join(tmp, "commands", "talos"), nil
+					}
+					return exec.LookPath(name)
+				}
+				t.Cleanup(func() { talosLookPath = before })
+				t.Setenv("TALOS_PREFIX", filepath.Join(tmp, "not-the-selected-installation"))
+			}
+			if mode == "legacy-venv" {
+				if err := os.Rename(wrapper, wrapper+".test-disabled"); err != nil {
+					t.Fatal(err)
+				}
+				t.Cleanup(func() {
+					if err := os.Rename(wrapper+".test-disabled", wrapper); err != nil {
+						t.Error(err)
+					}
+				})
+			}
+			if err := (&Talos{}).Configure("fixture-model"); err != nil {
+				t.Fatal(err)
+			}
+			if got := (&Talos{}).CurrentModel(); got != "fixture-model" {
+				t.Fatalf("configuration read-back: %q", got)
+			}
+			argv, err := (&Talos{}).command()
+			if err != nil {
+				t.Fatal(err)
+			}
+			cmd := talosAttachedCommand(argv, "chat")
+			cmd.Stdin = strings.NewReader("Reply with LAUNCHER_E2E_OK.\nexit\n")
+			var output bytes.Buffer
+			cmd.Stdout, cmd.Stderr = &output, &output
+			if err := cmd.Run(); err != nil {
+				t.Fatalf("chat failed: %v\n%s", err, output.String())
+			}
+			if !strings.Contains(output.String(), "LAUNCHER_E2E_OK") {
+				t.Fatalf("reply missing:\n%s", output.String())
+			}
+		})
+	}
+	if invalid.Load() != 0 || calls.Load() != 3 {
+		t.Fatalf("model transport: %d calls, %d invalid requests", calls.Load(), invalid.Load())
+	}
+	python := filepath.Join(prefix, ".venv", "bin", "python")
+	check := `import sqlite3,sys;d=sqlite3.connect('file:'+sys.argv[1]+'?mode=ro',uri=True);assert d.execute("select count(*) from events where type='done'").fetchone()[0]==3;print('Three completed chat turns persisted')`
+	out, err := exec.Command(python, "-B", "-c", check, filepath.Join(prefix, "data", "eventlog.db")).CombinedOutput()
+	if err != nil {
+		t.Fatalf("event-log read-back: %v\n%s", err, out)
+	}
+	t.Log(strings.TrimSpace(string(out)))
+}

--- a/cmd/launch/talos_test.go
+++ b/cmd/launch/talos_test.go
@@ -236,6 +236,61 @@ func TestTalosConfigureWrapsConfigSetFailure(t *testing.T) {
 	}
 }
 
+func TestTalosConfigureRejectsConflictingEnvOverride(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell test binaries")
+	}
+
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	clearTalosEnvVars(t)
+	t.Setenv("PATH", tmpDir)
+	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:11434")
+	t.Setenv("TALOS_MODEL", "qwen3.5")
+
+	log := filepath.Join(tmpDir, "talos-invocations.log")
+	writeTalosScript(t, tmpDir, "talos", fmt.Sprintf("#!/bin/sh\nprintf '[%%s]\\n' \"$*\" >> %q\n", log))
+
+	err := (&Talos{}).Configure("gemma4")
+	if err == nil || !strings.Contains(err.Error(), "TALOS_MODEL") || !strings.Contains(err.Error(), "overrides") {
+		t.Fatalf("expected env override error, got %v", err)
+	}
+
+	// Nothing may be written when the saved config would not take effect.
+	if _, statErr := os.Stat(log); !os.IsNotExist(statErr) {
+		t.Fatalf("expected no talos invocations, log exists")
+	}
+}
+
+func TestTalosConfigureAcceptsMatchingEnvOverride(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell test binaries")
+	}
+
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	clearTalosEnvVars(t)
+	t.Setenv("PATH", tmpDir)
+	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:11434")
+	t.Setenv("TALOS_MODEL_PROVIDER", "ollama")
+	t.Setenv("TALOS_MODEL", "gemma4")
+
+	log := filepath.Join(tmpDir, "talos-invocations.log")
+	writeTalosScript(t, tmpDir, "talos", fmt.Sprintf("#!/bin/sh\nprintf '[%%s]\\n' \"$*\" >> %q\n", log))
+
+	if err := (&Talos{}).Configure("gemma4"); err != nil {
+		t.Fatalf("Configure returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "[config set TALOS_MODEL gemma4]") {
+		t.Fatalf("expected config set calls, got %q", data)
+	}
+}
+
 func TestTalosCurrentModel(t *testing.T) {
 	tmpDir := t.TempDir()
 	setTestHome(t, tmpDir)

--- a/cmd/launch/talos_test.go
+++ b/cmd/launch/talos_test.go
@@ -1,0 +1,420 @@
+package launch
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func withTalosPlatform(t *testing.T, goos string) {
+	t.Helper()
+	old := talosGOOS
+	talosGOOS = goos
+	t.Cleanup(func() {
+		talosGOOS = old
+	})
+}
+
+func withTalosUserHome(t *testing.T, dir string) {
+	t.Helper()
+	old := talosUserHome
+	talosUserHome = func() (string, error) { return dir, nil }
+	t.Cleanup(func() {
+		talosUserHome = old
+	})
+}
+
+// clearTalosEnvVars keeps the host's Talos environment out of tests: the
+// installer-supported overrides would redirect prefix and secrets resolution.
+func clearTalosEnvVars(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{"TALOS_PREFIX", "TALOS_SECRETS_ENV", "TALOS_MODEL_PROVIDER", "TALOS_MODEL", "OLLAMA_API_KEY"} {
+		t.Setenv(key, "")
+	}
+}
+
+func writeTalosScript(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestTalosIntegration(t *testing.T) {
+	talos := &Talos{}
+
+	t.Run("implements Runner", func(t *testing.T) {
+		var _ Runner = talos
+	})
+
+	t.Run("implements managed single model", func(t *testing.T) {
+		var _ ManagedSingleModel = talos
+	})
+
+	t.Run("implements supported integration", func(t *testing.T) {
+		var _ SupportedIntegration = talos
+	})
+}
+
+func TestTalosSupportedByPlatform(t *testing.T) {
+	withTalosPlatform(t, "windows")
+	if err := (&Talos{}).Supported(); err == nil {
+		t.Fatal("expected windows to be unsupported")
+	}
+
+	withTalosPlatform(t, "darwin")
+	if err := (&Talos{}).Supported(); err != nil {
+		t.Fatalf("expected darwin to be supported, got %v", err)
+	}
+}
+
+func TestTalosCommandPrefersPathShim(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell test binaries")
+	}
+
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	clearTalosEnvVars(t)
+	t.Setenv("PATH", tmpDir)
+
+	bin := writeTalosScript(t, tmpDir, "talos", "#!/bin/sh\nexit 0\n")
+
+	argv, err := (&Talos{}).command()
+	if err != nil {
+		t.Fatalf("command returned error: %v", err)
+	}
+	if len(argv) != 1 || argv[0] != bin {
+		t.Fatalf("expected PATH shim [%s], got %v", bin, argv)
+	}
+}
+
+func TestTalosCommandFallsBackToInstallerVenv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell test binaries")
+	}
+
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	withTalosUserHome(t, tmpDir)
+	clearTalosEnvVars(t)
+	t.Setenv("PATH", tmpDir)
+
+	// The installer puts everything under ~/talos and adds nothing to PATH.
+	python := filepath.Join(tmpDir, "talos", ".venv", "bin", "python")
+	if err := os.MkdirAll(filepath.Dir(python), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(python, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	argv, err := (&Talos{}).command()
+	if err != nil {
+		t.Fatalf("command returned error: %v", err)
+	}
+	want := []string{python, "-m", "talos"}
+	if strings.Join(argv, " ") != strings.Join(want, " ") {
+		t.Fatalf("expected %v, got %v", want, argv)
+	}
+}
+
+func TestTalosCommandHonorsPrefixOverride(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell test binaries")
+	}
+
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	clearTalosEnvVars(t)
+	t.Setenv("PATH", tmpDir)
+
+	prefix := filepath.Join(tmpDir, "custom-prefix")
+	python := filepath.Join(prefix, ".venv", "bin", "python")
+	if err := os.MkdirAll(filepath.Dir(python), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(python, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TALOS_PREFIX", prefix)
+
+	argv, err := (&Talos{}).command()
+	if err != nil {
+		t.Fatalf("command returned error: %v", err)
+	}
+	if argv[0] != python {
+		t.Fatalf("expected venv python under TALOS_PREFIX, got %v", argv)
+	}
+}
+
+func TestTalosConfigureLocalModelUsesTalosConfigSurface(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell test binaries")
+	}
+
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	clearTalosEnvVars(t)
+	t.Setenv("PATH", tmpDir)
+	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:11434")
+
+	log := filepath.Join(tmpDir, "talos-invocations.log")
+	writeTalosScript(t, tmpDir, "talos", fmt.Sprintf("#!/bin/sh\nprintf '[%%s]\\n' \"$*\" >> %q\n", log))
+
+	if err := (&Talos{}).Configure("gemma4"); err != nil {
+		t.Fatalf("Configure returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	want := []string{
+		"[config set TALOS_MODEL_PROVIDER ollama]",
+		"[config set TALOS_MODEL gemma4]",
+	}
+	if strings.Join(lines, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("expected invocations %v, got %v", want, lines)
+	}
+}
+
+func TestTalosConfigureCloudModelStripsCloudTag(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell test binaries")
+	}
+
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	clearTalosEnvVars(t)
+	t.Setenv("PATH", tmpDir)
+	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:11434")
+
+	log := filepath.Join(tmpDir, "talos-invocations.log")
+	writeTalosScript(t, tmpDir, "talos", fmt.Sprintf("#!/bin/sh\nprintf '[%%s]\\n' \"$*\" >> %q\n", log))
+
+	if err := (&Talos{}).Configure("kimi-k2.5:cloud"); err != nil {
+		t.Fatalf("Configure returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	want := []string{
+		"[config set TALOS_MODEL_PROVIDER ollama-cloud]",
+		"[config set TALOS_MODEL kimi-k2.5]",
+	}
+	if strings.Join(lines, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("expected invocations %v, got %v", want, lines)
+	}
+}
+
+func TestTalosConfigureWrapsConfigSetFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell test binaries")
+	}
+
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	clearTalosEnvVars(t)
+	t.Setenv("PATH", tmpDir)
+	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:11434")
+
+	writeTalosScript(t, tmpDir, "talos", "#!/bin/sh\necho 'unknown key' >&2\nexit 1\n")
+
+	err := (&Talos{}).Configure("gemma4")
+	if err == nil || !strings.Contains(err.Error(), "talos config set TALOS_MODEL_PROVIDER") {
+		t.Fatalf("expected wrapped config set failure, got %v", err)
+	}
+}
+
+func TestTalosCurrentModel(t *testing.T) {
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	withTalosUserHome(t, tmpDir)
+	clearTalosEnvVars(t)
+
+	writeConfig := func(content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(tmpDir, "talos", "talos.env"), []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Join(tmpDir, "talos"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("returns empty when nothing is configured", func(t *testing.T) {
+		writeConfig("# fresh install\n")
+		if got := (&Talos{}).CurrentModel(); got != "" {
+			t.Fatalf("expected empty current model, got %q", got)
+		}
+	})
+
+	t.Run("returns local ollama model", func(t *testing.T) {
+		writeConfig("TALOS_MODEL_PROVIDER=ollama\nTALOS_MODEL=gemma4\n")
+		if got := (&Talos{}).CurrentModel(); got != "gemma4" {
+			t.Fatalf("expected gemma4, got %q", got)
+		}
+	})
+
+	t.Run("reports cloud model with launch naming", func(t *testing.T) {
+		writeConfig("TALOS_MODEL_PROVIDER=ollama-cloud\nTALOS_MODEL=kimi-k2.5\n")
+		if got := (&Talos{}).CurrentModel(); got != "kimi-k2.5:cloud" {
+			t.Fatalf("expected kimi-k2.5:cloud, got %q", got)
+		}
+	})
+
+	t.Run("ignores models owned by another provider", func(t *testing.T) {
+		writeConfig("TALOS_MODEL_PROVIDER=anthropic\nTALOS_MODEL=claude-opus\n")
+		if got := (&Talos{}).CurrentModel(); got != "" {
+			t.Fatalf("expected empty current model, got %q", got)
+		}
+	})
+
+	t.Run("secrets file overrides the main config", func(t *testing.T) {
+		writeConfig("TALOS_MODEL_PROVIDER=anthropic\nTALOS_MODEL=claude-opus\n")
+		secretsPath := filepath.Join(tmpDir, "secrets.env")
+		if err := os.WriteFile(secretsPath, []byte("TALOS_MODEL_PROVIDER=ollama\nTALOS_MODEL=qwen3.5\n"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("TALOS_SECRETS_ENV", secretsPath)
+		if got := (&Talos{}).CurrentModel(); got != "qwen3.5" {
+			t.Fatalf("expected qwen3.5, got %q", got)
+		}
+	})
+}
+
+func TestTalosRunPassthroughArgs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell test binaries")
+	}
+
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	clearTalosEnvVars(t)
+	t.Setenv("PATH", tmpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	writeTalosScript(t, tmpDir, "talos", "#!/bin/sh\nprintf '[%s]\\n' \"$*\" >> \"$HOME/talos-invocations.log\"\n")
+
+	if err := (&Talos{}).Run("", nil, []string{"--continue"}); err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "talos-invocations.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "[chat --continue]" {
+		t.Fatalf("expected chat session with passthrough args, got %q", got)
+	}
+}
+
+func TestTalosEnsureInstalledUnixPromptsBeforeInstall(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell test binaries")
+	}
+
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	withTalosUserHome(t, tmpDir)
+	clearTalosEnvVars(t)
+	withLauncherHooks(t)
+	t.Setenv("PATH", tmpDir)
+
+	writeTalosScript(t, tmpDir, "curl", "#!/bin/sh\nexit 0\n")
+	// The fake installer lays down the venv the real one would create.
+	writeTalosScript(t, tmpDir, "sh", fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> %q
+/bin/mkdir -p %q
+/bin/cat > %q <<'EOS'
+#!/bin/sh
+exit 0
+EOS
+/bin/chmod +x %q
+exit 0
+`, filepath.Join(tmpDir, "sh.log"), filepath.Join(tmpDir, "talos", ".venv", "bin"), filepath.Join(tmpDir, "talos", ".venv", "bin", "python"), filepath.Join(tmpDir, "talos", ".venv", "bin", "python")))
+
+	DefaultConfirmPrompt = func(prompt string, options ConfirmOptions) (bool, error) {
+		if prompt != "Talos is not installed. Install now?" {
+			t.Fatalf("unexpected install prompt %q", prompt)
+		}
+		return true, nil
+	}
+
+	if err := (&Talos{}).ensureInstalled(); err != nil {
+		t.Fatalf("ensureInstalled returned error: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, "sh.log"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "-c "+talosInstallScript) {
+		t.Fatalf("expected official install script invocation, got logs:\n%s", data)
+	}
+}
+
+func TestTalosEnsureInstalledUnixCanBeDeclined(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses POSIX shell test binaries")
+	}
+
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+	withTalosUserHome(t, tmpDir)
+	clearTalosEnvVars(t)
+	withLauncherHooks(t)
+	t.Setenv("PATH", tmpDir)
+
+	for _, name := range []string{"curl", "sh"} {
+		writeTalosScript(t, tmpDir, name, "#!/bin/sh\nexit 0\n")
+	}
+
+	DefaultConfirmPrompt = func(prompt string, options ConfirmOptions) (bool, error) {
+		if prompt != "Talos is not installed. Install now?" {
+			t.Fatalf("unexpected install prompt %q", prompt)
+		}
+		return false, nil
+	}
+
+	err := (&Talos{}).ensureInstalled()
+	if err == nil || !strings.Contains(err.Error(), "talos installation cancelled") {
+		t.Fatalf("expected install cancellation error, got %v", err)
+	}
+}
+
+func TestTalosParseEnvFile(t *testing.T) {
+	parsed := talosParseEnvFile([]byte(`
+# a comment
+TALOS_MODEL_PROVIDER=ollama
+TALOS_MODEL="qwen3.5"
+QUOTED='single'
+BROKEN_LINE
+EMPTY=
+`))
+
+	if got := parsed["TALOS_MODEL_PROVIDER"]; got != "ollama" {
+		t.Fatalf("expected ollama, got %q", got)
+	}
+	if got := parsed["TALOS_MODEL"]; got != "qwen3.5" {
+		t.Fatalf("expected quotes stripped, got %q", got)
+	}
+	if got := parsed["QUOTED"]; got != "single" {
+		t.Fatalf("expected single quotes stripped, got %q", got)
+	}
+	if _, ok := parsed["BROKEN_LINE"]; ok {
+		t.Fatal("expected line without = to be skipped")
+	}
+	if got, ok := parsed["EMPTY"]; !ok || got != "" {
+		t.Fatalf("expected empty value to be kept, got %q (present=%v)", got, ok)
+	}
+}

--- a/cmd/launch/talos_test.go
+++ b/cmd/launch/talos_test.go
@@ -3,6 +3,7 @@ package launch
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -105,7 +106,7 @@ func TestTalosCommandFallsBackToInstallerVenv(t *testing.T) {
 	clearTalosEnvVars(t)
 	t.Setenv("PATH", tmpDir)
 
-	// The installer puts everything under ~/talos and adds nothing to PATH.
+	// Older installations have only the venv, without bin/talos.
 	python := filepath.Join(tmpDir, "talos", ".venv", "bin", "python")
 	if err := os.MkdirAll(filepath.Dir(python), 0o755); err != nil {
 		t.Fatal(err)
@@ -387,7 +388,7 @@ func TestTalosEnsureInstalledUnixPromptsBeforeInstall(t *testing.T) {
 
 	writeTalosScript(t, tmpDir, "curl", "#!/bin/sh\nexit 0\n")
 	// The fake installer lays down the venv the real one would create.
-	writeTalosScript(t, tmpDir, "sh", fmt.Sprintf(`#!/bin/sh
+	writeTalosScript(t, tmpDir, "bash", fmt.Sprintf(`#!/bin/sh
 printf '%%s\n' "$*" >> %q
 /bin/mkdir -p %q
 /bin/cat > %q <<'EOS'
@@ -396,7 +397,7 @@ exit 0
 EOS
 /bin/chmod +x %q
 exit 0
-`, filepath.Join(tmpDir, "sh.log"), filepath.Join(tmpDir, "talos", ".venv", "bin"), filepath.Join(tmpDir, "talos", ".venv", "bin", "python"), filepath.Join(tmpDir, "talos", ".venv", "bin", "python")))
+`, filepath.Join(tmpDir, "bash.log"), filepath.Join(tmpDir, "talos", ".venv", "bin"), filepath.Join(tmpDir, "talos", ".venv", "bin", "python"), filepath.Join(tmpDir, "talos", ".venv", "bin", "python")))
 
 	DefaultConfirmPrompt = func(prompt string, options ConfirmOptions) (bool, error) {
 		if prompt != "Talos is not installed. Install now?" {
@@ -409,11 +410,11 @@ exit 0
 		t.Fatalf("ensureInstalled returned error: %v", err)
 	}
 
-	data, err := os.ReadFile(filepath.Join(tmpDir, "sh.log"))
+	data, err := os.ReadFile(filepath.Join(tmpDir, "bash.log"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(data), "-c "+talosInstallScript) {
+	if !strings.Contains(string(data), "-o pipefail -c "+talosInstallScript) {
 		t.Fatalf("expected official install script invocation, got logs:\n%s", data)
 	}
 }
@@ -430,7 +431,7 @@ func TestTalosEnsureInstalledUnixCanBeDeclined(t *testing.T) {
 	withLauncherHooks(t)
 	t.Setenv("PATH", tmpDir)
 
-	for _, name := range []string{"curl", "sh"} {
+	for _, name := range []string{"curl", "bash"} {
 		writeTalosScript(t, tmpDir, name, "#!/bin/sh\nexit 0\n")
 	}
 
@@ -471,5 +472,158 @@ EMPTY=
 	}
 	if got, ok := parsed["EMPTY"]; !ok || got != "" {
 		t.Fatalf("expected empty value to be kept, got %q (present=%v)", got, ok)
+	}
+}
+
+func TestTalosInstallerWrapperAndConfigStayTogether(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX launcher")
+	}
+	tmp := t.TempDir()
+	clearTalosEnvVars(t)
+	withTalosUserHome(t, tmp)
+	prefix := filepath.Join(tmp, "installed with spaces")
+	for _, dir := range []string{"bin", ".venv/bin", "talos"} {
+		if err := os.MkdirAll(filepath.Join(prefix, dir), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	wrapper := writeTalosScript(t, filepath.Join(prefix, "bin"), "talos", "#!/bin/sh\nexit 0\n")
+	writeTalosScript(t, filepath.Join(prefix, ".venv/bin"), "python", "#!/bin/sh\nexit 0\n")
+	if err := os.WriteFile(filepath.Join(prefix, "talos/__main__.py"), nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(prefix, "talos.env"), []byte("TALOS_MODEL_PROVIDER=ollama\nTALOS_MODEL=fixture-model\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TALOS_SECRETS_ENV", filepath.Join(tmp, "no-secrets"))
+	t.Run("prefix without PATH entry", func(t *testing.T) {
+		t.Setenv("PATH", tmp)
+		t.Setenv("TALOS_PREFIX", prefix)
+		argv, err := (&Talos{}).command()
+		if err != nil || len(argv) != 1 || argv[0] != wrapper {
+			t.Fatalf("wrapper not selected: %v, %v", argv, err)
+		}
+	})
+	t.Run("PATH symlink wins over another prefix", func(t *testing.T) {
+		bin := filepath.Join(tmp, "commands")
+		if err := os.Mkdir(bin, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(wrapper, filepath.Join(bin, "talos")); err != nil {
+			t.Fatal(err)
+		}
+		t.Setenv("PATH", bin)
+		t.Setenv("TALOS_PREFIX", filepath.Join(tmp, "different-installation"))
+		if got := (&Talos{}).CurrentModel(); got != "fixture-model" {
+			t.Fatalf("read config from wrong installation: %q", got)
+		}
+		paths := (&Talos{}).Paths()
+		canonical, err := filepath.EvalSymlinks(filepath.Join(prefix, "talos.env"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(paths) != 1 || paths[0] != canonical {
+			t.Fatalf("wrong config path: %v", paths)
+		}
+	})
+}
+
+func TestTalosLegacyVenvKeepsCallerDirectory(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX launcher")
+	}
+	tmp := t.TempDir()
+	clearTalosEnvVars(t)
+	prefix := filepath.Join(tmp, "legacy install")
+	bin := filepath.Join(prefix, ".venv/bin")
+	if err := os.MkdirAll(bin, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	log := filepath.Join(tmp, "invocations")
+	writeTalosScript(t, bin, "python", fmt.Sprintf("#!/bin/sh\nprintf '%%s|%%s|%%s\\n' \"$PWD\" \"$PYTHONPATH\" \"$*\" >> %q\n", log))
+	caller := filepath.Join(tmp, "project")
+	if err := os.Mkdir(caller, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(caller)
+	t.Setenv("PATH", tmp)
+	t.Setenv("TALOS_PREFIX", prefix)
+	t.Setenv("PYTHONPATH", filepath.Join(tmp, "existing-python-path"))
+	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:11434")
+	if err := (&Talos{}).Configure("fixture-model"); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&Talos{}).Run("", nil, []string{"--continue"}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(log)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected configure and run: %q", data)
+	}
+	wantPrefix := caller + "|" + prefix + string(os.PathListSeparator) + filepath.Join(tmp, "existing-python-path") + "|"
+	for _, line := range lines {
+		if !strings.HasPrefix(line, wantPrefix) {
+			t.Fatalf("caller/import context lost: %q", line)
+		}
+	}
+	if !strings.HasSuffix(lines[2], "-m talos chat --continue") {
+		t.Fatalf("arguments changed: %q", lines[2])
+	}
+}
+
+func TestTalosInstallExecutesBashAndPropagatesDownloadFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX launcher")
+	}
+	bash, err := exec.LookPath("bash")
+	if err != nil {
+		t.Skip("bash unavailable")
+	}
+	for _, failDownload := range []bool{false, true} {
+		t.Run(fmt.Sprintf("download-failure-%v", failDownload), func(t *testing.T) {
+			tmp := t.TempDir()
+			clearTalosEnvVars(t)
+			withTalosUserHome(t, tmp)
+			withLauncherHooks(t)
+			if err := os.Symlink(bash, filepath.Join(tmp, "bash")); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.Symlink("/bin/sh", filepath.Join(tmp, "sh")); err != nil {
+				t.Fatal(err)
+			}
+			prefix := filepath.Join(tmp, "prefix")
+			t.Setenv("TALOS_PREFIX", prefix)
+			t.Setenv("PATH", tmp)
+			marker := filepath.Join(tmp, "bash-proof")
+			curl := fmt.Sprintf("#!/bin/sh\n/bin/cat <<'INSTALLER'\nset -euo pipefail\ntrap ':' ERR\nvalues=(bash-only)\nprintf '%%s' \"${values[0]}\" > %q\n/bin/mkdir -p %q\nprintf '#!/bin/sh\\nexit 0\\n' > %q\n/bin/chmod +x %q\nINSTALLER\n", marker, filepath.Join(prefix, "bin"), filepath.Join(prefix, "bin/talos"), filepath.Join(prefix, "bin/talos"))
+			if failDownload {
+				curl += "exit 22\n"
+			}
+			writeTalosScript(t, tmp, "curl", curl)
+			prompts := 0
+			DefaultConfirmPrompt = func(_ string, _ ConfirmOptions) (bool, error) { prompts++; return true, nil }
+			err := (&Talos{}).ensureInstalled()
+			if failDownload {
+				if err == nil || !strings.Contains(err.Error(), "failed to install talos") {
+					t.Fatalf("download failure was lost: %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				data, err := os.ReadFile(marker)
+				if err != nil || string(data) != "bash-only" {
+					t.Fatalf("Bash installer did not run: %q %v", data, err)
+				}
+			}
+			if prompts != 1 {
+				t.Fatalf("install consent requested %d times", prompts)
+			}
+		})
 	}
 }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -160,7 +160,8 @@
               "/integrations/claude-desktop",
               "/integrations/openclaw",
               "/integrations/hermes",
-              "/integrations/hermes-desktop"
+              "/integrations/hermes-desktop",
+              "/integrations/talos"
             ]
           },
           {

--- a/docs/images/launch-icons/talos.svg
+++ b/docs/images/launch-icons/talos.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64" role="img" aria-label="Talos">
+  <title>Talos</title>
+  <!-- Vollfarbe. Master für helle und dunkle Untergründe. -->
+  <defs>
+    <linearGradient id="tm-bronze" x1="32" y1="4" x2="32" y2="60" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#E7BC7C"/><stop offset=".45" stop-color="#C08A47"/><stop offset="1" stop-color="#9A6A2C"/>
+    </linearGradient>
+    <linearGradient id="tm-ridge" x1="32" y1="16" x2="32" y2="44" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#EEC78B"/><stop offset="1" stop-color="#D4A264"/>
+    </linearGradient>
+    <linearGradient id="tm-amber" x1="32" y1="26" x2="32" y2="34" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#FFD692"/><stop offset="1" stop-color="#E49726"/>
+    </linearGradient>
+  </defs>
+  <path fill="url(#tm-bronze)" stroke="#57390F" stroke-width="1.6" stroke-linejoin="round" d="M24 4h16l16 8v20l-4 12-8 12-8 4h-8l-8-4-8-12-4-12V12Z"/>
+  <path fill="#A5732F" d="M27 21h10v21l-5 5-5-5Z"/>
+  <path fill="url(#tm-ridge)" d="M15.5 16.5h33L50 18v2.5L48.5 22H35v18l-3 3.5-3-3.5V22H15.5L14 20.5V18Z"/>
+  <path fill="#14100B" d="M11 22.5 27 26.5v8L12 35.5Z"/>
+  <path fill="#14100B" d="M53 22.5 37 26.5v8l15 1Z"/>
+  <rect x="-5.25" y="-2.8" width="10.5" height="5.6" rx="2" fill="url(#tm-amber)" transform="translate(19 29.6) rotate(12)"/>
+  <rect x="-5.25" y="-2.8" width="10.5" height="5.6" rx="2" fill="url(#tm-amber)" transform="translate(45 29.6) rotate(-12)"/>
+  <path fill="#14100B" d="M25.4 47h13.2a1.4 1.4 0 0 1 1.4 1.4v.8a1.4 1.4 0 0 1-1.4 1.4H25.4a1.4 1.4 0 0 1-1.4-1.4v-.8A1.4 1.4 0 0 1 25.4 47Z"/>
+</svg>

--- a/docs/integrations/index.mdx
+++ b/docs/integrations/index.mdx
@@ -39,6 +39,10 @@ Use open models in assistant apps.
   <Card title="Hermes Agent" icon="/images/launch-icons/hermes-agent.svg" href="/integrations/hermes">
     Open-source agent with self-improving skills, memory, and messaging.
   </Card>
+
+  <Card title="Talos" icon="/images/launch-icons/talos.svg" href="/integrations/talos">
+    Permission-gated agent whose actions are bounded, explained, and checkable.
+  </Card>
 </CardGroup>
 
 ## Work in your editor

--- a/docs/integrations/talos.mdx
+++ b/docs/integrations/talos.mdx
@@ -1,0 +1,73 @@
+---
+title: Talos
+---
+
+[Talos](https://talos-agent.ch) is a permission-gated personal agent. Its kernel classifies every action as **allow**, **needs-human**, or **deny** before it runs, and records what happened in a checkable audit log — an agent whose actions are bounded, explained, and reviewable after the fact.
+
+![Talos with Ollama](/images/launch-icons/talos.svg)
+
+## Quick start
+
+```bash
+ollama launch talos
+```
+
+Ollama handles everything automatically:
+
+1. **Install** — If Talos isn't installed, Ollama offers to run the official installer. The installer verifies the sha256 checksum and an Ed25519 release signature before it unpacks anything, runs Talos's full test suite and adversarial suite in front of you, and starts nothing on its own. Talos supports macOS and Linux and needs Python 3.11 or newer.
+2. **Model** — Pick a model from the selector (local or cloud)
+3. **Onboarding** — Ollama sets Talos's provider to Ollama (`http://localhost:11434/v1`, no API key needed) and your model as the primary, through Talos's own `talos config set` surface. Cloud models use Talos's Ollama Cloud provider instead.
+4. **Launch** — Starts `talos chat`, an interactive session where Talos asks for your approval before anything risky runs
+
+## Recommended models
+
+**Cloud models**:
+
+- `kimi-k2.5:cloud` — Multimodal reasoning with subagents
+- `glm-5.1:cloud` — Reasoning and code generation
+- `qwen3.5:cloud` — Reasoning, coding, and agentic tool use with vision
+- `minimax-m2.7:cloud` — Fast, efficient coding and real-world productivity
+
+**Local models:**
+
+- `gemma4` — Reasoning and code generation locally (~16 GB VRAM)
+- `qwen3.6` — Reasoning, coding, and visual understanding locally (~24 GB VRAM)
+
+More models at [ollama.com/search](https://ollama.com/search?c=cloud).
+
+For cloud models, Talos needs an Ollama API key. Talos refuses secrets on its command line by design, so add it once via `talos setup model` or your Talos env file (`OLLAMA_API_KEY`).
+
+## Approvals and the audit log
+
+Inside `talos chat`, actions the kernel classes as **needs-human** pause for your approval at the terminal. Every decision lands in Talos's event log, so you can review what the agent did and why:
+
+```bash
+talos events
+```
+
+For a single turn without approvals, use `talos ask "..."`.
+
+## Manual setup
+
+If you'd rather drive Talos's own setup instead of `ollama launch talos`, install it directly:
+
+```bash
+curl -fsSL https://talos-agent.ch/install.sh | sh
+```
+
+The installer puts everything under `~/talos` (override with `TALOS_PREFIX`) and adds nothing to your PATH — invoke it as `~/talos/.venv/bin/python -m talos`.
+
+### Connect to Ollama
+
+Local Ollama needs no key:
+
+```bash
+~/talos/.venv/bin/python -m talos config set TALOS_MODEL_PROVIDER ollama
+~/talos/.venv/bin/python -m talos config set TALOS_MODEL gemma4
+```
+
+Or run the interactive wizard, which also handles the Ollama Cloud provider and its API key without echoing it:
+
+```bash
+~/talos/.venv/bin/python -m talos setup model
+```

--- a/docs/integrations/talos.mdx
+++ b/docs/integrations/talos.mdx
@@ -14,7 +14,7 @@ ollama launch talos
 
 Ollama handles everything automatically:
 
-1. **Install** — If Talos isn't installed, Ollama offers to run the official installer. The installer verifies the sha256 checksum and an Ed25519 release signature before it unpacks anything, runs Talos's full test suite and adversarial suite in front of you, and starts nothing on its own. Talos supports macOS and Linux and needs Python 3.11 or newer.
+1. **Install** — If Talos isn't installed, Ollama offers to run the official installer. The installer verifies the sha256 checksum and an Ed25519 release signature before it unpacks anything, runs Talos's full test suite and adversarial suite in front of you, and starts nothing on its own. Talos supports macOS and Linux and needs Bash and Python 3.11 or newer.
 2. **Model** — Pick a model from the selector (local or cloud)
 3. **Onboarding** — Ollama sets Talos's provider to Ollama (`http://localhost:11434/v1`, no API key needed) and your model as the primary, through Talos's own `talos config set` surface. Cloud models use Talos's Ollama Cloud provider instead.
 4. **Launch** — Starts `talos chat`, an interactive session where Talos asks for your approval before anything risky runs
@@ -52,22 +52,26 @@ For a single turn without approvals, use `talos ask "..."`.
 If you'd rather drive Talos's own setup instead of `ollama launch talos`, install it directly:
 
 ```bash
-curl -fsSL https://talos-agent.ch/install.sh | sh
+curl -fsSL https://talos-agent.ch/install.sh | bash
 ```
 
-The installer puts everything under `~/talos` (override with `TALOS_PREFIX`) and adds nothing to your PATH — invoke it as `~/talos/.venv/bin/python -m talos`.
+The installer puts Talos under `~/talos` (override with `TALOS_PREFIX`) and provides `bin/talos` inside that directory. It also creates a `talos` symlink in `~/.local/bin` (override with `TALOS_BIN_DIR`) if no command already exists there. Add that directory to your PATH, or use `~/talos/bin/talos` directly.
+
+The Talos 0.19.0-alpha dependency lock requires macOS 14 or newer on native Apple Silicon. Its pinned ONNX Runtime package has no Intel macOS wheel, so an Intel or Rosetta Python cannot install that release.
+
+Ollama first uses a `talos` command on PATH, then checks the installation's `bin/talos`. Older installations with only `.venv/bin/python` are also supported. Launching preserves your current working directory, including relative workspace and secrets paths.
 
 ### Connect to Ollama
 
 Local Ollama needs no key:
 
 ```bash
-~/talos/.venv/bin/python -m talos config set TALOS_MODEL_PROVIDER ollama
-~/talos/.venv/bin/python -m talos config set TALOS_MODEL gemma4
+~/talos/bin/talos config set TALOS_MODEL_PROVIDER ollama
+~/talos/bin/talos config set TALOS_MODEL gemma4
 ```
 
 Or run the interactive wizard, which also handles the Ollama Cloud provider and its API key without echoing it:
 
 ```bash
-~/talos/.venv/bin/python -m talos setup model
+~/talos/bin/talos setup model
 ```


### PR DESCRIPTION
Adds [Talos](https://talos-agent.ch) as an `ollama launch` integration. Talos is a personal agent whose kernel checks tool permissions and records execution receipts. The integration follows the existing managed single-model launch flow and includes registry, help, README, documentation and navigation entries.

## Launch behaviour

- Detect a `talos` command on PATH, then `$TALOS_PREFIX/bin/talos` (default `~/talos/bin/talos`), with a fallback for older `.venv/bin/python -m talos` installations. Follow official wrapper symlinks when locating the selected installation's configuration.
- Offer the official installer if Talos is missing. Require Bash and execute `curl -fsSL https://talos-agent.ch/install.sh | bash` under `bash -o pipefail`, preserving download failures. The installer verifies the archive checksum and Ed25519 signature, runs its tests and adversarial suite, and starts no agent service.
- Configure provider and model through Talos's validated `config set` interface. Local models use `ollama`; `:cloud` models use `ollama-cloud` with the cloud suffix removed. Conflicting exported model/provider settings are rejected before any write.
- Start `talos chat` with terminal input/output attached and pass through extra arguments. Preserve the caller's working directory; the legacy Python fallback prepends the installation root to its child `PYTHONPATH`.

## Configuration boundaries

Cloud credentials remain in Talos's setup wizard or env file; the launcher does not place API keys on the command line. A non-default `OLLAMA_HOST` produces guidance for setting `TALOS_BASE_URL_OLLAMA`, which Talos protects from ordinary `config set` writes. Windows is unsupported.

The documentation reflects the current installer layout, including the optional `~/.local/bin/talos` symlink. It also records the current release dependency limitation: Talos 0.19.0-alpha requires native Apple Silicon/macOS 14+ on macOS because its pinned ONNX Runtime distribution has no Intel macOS wheel.

## Validation

- Talos regression tests passed twice consecutively on macOS and twice on Linux ARM64, including a real Bash-only installer fixture and download-failure propagation.
- The complete `cmd/launch` package tests and `go vet ./cmd/launch` passed. Package tests were run with `OLLAMA_CONTEXT_LENGTH` unset so an operator's setting cannot override unrelated Codex fixtures.
- Whole-repository Go build passed; `ollama launch --help` lists Talos.
- The opt-in `TestTalosReleasedInstaller` passed twice consecutively on native Apple Silicon: download the signed public release into a temporary prefix, run the installer's 2,614 passing tests (34 platform skips) and adversarial suite, configure a local fixture model, exercise real chat through the prefix wrapper, PATH symlink and legacy Python fallback, and read back three completed turns from SQLite. Only the model HTTP endpoint is a fixture; no operator model service or account is used.
- Gitleaks found no secrets in this patch. No manifests or lockfiles changed; OSV reports existing vulnerabilities in the branch's Go/npm dependencies, outside this launcher change.

The release installer test is opt-in because it downloads dependencies and executes the vendor suite: `TALOS_TEST_INSTALLER=1 go test ./cmd/launch -run '^TestTalosReleasedInstaller$' -v`. Use a native Go toolchain on Apple Silicon; a Rosetta toolchain can launch an Intel Python and hit the release limitation above.
