### PR TITLE
app/tools: preserve actual error details from web_fetch API responses

### DIFF
--- a/app/tools/web_fetch.go
+++ b/app/tools/web_fetch.go
@@ -126,6 +126,12 @@ func performWebFetch(ctx context.Context, targetURL string) (*FetchResponse, err
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
+		var errorResp struct {
+			Error string `json:"error"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&errorResp); err == nil && errorResp.Error != "" {
+			return nil, fmt.Errorf("fetch API error (status %d): %s", resp.StatusCode, errorResp.Error)
+		}
 		return nil, fmt.Errorf("fetch API error (status %d)", resp.StatusCode)
 	}
 


### PR DESCRIPTION
The `performWebFetch` function in `app/tools/web_fetch.go` was discarding error response bodies when the cloud API returned non-2xx status codes. When remote servers returned 403 Forbidden or 429 Too Many Requests, the client only reported a generic "fetch API error (status %d)" without including the actual error message from the API response.

The fix extracts the error message from the response body when present and includes it in the error returned to the caller. This preserves diagnostic information about why the request failed (rate limiting, access forbidden, etc.) rather than losing that context.

For example, when a remote server returns 403 and the cloud API returns `{"error": "forbidden"}` with a 403 status, the client now reports "fetch API error (status 403): forbidden" instead of just "fetch API error (status 403)".

Fixes #18143
