### PR TITLE
x/transfer: honor HTTP proxy settings

### DIFF
--- a/x/transfer/transfer.go
+++ b/x/transfer/transfer.go
@@ -121,6 +121,7 @@ var errMaxRetriesExceeded = errors.New("max retries exceeded")
 // defaultClient is a shared HTTP client with connection pooling.
 var defaultClient = &http.Client{
 	Transport: &http.Transport{
+		Proxy:               http.ProxyFromEnvironment,
 		MaxIdleConns:        100,
 		MaxIdleConnsPerHost: 100,
 		IdleConnTimeout:     90 * time.Second,

--- a/x/transfer/transfer_test.go
+++ b/x/transfer/transfer_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -140,6 +141,61 @@ func TestDownload(t *testing.T) {
 	}
 	if lastTotal.Load() != blob1.Size+blob2.Size+blob3.Size {
 		t.Errorf("Wrong total: got %d, want %d", lastTotal.Load(), blob1.Size+blob2.Size+blob3.Size)
+	}
+}
+
+const proxyTestHelperEnv = "OLLAMA_TRANSFER_PROXY_TEST_HELPER"
+
+func TestDownloadUsesHTTPProxy(t *testing.T) {
+	if os.Getenv(proxyTestHelperEnv) == "1" {
+		downloadThroughHTTPProxy(t)
+		return
+	}
+
+	content := []byte("downloaded through HTTP proxy")
+	var requests atomic.Int32
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Host != "registry.test" {
+			http.Error(w, "unexpected proxy target", http.StatusBadGateway)
+			return
+		}
+		requests.Add(1)
+		w.Write(content)
+	}))
+	defer proxy.Close()
+
+	cmd := exec.Command(os.Args[0], "-test.run=^TestDownloadUsesHTTPProxy$")
+	cmd.Env = append(os.Environ(),
+		proxyTestHelperEnv+"=1",
+		"HTTP_PROXY="+proxy.URL,
+		"http_proxy="+proxy.URL,
+		"NO_PROXY=",
+		"no_proxy=",
+	)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("download through HTTP proxy failed: %v\n%s", err, output)
+	}
+	if requests.Load() < 2 {
+		t.Fatalf("proxy received %d requests, want at least 2", requests.Load())
+	}
+}
+
+func downloadThroughHTTPProxy(t *testing.T) {
+	t.Helper()
+
+	content := []byte("downloaded through HTTP proxy")
+	digest := fmt.Sprintf("sha256:%x", sha256.Sum256(content))
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := Download(ctx, DownloadOptions{
+		Blobs:       []Blob{{Digest: digest, Size: int64(len(content))}},
+		BaseURL:     "http://registry.test",
+		DestDir:     t.TempDir(),
+		Concurrency: 1,
+	})
+	if err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- configure the transfer package's shared HTTP transport with `http.ProxyFromEnvironment`
- add an isolated subprocess regression that downloads a verified blob through an `httptest` proxy
- keep the existing connection-pooling settings unchanged

Fixes #15358.

The manifest client already follows the environment through Go's standard transport behavior, but the newer transfer download path constructs its own transport and omitted the proxy callback. The regression uses a non-routable `.test` origin, so it can only succeed when both transfer requests reach the configured local proxy.

## Testing

The new regression was first run against the original implementation and failed with `max retries exceeded` while trying to reach `registry.test`.

- `go test ./x/transfer -count=1`
- `go test -race ./x/transfer -count=1`
- `go vet ./x/transfer`
- `golangci-lint run ./x/transfer` — 0 issues
- `gofmt -d x/transfer/transfer.go x/transfer/transfer_test.go`
- `git diff --check`

## AI assistance

This contribution was developed with AI assistance. The issue scope, current-main call path, baseline failure, implementation, package tests, race test, static analysis, and final diff were independently reviewed and rerun before submission.