### PR TITLE
thinking: flush buffered content at end of stream

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -696,6 +696,11 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 				}
 			} else if thinkingState != nil {
 				thinking, content := thinkingState.AddContent(cr.Content)
+				if cr.Done {
+					flushedThinking, flushedContent := thinkingState.Flush()
+					thinking += flushedThinking
+					content += flushedContent
+				}
 				res.Thinking = thinking
 				res.Response = content
 			}
@@ -2840,6 +2845,11 @@ func (s *Server) ChatHandler(c *gin.Context) {
 
 				if thinkingState != nil {
 					thinkingContent, remainingContent := thinkingState.AddContent(res.Message.Content)
+					if r.Done {
+						flushedThinking, flushedContent := thinkingState.Flush()
+						thinkingContent += flushedThinking
+						remainingContent += flushedContent
+					}
 					if thinkingContent == "" && remainingContent == "" && !r.Done {
 						// need to accumulate more to decide what to send
 						return

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -2502,6 +2502,44 @@ func TestChatWithPromptEndingInThinkTag(t *testing.T) {
 		"The answer is 4.",
 		true)
 
+	testChatRequest(t, "flushes partial closing tag at end of stream",
+		"Think until the response ends",
+		"unfinished reasoning</",
+		"unfinished reasoning</",
+		"",
+		true)
+
+	t.Run("generate flushes partial closing tag at end of stream", func(t *testing.T) {
+		mock.CompletionFn = func(_ context.Context, _ llm.CompletionRequest, fn func(llm.CompletionResponse)) error {
+			fn(llm.CompletionResponse{Content: "unfinished reasoning</"})
+			fn(llm.CompletionResponse{Done: true, DoneReason: llm.DoneReasonStop})
+			return nil
+		}
+
+		think := true
+		noStream := false
+		w := createRequest(t, s.GenerateHandler, api.GenerateRequest{
+			Model:  "test-thinking",
+			Prompt: "Think until the response ends",
+			Think:  &api.ThinkValue{Value: think},
+			Stream: &noStream,
+		})
+		if w.Code != http.StatusOK {
+			t.Fatalf("expected status 200, got %d", w.Code)
+		}
+
+		var resp api.GenerateResponse
+		if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+			t.Fatal(err)
+		}
+		if resp.Thinking != "unfinished reasoning</" {
+			t.Errorf("expected thinking %q, got %q", "unfinished reasoning</", resp.Thinking)
+		}
+		if resp.Response != "" {
+			t.Errorf("expected empty content, got %q", resp.Response)
+		}
+	})
+
 	// Test streaming response with template-added <think>
 	t.Run("streaming with thinking", func(t *testing.T) {
 		var wg sync.WaitGroup

--- a/thinking/parser.go
+++ b/thinking/parser.go
@@ -73,6 +73,30 @@ func (s *Parser) AddContent(content string) (string, string) {
 	return thinkingSb.String(), remainingSb.String()
 }
 
+// Flush returns any content that was buffered while waiting to disambiguate a
+// partial tag. It should be called when no more content will be added.
+func (s *Parser) Flush() (thinking, content string) {
+	buffered := s.acc.String()
+	s.acc.Reset()
+
+	switch s.state {
+	case thinkingState_LookingForOpening:
+		content = buffered
+	case thinkingState_Thinking:
+		thinking = buffered
+	case thinkingState_ThinkingStartedEatingWhitespace,
+		thinkingState_ThinkingDoneEatingWhitespace:
+		// Whitespace adjacent to thinking tags is intentionally discarded.
+	case thinkingState_ThinkingDone:
+		content = buffered
+	default:
+		panic("unknown state")
+	}
+
+	s.state = thinkingState_ThinkingDone
+	return thinking, content
+}
+
 // the additional bool return is true iff we should continue eating
 func eat(s *Parser) (string, string, bool) {
 	switch s.state {

--- a/thinking/parser_test.go
+++ b/thinking/parser_test.go
@@ -1,6 +1,7 @@
 package thinking
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -33,6 +34,60 @@ func TestExtractThinking(t *testing.T) {
 		if gotContent != tt.wantContent || gotThinking != tt.wantThink {
 			t.Errorf("case %d: got (%q,%q), want (%q,%q)", i, gotThinking, gotContent, tt.wantThink, tt.wantContent)
 		}
+	}
+}
+
+func TestFlush(t *testing.T) {
+	tests := []struct {
+		name         string
+		chunks       []string
+		wantThinking string
+		wantContent  string
+	}{
+		{
+			name:        "partial opening tag is content",
+			chunks:      []string{"  <th", "i"},
+			wantContent: "  <thi",
+		},
+		{
+			name:         "partial closing tag is thinking",
+			chunks:       []string{"<think>reasoning</"},
+			wantThinking: "reasoning</",
+		},
+		{
+			name:        "whitespace without an opening tag is content",
+			chunks:      []string{"  \n"},
+			wantContent: "  \n",
+		},
+		{
+			name:   "whitespace after opening tag is discarded",
+			chunks: []string{"<think>  \n"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := Parser{OpeningTag: "<think>", ClosingTag: "</think>"}
+			var thinking, content strings.Builder
+			for _, chunk := range tt.chunks {
+				gotThinking, gotContent := parser.AddContent(chunk)
+				thinking.WriteString(gotThinking)
+				content.WriteString(gotContent)
+			}
+
+			gotThinking, gotContent := parser.Flush()
+			thinking.WriteString(gotThinking)
+			content.WriteString(gotContent)
+
+			if thinking.String() != tt.wantThinking || content.String() != tt.wantContent {
+				t.Errorf("got (%q, %q), want (%q, %q)", thinking.String(), content.String(), tt.wantThinking, tt.wantContent)
+			}
+
+			gotThinking, gotContent = parser.Flush()
+			if gotThinking != "" || gotContent != "" {
+				t.Errorf("second Flush returned (%q, %q), want empty output", gotThinking, gotContent)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- add an explicit end-of-stream flush for the generic thinking parser
- return partial opening tags as visible content and partial closing tags as thinking text
- flush parser state from both generate and chat completion callbacks when the runner reports done
- cover parser state behavior and final route delivery, including a separate empty done chunk

Fixes #18009

## Tests

- `go test ./thinking -count=1`
- `go test ./server -run "^TestChatWithPromptEndingInThinkTag$" -count=1`
- `go test ./server -count=1`