### PR TITLE
Expose GPU and basic system info (rebase of #7262, with tests)

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -510,3 +510,12 @@ func (c *Client) Whoami(ctx context.Context) (*UserResponse, error) {
 	}
 	return &resp, nil
 }
+
+// Info retrieves server information.
+func (c *Client) Info(ctx context.Context) (*InfoResponse, error) {
+	var resp InfoResponse
+	if err := c.do(ctx, http.MethodGet, "/api/info", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/api/types.go
+++ b/api/types.go
@@ -1356,3 +1356,73 @@ func FormatParams(params map[string][]string) (map[string]any, error) {
 
 	return out, nil
 }
+
+type SystemModelInfo struct {
+	// Store is the location where the server stores models in the filesystem.
+	Store string `json:"store"`
+
+	// Count is the number of models currently stored in the filesystem.
+	Count int `json:"count"`
+
+	// FilesystemUsed is the number of bytes used on the filesystem to store models
+	FilesystemUsed uint64 `json:"filesystem_used"`
+
+	// Running is the number of models currently running in the server.
+	Running int `json:"running"`
+
+	// VRAMUsed is the amount of GPU VRAM consumed by the loaded models
+	VRAMUsed uint64 `json:"vram_used"`
+}
+
+type SystemComputeInfo struct {
+	// Cores is the number of detected CPU Cores in the system
+	CPUCores int `json:"cpu_cores"`
+
+	// TotalMemory is the amount of system memory discovered by the server
+	TotalMemory uint64 `json:"total_memory"`
+
+	// FreeMemory is the amount of system memory available for loading new models
+	FreeMemory uint64 `json:"free_memory"`
+
+	// FreeSwap is the amount of swap space available for loading new models
+	FreeSwap uint64 `json:"free_swap"`
+}
+
+type GPUInfo struct {
+	// ID is the unique identifier to use for selection of this specific GPU by device vendor
+	ID string `json:"gpu_id"`
+
+	// Name is the model or other identifying information about the GPU
+	Name string `json:"name"`
+
+	// TotalMemory is the amount of video memory on the GPU
+	TotalMemory uint64 `json:"total_memory"`
+
+	// FreeMemory is the amount of video memory on the GPU available for loading new models
+	FreeMemory uint64 `json:"free_memory"`
+
+	// Compute is the GPU capability version information, specific to each device vendor
+	Compute string `json:"compute,omitempty"`
+
+	// Driver is the device driver detected for this GPU
+	Driver string `json:"driver,omitempty"`
+
+	// Runner is the default runner for this GPU
+	Runner string `json:"runner"`
+}
+
+type ComputeInfo struct {
+	SystemCompute SystemComputeInfo `json:"system_compute"`
+
+	SupportedGPUs []GPUInfo `json:"supported_gpus"`
+}
+
+// InfoResponse is the response returned from [Client.Info].
+type InfoResponse struct {
+	// Version is the current version of the server.
+	Version string `json:"version"`
+
+	Models SystemModelInfo `json:"models"`
+
+	ComputeInfo ComputeInfo `json:"compute"`
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2480,6 +2480,12 @@ func NewCLI() *cobra.Command {
 		},
 	}
 	gpuDiscoverCmd.Flags().StringArrayVar(&gpuDiscoverLibDirs, "lib-dir", nil, "Ollama runtime library directory")
+	infoCmd := &cobra.Command{
+		Use:     "info",
+		Short:   "Display system-wide information",
+		PreRunE: checkServerHeartbeat,
+		RunE:    InfoHandler,
+	}
 
 	envVars := envconfig.AsMap()
 
@@ -2497,6 +2503,7 @@ func NewCLI() *cobra.Command {
 		copyCmd,
 		deleteCmd,
 		serveCmd,
+		infoCmd,
 	} {
 		switch cmd {
 		case runCmd:
@@ -2549,6 +2556,7 @@ func NewCLI() *cobra.Command {
 		runnerCmd,
 		gpuDiscoverCmd,
 		launch.LaunchCmd(checkServerHeartbeat, runInteractiveTUI),
+		infoCmd,
 	)
 
 	return rootCmd

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -1,0 +1,189 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/version"
+)
+
+func InfoHandler(cmd *cobra.Command, args []string) error {
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Info(cmd.Context())
+	if err != nil {
+		return err
+	}
+	out := os.Stdout
+	prettyPrintClientInfo(out)
+	fmt.Fprint(out, "\n")
+
+	prettyPrintInfoResponse(out, *resp)
+
+	return nil
+}
+
+func prettyPrintClientInfo(out io.Writer) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding(" ")
+	indent := ""
+
+	cfgDir := ""
+	home, err := os.UserHomeDir()
+	if err == nil {
+		cfgDir = filepath.Join(home, ".ollama")
+	}
+
+	data := [][]string{
+		{
+			indent, "Version:", version.Version,
+		},
+		{
+			indent, "Configuration:", cfgDir,
+		},
+		{
+			indent, "Connection:", envconfig.Host().String(),
+		},
+	}
+	fmt.Fprint(out, "Client:\n")
+	table.AppendBulk(data)
+	table.Render()
+}
+
+func prettyPrintInfoResponse(out io.Writer, resp api.InfoResponse) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding(" ")
+	indent := ""
+	data := [][]string{
+		{
+			indent, "Version:", resp.Version,
+		},
+	}
+	fmt.Fprint(out, "Server:\n")
+	table.AppendBulk(data)
+	table.Render()
+	prettyPrintModels(out, " ", resp)
+	prettyPrintCompute(out, " ", resp)
+}
+
+func prettyPrintModels(out io.Writer, indent string, resp api.InfoResponse) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding(" ")
+	data := [][]string{
+		{
+			indent, "Store:", envconfig.Models(),
+		},
+		{
+			indent, "Downloaded:", strconv.Itoa(resp.Models.Count),
+		},
+		{
+			indent, "Filesystem Used:", format.HumanBytes(int64(resp.Models.FilesystemUsed)),
+		},
+		{
+			indent, "Running:", strconv.Itoa(resp.Models.Running),
+		},
+		{
+			indent, "VRAM Used:", format.HumanBytes(int64(resp.Models.VRAMUsed)),
+		},
+	}
+	fmt.Fprintf(out, "%sModels:\n", indent)
+	table.AppendBulk(data)
+	table.Render()
+}
+
+func prettyPrintCompute(out io.Writer, indent string, resp api.InfoResponse) {
+	fmt.Fprintf(out, "%sCompute:\n", indent)
+	indent += " "
+	prettyPrintSystem(out, indent, resp)
+	prettyPrintSupportedGPUs(out, indent, resp)
+}
+
+func prettyPrintSystem(out io.Writer, indent string, resp api.InfoResponse) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding(" ")
+	data := [][]string{
+		{
+			indent, "CPU Cores:", strconv.Itoa(resp.ComputeInfo.SystemCompute.CPUCores),
+		},
+		{
+			indent, "Total Memory:", format.HumanBytes(int64(resp.ComputeInfo.SystemCompute.TotalMemory)),
+		},
+		{
+			indent, "Free Memory:", format.HumanBytes(int64(resp.ComputeInfo.SystemCompute.FreeMemory)),
+		},
+		{
+			indent, "Free Swap:", format.HumanBytes(int64(resp.ComputeInfo.SystemCompute.FreeSwap)),
+		},
+	}
+	fmt.Fprintf(out, "%sSystem:\n", indent)
+	table.AppendBulk(data)
+	table.Render()
+}
+
+func prettyPrintSupportedGPUs(out io.Writer, indent string, resp api.InfoResponse) {
+	fmt.Fprintf(out, "%sSupported GPUs:\n", indent)
+	indent += " "
+	for _, gpu := range resp.ComputeInfo.SupportedGPUs {
+		prettyPrintSupportedGPU(out, indent, gpu)
+	}
+}
+
+func prettyPrintSupportedGPU(out io.Writer, indent string, gpu api.GPUInfo) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding(" ")
+	data := [][]string{
+		{
+			indent, "Name:", gpu.Name,
+		},
+		{
+			indent, "Total Memory:", format.HumanBytes(int64(gpu.TotalMemory)),
+		},
+		{
+			indent, "Free Memory:", format.HumanBytes(int64(gpu.FreeMemory)),
+		},
+	}
+
+	// Backends that don't report a compute capability or driver version (Metal)
+	// leave these empty; omit the rows rather than showing a blank value.
+	if gpu.Compute != "" {
+		data = append(data, []string{indent, "Compute:", gpu.Compute})
+	}
+	if gpu.Driver != "" {
+		data = append(data, []string{indent, "Driver:", gpu.Driver})
+	}
+	fmt.Fprintf(out, "%s%s %s:\n", indent, gpu.Runner, gpu.ID)
+	table.AppendBulk(data)
+	table.Render()
+}

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -36,7 +36,7 @@ func InfoHandler(cmd *cobra.Command, args []string) error {
 }
 
 func prettyPrintClientInfo(out io.Writer) {
-	table := tablewriter.NewWriter(os.Stdout)
+	table := tablewriter.NewWriter(out)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetHeaderLine(false)
 	table.SetBorder(false)
@@ -67,7 +67,7 @@ func prettyPrintClientInfo(out io.Writer) {
 }
 
 func prettyPrintInfoResponse(out io.Writer, resp api.InfoResponse) {
-	table := tablewriter.NewWriter(os.Stdout)
+	table := tablewriter.NewWriter(out)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetHeaderLine(false)
 	table.SetBorder(false)
@@ -87,7 +87,7 @@ func prettyPrintInfoResponse(out io.Writer, resp api.InfoResponse) {
 }
 
 func prettyPrintModels(out io.Writer, indent string, resp api.InfoResponse) {
-	table := tablewriter.NewWriter(os.Stdout)
+	table := tablewriter.NewWriter(out)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetHeaderLine(false)
 	table.SetBorder(false)
@@ -123,7 +123,7 @@ func prettyPrintCompute(out io.Writer, indent string, resp api.InfoResponse) {
 }
 
 func prettyPrintSystem(out io.Writer, indent string, resp api.InfoResponse) {
-	table := tablewriter.NewWriter(os.Stdout)
+	table := tablewriter.NewWriter(out)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetHeaderLine(false)
 	table.SetBorder(false)
@@ -151,13 +151,23 @@ func prettyPrintSystem(out io.Writer, indent string, resp api.InfoResponse) {
 func prettyPrintSupportedGPUs(out io.Writer, indent string, resp api.InfoResponse) {
 	fmt.Fprintf(out, "%sSupported GPUs:\n", indent)
 	indent += " "
+
+	// Say so explicitly rather than leaving the heading bare: "did it find my GPU?"
+	// is the question this command exists to answer, and an empty section reads as
+	// a rendering fault rather than an answer. The system block above already states
+	// the CPU budget, so there is nothing to add here.
+	if len(resp.ComputeInfo.SupportedGPUs) == 0 {
+		fmt.Fprintf(out, "%sNone detected\n", indent)
+		return
+	}
+
 	for _, gpu := range resp.ComputeInfo.SupportedGPUs {
 		prettyPrintSupportedGPU(out, indent, gpu)
 	}
 }
 
 func prettyPrintSupportedGPU(out io.Writer, indent string, gpu api.GPUInfo) {
-	table := tablewriter.NewWriter(os.Stdout)
+	table := tablewriter.NewWriter(out)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetHeaderLine(false)
 	table.SetBorder(false)

--- a/cmd/info_test.go
+++ b/cmd/info_test.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/api"
+)
+
+func TestPrettyPrintSupportedGPUsNoneDetected(t *testing.T) {
+	var buf bytes.Buffer
+	prettyPrintSupportedGPUs(&buf, " ", api.InfoResponse{})
+
+	out := buf.String()
+	if !strings.Contains(out, "Supported GPUs:") {
+		t.Errorf("missing heading, got %q", out)
+	}
+	// "did it find my GPU?" must be answered, not left to an empty section
+	if !strings.Contains(out, "None detected") {
+		t.Errorf("a server with no GPUs should say so, got %q", out)
+	}
+}
+
+func TestPrettyPrintSupportedGPUs(t *testing.T) {
+	var buf bytes.Buffer
+	prettyPrintSupportedGPUs(&buf, " ", api.InfoResponse{
+		ComputeInfo: api.ComputeInfo{
+			SupportedGPUs: []api.GPUInfo{{
+				ID:          "0",
+				Name:        "NVIDIA GeForce RTX 4080 Laptop GPU",
+				TotalMemory: 12878610432,
+				FreeMemory:  12878610432,
+				Compute:     "8.9",
+				Driver:      "13.2",
+				Runner:      "CUDA",
+			}},
+		},
+	})
+
+	out := buf.String()
+	for _, want := range []string{"CUDA 0:", "RTX 4080", "Compute:", "8.9", "Driver:", "13.2"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "None detected") {
+		t.Errorf("a populated list should not report none detected, got:\n%s", out)
+	}
+}
+
+// A backend that reports no compute capability or driver version (Metal) leaves
+// those fields empty; the rows are dropped rather than printed blank.
+func TestPrettyPrintSupportedGPUsOmitsEmptyRows(t *testing.T) {
+	var buf bytes.Buffer
+	prettyPrintSupportedGPUs(&buf, " ", api.InfoResponse{
+		ComputeInfo: api.ComputeInfo{
+			SupportedGPUs: []api.GPUInfo{{
+				ID:          "0",
+				Name:        "MTL0",
+				TotalMemory: 12712935424,
+				FreeMemory:  12711886848,
+				Runner:      "Metal",
+			}},
+		},
+	})
+
+	out := buf.String()
+	if !strings.Contains(out, "MTL0") {
+		t.Fatalf("expected the device, got:\n%s", out)
+	}
+	if strings.Contains(out, "Compute:") {
+		t.Errorf("compute row should be omitted when unknown, got:\n%s", out)
+	}
+	if strings.Contains(out, "Driver:") {
+		t.Errorf("driver row should be omitted when unknown, got:\n%s", out)
+	}
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"runtime"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -1909,6 +1910,7 @@ func (s *Server) GenerateRoutes() (http.Handler, error) {
 	r.POST("/api/chat", s.withInferenceRequestLogging("/api/chat", s.ChatHandler)...)
 	r.POST("/api/embed", s.EmbedHandler)
 	r.POST("/api/embeddings", s.EmbeddingsHandler)
+	r.GET("/api/info", s.InfoHandler)
 
 	// Inference (OpenAI compatibility)
 	// TODO(cloud-stage-a): apply Modelfile overlay deltas for local models with cloud
@@ -2435,6 +2437,74 @@ func writeChatResponse(c *gin.Context, req api.ChatRequest, ch chan any) {
 	}
 
 	streamResponse(c, ch)
+}
+
+func (s *Server) InfoHandler(c *gin.Context) {
+	// Read discovery through the scheduler's hooks rather than calling discover
+	// directly, so the reported devices are the same ones the scheduler places
+	// models on (and so this handler is testable with injected devices).
+	devices := s.sched.getGpuFn(c.Request.Context(), nil)
+
+	gpus := make([]api.GPUInfo, len(devices))
+	for i, dev := range devices {
+		gpus[i] = api.GPUInfo{
+			ID:          dev.ID,
+			Name:        dev.Name,
+			TotalMemory: dev.TotalMemory,
+			FreeMemory:  dev.FreeMemory,
+			Runner:      dev.Library,
+		}
+
+		// Compute capability and driver version are CUDA/ROCm concepts; a backend
+		// that doesn't report them (Metal) leaves the versions at zero, which would
+		// otherwise surface as a meaningless "0.0". Report them only when known.
+		if dev.ComputeMajor > 0 || dev.ComputeMinor > 0 {
+			gpus[i].Compute = dev.Compute()
+		}
+		if dev.DriverMajor > 0 || dev.DriverMinor > 0 {
+			gpus[i].Driver = dev.Driver()
+		}
+	}
+
+	ms, _ := manifest.Manifests(true)
+	var fsUsed uint64
+	counted := map[string]struct{}{}
+	for _, m := range ms {
+		for _, l := range m.Layers {
+			// a layer shared by several models occupies the store once
+			if _, dup := counted[l.Digest]; !dup {
+				counted[l.Digest] = struct{}{}
+				fsUsed += uint64(l.Size)
+			}
+		}
+	}
+
+	loaded := s.sched.loadedModels()
+	var vramUsed uint64
+	for _, r := range loaded {
+		vramUsed += uint64(r.sizeVRAM)
+	}
+
+	sysInfo := s.sched.getSystemInfoFn()
+	c.JSON(http.StatusOK, api.InfoResponse{
+		Version: version.Version,
+		Models: api.SystemModelInfo{
+			Store:          envconfig.Models(),
+			Count:          len(ms),
+			FilesystemUsed: fsUsed,
+			Running:        len(loaded),
+			VRAMUsed:       vramUsed,
+		},
+		ComputeInfo: api.ComputeInfo{
+			SystemCompute: api.SystemComputeInfo{
+				CPUCores:    runtime.NumCPU(),
+				TotalMemory: sysInfo.TotalMemory,
+				FreeMemory:  sysInfo.FreeMemory,
+				FreeSwap:    sysInfo.FreeSwap,
+			},
+			SupportedGPUs: gpus,
+		},
+	})
 }
 
 func (s *Server) ChatHandler(c *gin.Context) {

--- a/server/routes_info_test.go
+++ b/server/routes_info_test.go
@@ -205,3 +205,27 @@ func TestInfoHandlerReportsKnownComputeAndDriver(t *testing.T) {
 		t.Errorf("runner: got %q, want %q", gpu.Runner, "CUDA")
 	}
 }
+
+// A CPU-only server reports an empty device list rather than failing. The system
+// memory block is the whole compute budget in that case, so it must still be there.
+func TestInfoHandlerNoDevices(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	s := &Server{
+		sched: &Scheduler{
+			getSystemInfoFn: getSystemInfoFn,
+			getGpuFn: func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo {
+				return nil
+			},
+		},
+	}
+
+	got := infoResponse(t, s)
+
+	if len(got.ComputeInfo.SupportedGPUs) != 0 {
+		t.Errorf("expected no GPUs, got %d", len(got.ComputeInfo.SupportedGPUs))
+	}
+	if got.ComputeInfo.SystemCompute.TotalMemory != 32*format.GigaByte {
+		t.Errorf("system memory should still be reported: got %d", got.ComputeInfo.SystemCompute.TotalMemory)
+	}
+}

--- a/server/routes_info_test.go
+++ b/server/routes_info_test.go
@@ -1,0 +1,207 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/types/model"
+	"github.com/ollama/ollama/version"
+)
+
+// infoTestServer builds a server whose discovery is the fake pair from sched_test.go
+// (one 24GB Metal device, 32GB of system memory), so the reported values are
+// deterministic and the test does not depend on the machine it runs on.
+func infoTestServer(t *testing.T) *Server {
+	t.Helper()
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	return &Server{
+		sched: &Scheduler{
+			getGpuFn:        getGpuFn,
+			getSystemInfoFn: getSystemInfoFn,
+		},
+	}
+}
+
+func infoResponse(t *testing.T, s *Server) api.InfoResponse {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/info", nil)
+
+	s.InfoHandler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var got api.InfoResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding response: %v (body %q)", err, w.Body.String())
+	}
+	return got
+}
+
+// createInfoTestModel writes a model into OLLAMA_MODELS. It mirrors the model
+// creation inside TestRoutes, which lives in a closure and cannot be reused here.
+func createInfoTestModel(t *testing.T, name, digest string) {
+	t.Helper()
+
+	fn := func(resp api.ProgressResponse) { t.Logf("Status: %s", resp.Status) }
+
+	baseLayers, err := ggufLayers(digest, "test.gguf", fn)
+	if err != nil {
+		t.Fatalf("failed to build layers: %v", err)
+	}
+
+	config := &model.ConfigV2{
+		OS:           "linux",
+		Architecture: "amd64",
+	}
+
+	r := api.CreateRequest{Name: name, Files: map[string]string{"test.gguf": digest}}
+	if err := createModel(r, model.ParseName(name), baseLayers, config, fn); err != nil {
+		t.Fatalf("failed to create model %s: %v", name, err)
+	}
+}
+
+func TestInfoHandlerReportsDiscoveredDevices(t *testing.T) {
+	got := infoResponse(t, infoTestServer(t))
+
+	if len(got.ComputeInfo.SupportedGPUs) != 1 {
+		t.Fatalf("expected 1 GPU, got %d", len(got.ComputeInfo.SupportedGPUs))
+	}
+
+	gpu := got.ComputeInfo.SupportedGPUs[0]
+	if gpu.TotalMemory != 24*format.GigaByte {
+		t.Errorf("total memory: got %d, want %d", gpu.TotalMemory, 24*format.GigaByte)
+	}
+	if gpu.FreeMemory != 12*format.GigaByte {
+		t.Errorf("free memory: got %d, want %d", gpu.FreeMemory, 12*format.GigaByte)
+	}
+	if gpu.Runner != "Metal" {
+		t.Errorf("runner: got %q, want %q", gpu.Runner, "Metal")
+	}
+}
+
+func TestInfoHandlerReportsSystemCompute(t *testing.T) {
+	got := infoResponse(t, infoTestServer(t))
+
+	sys := got.ComputeInfo.SystemCompute
+	if sys.TotalMemory != 32*format.GigaByte {
+		t.Errorf("system total memory: got %d, want %d", sys.TotalMemory, 32*format.GigaByte)
+	}
+	if sys.FreeMemory != 26*format.GigaByte {
+		t.Errorf("system free memory: got %d, want %d", sys.FreeMemory, 26*format.GigaByte)
+	}
+	if sys.CPUCores != runtime.NumCPU() {
+		t.Errorf("cpu cores: got %d, want %d", sys.CPUCores, runtime.NumCPU())
+	}
+	if got.Version != version.Version {
+		t.Errorf("version: got %q, want %q", got.Version, version.Version)
+	}
+}
+
+// With nothing loaded the memory counters are zero rather than absent, so a client
+// can render "0 B in use" without special-casing an idle server.
+func TestInfoHandlerIdleServerReportsZeroUsage(t *testing.T) {
+	got := infoResponse(t, infoTestServer(t))
+
+	if got.Models.Running != 0 {
+		t.Errorf("running: got %d, want 0", got.Models.Running)
+	}
+	if got.Models.VRAMUsed != 0 {
+		t.Errorf("vram used: got %d, want 0", got.Models.VRAMUsed)
+	}
+	if got.Models.Count != 0 {
+		t.Errorf("model count: got %d, want 0 for an empty store", got.Models.Count)
+	}
+}
+
+// A layer shared by several models occupies the store once, so filesystem usage
+// counts each digest a single time: adding a second model built from the same
+// file must not grow the reported total.
+func TestInfoHandlerCountsSharedLayersOnce(t *testing.T) {
+	s := infoTestServer(t)
+	_, digest := createTestFile(t, "ollama-model")
+
+	createInfoTestModel(t, "shared-a", digest)
+	first := infoResponse(t, s)
+	if first.Models.Count != 1 {
+		t.Fatalf("model count: got %d, want 1", first.Models.Count)
+	}
+	if first.Models.FilesystemUsed == 0 {
+		t.Fatal("filesystem used should be non-zero once a model exists")
+	}
+
+	// same source file → same layer digests, already counted
+	createInfoTestModel(t, "shared-b", digest)
+	second := infoResponse(t, s)
+
+	if second.Models.Count != 2 {
+		t.Fatalf("model count: got %d, want 2", second.Models.Count)
+	}
+	if second.Models.FilesystemUsed != first.Models.FilesystemUsed {
+		t.Errorf("shared layers counted twice: got %d, want %d (unchanged)",
+			second.Models.FilesystemUsed, first.Models.FilesystemUsed)
+	}
+}
+
+// Metal reports no compute capability or driver version, so those fields are
+// omitted rather than sent as a meaningless "0.0".
+func TestInfoHandlerOmitsUnknownComputeAndDriver(t *testing.T) {
+	got := infoResponse(t, infoTestServer(t))
+
+	gpu := got.ComputeInfo.SupportedGPUs[0]
+	if gpu.Compute != "" {
+		t.Errorf("compute: got %q, want empty for a backend that doesn't report it", gpu.Compute)
+	}
+	if gpu.Driver != "" {
+		t.Errorf("driver: got %q, want empty for a backend that doesn't report it", gpu.Driver)
+	}
+}
+
+// ...but a backend that does report them (CUDA) still gets them through.
+func TestInfoHandlerReportsKnownComputeAndDriver(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	s := &Server{
+		sched: &Scheduler{
+			getSystemInfoFn: getSystemInfoFn,
+			getGpuFn: func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo {
+				return []ml.DeviceInfo{{
+					DeviceID:     ml.DeviceID{ID: "0", Library: "CUDA"},
+					Name:         "NVIDIA GeForce RTX 3090",
+					TotalMemory:  24 * format.GigaByte,
+					FreeMemory:   20 * format.GigaByte,
+					ComputeMajor: 8,
+					ComputeMinor: 6,
+					DriverMajor:  12,
+					DriverMinor:  4,
+				}}
+			},
+		},
+	}
+
+	gpu := infoResponse(t, s).ComputeInfo.SupportedGPUs[0]
+	if gpu.Compute != "8.6" {
+		t.Errorf("compute: got %q, want %q", gpu.Compute, "8.6")
+	}
+	if gpu.Driver != "12.4" {
+		t.Errorf("driver: got %q, want %q", gpu.Driver, "12.4")
+	}
+	if gpu.Runner != "CUDA" {
+		t.Errorf("runner: got %q, want %q", gpu.Runner, "CUDA")
+	}
+}


### PR DESCRIPTION
This is @dhiltgen's #7262 rebased onto current `main`, adapted to today's device-discovery API, with tests added. It adds `GET /api/info` and an `ollama info` CLI reporting server version, model store usage, system memory, and per-GPU total/free VRAM.

I asked on #7262 whether a rebase would be welcome ([comment](https://github.com/ollama/ollama/pull/7262#issuecomment-5194802120)) and didn't hear back, so I've done it — happy for this to be closed in favour of pushing to the original branch instead, whichever is easier to review.

### Why

There is currently no way to ask the server what GPUs it found or how much VRAM they have: `/api/ps` reports per-model usage only, and the totals appear solely in log lines. That makes "did Ollama actually find my GPU, and how big a model fits?" a log-grepping exercise.

This PR is already the standing answer to that question — it has been pointed at from six issues over two years, twice by @rick-github in the last eight months:

- #15148 — *"'ollama serve' should report what GPUs if any it found"*: the reporter couldn't tell whether their GPUs had been detected, because `msg="inference compute" id=GPU-b5d...` is opaque. The workaround offered was a shell function to `grep` the logs and `sed` the line apart; the thread closes by linking here.
- #3822 — *"It would be helpful if there was an API endpoint to see the hardware details that the Ollama server is running on."*; Issue that the above issue was marked a duplicate of.
- #13723 — *"RFE: Add a status command"*
- #1246 — *"Status endpoint needed"* (open since 2023)
- #3314, #7112, #7285

My own use case is a VRAM gauge in a browser extension driving a local Ollama through OpenWebUI: `/api/ps` gives the numerator, and there is no way to get the denominator.

### What changed versus the original PR

`discover` moved on considerably since 2024, so the handler needed rewriting rather than just re-applying:

| Original | Now |
| --- | --- |
| `discover.GetSystemInfo().GPUs` | `ml.SystemInfo` carries memory only; devices come from `GPUDevices()` |
| `sysInfo.System.CPUs[].CoreCount` | no longer exists in the tree → `runtime.NumCPU()` |
| `gpu.Compute` field | `dev.Compute()` method |
| hand-formatted `DriverMajor.DriverMinor` | `dev.Driver()` method |
| `s.sched.loaded` + manual `loadedMu` locking | `s.sched.loadedModels()` accessor |
| `Manifests(true)` | `manifest.Manifests(true)` |

Two further notes on the adaptation:

- The original also added manual `loadedMu` locking to `PsHandler`; `main` has since solved that properly with the `loadedModels()` accessor, so that hunk is dropped rather than merged.
- `AvailableRunners` depended on the now-deleted `runners` package. The PR's own second commit had already removed that field, so I kept the removal rather than reviving it.

### Discovery is read through the scheduler's hooks

The handler calls `s.sched.getGpuFn` / `s.sched.getSystemInfoFn` rather than `discover.*` directly. Three reasons: it matches how the rest of the server reads discovery, it means `/api/info` reports the same devices the scheduler actually places models on, and it makes the handler testable with the injected fakes that already exist in `sched_test.go`. Without that, testing this would have meant running real GPU discovery inside a unit test.

### Two dead fields removed

`ComputeInfo` declared `unsupported_gpus` and `discovery_errors`, but nothing populated them — they're leftovers from a feature @dhiltgen removed while the PR was open:

> "removed the unsupported logic as it conflicts with other ongoing discovery refinements"
> "Discovery errors and unsupported GPUs removed from the API and UX as it conflicts with other ongoing work around GPU discovery"

The logic went; the fields stayed, so today they would ship as permanently empty. They also can't easily be revived — `filterUnsupportedROCmDevices` removes unusable devices before `GPUDevices()` returns, so populating them would mean changing what discovery hands back. Happy to restore either field if you'd rather keep the shape for future use.

### Compute capability and driver version are omitted when unknown

These are CUDA/ROCm concepts. On Metal both versions are zero, so `dev.Compute()` / `dev.Driver()` render a meaningless `"0.0"`. They're now populated only when the backend reports them (`omitempty`, and the CLI drops the row), which preserves the intent of the original's `if gpu.DriverMajor > 0` guard.

### Tests

The original PR had none; `CONTRIBUTING.md` asks for them. `server/routes_info_test.go` covers:

- reported device values and system memory, via the existing injected discovery, so results don't depend on the host
- an idle server reporting zero usage rather than omitting the counters
- a layer shared by two models counted once (the only real logic in the handler)
- compute/driver reported when the backend knows them, omitted when it doesn't

Each of the three commits builds independently.

### Verified on two backends

**macOS / Metal** (M4, 16 GB unified):

```
 Compute:
  System:
   CPU Cores:    10
   Total Memory: 17 GB
   Free Memory:  3.3 GB
  Supported GPUs:
   Metal 0:
    Name:         MTL0
    Total Memory: 12 GB
    Free Memory:  12 GB
```

```json
{ "gpu_id": "0", "name": "MTL0", "total_memory": 12712935424,
  "free_memory": 12711886848, "runner": "Metal" }
```

Note Metal reports the recommended working set (~12.7 GB of 16 GB), not total system memory — which is the number you'd want for "will this model fit", but worth knowing it isn't RAM.

**Linux / CUDA** (2× RTX PRO 6000 Blackwell, NVIDIA driver 595.84, CUDA 13.2):

```
 Supported GPUs:
  CUDA 0:                        CUDA 1:
   Name:         CUDA0            Name:         CUDA1
   Total Memory: 101 GB           Total Memory: 101 GB
   Free Memory:  62 GB            Free Memory:  101 GB
   Compute:      12.0             Compute:      12.0
   Driver:       13.2             Driver:       13.2
```

```json
[{"gpu_id":"0","name":"CUDA0","total_memory":101972967424,"free_memory":62853742592,
  "compute":"12.0","driver":"13.2","runner":"CUDA"},
 {"gpu_id":"1","name":"CUDA1","total_memory":101972967424,"free_memory":101386813440,
  "compute":"12.0","driver":"13.2","runner":"CUDA"}]
```

`compute` matches `nvidia-smi --query-gpu=compute_cap` exactly. `total_memory` is 99.35% of the board total (`cudaMemGetInfo` excludes ~638 MiB of context/ECC overhead), and the free figures are live rather than a copy of total — GPU 0 read 62 GB because another Ollama instance had a 27B model resident on it while GPU 1 sat idle.

Note `driver` is the **CUDA driver-API version** (13.2), not the NVIDIA driver number (595.84) — same convention as the original PR's example output, but worth naming since the two are easy to confuse.

### Open questions

- Would you rather this went to the original branch as a PR against #7262?
- `ollama info` prints `Version: 0.0.0` in a dev build (no ldflags) — worth a friendlier fallback, or is that fine?
- Should `driver` be labelled as the CUDA driver-API version? A user comparing it against `nvidia-smi` will see 13.2 vs 595.84 and reasonably wonder which is wrong.

<sub>Build note, unrelated to the change: a narrowed CUDA build (`-DOLLAMA_LLAMA_BACKENDS=cuda_v13`) stages `libcudart`/`libcublas` but not `libnccl.so.2`, which `libggml-cuda.so` links against. The backend then fails to load and discovery silently falls back to CPU-only — i.e. an empty `supported_gpus`, with nothing in the log about it. Staging `libnccl.so.2` into `build/lib/ollama/cuda_v13/` fixes it. Flagging in case anyone reviewing with a narrowed backend list sees an empty device list and blames this PR.</sub>

Commits 1–2 keep @dhiltgen as author; the third (tests) is mine.
