### PR TITLE
api: clamp keep_alive durations that overflow int64

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -1262,8 +1262,12 @@ func (d *Duration) UnmarshalJSON(b []byte) (err error) {
 	case float64:
 		if t < 0 {
 			d.Duration = time.Duration(math.MaxInt64)
+		} else if s := t * float64(time.Second); s >= float64(math.MaxInt64) {
+			// converting an out-of-range float64 yields an implementation-defined
+			// value, so clamp instead of letting it wrap negative
+			d.Duration = time.Duration(math.MaxInt64)
 		} else {
-			d.Duration = time.Duration(t * float64(time.Second))
+			d.Duration = time.Duration(s)
 		}
 	case string:
 		d.Duration, err = time.ParseDuration(t)

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -74,6 +74,16 @@ func TestKeepAliveParsingFromJSON(t *testing.T) {
 			req:  `{ "keep_alive": "-1m" }`,
 			exp:  &Duration{math.MaxInt64},
 		},
+		{
+			name: "Overflow Integer",
+			req:  `{ "keep_alive": 1000000000000 }`,
+			exp:  &Duration{math.MaxInt64},
+		},
+		{
+			name: "Overflow Float",
+			req:  `{ "keep_alive": 1e20 }`,
+			exp:  &Duration{math.MaxInt64},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
A `keep_alive` large enough to overflow int64 nanoseconds wraps negative, and the scheduler expires a runner whose session duration is `<= 0`. A request asking to keep a model loaded for a very long time therefore unloads it immediately.

`Duration.UnmarshalJSON` multiplied the float64 seconds by `time.Second` and converted without a range check. Converting an out-of-range float64 is implementation-defined; on amd64 it yields `math.MinInt64`. The negative and string branches already clamp to `math.MaxInt64`, so this clamps too when the multiplication would overflow.

Before, with the two added cases:

```
--- FAIL: TestKeepAliveParsingFromJSON/Overflow_Integer
    expected: &api.Duration{Duration:9223372036854775807}
    actual  : &api.Duration{Duration:-9223372036854775808}
```

After: `ok github.com/ollama/ollama/api`, and `go vet ./api/` is clean.

The parsing change is covered by the test. I traced the unload consequence by reading `sched.go` (`:484` copies the duration onto the runner, `:386` expires it when `<= 0`) rather than reproducing it against a running server. I could not build `./server/...` here: `x/mlxrunner/mlx` has undefined references on a clean checkout, unrelated to this change.
