### PR TITLE
launch: add OpenAmer integration

### DIFF
--- a/app/ui/app/public/launch-icons/openamer.svg
+++ b/app/ui/app/public/launch-icons/openamer.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#e8f4fd"/>
+  <path d="M32 14 L48 50 H41.5 L32 27.5 L22.5 50 H16 Z" fill="#2f80ed"/>
+  <circle cx="32" cy="20" r="4" fill="#2f80ed"/>
+</svg>

--- a/app/ui/app/src/lib/launchCommands.ts
+++ b/app/ui/app/src/lib/launchCommands.ts
@@ -32,4 +32,5 @@ export const INTEGRATION_ICONS: Record<string, IntegrationIcon> = {
   omp: { src: "/launch-icons/oh-my-pi.svg" },
   pool: { src: "/launch-icons/poolside.svg" },
   qwen: { src: "/launch-icons/qwen-code.svg" },
+  openamer: { src: "/launch-icons/openamer.svg" },
 };

--- a/cmd/launch/integrations_test.go
+++ b/cmd/launch/integrations_test.go
@@ -68,6 +68,7 @@ func TestIntegrationLookup(t *testing.T) {
 		{"muse alias", "muse-code", true, "Muse Code"},
 		{"droid", "droid", true, "Droid"},
 		{"dsh", "dsh", true, "DeepSeek Harness"},
+		{"openamer", "openamer", true, "OpenAmer"},
 		{"deepseek harness alias", "deepseek-harness", true, "DeepSeek Harness"},
 		{"opencode", "opencode", true, "OpenCode"},
 		{"omp", "omp", true, "Oh My Pi"},
@@ -90,7 +91,7 @@ func TestIntegrationLookup(t *testing.T) {
 }
 
 func TestIntegrationRegistry(t *testing.T) {
-	expectedIntegrations := []string{"claude", "claude-desktop", "cline", "codex", "chatgpt", "kimi", "muse", "droid", "dsh", "opencode", "omp", "hermes", "hermes-desktop", "pool", "qwen"}
+	expectedIntegrations := []string{"claude", "claude-desktop", "cline", "codex", "chatgpt", "kimi", "muse", "droid", "dsh", "openamer", "opencode", "omp", "hermes", "hermes-desktop", "pool", "qwen"}
 	for _, name := range expectedIntegrations {
 		t.Run(name, func(t *testing.T) {
 			r, ok := integrations[name]

--- a/cmd/launch/openamer.go
+++ b/cmd/launch/openamer.go
@@ -1,0 +1,311 @@
+package launch
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/ollama/ollama/cmd/internal/fileutil"
+	"github.com/ollama/ollama/envconfig"
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	openamerIntegrationName = "openamer"
+	openamerProvider        = "ollama"
+	openamerAPIKeyEnv       = "OLLAMA_LAUNCH_OPENAMER_API_KEY"
+	openamerBinary          = "openamer"
+	openamerPipPackage      = "openamer-agent"
+)
+
+var (
+	openamerLookPath = exec.LookPath
+	openamerCommand  = exec.Command
+	openamerGOOS     = runtime.GOOS
+)
+
+// OpenAmer is the Ollama-managed OpenAmer integration. OpenAmer is a personal
+// AI agent that learns across sessions. Ollama redirects only the launch-owned
+// settings document for this invocation; the user's normal config, memories,
+// skills, and credentials remain available and untouched.
+type OpenAmer struct{}
+
+func (o *OpenAmer) String() string { return "OpenAmer" }
+
+func (o *OpenAmer) Run(_ string, _ []LaunchModel, args []string) error {
+	bin, err := openAmerLaunchCommand(args)
+	if err != nil {
+		return err
+	}
+	bin.Env = openAmerLaunchEnv(os.Environ())
+	bin.Stdin = os.Stdin
+	bin.Stdout = os.Stdout
+	bin.Stderr = os.Stderr
+	return bin.Run()
+}
+
+func openAmerLaunchCommand(args []string) (*exec.Cmd, error) {
+	path, err := openamerLookPath(openamerBinary)
+	if err != nil {
+		return nil, fmt.Errorf("openamer is not installed: %w", err)
+	}
+	return openAmerShimCommand(path, args)
+}
+
+// Windows pip console scripts are .exe launchers but some users install via
+// wrappers (.cmd/.bat shims), which cannot be passed safely to CreateProcess
+// with an argv. Route through the underlying Python interpreter when a shim is
+// detected so passthrough arguments remain data rather than cmd.exe syntax.
+func openAmerShimCommand(shim string, args []string) (*exec.Cmd, error) {
+	if openamerGOOS != "windows" || !openAmerIsCommandShim(shim) {
+		return openamerCommand(shim, args...), nil
+	}
+
+	script := strings.TrimSuffix(shim, filepath.Ext(shim))
+	// pip console scripts on Windows ship a shimless companion script
+	// without a file extension (e.g. ...\Scripts\openamer) that Python can
+	// execute directly.
+	entrypoint := script
+	if _, err := os.Stat(entrypoint); err != nil {
+		return nil, fmt.Errorf("resolve Windows entrypoint for %s: %w", filepath.Base(shim), err)
+	}
+
+	python, err := openamerLookPath("python")
+	if err != nil {
+		return nil, fmt.Errorf("python is required to run %s on Windows: %w", filepath.Base(shim), err)
+	}
+	return openamerCommand(python, append([]string{entrypoint}, args...)...), nil
+}
+
+func openAmerIsCommandShim(path string) bool {
+	ext := strings.ToLower(filepath.Ext(path))
+	return ext == ".cmd" || ext == ".bat"
+}
+
+func openAmerUpsertEnv(env []string, key, value string) []string {
+	prefix := key + "="
+	out := make([]string, 0, len(env)+1)
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return append(out, prefix+value)
+}
+
+func openAmerLaunchEnv(env []string) []string {
+	return openAmerUpsertEnv(env, openamerAPIKeyEnv, "ollama")
+}
+
+func ensureOpenAmerInstalled() (string, error) {
+	if path, err := openamerLookPath(openamerBinary); err == nil {
+		return path, nil
+	}
+	if _, err := openamerLookPath("python"); err != nil {
+		if _, err := openamerLookPath("python3"); err != nil {
+			return "", fmt.Errorf("openamer is not installed and Python (pip) is required\n\nInstall Python first:\n  https://www.python.org/downloads/\n\nOr use the installer:\n  curl -fsSL https://openamer.dev/scripts/install.sh | bash\n\nThen re-run:\n  ollama launch openamer")
+		}
+	}
+
+	ok, err := ConfirmPrompt("OpenAmer is not installed. Install with pip?")
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("openamer installation cancelled")
+	}
+
+	fmt.Fprintln(os.Stderr, "\nInstalling OpenAmer...")
+	pip := "pip"
+	if _, err := openamerLookPath("pip"); err != nil {
+		pip = "pip3"
+		if _, err := openamerLookPath(pip); err != nil {
+			pip = "python"
+		}
+	}
+	pipArgs := []string{"install", "--user", openamerPipPackage}
+	if pip == "python" {
+		pipArgs = append([]string{"-m", "pip"}, pipArgs...)
+	}
+	cmd := openamerCommand(pip, pipArgs...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to install openamer: %w", err)
+	}
+
+	path, err := openamerLookPath(openamerBinary)
+	if err != nil {
+		return "", fmt.Errorf("openamer was installed but %s was not found on PATH\n\nYou may need to restart your shell", openamerBinary)
+	}
+	fmt.Fprintf(os.Stderr, "%sOpenAmer installed successfully%s\n\n", ansiGreen, ansiReset)
+	return path, nil
+}
+
+func (o *OpenAmer) Paths() []string {
+	settingsPath, err := openAmerSettingsPath()
+	if err != nil {
+		return nil
+	}
+	return []string{settingsPath}
+}
+
+func (o *OpenAmer) Configure(modelName string) error {
+	return o.ConfigureWithModels(modelName, []LaunchModel{fallbackLaunchModel(modelName)})
+}
+
+func (o *OpenAmer) ConfigureWithModels(primary string, models []LaunchModel) error {
+	if strings.TrimSpace(primary) == "" {
+		return nil
+	}
+	if len(models) == 0 {
+		models = []LaunchModel{fallbackLaunchModel(primary)}
+	}
+	if selected, ok := findLaunchModel(models, primary); ok {
+		primary = selected.Name
+	}
+
+	settingsPath, err := openAmerSettingsPath()
+	if err != nil {
+		return err
+	}
+	settings, err := readOpenAmerYAML(settingsPath)
+	if err != nil {
+		return fmt.Errorf("parse openamer launch settings: %w", err)
+	}
+	if err := applyOpenAmerSettings(settings, primary, models); err != nil {
+		return err
+	}
+
+	data, err := yaml.Marshal(settings)
+	if err != nil {
+		return err
+	}
+	return writeOpenAmerFile(settingsPath, data)
+}
+
+func readOpenAmerYAML(path string) (map[string]any, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return make(map[string]any), nil
+		}
+		return nil, err
+	}
+	settings := make(map[string]any)
+	if err := yaml.Unmarshal(data, &settings); err != nil {
+		return nil, err
+	}
+	if settings == nil {
+		settings = make(map[string]any)
+	}
+	return settings, nil
+}
+
+func applyOpenAmerSettings(settings map[string]any, primary string, models []LaunchModel) error {
+	settings["provider"] = map[string]any{
+		"name":     openamerProvider,
+		"baseURL":  openAmerBaseURL(),
+		"apiKeyEnv": openamerAPIKeyEnv,
+		"model":    primary,
+		"models":   openAmerModelNames(primary, models),
+	}
+	return nil
+}
+
+func openAmerModelConfigs(primary string, models []LaunchModel) []any {
+	ordered := append([]LaunchModel(nil), models...)
+	if selected, ok := findLaunchModel(ordered, primary); ok {
+		ordered = append([]LaunchModel{selected}, removeLaunchModel(ordered, primary)...)
+	} else {
+		ordered = append([]LaunchModel{fallbackLaunchModel(primary)}, ordered...)
+	}
+
+	configs := make([]any, 0, len(ordered))
+	seen := make(map[string]bool, len(ordered))
+	for _, item := range ordered {
+		if item.Name == "" || seen[item.Name] {
+			continue
+		}
+		seen[item.Name] = true
+		configs = append(configs, item.Name)
+	}
+	return configs
+}
+
+func (o *OpenAmer) CurrentModel() string {
+	settingsPath, err := openAmerSettingsPath()
+	if err != nil {
+		return ""
+	}
+	settings, err := readOpenAmerYAML(settingsPath)
+	if err != nil {
+		return ""
+	}
+	provider, _ := settings["provider"].(map[string]any)
+	if provider == nil {
+		return ""
+	}
+	if name, _ := provider["name"].(string); name != openamerProvider {
+		return ""
+	}
+	if !openAmerProviderHealthy(provider) {
+		return ""
+	}
+	modelName, _ := provider["model"].(string)
+	return modelName
+}
+
+func openAmerProviderHealthy(provider map[string]any) bool {
+	baseURL, _ := provider["baseURL"].(string)
+	if strings.TrimRight(baseURL, "/") != strings.TrimRight(openAmerBaseURL(), "/") {
+		return false
+	}
+	apiKeyEnv, _ := provider["apiKeyEnv"].(string)
+	return apiKeyEnv == openamerAPIKeyEnv
+}
+
+func (o *OpenAmer) Onboard() error {
+	return config.MarkIntegrationOnboarded(openamerIntegrationName)
+}
+
+func (o *OpenAmer) RequiresInteractiveOnboarding() bool { return false }
+
+func openAmerBaseURL() string {
+	return strings.TrimRight(envconfig.ConnectableHost().String(), "/") + "/v1"
+}
+
+func openAmerConfigDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".ollama", "launch", "openamer"), nil
+}
+
+func openAmerSettingsPath() (string, error) {
+	dir, err := openAmerConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "settings.yaml"), nil
+}
+
+func writeOpenAmerFile(path string, data []byte) error {
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return err
+	}
+	if err := os.Chmod(dir, 0o700); err != nil {
+		return err
+	}
+	if err := fileutil.WriteWithBackup(path, data, openamerIntegrationName); err != nil {
+		return err
+	}
+	return os.Chmod(path, 0o600)
+}

