### PR TITLE
docs: fix typo nothink -> nothing

### DIFF
--- a/docs/capabilities/thinking.mdx
+++ b/docs/capabilities/thinking.mdx
@@ -147,7 +147,7 @@ Thinking streams interleave reasoning tokens before answer tokens. Detect the fi
 - Enable thinking for a single run: `ollama run deepseek-r1 --think "Where should I visit in Lisbon?"`
 - Disable thinking: `ollama run deepseek-r1 --think=false "Summarize this article"`
 - Hide the trace while still using a thinking model: `ollama run deepseek-r1 --hidethinking "Is 9.9 bigger or 9.11?"`
-- Inside interactive sessions, toggle with `/set think` or `/set nothink`.
+- Inside interactive sessions, toggle with `/set think` or `/set nothing`.
 - GPT-OSS only accepts levels: `ollama run gpt-oss --think=low "Draft a headline"` (replace `low` with `medium` or `high` as needed).
 
 <Note>Thinking is enabled by default in the CLI and API for supported models.</Note>

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,7 @@ go run . serve
 ```
 
 > [!NOTE]
-> Ollama includes native code compiled with CGO.  From time to time these data structures can change and CGO can get out of sync resulting in unexpected crashes.  You can force a full build of the native code by running `go clean -cache` first. 
+> Ollama includes native code compiled with CGO. From time to time these data structures can change and CGO can get out of sync resulting in unexpected crashes. You can force a full build of the native code by running `go clean -cache` first.
 
 ## Native build model
 


### PR DESCRIPTION
Fix typo at docs/capabilities/thinking.mdx:150 nothink -> nothing