### PR TITLE
fs/gguf: honor general.alignment declared as uint32

### DIFF
--- a/fs/gguf/gguf.go
+++ b/fs/gguf/gguf.go
@@ -84,7 +84,7 @@ func Open(path string) (f *File, err error) {
 	f.tensors.successFunc = func() error {
 		offset := f.reader.offset
 
-		alignment := cmp.Or(f.KeyValue("general.alignment").Int(), 32)
+		alignment := int64(cmp.Or(f.KeyValue("general.alignment").Uint(), 32))
 		if alignment <= 0 {
 			return fmt.Errorf("%w alignment %d", ErrUnsupported, alignment)
 		}

--- a/fs/gguf/gguf_test.go
+++ b/fs/gguf/gguf_test.go
@@ -2,6 +2,7 @@ package gguf_test
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"strconv"
 	"strings"
@@ -223,6 +224,88 @@ func TestRead(t *testing.T) {
 
 	if b.Len() != int(ti.NumBytes()) {
 		t.Errorf(`ReadFrom TensorReader("output.weight") length = %d, want %d`, b.Len(), ti.NumBytes())
+	}
+}
+
+func createAlignedBinFile(tb testing.TB, alignment uint32, filler int) (string, [][]byte) {
+	tb.Helper()
+	f, err := os.CreateTemp(tb.TempDir(), "")
+	if err != nil {
+		tb.Fatal(err)
+	}
+	defer f.Close()
+
+	kv := ggml.KV{
+		"general.architecture": "llama",
+		// filler varies where the metadata section ends so that the tensor data
+		// starts on a boundary that is aligned for alignment but not for 32
+		"llama.filler": strings.Repeat("x", filler),
+	}
+	if alignment != 0 {
+		kv["general.alignment"] = alignment
+	}
+
+	want := [][]byte{
+		bytes.Repeat([]byte{0xAA}, 16),
+		bytes.Repeat([]byte{0xBB}, 16),
+		bytes.Repeat([]byte{0xCC}, 16),
+	}
+	tensors := make([]*ggml.Tensor, len(want))
+	for i, data := range want {
+		tensors[i] = &ggml.Tensor{
+			Name:     string(rune('a'+i)) + ".weight",
+			Kind:     0,
+			Shape:    []uint64{4},
+			WriterTo: bytes.NewBuffer(data),
+		}
+	}
+
+	if err := ggml.WriteGGUF(f, kv, tensors); err != nil {
+		tb.Fatal(err)
+	}
+
+	return f.Name(), want
+}
+
+func TestReadAlignment(t *testing.T) {
+	cases := map[string]uint32{
+		"default": 0,
+		"16":      16,
+		"64":      64,
+	}
+
+	for name, alignment := range cases {
+		t.Run(name, func(t *testing.T) {
+			for filler := range 32 {
+				p, want := createAlignedBinFile(t, alignment, filler)
+
+				f, err := gguf.Open(p)
+				if err != nil {
+					t.Fatalf("filler %d: Open error: %v", filler, err)
+				}
+
+				for i, want := range want {
+					name := string(rune('a'+i)) + ".weight"
+					_, r, err := f.TensorReader(name)
+					if err != nil {
+						t.Errorf("filler %d: TensorReader(%q) error: %v", filler, name, err)
+						continue
+					}
+
+					got, err := io.ReadAll(r)
+					if err != nil {
+						t.Errorf("filler %d: ReadAll TensorReader(%q) error: %v", filler, name, err)
+						continue
+					}
+
+					if !bytes.Equal(got, want) {
+						t.Errorf("filler %d: TensorReader(%q) = %x, want %x", filler, name, got, want)
+					}
+				}
+
+				f.Close()
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
`fs/gguf` reads `general.alignment` with `Value.Int()`. The GGUF spec declares that key as `uint32`, and `Value.Int()` only accepts signed reflect kinds, so it returns 0 for every conforming file and the alignment silently falls back to 32.

The sibling parser gets this right: `fs/ggml/gguf.go:253` uses `kv.Uint("general.alignment", 32)`, and `WriteGGUF` pads with `kv.Uint` too. So the two GGUF parsers in this repo disagree about where tensor data starts in the same file, and files this repo writes are misread by one of them.

It bites when the metadata section ends on a boundary that is aligned for the declared alignment but not for 32. The data offset gets rounded up and every tensor is read from the wrong place. With `general.alignment=16` and three 16-byte tensors, `TensorReader("a.weight")` hands back b's bytes and `TensorReader("b.weight")` hands back c's, no error raised. Other layouts fail with `offset+size exceeds file size` instead.

The oracle is the spec plus `fs/ggml` on the same bytes. The test writes files with `ggml.WriteGGUF` and reads every tensor back, sweeping 32 metadata sizes across alignment 16, 64, and the default. 119 assertions fail before the fix and pass after. `go test -race ./fs/...` and `./server/...` pass, `go vet` is clean.

Not covered: an alignment that is not a power of two, and a declared alignment of 0 is rejected rather than defaulted, matching `fs/ggml`.

I used Claude to help find this and write the test.