--- a/cmd/launch/openamer_test.go
+++ b/cmd/launch/openamer_test.go
@@ -1,0 +1,222 @@
+package launch
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/types/model"
+	"gopkg.in/yaml.v3"
+)
+
+func TestOpenAmerRegistry(t *testing.T) {
+	spec, err := LookupIntegrationSpec("openamer")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if spec.Name != openamerIntegrationName {
+		t.Fatalf("canonical name = %q, want %q", spec.Name, openamerIntegrationName)
+	}
+	if spec.Runner.String() != "OpenAmer" {
+		t.Fatalf("display name = %q", spec.Runner.String())
+	}
+	if got := strings.Join(spec.Install.Command, " "); got != "pip install --user openamer-agent" {
+		t.Fatalf("install command = %q", got)
+	}
+	if spec.Install.URL != "https://github.com/openamer/openamer" {
+		t.Fatalf("install URL = %q", spec.Install.URL)
+	}
+}
+
+func TestOpenAmerConfigureWritesSettingsAndIsIdempotent(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:12345")
+
+	settingsPath, err := openAmerSettingsPath()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Dir(settingsPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	existing := []byte("# keep-comment\ntheme: dark\n")
+	if err := os.WriteFile(settingsPath, existing, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	models := []LaunchModel{
+		{Name: "qwen3.5:latest", ContextLength: 262144, MaxOutputTokens: 32768, Capabilities: []model.Capability{model.CapabilityVision}},
+		{Name: "kimi-k2.6:cloud", ContextLength: 262144, MaxOutputTokens: 262144},
+	}
+	oa := &OpenAmer{}
+	if err := oa.ConfigureWithModels("qwen3.5", models); err != nil {
+		t.Fatal(err)
+	}
+	first, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := oa.ConfigureWithModels("qwen3.5", models); err != nil {
+		t.Fatal(err)
+	}
+	second, _ := os.ReadFile(settingsPath)
+	if string(first) != string(second) {
+		t.Fatal("repeated configuration changed Ollama-managed files")
+	}
+	if !strings.Contains(string(first), "# keep-comment") {
+		t.Fatalf("settings did not preserve existing content:\n%s", first)
+	}
+
+	var settings map[string]any
+	if err := yaml.Unmarshal(first, &settings); err != nil {
+		t.Fatal(err)
+	}
+	if theme, _ := settings["theme"].(string); theme != "dark" {
+		t.Fatalf("unrelated settings were not preserved: %#v", settings["theme"])
+	}
+	provider, _ := settings["provider"].(map[string]any)
+	if provider == nil {
+		t.Fatal("provider settings were not written")
+	}
+	if provider["baseURL"] != "http://127.0.0.1:12345/v1" || provider["apiKeyEnv"] != openamerAPIKeyEnv {
+		t.Fatalf("Ollama provider = %#v", provider)
+	}
+	if provider["model"] != "qwen3.5:latest" {
+		t.Fatalf("provider model = %#v", provider["model"])
+	}
+	models_, _ := provider["models"].([]any)
+	if len(models_) != 2 || models_[0] != "qwen3.5:latest" || models_[1] != "kimi-k2.6:cloud" {
+		t.Fatalf("configured models = %#v", models_)
+	}
+
+	if got := oa.CurrentModel(); got != "qwen3.5:latest" {
+		t.Fatalf("CurrentModel() = %q", got)
+	}
+}
+
+func TestOpenAmerCurrentModelRejectsDrift(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:11434")
+	oa := &OpenAmer{}
+	if err := oa.Configure("qwen3.5"); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("OLLAMA_HOST", "http://127.0.0.1:9999")
+	if got := oa.CurrentModel(); got != "" {
+		t.Fatalf("CurrentModel() = %q for stale endpoint", got)
+	}
+}
+
+func TestOpenAmerCurrentModelEmptyWithoutSettings(t *testing.T) {
+	setTestHome(t, t.TempDir())
+	if got := (&OpenAmer{}).CurrentModel(); got != "" {
+		t.Fatalf("CurrentModel() = %q, want empty", got)
+	}
+}
+
+func TestOpenAmerRunPassthrough(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell test binary")
+	}
+
+	home := t.TempDir()
+	setTestHome(t, home)
+	binDir := t.TempDir()
+	logPath := filepath.Join(home, "openamer-invocation")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$OA_TEST_LOG\"\nprintf '%s\\n' \"$OLLAMA_LAUNCH_OPENAMER_API_KEY\" >> \"$OA_TEST_LOG\"\n"
+	bin := filepath.Join(binDir, "openamer")
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", strings.Join([]string{binDir, "/bin", "/usr/bin"}, string(os.PathListSeparator)))
+	t.Setenv("OA_TEST_LOG", logPath)
+	t.Setenv(openamerAPIKeyEnv, "do-not-keep")
+
+	oa := &OpenAmer{}
+	if err := oa.Run("qwen3.5", nil, []string{"--help"}); err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "--help\nollama\n"
+	if string(data) != want {
+		t.Fatalf("invocation = %q, want %q", data, want)
+	}
+}
+
+func TestEnsureOpenAmerInstalledUsesPip(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell test binary")
+	}
+
+	home := t.TempDir()
+	binDir := t.TempDir()
+	logPath := filepath.Join(home, "pip-invocation")
+	pip := filepath.Join(binDir, "pip")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$OA_PIP_LOG\"\nprintf '#!/bin/sh\\nexit 0\\n' > \"$OA_INSTALLED_BIN\"\nchmod +x \"$OA_INSTALLED_BIN\"\n"
+	if err := os.WriteFile(pip, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	oaBin := filepath.Join(binDir, "openamer")
+	t.Setenv("PATH", strings.Join([]string{binDir, "/bin", "/usr/bin"}, string(os.PathListSeparator)))
+	t.Setenv("OA_PIP_LOG", logPath)
+	t.Setenv("OA_INSTALLED_BIN", oaBin)
+
+	restore := withLaunchConfirmPolicy(launchConfirmPolicy{yes: true})
+	defer restore()
+	path, err := ensureOpenAmerInstalled()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if path != oaBin {
+		t.Fatalf("installed path = %q, want %q", path, oaBin)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "install\n--user\nopenamer-agent\n" {
+		t.Fatalf("pip invocation = %q", data)
+	}
+}
+
+func TestOpenAmerShimHandling(t *testing.T) {
+	t.Run("passthrough on posix", func(t *testing.T) {
+		cmd, err := openAmerShimCommand("/usr/local/bin/openamer", []string{"run"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !slices.Equal(cmd.Args, []string{"/usr/local/bin/openamer", "run"}) {
+			t.Fatalf("command args = %v", cmd.Args)
+		}
+	})
+}
+
+func TestOpenAmerUpsertEnv(t *testing.T) {
+	got := openAmerUpsertEnv([]string{"A=1", openamerAPIKeyEnv + "=old"}, openamerAPIKeyEnv, "ollama")
+	want := []string{"A=1", openamerAPIKeyEnv + "=ollama"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("env = %v, want %v", got, want)
+	}
+}
+
+func TestOpenAmerLaunchArgs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("uses a POSIX shell test binary")
+	}
+	// Validate the shim detection helper on representative names.
+	if !openAmerIsCommandShim("C:\\Python311\\Scripts\\openamer.cmd") {
+		t.Fatal("expected .cmd to be detected as shim")
+	}
+	if openAmerIsCommandShim("/usr/bin/openamer") {
+		t.Fatal("expected plain path to not be a shim")
+	}
+}

--- a/cmd/launch/registry.go
+++ b/cmd/launch/registry.go
@@ -33,7 +33,7 @@ type IntegrationInfo struct {
 	Description string
 }
 
-var launcherIntegrationOrder = []string{"claude", "chatgpt", "hermes", "openclaw", "opencode", "hermes-desktop", "codex", "copilot", "omp", "cline", "droid", "dsh", "pi", "pool", "qwen"}
+var launcherIntegrationOrder = []string{"claude", "chatgpt", "hermes", "openclaw", "opencode", "hermes-desktop", "codex", "copilot", "omp", "cline", "droid", "dsh", "pi", "pool", "qwen", "openamer"}
 
 var integrationSpecs = []*IntegrationSpec{
 	{
@@ -182,6 +182,23 @@ var integrationSpecs = []*IntegrationSpec{
 			},
 			URL:     "https://github.com/deepseek-ai/deepseek-harness",
 			Command: []string{"npm", "install", "-g", deepSeekHarnessNpmPackage},
+		},
+	},
+	{
+		Name:        openamerIntegrationName,
+		Runner:      &OpenAmer{},
+		Description: "Personal AI agent that learns across sessions",
+		Install: IntegrationInstallSpec{
+			CheckInstalled: func() bool {
+				_, err := openamerLookPath(openamerBinary)
+				return err == nil
+			},
+			EnsureInstalled: func() error {
+				_, err := ensureOpenAmerInstalled()
+				return err
+			},
+			URL:     "https://github.com/openamer/openamer",
+			Command: []string{"pip", "install", "--user", openamerPipPackage},
 		},
 	},
 	{

--- a/docs/images/launch-icons/openamer.svg
+++ b/docs/images/launch-icons/openamer.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#e8f4fd"/>
+  <path d="M32 14 L48 50 H41.5 L32 27.5 L22.5 50 H16 Z" fill="#2f80ed"/>
+  <circle cx="32" cy="20" r="4" fill="#2f80ed"/>
+</svg>

--- a/docs/integrations/index.mdx
+++ b/docs/integrations/index.mdx
@@ -39,6 +39,10 @@ Use open models in assistant apps.
   <Card title="Hermes Agent" icon="/images/launch-icons/hermes-agent.svg" href="/integrations/hermes">
     Open-source agent with self-improving skills, memory, and messaging.
   </Card>
+
+  <Card title="OpenAmer" icon="/images/launch-icons/openamer.svg" href="/integrations/openamer">
+    Personal AI agent that learns across sessions.
+  </Card>
 </CardGroup>
 
 ## Work in your editor

--- a/docs/integrations/openamer.mdx
+++ b/docs/integrations/openamer.mdx
@@ -1,0 +1,64 @@
+---
+title: OpenAmer
+---
+
+OpenAmer is a personal AI agent that learns across sessions. Skills, memories, and workflows persist between conversations, so the agent gets more useful over time instead of starting from scratch.
+
+## Quick start
+
+```bash
+ollama launch openamer
+```
+
+Ollama handles everything automatically:
+
+1. **Install** — If OpenAmer isn't installed, Ollama prompts to install it via pip
+2. **Model** — Pick a model from the selector (local or cloud)
+3. **Provider** — Ollama configures OpenAmer to use your Ollama host as the model provider and writes the settings under `~/.ollama/launch/openamer/`
+4. **Launch** — Runs `openamer` with your selected model
+
+Your normal OpenAmer config, memories, skills, and credentials remain available and untouched.
+
+## Configure without launching
+
+To change the model without starting the agent:
+
+```bash
+ollama launch openamer --config
+```
+
+To use a specific model directly:
+
+```bash
+ollama launch openamer --model qwen3.5
+```
+
+## Recommended models
+
+**Cloud models**:
+
+- `qwen3.5:cloud` — Reasoning, coding, and agentic tool use with vision
+- `glm-5.1:cloud` — Reasoning and code generation
+- `kimi-k2.5:cloud` — Multimodal reasoning with long context
+
+**Local models:**
+
+- `gemma4` — Reasoning and code generation locally (~16 GB VRAM)
+- `qwen3.5` — Reasoning, coding, and visual understanding locally (~11 GB VRAM)
+- `llama3.2` — Lightweight everyday assistant
+
+More models at [ollama.com/search](https://ollama.com/search?c=cloud).
+
+## Installing OpenAmer manually
+
+```bash
+pip install --user openamer-agent
+```
+
+Or with the installer script (Linux/macOS):
+
+```bash
+curl -fsSL https://openamer.dev/scripts/install.sh | bash
+```
+
+OpenAmer source and documentation: [github.com/openamer/openamer](https://github.com/openamer/openamer)


### PR DESCRIPTION
## Summary

Adds [OpenAmer](https://github.com/openamer/openamer) as an `ollama launch` integration. OpenAmer is a personal AI agent (Python CLI, pip package `openamer-agent`) that learns across sessions — skills, memories, and workflows persist between conversations.

## Changes

- `cmd/launch/openamer.go` — new `OpenAmer` runner following the existing integration patterns (modeled on the DeepSeek Harness integration):
  - `Run` executes the `openamer` binary with passthrough args and upserts `OLLAMA_LAUNCH_OPENAMER_API_KEY=ollama` in the child environment
  - `EnsureInstalled` checks `openamer` on PATH; if missing, prompts and installs via `pip install --user openamer-agent` (with installer-script fallback hint)
  - `Configure`/`ConfigureWithModels` write Ollama-managed settings (provider baseURL/models) to `~/.ollama/launch/openamer/settings.yaml`, preserving unrelated user content, plus `CurrentModel` drift detection against the configured Ollama host
  - Windows `.cmd`/`.bat` shim handling: routes through the underlying Python console-script entrypoint instead of passing cmd shims to `CreateProcess`
- `cmd/launch/registry.go` — registers the `openamer` integration and adds it to `launcherIntegrationOrder`
- `cmd/launch/openamer_test.go` — tests for registry entry, configure idempotency/content preservation, current-model drift rejection, run passthrough, pip install flow, env upsert, and Windows shim detection
- `cmd/launch/integrations_test.go` — extends the lookup table and expected-integrations list
- UI: icon entry in `app/ui/app/src/lib/launchCommands.ts` + `openamer.svg` in `app/ui/app/public/launch-icons/` and `docs/images/launch-icons/`
- Docs: new `docs/integrations/openamer.mdx` and a card in `docs/integrations/index.mdx` (Connect an assistant section)

## Test plan

- [x] Unit tests added for the new runner (`cmd/launch/openamer_test.go`) and registry/table tests updated
- [ ] `go test ./cmd/launch/...` — not run locally (Go toolchain not available on this machine); CI will validate
- [ ] Manual smoke test of `ollama launch openamer` with a local model
