### PR TITLE
docs: fix grammar in troubleshooting guide

### DIFF
--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -43,7 +43,7 @@ Join the [Discord](https://discord.gg/ollama) for help interpreting the logs.
 
 ## LLM libraries
 
-Ollama includes multiple LLM libraries compiled for different GPUs and CPU vector features. Ollama tries to pick the best one based on the capabilities of your system. If this autodetection has problems, or you run into other problems (e.g. crashes in your GPU) you can workaround this by forcing a specific LLM library. `cpu_avx2` will perform the best, followed by `cpu_avx` an the slowest but most compatible is `cpu`. Rosetta emulation under MacOS will work with the `cpu` library.
+Ollama includes multiple LLM libraries compiled for different GPUs and CPU vector features. Ollama tries to pick the best one based on the capabilities of your system. If this autodetection has problems, or you run into other problems (e.g., crashes in your GPU) you can work around this by forcing a specific LLM library. `cpu_avx2` will perform the best, followed by `cpu_avx` and the slowest but most compatible is `cpu`. Rosetta emulation under macOS will work with the `cpu` library.
 
 In the server log, you will see a message that looks something like this (varies from release to release):
 


### PR DESCRIPTION
Fix grammar and typos: workaround -> work around, an the -> and the, MacOS -> macOS, e.g. -> e.g.,
