### PR TITLE
docs: update Msty link from .app to .ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ console.log(response.message.content);
 - [ConfiChat](https://github.com/1runeberg/confichat) - Privacy-focused with optional encryption
 - [LLocal.in](https://github.com/kartikm7/llocal) - Electron desktop client
 - [MindMac](https://mindmac.app) - AI chat client for Mac
-- [Msty](https://msty.app) - Multi-model desktop client
+- [Msty](https://msty.ai) - Multi-model desktop client
 - [BoltAI for Mac](https://boltai.com) - AI chat client for Mac
 - [IntelliBar](https://intellibar.app/) - AI-powered assistant for macOS
 - [Kerlig AI](https://www.kerlig.com/) - AI writing assistant for macOS


### PR DESCRIPTION
Closes #18045

## Why this fix is correct
The Msty entry in the README linked to `https://msty.app`, which is the project's outdated domain. The issue reports the current/active URL is `https://msty.ai`, so users clicking the link would land on a stale or incorrect destination.

## Alternatives I considered
- Removing the Msty entry entirely — overkill; the tool is still useful and listed in the community integrations section.
- Keeping `.app` — leaves a stale link, which is exactly the bug.

## Suggested for maintainers
Trivial docs-only change; safe to merge directly. If Msty has any other domain variants in the repo, a quick sweep for `.msty.app` / `msty.app` elsewhere would keep the README consistent.