### PR TITLE
docs: fix typo whats -> what's

### DIFF
--- a/docs/capabilities/vision.mdx
+++ b/docs/capabilities/vision.mdx
@@ -7,7 +7,7 @@ Vision models accept images alongside text so the model can describe, classify, 
 ## Quick start
 
 ```shell
-ollama run gemma4 ./image.png whats in this image?
+ollama run gemma4 ./image.png what's in this image?
 ```
 
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,7 +14,7 @@ go run . serve
 ```
 
 > [!NOTE]
-> Ollama includes native code compiled with CGO.  From time to time these data structures can change and CGO can get out of sync resulting in unexpected crashes.  You can force a full build of the native code by running `go clean -cache` first. 
+> Ollama includes native code compiled with CGO. From time to time these data structures can change and CGO can get out of sync resulting in unexpected crashes. You can force a full build of the native code by running `go clean -cache` first.
 
 ## Native build model
 


### PR DESCRIPTION
Fix typo at docs/capabilities/vision.mdx:10 whats -> what's