### PR TITLE
docs: fix grammar large amounts whitespace -> large amounts of whitespace

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -67,7 +67,7 @@ Structured outputs are supported by providing a JSON schema in the `format` para
 Enable JSON mode by setting the `format` parameter to `json`. This will structure the response as a valid JSON object. See the JSON mode [example](#request-json-mode) below.
 
 > [!IMPORTANT]
-> It's important to instruct the model to use JSON in the `prompt`. Otherwise, the model may generate large amounts whitespace.
+> It's important to instruct the model to use JSON in the `prompt`. Otherwise, the model may generate large amounts of whitespace.
 
 ### Examples
 


### PR DESCRIPTION
Fix grammar in docs/api.md:70: large amounts whitespace -> large amounts of whitespace.