### PR TITLE
docs: add TeeChat to community desktop integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ console.log(response.message.content);
 - [Kerlig AI](https://www.kerlig.com/) - AI writing assistant for macOS
 - [Hillnote](https://hillnote.com) - Markdown-first AI workspace
 - [Perfect Memory AI](https://www.perfectmemory.ai/) - Productivity AI personalized by screen and meeting history
+- [TeeChat](https://www.teechat.ai) - Chats as Markdown files on your disk ([setup](https://www.teechat.ai/blog/local-ollama-and-web-search))
 
 #### Mobile
 


### PR DESCRIPTION
Adds TeeChat under Community Integrations → Chat Interfaces → Desktop.

TeeChat is a Mac / Windows / Linux desktop client. Local mode auto-detects Ollama at `127.0.0.1:11434` (`GET /api/tags`, `POST /api/chat`). Conversations are stored as Markdown files in a user-chosen folder, not a local database.

Setup walkthrough: https://www.teechat.ai/blog/local-ollama-and-web-search
Downloads: https://www.teechat.ai/download

Local mode is free and does not require an account.