### PR TITLE
docs: fix macOS casing

### DIFF
--- a/docs/macos.mdx
+++ b/docs/macos.mdx
@@ -4,7 +4,7 @@ title: macOS
 
 ## System Requirements
 
-* MacOS Sonoma (v14) or newer
+* macOS Sonoma (v14) or newer
 * Apple M series (CPU and GPU support) or x86 (CPU only)
 
 
@@ -21,7 +21,7 @@ To install the Ollama application somewhere other than `Applications`, place the
 
 ## Troubleshooting
 
-Ollama on MacOS stores files in a few different locations.
+Ollama on macOS stores files in a few different locations.
 - `~/.ollama` contains models and configuration
 - `~/.ollama/logs` contains logs
     - *app.log* contains most recent logs from the GUI application


### PR DESCRIPTION
Fix proper casing: MacOS -> macOS.
