### PR TITLE
launch: add AtomCode integration

### DIFF
--- a/cmd/launch/atomcode.go
+++ b/cmd/launch/atomcode.go
@@ -1,0 +1,183 @@
+package launch
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/ollama/ollama/envconfig"
+)
+
+// AtomCode implements Runner for the AtomCode CLI integration.
+type AtomCode struct{}
+
+func (a *AtomCode) String() string { return "AtomCode" }
+
+func (a *AtomCode) findPath() (string, error) {
+	if p, err := exec.LookPath("atomcode"); err == nil {
+		return p, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	name := "atomcode"
+	if runtime.GOOS == "windows" {
+		name = "atomcode.exe"
+	}
+	for _, fallback := range []string{
+		filepath.Join(home, ".local", "bin", name),
+	} {
+		if _, err := os.Stat(fallback); err == nil {
+			return fallback, nil
+		}
+	}
+	return "", fmt.Errorf("atomcode binary not found")
+}
+
+func (a *AtomCode) Run(model string, models []LaunchModel, args []string) error {
+	bin, err := ensureAtomCodeInstalled()
+	if err != nil {
+		return err
+	}
+
+	configPath, err := atomCodeConfigPath()
+	if err != nil {
+		return err
+	}
+	if err := writeAtomCodeConfig(configPath, model, models); err != nil {
+		return fmt.Errorf("failed to configure atomcode: %w", err)
+	}
+
+	runArgs := []string{"--config", configPath, "--provider", atomCodeProvider, "--model", model}
+	runArgs = append(runArgs, args...)
+
+	cmd := exec.Command(bin, runArgs...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func ensureAtomCodeInstalled() (string, error) {
+	if path, err := (&AtomCode{}).findPath(); err == nil {
+		return path, nil
+	}
+
+	if err := checkAtomCodeInstallerDependencies(); err != nil {
+		return "", err
+	}
+
+	ok, err := ConfirmPrompt("AtomCode is not installed. Install now?")
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("atomcode installation cancelled")
+	}
+
+	bin, args, err := atomCodeInstallerCommand(runtime.GOOS)
+	if err != nil {
+		return "", err
+	}
+
+	fmt.Fprintf(os.Stderr, "\nInstalling AtomCode...\n")
+	cmd := exec.Command(bin, args...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("failed to install atomcode: %w", err)
+	}
+
+	path, err := (&AtomCode{}).findPath()
+	if err != nil {
+		return "", fmt.Errorf("atomcode was installed but the binary was not found on PATH\n\nYou may need to restart your shell")
+	}
+
+	fmt.Fprintf(os.Stderr, "%sAtomCode installed successfully%s\n\n", ansiGreen, ansiReset)
+	return path, nil
+}
+
+func checkAtomCodeInstallerDependencies() error {
+	switch runtime.GOOS {
+	case "windows":
+		if _, err := exec.LookPath("powershell"); err != nil {
+			return fmt.Errorf("atomcode is not installed and required dependencies are missing\n\nInstall the following first:\n  PowerShell: https://learn.microsoft.com/powershell/\n\nThen re-run:\n  ollama launch atomcode")
+		}
+	default:
+		var missing []string
+		if _, err := exec.LookPath("curl"); err != nil {
+			missing = append(missing, "curl: https://curl.se/")
+		}
+		if _, err := exec.LookPath("bash"); err != nil {
+			missing = append(missing, "bash: https://www.gnu.org/software/bash/")
+		}
+		if len(missing) > 0 {
+			return fmt.Errorf("atomcode is not installed and required dependencies are missing\n\nInstall the following first:\n  %s\n\nThen re-run:\n  ollama launch atomcode", strings.Join(missing, "\n  "))
+		}
+	}
+	return nil
+}
+
+func atomCodeInstallerCommand(goos string) (string, []string, error) {
+	switch goos {
+	case "windows":
+		return "powershell", []string{
+			"-NoProfile",
+			"-ExecutionPolicy",
+			"Bypass",
+			"-Command",
+			"irm https://raw.atomgit.com/atomgit_atomcode/atomcode/raw/main/scripts/install.ps1 | iex",
+		}, nil
+	case "darwin", "linux":
+		return "bash", []string{
+			"-c",
+			"curl -fsSL https://raw.atomgit.com/atomgit_atomcode/atomcode/raw/main/scripts/install.sh | sh",
+		}, nil
+	default:
+		return "", nil, fmt.Errorf("unsupported platform for atomcode install: %s", goos)
+	}
+}
+
+const atomCodeProvider = "ollama"
+
+// atomCodeConfigPath returns the launcher-owned config that routes AtomCode to
+// Ollama. It is regenerated on every launch so the user's own
+// ~/.atomcode/config.toml is never modified.
+func atomCodeConfigPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".atomcode", "ollama-launch.toml"), nil
+}
+
+func writeAtomCodeConfig(configPath, model string, models []LaunchModel) error {
+	var b strings.Builder
+	fmt.Fprintf(&b, "default_provider = %q\n\n", atomCodeProvider)
+	fmt.Fprintf(&b, "[providers.%s]\n", atomCodeProvider)
+	fmt.Fprintf(&b, "type = %q\n", atomCodeProvider)
+	fmt.Fprintf(&b, "model = %q\n", model)
+	fmt.Fprintf(&b, "base_url = %q\n", strings.TrimRight(envconfig.Host().String(), "/"))
+	if ctx := atomCodeModelContext(models, model); ctx > 0 {
+		fmt.Fprintf(&b, "context_window = %d\n", ctx)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(configPath, []byte(b.String()), 0o644)
+}
+
+func atomCodeModelContext(models []LaunchModel, model string) int {
+	for _, m := range models {
+		if m.Name == model && m.ContextLength > 0 {
+			return m.ContextLength
+		}
+	}
+	return 0
+}

--- a/cmd/launch/atomcode_test.go
+++ b/cmd/launch/atomcode_test.go
@@ -1,0 +1,56 @@
+package launch
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAtomCodeIntegration(t *testing.T) {
+	a := &AtomCode{}
+	if got := a.String(); got != "AtomCode" {
+		t.Errorf("String() = %q, want %q", got, "AtomCode")
+	}
+	var _ Runner = a
+}
+
+func TestWriteAtomCodeConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ollama-launch.toml")
+	if err := writeAtomCodeConfig(path, "qwen3:32b", []LaunchModel{{Name: "qwen3:32b", ContextLength: 32768}}); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := string(data)
+	for _, want := range []string{
+		`default_provider = "ollama"`,
+		"[providers.ollama]",
+		`type = "ollama"`,
+		`model = "qwen3:32b"`,
+		"base_url = ",
+		"context_window = 32768",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("config missing %q:\n%s", want, text)
+		}
+	}
+}
+
+func TestWriteAtomCodeConfigOmitsUnknownContext(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "ollama-launch.toml")
+	if err := writeAtomCodeConfig(path, "qwen3:32b", nil); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(data), "context_window") {
+		t.Errorf("context_window should be omitted when model context is unknown:\n%s", data)
+	}
+}

