### PR TITLE
mlx: dedup dependency files

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -666,6 +666,7 @@ jobs:
               lib/ollama/vulkan*)        echo $COMPONENT >>ollama-${{ matrix.os }}-${{ matrix.arch }}.tar.in ;;
               lib/ollama/mlx*)           echo $COMPONENT >>ollama-${{ matrix.os }}-${{ matrix.arch }}-mlx.tar.in ;;
               lib/ollama/include*)       echo $COMPONENT >>ollama-${{ matrix.os }}-${{ matrix.arch }}-mlx.tar.in ;;
+              lib/ollama/*_LICENSE|lib/ollama/*_NOTICE) echo $COMPONENT >>ollama-${{ matrix.os }}-${{ matrix.arch }}.tar.in ;;
               lib/ollama/cuda_jetpack5)  echo $COMPONENT >>ollama-${{ matrix.os }}-${{ matrix.arch }}-jetpack5.tar.in ;;
               lib/ollama/cuda_jetpack6)  echo $COMPONENT >>ollama-${{ matrix.os }}-${{ matrix.arch }}-jetpack6.tar.in ;;
               lib/ollama/rocm_v*)        echo $COMPONENT >>ollama-${{ matrix.os }}-${{ matrix.arch }}-rocm.tar.in ;;

--- a/.github/workflows/test-llamacpp-update.yaml
+++ b/.github/workflows/test-llamacpp-update.yaml
@@ -240,6 +240,7 @@ jobs:
               lib/ollama/vulkan*)       echo "${COMPONENT}" >>ollama-linux-${{ matrix.arch }}.tar.in ;;
               lib/ollama/mlx*)          echo "${COMPONENT}" >>ollama-linux-${{ matrix.arch }}-mlx.tar.in ;;
               lib/ollama/include*)      echo "${COMPONENT}" >>ollama-linux-${{ matrix.arch }}-mlx.tar.in ;;
+              lib/ollama/*_LICENSE|lib/ollama/*_NOTICE) echo "${COMPONENT}" >>ollama-linux-${{ matrix.arch }}.tar.in ;;
               lib/ollama/cuda_jetpack5) echo "${COMPONENT}" >>ollama-linux-${{ matrix.arch }}-jetpack5.tar.in ;;
               lib/ollama/cuda_jetpack6) echo "${COMPONENT}" >>ollama-linux-${{ matrix.arch }}-jetpack6.tar.in ;;
               lib/ollama/rocm_v*)       echo "${COMPONENT}" >>ollama-linux-${{ matrix.arch }}-rocm.tar.in ;;

--- a/cmake/mlx/CMakeLists.txt
+++ b/cmake/mlx/CMakeLists.txt
@@ -145,17 +145,17 @@ install(TARGETS mlx mlxc ollama_xgrammar
 )
 install(FILES
     "${xgrammar_SOURCE_DIR}/LICENSE"
-    DESTINATION ${OLLAMA_INSTALL_DIR}
+    DESTINATION ${OLLAMA_LIB_DIR}
     RENAME XGRAMMAR_LICENSE
     COMPONENT MLX)
 install(FILES
     "${xgrammar_SOURCE_DIR}/NOTICE"
-    DESTINATION ${OLLAMA_INSTALL_DIR}
+    DESTINATION ${OLLAMA_LIB_DIR}
     RENAME XGRAMMAR_NOTICE
     COMPONENT MLX)
 install(FILES
     "${xgrammar_SOURCE_DIR}/3rdparty/dlpack/LICENSE"
-    DESTINATION ${OLLAMA_INSTALL_DIR}
+    DESTINATION ${OLLAMA_LIB_DIR}
     RENAME DLPACK_LICENSE
     COMPONENT MLX)
 file(READ "${xgrammar_SOURCE_DIR}/3rdparty/picojson/picojson.h" _picojson_header LIMIT 4096)
@@ -168,7 +168,7 @@ string(SUBSTRING "${_picojson_header}" 0 ${_picojson_license_end} _picojson_lice
 file(WRITE "${CMAKE_BINARY_DIR}/PICOJSON_LICENSE" "${_picojson_license}\n")
 install(FILES
     "${CMAKE_BINARY_DIR}/PICOJSON_LICENSE"
-    DESTINATION ${OLLAMA_INSTALL_DIR}
+    DESTINATION ${OLLAMA_LIB_DIR}
     COMPONENT MLX)
 install(RUNTIME_DEPENDENCY_SET mlx_runtime_deps
     DIRECTORIES ${MLX_RUNTIME_DIRS}

--- a/scripts/build_darwin.sh
+++ b/scripts/build_darwin.sh
@@ -255,7 +255,7 @@ _build_macapp() {
 
     rm -f dist/Ollama-darwin.zip
     ditto -c -k --norsrc --keepParent dist/Ollama.app dist/Ollama-darwin.zip
-    (cd dist/Ollama.app/Contents/Resources/; tar -cf - ollama llama-server llama-quantize *.so *.dylib *.metallib mlx_metal_v*/ 2>/dev/null) | gzip -9vc > dist/ollama-darwin.tgz
+    (cd dist/Ollama.app/Contents/Resources/; tar -cf - ollama llama-server llama-quantize *.so *.dylib *.metallib *_LICENSE *_NOTICE mlx_metal_v*/ 2>/dev/null) | gzip -9vc > dist/ollama-darwin.tgz
 
     # Notarize and Staple
     if [ -n "$APPLE_IDENTITY" ]; then


### PR DESCRIPTION
Put license files in lib/ollama so runner dirs don't duplicate them, and package in the base package(s).