### PR TITLE
app/ui: preserve unsent draft message when switching chats

### DIFF
--- a/app/ui/app/src/components/ChatForm.interaction.test.tsx
+++ b/app/ui/app/src/components/ChatForm.interaction.test.tsx
@@ -1,0 +1,269 @@
+import { act, create } from "react-test-renderer";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import ChatForm from "./ChatForm";
+
+const mocks = vi.hoisted(() => {
+  const draftStore = new Map<string, unknown>();
+  return {
+    draftStore,
+    queryClient: {
+      getQueryData: (key: unknown[]) => draftStore.get(JSON.stringify(key)),
+      setQueryData: (key: unknown[], value: unknown) =>
+        draftStore.set(JSON.stringify(key), value),
+      cancelQueries: vi.fn().mockResolvedValue(undefined),
+      invalidateQueries: vi.fn(),
+    },
+    onSubmit: vi.fn(),
+    sendMessageMutate: vi.fn(),
+  };
+});
+
+vi.mock("@tanstack/react-query", () => ({
+  useQueryClient: () => mocks.queryClient,
+  useMutation: () => ({ mutate: mocks.sendMessageMutate }),
+}));
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => vi.fn(),
+}));
+
+vi.mock("@/hooks/useChats", () => ({
+  useSendMessage: () => ({ mutate: mocks.sendMessageMutate }),
+  useIsStreaming: () => false,
+  useCancelMessage: () => vi.fn(),
+}));
+
+vi.mock("@/hooks/useSelectedModel", () => ({
+  useSelectedModel: () => ({
+    selectedModel: { model: "llama3", isCloud: () => false },
+  }),
+}));
+
+vi.mock("@/hooks/useModelCapabilities", () => ({
+  useHasVisionCapability: () => false,
+  useHasToolsCapability: () => false,
+}));
+
+vi.mock("@/hooks/useUser", () => ({
+  useUser: () => ({ isAuthenticated: true, isLoading: false }),
+}));
+
+vi.mock("@/hooks/useSettings", () => ({
+  useSettings: () => ({
+    settings: {
+      webSearchEnabled: false,
+      thinkEnabled: false,
+      thinkLevel: "medium",
+    },
+    setSettings: vi.fn(),
+  }),
+}));
+
+vi.mock("@/hooks/useCloudStatus", () => ({
+  useCloudStatus: () => ({ cloudDisabled: false }),
+}));
+
+vi.mock("@/utils/fileValidation", () => ({
+  processFiles: vi.fn(async (files: unknown[]) => ({
+    validFiles: files,
+    errors: [],
+  })),
+}));
+
+vi.mock("@/utils/imageUtils", () => ({
+  isImageFile: () => false,
+}));
+
+vi.mock("@/gotypes", () => ({
+  ErrorEvent: class {
+    opts: Record<string, unknown>;
+    constructor(opts: Record<string, unknown>) {
+      this.opts = opts;
+    }
+  },
+  Message: class {},
+}));
+
+vi.mock("@/components/Logo", () => ({ default: () => null }));
+vi.mock("@/components/ModelPicker", () => ({
+  ModelPicker: () => null,
+}));
+vi.mock("@/components/WebSearchButton", () => ({
+  WebSearchButton: () => null,
+}));
+vi.mock("@/components/ImageThumbnail", () => ({
+  ImageThumbnail: () => null,
+}));
+vi.mock("./ThinkButton", () => ({ ThinkButton: () => null }));
+vi.mock("./ErrorMessage", () => ({ ErrorMessage: () => null }));
+vi.mock("@/components/DisplayLogin", () => ({
+  DisplayLogin: () => null,
+}));
+
+const stubGlobals = () => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.stubGlobal("window", {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    setTimeout: globalThis.setTimeout.bind(globalThis),
+    clearTimeout: globalThis.clearTimeout.bind(globalThis),
+  });
+  vi.stubGlobal("document", {
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+  });
+};
+
+const typeInto = async (
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  renderer: any,
+  value: string,
+) => {
+  const textarea = renderer.root.findByType("textarea");
+  await act(async () => {
+    textarea.props.onChange({
+      target: { value, style: {} as CSSStyleDeclaration },
+    });
+  });
+};
+
+describe("ChatForm draft persistence", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.draftStore.clear();
+    stubGlobals();
+  });
+
+  it("restores a typed draft after unmounting and remounting for the same chat", async () => {
+    let renderer: ReturnType<typeof create> | undefined;
+    try {
+      await act(async () => {
+        renderer = create(
+          <ChatForm
+            hasMessages={true}
+            chatId="chat-a"
+            onSubmit={mocks.onSubmit}
+          />,
+        );
+      });
+
+      await typeInto(renderer, "hello from chat A");
+      await act(async () => {
+        renderer!.unmount();
+      });
+
+      let restored: ReturnType<typeof create> | undefined;
+      await act(async () => {
+        restored = create(
+          <ChatForm
+            hasMessages={true}
+            chatId="chat-a"
+            onSubmit={mocks.onSubmit}
+          />,
+        );
+      });
+
+      const textarea = restored!.root.findByType("textarea");
+      expect(textarea.props.value).toBe("hello from chat A");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("keeps separate drafts per chat when switching between chats", async () => {
+    let renderer: ReturnType<typeof create> | undefined;
+    try {
+      await act(async () => {
+        renderer = create(
+          <ChatForm
+            hasMessages={true}
+            chatId="chat-a"
+            onSubmit={mocks.onSubmit}
+          />,
+        );
+      });
+
+      await typeInto(renderer, "draft for A");
+
+      await act(async () => {
+        renderer!.update(
+          <ChatForm
+            hasMessages={true}
+            chatId="chat-b"
+            onSubmit={mocks.onSubmit}
+          />,
+        );
+      });
+
+      // Chat B has no draft yet
+      expect(renderer!.root.findByType("textarea").props.value).toBe("");
+
+      // Switch back to chat A: the draft should still be there
+      await act(async () => {
+        renderer!.update(
+          <ChatForm
+            hasMessages={true}
+            chatId="chat-a"
+            onSubmit={mocks.onSubmit}
+          />,
+        );
+      });
+
+      expect(renderer!.root.findByType("textarea").props.value).toBe(
+        "draft for A",
+      );
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("clears the saved draft after the message is submitted", async () => {
+    let renderer: ReturnType<typeof create> | undefined;
+    try {
+      await act(async () => {
+        renderer = create(
+          <ChatForm
+            hasMessages={true}
+            chatId="chat-a"
+            onSubmit={mocks.onSubmit}
+          />,
+        );
+      });
+
+      await typeInto(renderer, "to be sent");
+
+      const textarea = renderer!.root.findByType("textarea");
+      await act(async () => {
+        textarea.props.onKeyDown({
+          key: "Enter",
+          shiftKey: false,
+          preventDefault: vi.fn(),
+        });
+      });
+
+      expect(mocks.onSubmit).toHaveBeenCalledWith(
+        "to be sent",
+        expect.any(Object),
+      );
+      expect(renderer!.root.findByType("textarea").props.value).toBe("");
+
+      // Remount: the draft must not come back
+      await act(async () => {
+        renderer!.unmount();
+      });
+      let remounted: ReturnType<typeof create> | undefined;
+      await act(async () => {
+        remounted = create(
+          <ChatForm
+            hasMessages={true}
+            chatId="chat-a"
+            onSubmit={mocks.onSubmit}
+          />,
+        );
+      });
+      expect(remounted!.root.findByType("textarea").props.value).toBe("");
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+});

--- a/app/ui/app/src/components/ChatForm.tsx
+++ b/app/ui/app/src/components/ChatForm.tsx
@@ -16,6 +16,7 @@ import {
   useCancelMessage,
 } from "@/hooks/useChats";
 import { useNavigate } from "@tanstack/react-router";
+import { useQueryClient } from "@tanstack/react-query";
 import { useSelectedModel } from "@/hooks/useSelectedModel";
 import {
   useHasVisionCapability,
@@ -92,12 +93,21 @@ function ChatForm({
   onCancelEdit,
   onFilesReceived,
 }: ChatFormProps) {
-  const [message, setMessage] = useState<MessageInput>({
-    content: "",
+  const queryClient = useQueryClient();
+  const getChatDraft = useCallback(
+    (id: string) => queryClient.getQueryData<string>(["chatDraft", id]) ?? "",
+    [queryClient],
+  );
+  const [message, setMessage] = useState<MessageInput>(() => ({
+    content: queryClient.getQueryData<string>(["chatDraft", chatId]) ?? "",
     attachments: [],
     fileErrors: [],
-  });
+  }));
   const [isEditing, setIsEditing] = useState<boolean>(false);
+  const prevDraftChatIdRef = useRef(chatId);
+  const hadEditingMessageRef = useRef(false);
+  // Captured at mount so the caret can be moved to the end after a restored draft
+  const restoredDraftAtMountRef = useRef(getChatDraft(chatId));
   const compositionEndTimeoutRef = useRef<number | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -270,6 +280,37 @@ function ChatForm({
     }
   };
 
+  // Move the caret to the end of the textarea (used after restoring a draft)
+  const moveCaretToEnd = useCallback(() => {
+    if (textareaRef.current) {
+      const position = textareaRef.current.value.length;
+      textareaRef.current.setSelectionRange(position, position);
+    }
+  }, []);
+
+  // Restore the saved draft for a chat (used when switching between chats)
+  const restoreChatDraft = useCallback(
+    (id: string) => {
+      const draft = getChatDraft(id);
+      setMessage({
+        content: draft,
+        attachments: [],
+        fileErrors: [],
+      });
+
+      // Reset textarea height to fit the restored draft
+      setTimeout(() => {
+        if (textareaRef.current) {
+          textareaRef.current.style.height = "auto";
+          textareaRef.current.style.height =
+            Math.min(textareaRef.current.scrollHeight, 24 * 8) + "px";
+          moveCaretToEnd();
+        }
+      }, 0);
+    },
+    [getChatDraft, moveCaretToEnd],
+  );
+
   // Clear loginPromptFeature when user becomes authenticated or no features are enabled
   useEffect(() => {
     if (
@@ -284,11 +325,21 @@ function ChatForm({
   // When entering edit mode, populate the composition with existing data
   useEffect(() => {
     if (!editingMessage) {
-      // Clear composition and reset textarea height when not editing
-      resetChatForm();
+      // Only reset when leaving edit mode (not on initial mount), preserving
+      // any restored draft; if the chat changed while editing, restore that
+      // chat's draft instead of clearing.
+      if (hadEditingMessageRef.current) {
+        hadEditingMessageRef.current = false;
+        if (prevDraftChatIdRef.current === chatId) {
+          resetChatForm();
+        } else {
+          restoreChatDraft(chatId);
+        }
+      }
       return;
     }
 
+    hadEditingMessageRef.current = true;
     const existingAttachments =
       editingMessage.originalMessage?.attachments || [];
     setMessage({
@@ -300,7 +351,7 @@ function ChatForm({
       })),
       fileErrors: [],
     });
-  }, [editingMessage]);
+  }, [editingMessage, chatId, restoreChatDraft]);
 
   // Focus and setup textarea when editing
   useLayoutEffect(() => {
@@ -314,10 +365,19 @@ function ChatForm({
     }
   }, [editingMessage]);
 
-  // Clear composition and reset textarea height when chatId changes
+  // Restore the saved draft when switching between chats instead of clearing it
   useEffect(() => {
-    resetChatForm();
-  }, [chatId]);
+    if (prevDraftChatIdRef.current === chatId) return;
+    prevDraftChatIdRef.current = chatId;
+    restoreChatDraft(chatId);
+  }, [chatId, restoreChatDraft]);
+
+  // On initial mount, if a saved draft was restored, place the caret at the end
+  useEffect(() => {
+    if (restoredDraftAtMountRef.current) {
+      moveCaretToEnd();
+    }
+  }, [moveCaretToEnd]);
 
   // Auto-focus textarea when autoFocus is true or when streaming completes (but not when editing)
   useEffect(() => {
@@ -531,6 +591,9 @@ function ChatForm({
       fileErrors: [],
     });
 
+    // Clear the saved draft for this chat after it was sent
+    queryClient.setQueryData(["chatDraft", chatId], "");
+
     // Reset textarea height and refocus after submit
     setTimeout(() => {
       if (textareaRef.current) {
@@ -628,6 +691,12 @@ function ChatForm({
   // Auto-resize textarea function
   const handleTextareaChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
     setMessage((prev) => ({ ...prev, content: e.target.value }));
+
+    // Persist the draft per chat so it survives switching between chats.
+    // Skip while editing an existing message so its text isn't saved as a draft.
+    if (!editingMessage) {
+      queryClient.setQueryData(["chatDraft", chatId], e.target.value);
+    }
 
     // Reset height to auto to get the correct scrollHeight, then cap at 8 lines
     e.target.style.height = "auto";


### PR DESCRIPTION
Fixes #18138

## Problem

An unsent draft in a chat's composer is lost when you navigate to another chat and back. `ChatForm` stored the draft only in local `useState` and reset it whenever `chatId` changed, and the chat view remounts `ChatForm` on navigation (`Chat.tsx` uses `key={chatId}`).

## Changes

Persist the draft **per chat** in the TanStack Query cache (already a project dependency — no new deps), keyed by `["chatDraft", chatId]`:

- `handleTextareaChange` saves the draft on every keystroke (skipped while editing an existing message).
- `ChatForm` restores the saved draft on mount and when switching chats, instead of clearing it.
- `handleSubmit` clears the saved draft after the message is sent, so it doesn't resurrect on return.
- Edit-mode interplay handled: canceling an edit keeps the pre-edit draft; switching chats while editing restores the new chat's draft.
- The textarea caret is placed at the end of the restored draft.

## Tests

Added `ChatForm.interaction.test.tsx` (follows the existing `*.interaction.test.tsx` pattern) covering:

1. Draft survives unmount → remount for the same chat.
2. Separate drafts are kept per chat when switching A → B → A.
3. Draft is cleared after submit and does not return.

All 3 pass (`npx vitest run src/components/ChatForm.interaction.test.tsx`), and `tsc -b` is clean.

## Notes

- Pre-existing `Onboarding.test.tsx` failures on `main` are unrelated to this change (verified on a pristine checkout) — not addressed here to keep the change scoped.
- Scope is in-memory (query cache) persistence for the app session, matching the reported bug; cross-restart persistence could be a follow-up via the Go `store` package if desired.