### PR TITLE
docs: fix spelling in API introduction

### DIFF
--- a/docs/api/introduction.mdx
+++ b/docs/api/introduction.mdx
@@ -44,4 +44,4 @@ Several community-maintained libraries are available for Ollama. For a full list
 
 ## Versioning
 
-Ollama's API isn't strictly versioned, but the API is expected to be stable and backwards compatible. Deprecations are rare and will be announced in the [release notes](https://github.com/ollama/ollama/releases).
+Ollama's API isn't strictly versioned, but the API is expected to be stable and backward compatible. Deprecations are rare and will be announced in the [release notes](https://github.com/ollama/ollama/releases).


### PR DESCRIPTION
Use American spelling: backwards -> backward.