### PR TITLE
api: accept nested object required schemas

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -426,9 +426,21 @@ type ToolProperty struct {
 	Required    []string           `json:"required,omitempty"`
 }
 
+func unmarshalToolRequired(data []byte) ([]string, error) {
+	required := bytes.TrimSpace(data)
+	if len(required) == 0 || bytes.Equal(required, []byte("null")) || required[0] == '{' {
+		return nil, nil
+	}
+
+	var values []string
+	if err := json.Unmarshal(required, &values); err != nil {
+		return nil, err
+	}
+	return values, nil
+}
+
 func (tp *ToolProperty) UnmarshalJSON(data []byte) error {
 	type toolProperty ToolProperty
-	tp.Required = nil
 	var value struct {
 		*toolProperty
 		Required json.RawMessage `json:"required"`
@@ -439,12 +451,9 @@ func (tp *ToolProperty) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
-	required := bytes.TrimSpace(value.Required)
-	if len(required) == 0 || bytes.Equal(required, []byte("null")) || required[0] == '{' {
-		return nil
-	}
-
-	return json.Unmarshal(required, &tp.Required)
+	var err error
+	tp.Required, err = unmarshalToolRequired(value.Required)
+	return err
 }
 
 // ToTypeScriptType converts a ToolProperty to a TypeScript type string
@@ -498,6 +507,23 @@ type ToolFunctionParameters struct {
 	Items      any                `json:"items,omitempty"`
 	Required   []string           `json:"required,omitempty"`
 	Properties *ToolPropertiesMap `json:"properties"`
+}
+
+func (t *ToolFunctionParameters) UnmarshalJSON(data []byte) error {
+	type toolFunctionParameters ToolFunctionParameters
+	var value struct {
+		*toolFunctionParameters
+		Required json.RawMessage `json:"required"`
+	}
+	value.toolFunctionParameters = (*toolFunctionParameters)(t)
+
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+
+	var err error
+	t.Required, err = unmarshalToolRequired(value.Required)
+	return err
 }
 
 func (t *ToolFunctionParameters) String() string {

--- a/api/types.go
+++ b/api/types.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"iter"
@@ -423,6 +424,27 @@ type ToolProperty struct {
 	Enum        []any              `json:"enum,omitempty"`
 	Properties  *ToolPropertiesMap `json:"properties,omitempty"`
 	Required    []string           `json:"required,omitempty"`
+}
+
+func (tp *ToolProperty) UnmarshalJSON(data []byte) error {
+	type toolProperty ToolProperty
+	tp.Required = nil
+	var value struct {
+		*toolProperty
+		Required json.RawMessage `json:"required"`
+	}
+	value.toolProperty = (*toolProperty)(tp)
+
+	if err := json.Unmarshal(data, &value); err != nil {
+		return err
+	}
+
+	required := bytes.TrimSpace(value.Required)
+	if len(required) == 0 || bytes.Equal(required, []byte("null")) || required[0] == '{' {
+		return nil
+	}
+
+	return json.Unmarshal(required, &tp.Required)
 }
 
 // ToTypeScriptType converts a ToolProperty to a TypeScript type string

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -688,6 +688,41 @@ func TestToolPropertyNestedProperties(t *testing.T) {
 	}
 }
 
+func TestToolPropertyNestedRequiredCompatibility(t *testing.T) {
+	var prop ToolProperty
+	err := json.Unmarshal([]byte(`{
+		"type": "object",
+		"required": ["outer"],
+		"properties": {
+			"outer": {
+				"type": "object",
+				"required": {"circle": ["radius"]},
+				"properties": {"radius": {"type": "number"}}
+			},
+			"nullable": {"type": "object", "required": null},
+			"inner": {"type": "object", "required": ["value"]}
+		}
+	}`), &prop)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"outer"}, prop.Required)
+	assert.Empty(t, prop.Properties.ToMap()["outer"].Required)
+	assert.Nil(t, prop.Properties.ToMap()["nullable"].Required)
+	assert.Equal(t, []string{"value"}, prop.Properties.ToMap()["inner"].Required)
+
+	var reused ToolProperty
+	require.NoError(t, json.Unmarshal([]byte(`{"required":["old"]}`), &reused))
+	require.NoError(t, json.Unmarshal([]byte(`{"required":{}}`), &reused))
+	assert.Empty(t, reused.Required)
+
+	var invalid ToolProperty
+	err = json.Unmarshal([]byte(`{"required": "outer"}`), &invalid)
+	assert.Error(t, err)
+
+	var params ToolFunctionParameters
+	err = json.Unmarshal([]byte(`{"type":"object","required":{},"properties":{}}`), &params)
+	assert.Error(t, err)
+}
+
 func TestToolFunctionParameters_String(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -720,6 +720,14 @@ func TestToolPropertyNestedRequiredCompatibility(t *testing.T) {
 
 	var params ToolFunctionParameters
 	err = json.Unmarshal([]byte(`{"type":"object","required":{},"properties":{}}`), &params)
+	require.NoError(t, err)
+	assert.Empty(t, params.Required)
+
+	err = json.Unmarshal([]byte(`{"type":"object","required":null,"properties":{}}`), &params)
+	require.NoError(t, err)
+	assert.Nil(t, params.Required)
+
+	err = json.Unmarshal([]byte(`{"type":"object","required":"outer","properties":{}}`), &params)
 	assert.Error(t, err)
 }
 

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -30,6 +30,35 @@ const (
 	image  = `iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=`
 )
 
+func TestChatCompletionRequestAcceptsNestedRequiredObject(t *testing.T) {
+	var req ChatCompletionRequest
+	err := json.Unmarshal([]byte(`{
+		"model": "test-model",
+		"tools": [{
+			"type": "function",
+			"function": {
+				"name": "calculate_area",
+				"parameters": {
+					"type": "object",
+					"properties": {
+						"dimensions": {
+							"type": "object",
+							"required": {"circle": ["radius"]},
+							"properties": {"radius": {"type": "number"}}
+						}
+					}
+				}
+			}
+		}]
+	}`), &req)
+	if err != nil {
+		t.Fatalf("expected nested required object to be ignored, got error: %v", err)
+	}
+	if len(req.Tools) != 1 || req.Tools[0].Function.Name != "calculate_area" {
+		t.Fatalf("unexpected parsed tools: %#v", req.Tools)
+	}
+}
+
 func TestFromChatRequest_Basic(t *testing.T) {
 	req := ChatCompletionRequest{
 		Model: "test-model",

--- a/openai/openai_test.go
+++ b/openai/openai_test.go
@@ -30,6 +30,32 @@ const (
 	image  = `iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=`
 )
 
+func TestFromChatRequest_Basic(t *testing.T) {
+	req := ChatCompletionRequest{
+		Model: "test-model",
+		Messages: []Message{
+			{Role: "user", Content: "Hello"},
+		},
+	}
+
+	result, err := FromChatRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.Model != "test-model" {
+		t.Errorf("expected model 'test-model', got %q", result.Model)
+	}
+
+	if len(result.Messages) != 1 {
+		t.Fatalf("expected 1 message, got %d", len(result.Messages))
+	}
+
+	if result.Messages[0].Role != "user" || result.Messages[0].Content != "Hello" {
+		t.Errorf("unexpected message: %+v", result.Messages[0])
+	}
+}
+
 func TestChatCompletionRequestAcceptsNestedRequiredObject(t *testing.T) {
 	var req ChatCompletionRequest
 	err := json.Unmarshal([]byte(`{
@@ -56,32 +82,6 @@ func TestChatCompletionRequestAcceptsNestedRequiredObject(t *testing.T) {
 	}
 	if len(req.Tools) != 1 || req.Tools[0].Function.Name != "calculate_area" {
 		t.Fatalf("unexpected parsed tools: %#v", req.Tools)
-	}
-}
-
-func TestFromChatRequest_Basic(t *testing.T) {
-	req := ChatCompletionRequest{
-		Model: "test-model",
-		Messages: []Message{
-			{Role: "user", Content: "Hello"},
-		},
-	}
-
-	result, err := FromChatRequest(req)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-
-	if result.Model != "test-model" {
-		t.Errorf("expected model 'test-model', got %q", result.Model)
-	}
-
-	if len(result.Messages) != 1 {
-		t.Fatalf("expected 1 message, got %d", len(result.Messages))
-	}
-
-	if result.Messages[0].Role != "user" || result.Messages[0].Content != "Hello" {
-		t.Errorf("unexpected message: %+v", result.Messages[0])
 	}
 }
 


### PR DESCRIPTION
## Summary

OpenAI-compatible tool schemas accepted by the local Ollama API can contain non-array `required` values in nested JSON Schema objects. Decoding these values through `[]string` currently rejects the entire request.

This change makes nested and top-level `required: null` or object values non-fatal while preserving normal array parsing and rejecting other invalid scalar values. The same compatibility rule is used for `api.ToolProperty` and `api.ToolFunctionParameters`.

This PR is limited to the open-source local API request types. It does not modify or claim to fix the Ollama Cloud request path used by #18051; that path is handled outside this repository. The local behavior covered here is related to the request-schema compatibility described in #18051.

## Tests

- `go test -count=1 ./api ./openai`
- `go vet ./api ./openai`
- `git diff --check`

The full repository test suite was not run because this environment lacks generated app assets and some platform-specific/CGO dependencies required by unrelated packages.

## Scope and limitations

- No model-specific behavior or model-name branching is added.
- Cloud-side parsing and forwarding remain unchanged and require a change in the Cloud service.

Related to #18051
