### PR TITLE
docs: add AI Novel Writer to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ console.log(response.message.content);
 - [Ollama Fortress](https://github.com/ParisNeo/ollama_proxy_server) - Security proxy for Ollama
 - [1Panel](https://github.com/1Panel-dev/1Panel/) - Web-based Linux server management
 - [Writeopia](https://github.com/Writeopia/Writeopia) - Text editor with Ollama integration
+- [AI Novel Writer](https://github.com/EthanYoQ/AI-Novel-Writer) - Open-source desktop workspace for planning, drafting, reviewing, and revising long-form fiction
 - [QA-Pilot](https://github.com/reid41/QA-Pilot) - GitHub code repository understanding
 - [Raycast extension](https://github.com/MassimilianoPasquini97/raycast_ollama) - Ollama in Raycast
 - [Painting Droid](https://github.com/mateuszmigas/painting-droid) - Painting app with AI integrations


### PR DESCRIPTION
AI Novel Writer is an open-source desktop workspace for long-form fiction. It supports Ollama through its OpenAI-compatible local endpoint and provides current Windows and macOS releases.

Repository: https://github.com/EthanYoQ/AI-Novel-Writer
Latest release: https://github.com/EthanYoQ/AI-Novel-Writer/releases/latest