### PR TITLE
docs: fix double space in app README

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -72,7 +72,7 @@ The `-dev` flag enables:
 
 ### macOS
 
-CI builds with Xcode 14.1 for OS compatibility prior to v13.  If you want to manually build v11+ support, you can download the older Xcode [here](https://developer.apple.com/services-account/download?path=/Developer_Tools/Xcode_14.1/Xcode_14.1.xip), extract, then `mv ./Xcode.app /Applications/Xcode_14.1.0.app` then activate with:
+CI builds with Xcode 14.1 for OS compatibility prior to v13. If you want to manually build v11+ support, you can download the older Xcode [here](https://developer.apple.com/services-account/download?path=/Developer_Tools/Xcode_14.1/Xcode_14.1.xip), extract, then `mv ./Xcode.app /Applications/Xcode_14.1.0.app` then activate with:
 
 ```
 export CGO_CFLAGS="-O3 -mmacosx-version-min=12.0"


### PR DESCRIPTION
Fix double space after period in app/README.md:75