### PR TITLE
fix(app): persist sidebar state and suppress open-animation on mount

### DIFF
--- a/app/ui/app/src/components/layout/layout.tsx
+++ b/app/ui/app/src/components/layout/layout.tsx
@@ -1,9 +1,18 @@
 import { Link } from "@tanstack/react-router";
 import { ChatIcon } from "@/components/ChatIcon";
 import { isWindowsPlatform } from "@/lib/platform";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
-let sessionSidebarOpen = false;
+const SIDEBAR_STORAGE_KEY = "sidebarOpen";
+
+function getInitialSidebarOpen(): boolean {
+  try {
+    const stored = localStorage.getItem(SIDEBAR_STORAGE_KEY);
+    return stored !== null ? stored === "true" : false;
+  } catch {
+    return false;
+  }
+}
 
 export function SidebarLayout({
   sidebar,
@@ -13,18 +22,28 @@ export function SidebarLayout({
   sidebar: React.ReactNode;
   title?: string;
 }>) {
-  const [sidebarOpen, setSidebarOpen] = useState(sessionSidebarOpen);
+  const [sidebarOpen, setSidebarOpen] = useState(getInitialSidebarOpen);
+  const [mounted, setMounted] = useState(false);
   const isWindows = isWindowsPlatform();
 
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
   const toggleSidebar = () => {
-    sessionSidebarOpen = !sidebarOpen;
-    setSidebarOpen(sessionSidebarOpen);
+    const next = !sidebarOpen;
+    try {
+      localStorage.setItem(SIDEBAR_STORAGE_KEY, String(next));
+    } catch {
+      // ignore storage errors in restricted environments
+    }
+    setSidebarOpen(next);
   };
 
   return (
     <div className="flex h-screen w-full overflow-hidden dark:bg-neutral-900">
       <div
-        className={`absolute flex mx-2 py-2 z-20 items-center transition-[left] duration-375 text-neutral-500 dark:text-neutral-400 ${sidebarOpen ? (isWindows ? "left-2" : "left-[140px]") : isWindows ? "left-2" : "left-20"}`}
+        className={`absolute flex mx-2 py-2 z-20 items-center ${mounted ? "transition-[left] duration-375" : ""} text-neutral-500 dark:text-neutral-400 ${sidebarOpen ? (isWindows ? "left-2" : "left-[140px]") : isWindows ? "left-2" : "left-20"}`}
       >
         <button
           onClick={toggleSidebar}
@@ -58,7 +77,7 @@ export function SidebarLayout({
         )}
       </div>
       <div
-        className={`flex max-h-screen flex-col transition-[width] duration-300 ${
+        className={`flex max-h-screen flex-col ${mounted ? "transition-[width] duration-300" : ""} ${
           sidebarOpen
             ? "w-48 border-r border-neutral-200 bg-neutral-50 dark:border-neutral-800 dark:bg-neutral-950/40"
             : "w-0"
@@ -71,7 +90,7 @@ export function SidebarLayout({
         ></div>
         {sidebarOpen && sidebar}
       </div>
-      <main className="flex min-w-0 flex-1 flex-col transition-all duration-300">
+      <main className={`flex min-w-0 flex-1 flex-col ${mounted ? "transition-all duration-300" : ""}`}>
         <div
           className={`h-13 z-10 flex w-full flex-none items-center bg-white dark:bg-neutral-900 ${title ? "" : isWindows ? "xl:hidden" : "xl:fixed xl:bg-transparent xl:dark:bg-transparent"}`}
           onDoubleClick={() => window.doubleClick && window.doubleClick()}
@@ -79,7 +98,7 @@ export function SidebarLayout({
         >
           {title && (
             <h1
-              className={`${sidebarOpen ? "pl-6" : isWindows ? "pl-16" : "pl-36"} transition-[padding-left] duration-300 font-rounded text-md font-medium dark:text-white`}
+              className={`${sidebarOpen ? "pl-6" : isWindows ? "pl-16" : "pl-36"} ${mounted ? "transition-[padding-left] duration-300" : ""} font-rounded text-md font-medium dark:text-white`}
             >
               {title}
             </h1>


### PR DESCRIPTION
Hey @dhiltgen ,@jmorganca,


## Summary

Fixes #12954 — the sidebar animates open on every page load when it was
previously open, creating an unpleasant stutter before the UI settles.

### Root cause

Two issues combined to produce the bug:

1. `sessionSidebarOpen` (module-level `let`) resets to `false` on each page load, so the sidebar always starts closed even if the user had it open.
2. Transition classes (`transition-[width]`, etc.) are unconditionally applied, so React's first render — which then corrects the position — plays the full CSS animation.

### Fix

**1 — localStorage persistence**

`useState(getInitialSidebarOpen)` is used (lazy initialiser form) so the storage read happens once and only on the client, not on every re-render.
`toggleSidebar` writes the new value back to `localStorage` on each toggle.

**2 — Suppress transitions on initial mount**

Every animated className is now conditionally applied based on a `mounted` state.
On the first render (before `useEffect` fires) the sidebar is positioned correctly from `localStorage` with **no CSS transition**. After React commits the initial paint and runs the effect, `mounted` becomes `true` and all transitions are enabled for subsequent user interactions.

### Behaviour

- Sidebar was open → reload: Starts open immediately, no animation ✓
- User toggles sidebar: Animates ✓
- `localStorage` throws: Defaults to closed gracefully ✓