### PR TITLE
mlxrunner: abort repeated token loops

### DIFF
--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -193,11 +193,25 @@ func (c *Client) Completion(ctx context.Context, req llm.CompletionRequest, fn f
 	}
 
 	scanner := bufio.NewScanner(resp.Body)
+	var lastToken string
+	var tokenRepeat int
 	for scanner.Scan() {
 		var raw CompletionResponse
 		if err := json.Unmarshal(scanner.Bytes(), &raw); err != nil {
 			slog.Debug("mlx response parse error", "error", err, "line", string(scanner.Bytes()))
 			continue
+		}
+
+		switch token := strings.TrimSpace(raw.Content); {
+		case token == lastToken:
+			tokenRepeat++
+		default:
+			lastToken = token
+			tokenRepeat = 0
+		}
+		if tokenRepeat > 30 {
+			slog.Debug("prediction aborted, token repeat limit reached")
+			return ctx.Err()
 		}
 
 		if raw.Error != nil {

--- a/x/mlxrunner/client_test.go
+++ b/x/mlxrunner/client_test.go
@@ -1,0 +1,49 @@
+package mlxrunner
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/llm"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestClientCompletionAbortsRepeatedTokens(t *testing.T) {
+	var body strings.Builder
+	for range 32 {
+		fmt.Fprintln(&body, `{"Content":"repeat"}`)
+	}
+	fmt.Fprintln(&body, `{"Done":true}`)
+
+	c := &Client{
+		client: &http.Client{Transport: roundTripFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       io.NopCloser(strings.NewReader(body.String())),
+			}, nil
+		})},
+	}
+
+	var responses []llm.CompletionResponse
+	if err := c.Completion(context.Background(), llm.CompletionRequest{}, func(resp llm.CompletionResponse) {
+		responses = append(responses, resp)
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := len(responses), 31; got != want {
+		t.Fatalf("received %d responses, want %d", got, want)
+	}
+	if responses[len(responses)-1].Done {
+		t.Fatal("received final response after repeat limit")
+	}
+}


### PR DESCRIPTION
Apply the existing repeat detector logic to streamed MLX completions so runaway generations stop at the same repeat limit.