--- a/cmd/launch/integrations_test.go
+++ b/cmd/launch/integrations_test.go
@@ -1922,7 +1922,7 @@ func TestListIntegrationInfos(t *testing.T) {
 		for _, info := range infos {
 			got = append(got, info.Name)
 		}
-		wantPrefix := []string{"claude", "chatgpt", "hermes", "openclaw", "opencode", "hermes-desktop", "codex", "copilot", "omp"}
+		wantPrefix := []string{"claude", "chatgpt", "hermes", "openclaw", "atomcode", "opencode", "hermes-desktop", "codex", "copilot", "omp"}
 		if codexAppSupported() != nil {
 			wantPrefix = slices.DeleteFunc(wantPrefix, func(name string) bool { return name == "chatgpt" })
 		}

--- a/cmd/launch/launch.go
+++ b/cmd/launch/launch.go
@@ -290,6 +290,7 @@ Supported integrations:
   chatgpt         ChatGPT (aliases: codex-app, codex-desktop, codex-gui)
   hermes          Hermes Agent
   openclaw        OpenClaw (aliases: clawdbot, moltbot)
+  atomcode        AtomCode
   opencode        OpenCode
   codex           Codex
   hermes-desktop  Hermes Desktop

--- a/cmd/launch/registry.go
+++ b/cmd/launch/registry.go
@@ -33,7 +33,7 @@ type IntegrationInfo struct {
 	Description string
 }
 
-var launcherIntegrationOrder = []string{"claude", "chatgpt", "hermes", "openclaw", "opencode", "hermes-desktop", "codex", "copilot", "omp", "cline", "droid", "dsh", "pi", "pool", "qwen"}
+var launcherIntegrationOrder = []string{"claude", "chatgpt", "hermes", "openclaw", "atomcode", "opencode", "hermes-desktop", "codex", "copilot", "omp", "cline", "droid", "dsh", "pi", "pool", "qwen"}
 
 var integrationSpecs = []*IntegrationSpec{
 	{
@@ -182,6 +182,22 @@ var integrationSpecs = []*IntegrationSpec{
 			},
 			URL:     "https://github.com/deepseek-ai/deepseek-harness",
 			Command: []string{"npm", "install", "-g", deepSeekHarnessNpmPackage},
+		},
+	},
+	{
+		Name:        "atomcode",
+		Runner:      &AtomCode{},
+		Description: "AtomGit's open-source AI coding agent for the terminal",
+		Install: IntegrationInstallSpec{
+			CheckInstalled: func() bool {
+				_, err := (&AtomCode{}).findPath()
+				return err == nil
+			},
+			EnsureInstalled: func() error {
+				_, err := ensureAtomCodeInstalled()
+				return err
+			},
+			URL: "https://atomcode.atomgit.com",
 		},
 	},
 	{

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -19,6 +19,7 @@ Configure and launch external applications to use Ollama models. This provides a
 #### Supported integrations
 
 - **OpenCode** - Open-source coding assistant
+- **AtomCode** - AtomGit's open-source terminal coding agent
 - **Claude Code** - Anthropic's agentic coding tool
 - **Codex** - OpenAI's coding assistant
 - **VS Code** - Microsoft's IDE with built-in AI chat

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -168,6 +168,7 @@
             "expanded": true,
             "pages": [
               "/integrations/claude-code",
+              "/integrations/atomcode",
               "/integrations/opencode",
               "/integrations/deepseek-harness",
               "/integrations/cline-cli",

--- a/docs/integrations/atomcode.mdx
+++ b/docs/integrations/atomcode.mdx
@@ -1,0 +1,38 @@
+---
+title: AtomCode
+---
+
+AtomCode is an open-source AI coding agent for the terminal, built by [AtomGit](https://atomcode.atomgit.com). Use it with Ollama local and cloud models.
+
+## Quick start
+
+Launch AtomCode with Ollama:
+
+```bash
+ollama launch atomcode
+```
+
+Ollama installs AtomCode if needed, configures it to use your Ollama server, and starts it with the selected model.
+
+To launch with a specific model:
+
+```bash
+ollama launch atomcode --model qwen3:32b
+```
+
+Use `--yes` for scripts, Docker, or CI:
+
+```bash
+ollama launch atomcode --model qwen3:32b --yes
+```
+
+## Usage
+
+AtomCode works like other terminal coding agents: describe a task in natural language and it reads, edits, runs, and verifies code in your project.
+
+Each launch writes a dedicated config file to `~/.atomcode/ollama-launch.toml` and starts AtomCode with `--config` pointing at it, so your own `~/.atomcode/config.toml` is never modified. Inside AtomCode you can switch models at any time with `/model`.
+
+## Requirements
+
+- [AtomCode](https://atomcode.atomgit.com/docs/en/getting-started.html) — installed automatically on first launch when missing
+- Function calling works best with instruct-tuned models such as `qwen3` or `llama3.2`; weaker local models may not invoke tools reliably

--- a/docs/integrations/index.mdx
+++ b/docs/integrations/index.mdx
@@ -18,6 +18,10 @@ Run `ollama launch` to see the latest integrations you can run from the terminal
     Open-source coding agent that edits, runs, and iterates on code.
   </Card>
 
+  <Card title="AtomCode" href="/integrations/atomcode">
+    AtomGit's open-source terminal coding agent with tools and code-graph analysis.
+  </Card>
+
   <Card title="DeepSeek Harness" icon="/images/launch-icons/deepseek-harness.svg" href="/integrations/deepseek-harness">
     DeepSeek's open-source agent harness with subagents and web search.
   </Card>


### PR DESCRIPTION
## Summary

Adds `ollama launch atomcode`, following the same pattern as existing integrations (e.g. `ollama launch claude` / `codex`).

- New `cmd/launch/atomcode.go`: detects/installs the AtomCode CLI, writes a launcher-owned config (`~/.atomcode/ollama-launch.toml`) that routes AtomCode to Ollama, and launches with `atomcode --config <file> --provider ollama --model <model>`.
- The user's own `~/.atomcode/config.toml` is never modified; the managed config is regenerated on each launch.
- Registered in `cmd/launch/registry.go` (canonical name `atomcode`, visible in the launcher menu), plus help text in `cmd/launch/launch.go`.
- Docs: new `docs/integrations/atomcode.mdx`, sidebar entry in `docs/docs.json`, card in `docs/integrations/index.mdx`, and listing in `docs/cli.mdx`.

## Verification

- `go build ./cmd/...` passes
- `go test ./cmd/launch/` passes (new unit tests for the config writer + existing suite)

## Notes

- Install path mirrors the Claude integration: official one-click installer (curl | sh on macOS/Linux, irm | iex on Windows).
- The `ollama` provider type uses the Ollama daemon root as `base_url` (no `/v1` suffix); AtomCode appends `/api/chat` itself.
