### PR TITLE
llm: use direct I/O for integrated Vulkan GPUs, matching CUDA/ROCm

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -622,11 +622,17 @@ func appendFlashAttentionArgs(params []string, gpus []ml.DeviceInfo) []string {
 }
 
 // appendLoadModeArgs selects llama-server's single model loading mode. Direct I/O
-// skips the page cache on load for integrated CUDA/ROCm GPUs, which share system
-// memory with the CPU and would otherwise double-buffer weights.
+// skips the page cache on load for integrated CUDA/ROCm/Vulkan GPUs, which share
+// system memory with the CPU and would otherwise double-buffer weights.
+//
+// This also keeps load time bounded on integrated Vulkan devices that report no
+// mmap support (e.g. Virtio-GPU/Venus): llama.cpp's default "auto" load mode
+// silently falls back from mmap to an unbuffered read in that case, which is
+// dramatically slower on virtualized storage and can exceed OLLAMA_LOAD_TIMEOUT
+// well before the model finishes loading. See #18123.
 func appendLoadModeArgs(params []string, opts api.Options, gpus []ml.DeviceInfo) []string {
 	for _, g := range gpus {
-		if runtime.GOOS == "linux" && g.Integrated && (strings.EqualFold(g.Library, "CUDA") || strings.EqualFold(g.Library, "ROCm")) {
+		if runtime.GOOS == "linux" && g.Integrated && (strings.EqualFold(g.Library, "CUDA") || strings.EqualFold(g.Library, "ROCm") || strings.EqualFold(g.Library, "Vulkan")) {
 			return append(params, "--load-mode", "dio")
 		}
 	}

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -2070,7 +2070,9 @@ func TestAppendLoadModeArgs(t *testing.T) {
 
 	integratedCUDA := []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}, Integrated: true}}
 	integratedROCm := []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "rocm"}, Integrated: true}}
+	integratedVulkan := []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Vulkan"}, Integrated: true}}
 	discreteCUDA := []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "CUDA"}}}
+	discreteVulkan := []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Vulkan"}}}
 	integratedMetal := []ml.DeviceInfo{{DeviceID: ml.DeviceID{Library: "Metal"}, Integrated: true}}
 
 	// Direct I/O is only selected on Linux, so the expectation depends on the host.
@@ -2118,6 +2120,17 @@ func TestAppendLoadModeArgs(t *testing.T) {
 			want: dio,
 		},
 		{
+			// Regression test for #18123: llama.cpp's "auto" load mode falls back
+			// from mmap to an unbuffered read on any device that reports no mmap
+			// support (integrated Vulkan GPUs, e.g. Virtio-GPU/Venus, always do).
+			// That fallback is dramatically slower on virtualized storage and can
+			// blow past OLLAMA_LOAD_TIMEOUT. Direct I/O keeps load time bounded.
+			name: "integrated vulkan selects dio",
+			opts: api.DefaultOptions(),
+			gpus: integratedVulkan,
+			want: dio,
+		},
+		{
 			name: "integrated metal does not select dio",
 			opts: api.DefaultOptions(),
 			gpus: integratedMetal,
@@ -2127,6 +2140,12 @@ func TestAppendLoadModeArgs(t *testing.T) {
 			name: "discrete cuda does not select dio",
 			opts: api.DefaultOptions(),
 			gpus: discreteCUDA,
+			want: []string{"base"},
+		},
+		{
+			name: "discrete vulkan does not select dio",
+			opts: api.DefaultOptions(),
+			gpus: discreteVulkan,
 			want: []string{"base"},
 		},
 		{


### PR DESCRIPTION
## Summary

Fixes #18123. Model loads on integrated Vulkan GPUs (e.g. Virtio-GPU/Venus in a VM) regressed between 0.32.9 and 0.32.10, eventually timing out with "timed out waiting for llama-server to start" even though llama-server was still alive and loading.

**Root cause:** the llama.cpp bump in #17702 (`b10353` -> `b10380`) picked up an upstream change that makes `auto` the default model load mode. That mode disables mmap for any device whose backend reports no mmap support, and the Vulkan backend reports exactly that for every integrated GPU (`mmap_support = !is_integrated_gpu` in `ggml-vulkan.cpp`). So integrated-Vulkan loads silently fall back from `mmap` to an unbuffered read, which is dramatically slower — confirmed directly from the reporter's own before/after logs loading the identical model on identical hardware: `load_mode = mmap` at 1.76s in 0.32.9 vs. `load_mode = none` at 98.95s in 0.32.10, a ~56x slowdown for a small model. For the actual failing (larger) model this pushes load time past `OLLAMA_LOAD_TIMEOUT`.

This is the same class of problem #17545 already fixed for integrated CUDA/ROCm GPUs, by forcing `--load-mode dio` instead of relying on llama-server's default. Vulkan was never added to that condition — this PR adds it.

- `llm/llama_server.go`: extend `appendLoadModeArgs`'s integrated-GPU direct-I/O case to include Vulkan.
- `llm/llama_server_test.go`: add `"integrated vulkan selects dio"` (regression case for #18123) and `"discrete vulkan does not select dio"` (guards against over-broadening) to `TestAppendLoadModeArgs`.

## Test plan

- [x] `go test ./llm/ -run TestAppendLoadModeArgs -v` — all subtests pass, including the two new ones
- [x] Confirmed the new "integrated vulkan selects dio" case fails against the pre-fix code and passes after the fix
- [x] `go test ./llm/...` — full package passes
- [x] `gofmt -l` / `go vet ./llm/...` — clean
- [ ] Not reproduced end-to-end against real Virtio-GPU/Venus hardware or an actual Gemma4 load (not available in this environment) — root cause instead established via the tag-to-tag llama.cpp diff plus the reporter's own logs, both cited above