### PR TITLE
docs: fix hyphenation open-source and trailing whitespace in nemoclaw guide

### DIFF
--- a/docs/integrations/nemoclaw.mdx
+++ b/docs/integrations/nemoclaw.mdx
@@ -2,7 +2,7 @@
 title: NemoClaw
 ---
 
-NemoClaw is NVIDIA's open source security stack for [OpenClaw](/integrations/openclaw). It wraps OpenClaw with the NVIDIA OpenShell runtime to provide kernel-level sandboxing, network policy controls, and audit trails for AI agents. 
+NemoClaw is NVIDIA's open-source security stack for [OpenClaw](/integrations/openclaw). It wraps OpenClaw with the NVIDIA OpenShell runtime to provide kernel-level sandboxing, network policy controls, and audit trails for AI agents.
 
 ## Quick start
 


### PR DESCRIPTION
Fix open source -> open-source and trailing whitespace in docs/integrations/nemoclaw.mdx:5