### PR TITLE
app: polish integration settings UI

### DIFF
--- a/app/ui/app/src/components/ClaudeDesktopModelsSettings.interaction.test.tsx
+++ b/app/ui/app/src/components/ClaudeDesktopModelsSettings.interaction.test.tsx
@@ -171,6 +171,110 @@ function textContent(node: ReactTestInstance): string {
 }
 
 describe("ClaudeDesktopModelsSettings interactions", () => {
+  it("navigates available picker options with arrow keys and selects with Enter", async () => {
+    class TestHTMLElement {
+      focus() {}
+    }
+    const focus = vi.fn();
+    const scrollIntoView = vi.fn();
+    vi.stubGlobal("window", {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      HTMLElement: TestHTMLElement,
+    });
+    vi.stubGlobal("document", {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    });
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+
+    const initialStatus = testStatus();
+    initialStatus.models.splice(1, 0, {
+      name: "pro-only:cloud",
+      displayName: "pro-only:cloud",
+      cloud: true,
+      selected: false,
+      availability: "unavailable",
+      reason: "upgrade_required",
+    });
+
+    let renderer: ReactTestRenderer | undefined;
+    try {
+      await act(async () => {
+        renderer = create(
+          <ClaudeDesktopModelsSettings
+            initialLocalModels={[]}
+            initialStatus={initialStatus}
+          />,
+          {
+            createNodeMock: (element) =>
+              element.type === "input"
+                ? { focus }
+                : element.type === "button" && element.props.role === "option"
+                  ? { scrollIntoView }
+                  : null,
+          },
+        );
+        await Promise.resolve();
+      });
+      await act(async () => {
+        pickerButton(renderer!).props.onClick();
+        await Promise.resolve();
+      });
+
+      const search = () =>
+        renderer!.root.findByProps({
+          "aria-label": "Find model for Fable 5",
+        });
+      const preventDefault = vi.fn();
+      expect(search().props.role).toBe("combobox");
+      expect(search().props["aria-controls"]).toBe(
+        "claude-route-claude-fable-5-listbox",
+      );
+      expect(search().props["aria-activedescendant"]).toBe(
+        "claude-route-claude-fable-5-listbox-option-0",
+      );
+
+      await act(async () => {
+        search().props.onKeyDown({ key: "ArrowDown", preventDefault });
+      });
+      expect(search().props["aria-activedescendant"]).toBe(
+        "claude-route-claude-fable-5-listbox-option-2",
+      );
+      expect(scrollIntoView).toHaveBeenCalledWith({ block: "nearest" });
+
+      await act(async () => {
+        search().props.onKeyDown({ key: "ArrowUp", preventDefault });
+      });
+      expect(search().props["aria-activedescendant"]).toBe(
+        "claude-route-claude-fable-5-listbox-option-0",
+      );
+
+      await act(async () => {
+        search().props.onKeyDown({ key: "ArrowDown", preventDefault });
+      });
+      await act(async () => {
+        search().props.onKeyDown({ key: "Enter", preventDefault });
+        await Promise.resolve();
+      });
+      expect(
+        pickerButton(renderer!).findAllByType("span")[0].children.join(""),
+      ).toBe("kimi-k3:cloud");
+      expect(
+        renderer!.root.findAllByProps({
+          "aria-label": "Find model for Fable 5",
+        }),
+      ).toHaveLength(0);
+      expect(preventDefault).toHaveBeenCalledTimes(4);
+    } finally {
+      await act(async () => {
+        renderer?.unmount();
+        await Promise.resolve();
+      });
+      vi.unstubAllGlobals();
+    }
+  });
+
   it("opens below without scrolling and disables auto mode for draft changes", async () => {
     class TestHTMLElement {
       focus() {}

--- a/app/ui/app/src/components/ClaudeDesktopModelsSettings.tsx
+++ b/app/ui/app/src/components/ClaudeDesktopModelsSettings.tsx
@@ -20,6 +20,7 @@ import {
 import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import {
   forwardRef,
+  type KeyboardEvent,
   useCallback,
   useEffect,
   useImperativeHandle,
@@ -169,6 +170,7 @@ function ClaudeModelPicker({
       >
         {({ close }) => (
           <ClaudeModelPickerOptions
+            id={id}
             routeName={routeName}
             value={value}
             models={models}
@@ -184,24 +186,69 @@ function ClaudeModelPicker({
 }
 
 function ClaudeModelPickerOptions({
+  id,
   routeName,
   value,
   models,
   onChange,
 }: Pick<
   ClaudeModelPickerProps,
-  "routeName" | "value" | "models" | "onChange"
+  "id" | "routeName" | "value" | "models" | "onChange"
 >) {
   const [query, setQuery] = useState("");
+  const [highlightedModel, setHighlightedModel] = useState(() => {
+    const selected = models.find(
+      (model) => model.name === value && modelIsAvailable(model),
+    );
+    return selected?.name ?? models.find(modelIsAvailable)?.name ?? "";
+  });
   const searchRef = useRef<HTMLInputElement>(null);
+  const optionRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+  const listboxId = `${id}-listbox`;
   const normalizedQuery = query.trim().toLowerCase();
   const filteredModels = models.filter((model) =>
     model.displayName.toLowerCase().includes(normalizedQuery),
   );
+  const availableModels = filteredModels.filter(modelIsAvailable);
+  const highlightedIndex = filteredModels.findIndex(
+    (model) => model.name === highlightedModel && modelIsAvailable(model),
+  );
+  const activeOptionId =
+    highlightedIndex >= 0
+      ? `${listboxId}-option-${highlightedIndex}`
+      : undefined;
 
   useEffect(() => {
     searchRef.current?.focus({ preventScroll: true });
   }, []);
+
+  const highlight = (model: ClaudeDesktopModelStatus) => {
+    setHighlightedModel(model.name);
+    optionRefs.current[model.name]?.scrollIntoView({ block: "nearest" });
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (availableModels.length === 0) return;
+
+    const currentIndex = availableModels.findIndex(
+      (model) => model.name === highlightedModel,
+    );
+    if (event.key === "ArrowDown") {
+      event.preventDefault();
+      highlight(availableModels[(currentIndex + 1) % availableModels.length]);
+    } else if (event.key === "ArrowUp") {
+      event.preventDefault();
+      const previous =
+        currentIndex < 0
+          ? availableModels.length - 1
+          : (currentIndex - 1 + availableModels.length) %
+            availableModels.length;
+      highlight(availableModels[previous]);
+    } else if (event.key === "Enter" && currentIndex >= 0) {
+      event.preventDefault();
+      onChange(availableModels[currentIndex].name);
+    }
+  };
 
   return (
     <>
@@ -210,29 +257,49 @@ function ClaudeModelPickerOptions({
         <input
           ref={searchRef}
           type="text"
+          role="combobox"
           value={query}
           onChange={(event) => setQuery(event.target.value)}
+          onKeyDown={handleKeyDown}
           placeholder="Find model..."
           aria-label={`Find model for ${routeName}`}
+          aria-autocomplete="list"
+          aria-expanded="true"
+          aria-controls={listboxId}
+          aria-activedescendant={activeOptionId}
           autoCorrect="off"
           autoComplete="off"
           className="min-w-0 flex-1 border-none bg-transparent py-0.5 outline-none"
         />
       </div>
-      <div role="listbox" className="min-h-0 overflow-y-auto py-1">
-        {filteredModels.map((model) => {
+      <div
+        id={listboxId}
+        role="listbox"
+        aria-label={`Ollama models for ${routeName}`}
+        className="min-h-0 overflow-y-auto py-1"
+      >
+        {filteredModels.map((model, index) => {
           const available = modelIsAvailable(model);
           const statusLabel = claudeDesktopModelStatusLabel(model);
           const selected = value === model.name;
+          const highlighted = highlightedModel === model.name && available;
           return (
             <button
               key={model.name}
+              ref={(node) => {
+                optionRefs.current[model.name] = node;
+              }}
+              id={`${listboxId}-option-${index}`}
               type="button"
               role="option"
+              tabIndex={-1}
               aria-selected={selected}
               disabled={!available}
               onClick={() => onChange(model.name)}
-              className="flex w-full cursor-pointer items-start gap-2 px-3 py-2 text-left hover:bg-neutral-100 focus:bg-neutral-100 focus:outline-none disabled:cursor-not-allowed disabled:opacity-45 dark:hover:bg-neutral-700/60 dark:focus:bg-neutral-700/60"
+              onMouseEnter={() => available && setHighlightedModel(model.name)}
+              className={`flex w-full cursor-pointer items-start gap-2 px-3 py-2 text-left hover:bg-neutral-100 focus:bg-neutral-100 focus:outline-none disabled:cursor-not-allowed disabled:opacity-45 dark:hover:bg-neutral-700/60 dark:focus:bg-neutral-700/60 ${
+                highlighted ? "bg-neutral-100 dark:bg-neutral-700/60" : ""
+              }`}
             >
               <span className="mt-0.5 h-4 w-4 flex-shrink-0">
                 {selected && <CheckIcon className="h-4 w-4" />}
@@ -636,7 +703,7 @@ export const ClaudeDesktopModelsSettings = forwardRef<
               {mappings.map((mapping) => (
                 <div
                   key={mapping.routeId}
-                  className="relative grid min-h-12 grid-cols-[5.5rem_3.75rem_minmax(0,1fr)] items-center gap-2 py-1 max-sm:grid-cols-1 max-sm:gap-2"
+                  className="grid min-h-12 grid-cols-[5.5rem_3.75rem_minmax(0,1fr)] items-center gap-2 py-1 max-sm:grid-cols-1 max-sm:gap-2"
                 >
                   <div className="min-w-0">
                     <span className="block text-sm font-medium text-neutral-800 dark:text-neutral-200">
@@ -645,7 +712,7 @@ export const ClaudeDesktopModelsSettings = forwardRef<
                   </div>
                   <ArrowRightIcon
                     aria-hidden="true"
-                    className="absolute left-[6.6625rem] h-4 w-4 -translate-x-1/2 text-neutral-300 dark:text-neutral-500 max-sm:hidden"
+                    className="col-start-2 h-4 w-4 justify-self-center text-neutral-300 dark:text-neutral-500 max-sm:hidden"
                   />
                   <div className="col-start-3 w-2/3 min-w-0 max-sm:col-start-auto max-sm:w-full">
                     <ClaudeModelPicker

--- a/app/ui/app/src/components/Settings.interaction.test.tsx
+++ b/app/ui/app/src/components/Settings.interaction.test.tsx
@@ -34,7 +34,12 @@ vi.mock("@/components/ClaudeDesktopModelsSettings", () => ({
 
 vi.mock("@/hooks/useUser", () => ({
   useUser: () => ({
-    user: { name: "Paid user", email: "paid@example.com", plan: "pro" },
+    user: {
+      name: "Paid user",
+      email: "paid@example.com",
+      plan: "pro",
+      avatarurl: "https://example.com/avatar.png",
+    },
     isAuthenticated: true,
     refreshUser: vi.fn(),
     isRefreshing: false,
@@ -139,7 +144,7 @@ function deferred<T>() {
   return { promise, resolve };
 }
 
-describe("Settings reset interactions", () => {
+describe("Settings interactions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.isWindows = false;
@@ -163,6 +168,26 @@ describe("Settings reset interactions", () => {
       OLLAMA_TOOLS: false,
     });
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  });
+
+  it("top-aligns the account avatar with the identity block", async () => {
+    let renderer;
+    try {
+      await act(async () => {
+        renderer = create(<Settings />);
+        await Promise.resolve();
+      });
+
+      const avatar = renderer!.root.findByProps({ alt: "Paid user" });
+      expect(avatar.parent?.props.className).toContain("items-start");
+      expect(avatar.parent?.props.className).not.toContain("items-center");
+    } finally {
+      await act(async () => {
+        renderer?.unmount();
+        await Promise.resolve();
+      });
+      vi.unstubAllGlobals();
+    }
   });
 
   it("locks every control and shows Saved after reset succeeds", async () => {

--- a/app/ui/app/src/components/Settings.tsx
+++ b/app/ui/app/src/components/Settings.tsx
@@ -485,7 +485,7 @@ export default function Settings() {
                     <div className="h-10 w-10 bg-neutral-200 dark:bg-neutral-700 rounded-full animate-pulse"></div>
                   </div>
                 ) : user && user.name ? (
-                  <div className="flex items-center justify-between">
+                  <div className="flex items-start justify-between">
                     <div>
                       <div className="flex items-center space-x-2">
                         <Label className="text-sm font-medium text-neutral-900 dark:text-white">

--- a/app/ui/app/src/components/layout/layout.test.tsx
+++ b/app/ui/app/src/components/layout/layout.test.tsx
@@ -17,7 +17,20 @@ describe("SidebarLayout", () => {
     );
 
     expect(html).toContain("pl-36");
+    expect(html).toContain("translate-y-px");
     expect(html).toContain("transition-[padding-left]");
     expect(html).toContain("duration-300");
+  });
+
+  it("keeps the titlebar control adjustment specific to macOS", () => {
+    vi.stubGlobal("window", { OLLAMA_PLATFORM: "windows" });
+
+    const html = renderToStaticMarkup(
+      <SidebarLayout title="Settings" sidebar={<nav />}>
+        <div />
+      </SidebarLayout>,
+    );
+
+    expect(html).not.toContain("translate-y-px");
   });
 });

--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -24,7 +24,7 @@ export function SidebarLayout({
   return (
     <div className="flex h-screen w-full overflow-hidden dark:bg-neutral-900">
       <div
-        className={`absolute flex mx-2 py-2 z-20 items-center transition-[left] duration-375 text-neutral-500 dark:text-neutral-400 ${sidebarOpen ? (isWindows ? "left-2" : "left-[140px]") : isWindows ? "left-2" : "left-20"}`}
+        className={`absolute flex mx-2 py-2 z-20 items-center transition-[left] duration-375 text-neutral-500 dark:text-neutral-400 ${isWindows ? "" : "translate-y-px"} ${sidebarOpen ? (isWindows ? "left-2" : "left-[140px]") : isWindows ? "left-2" : "left-20"}`}
       >
         <button
           onClick={toggleSidebar}


### PR DESCRIPTION
## Summary

- add accessible keyboard navigation to the Claude Settings model picker, including unavailable-option skipping and active-option semantics
- align the Claude route arrows and the macOS sidebar controls
- top-align the signed-in account avatar with the profile identity block
- add focused interaction and layout regression tests

## Testing

- npm test -- --run (109 tests)
- npm run build
- targeted ESLint and Prettier checks