### PR TITLE
docs: fix double spaces in docker guide lists

### DIFF
--- a/docs/docker.mdx
+++ b/docs/docker.mdx
@@ -10,7 +10,7 @@ Install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-
 
 ### Install with Apt
 
-1.  Configure the repository
+1. Configure the repository
 
     ```shell
     curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey \
@@ -21,7 +21,7 @@ Install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-
     sudo apt-get update
     ```
 
-2.  Install the NVIDIA Container Toolkit packages
+2. Install the NVIDIA Container Toolkit packages
 
     ```shell
     sudo apt-get install -y nvidia-container-toolkit
@@ -29,14 +29,14 @@ Install the [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-
 
 ### Install with Yum or Dnf
 
-1.  Configure the repository
+1. Configure the repository
 
     ```shell
     curl -fsSL https://nvidia.github.io/libnvidia-container/stable/rpm/nvidia-container-toolkit.repo \
         | sudo tee /etc/yum.repos.d/nvidia-container-toolkit.repo
     ```
 
-2.  Install the NVIDIA Container Toolkit packages
+2. Install the NVIDIA Container Toolkit packages
 
     ```shell
     sudo yum install -y nvidia-container-toolkit


### PR DESCRIPTION
Fix double spaces after list markers in docs/docker.mdx