### PR TITLE
docs: remove trailing spaces in context-length guide

### DIFF
--- a/docs/context-length.mdx
+++ b/docs/context-length.mdx
@@ -2,7 +2,7 @@
 title: Context length
 ---
 
-Context length is the maximum number of tokens that the model has access to in memory.  
+Context length is the maximum number of tokens that the model has access to in memory.
 
 <Note>
   Ollama defaults to the following context lengths based on VRAM:
@@ -25,7 +25,7 @@ Change the slider in the Ollama app under settings to your desired context lengt
 ![Context length in Ollama app](./images/ollama-settings.png)
 
 ### CLI
-If editing the context length for Ollama is not possible, the context length can also be updated when serving Ollama.  
+If editing the context length for Ollama is not possible, the context length can also be updated when serving Ollama.
 ```
 OLLAMA_CONTEXT_LENGTH=64000 ollama serve
 ```


### PR DESCRIPTION
Remove trailing double spaces (unintended Markdown hard breaks).
