### PR TITLE
server: don't drop the final answer when a model omits its closing thinking tag

### DIFF
--- a/model/parsers/parsers.go
+++ b/model/parsers/parsers.go
@@ -23,6 +23,17 @@ type Parser interface {
 	HasThinkingSupport() bool
 }
 
+// ThinkingStateReporter is an optional interface a Parser may implement to
+// report that it is still inside an unterminated thinking block. Callers use it
+// to distinguish "the model never closed its thinking tag" from "the model
+// produced no content", which are indistinguishable from Add's return values
+// alone.
+type ThinkingStateReporter interface {
+	// UnclosedThinking reports whether the parser is still collecting thinking
+	// because it has not seen a closing thinking tag.
+	UnclosedThinking() bool
+}
+
 type ParserConstructor func() Parser
 
 type ParserRegistry struct {

--- a/model/parsers/qwen35.go
+++ b/model/parsers/qwen35.go
@@ -45,6 +45,12 @@ func (p *Qwen35Parser) HasThinkingSupport() bool {
 	return true
 }
 
+// UnclosedThinking implements ThinkingStateReporter. It reports whether the
+// parser is still in the thinking state, i.e. no closing thinking tag was seen.
+func (p *Qwen35Parser) UnclosedThinking() bool {
+	return p.state == qwen35ParserStateCollectingThinking
+}
+
 func (p *Qwen35Parser) PreservedTokens() []string {
 	return []string{
 		qwen35ThinkingOpenTag,

--- a/model/parsers/qwen35_test.go
+++ b/model/parsers/qwen35_test.go
@@ -513,3 +513,95 @@ func TestQwen35ParserThinkingTruncatedWithoutCloseTag(t *testing.T) {
 		t.Fatalf("expected no tool calls, got %d", len(calls))
 	}
 }
+
+func TestQwen35ParserUnclosedThinkingReportedWhileCollecting(t *testing.T) {
+	parser := ParserForName("qwen3.5")
+	if parser == nil {
+		t.Fatal("expected qwen3.5 parser")
+	}
+
+	reporter, ok := parser.(ThinkingStateReporter)
+	if !ok {
+		t.Fatal("expected qwen3.5 parser to implement ThinkingStateReporter")
+	}
+
+	parser.Init(nil, nil, &api.ThinkValue{Value: true})
+	if !reporter.UnclosedThinking() {
+		t.Fatal("expected UnclosedThinking to be true before any closing tag")
+	}
+
+	if _, _, _, err := parser.Add("Reasoning that never closes", true); err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if !reporter.UnclosedThinking() {
+		t.Fatal("expected UnclosedThinking to stay true when no closing tag was seen")
+	}
+}
+
+func TestQwen35ParserUnclosedThinkingClearedByCloseTag(t *testing.T) {
+	parser := ParserForName("qwen3.5")
+	if parser == nil {
+		t.Fatal("expected qwen3.5 parser")
+	}
+
+	reporter, ok := parser.(ThinkingStateReporter)
+	if !ok {
+		t.Fatal("expected qwen3.5 parser to implement ThinkingStateReporter")
+	}
+
+	parser.Init(nil, nil, &api.ThinkValue{Value: true})
+	content, thinking, _, err := parser.Add("Let me think...</think>Answer.", true)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if thinking != "Let me think..." {
+		t.Fatalf("expected thinking %q, got %q", "Let me think...", thinking)
+	}
+	if content != "Answer." {
+		t.Fatalf("expected content %q, got %q", "Answer.", content)
+	}
+	if reporter.UnclosedThinking() {
+		t.Fatal("expected UnclosedThinking to be false after a closing tag")
+	}
+}
+
+func TestQwen35ParserUnclosedThinkingClearedByToolCall(t *testing.T) {
+	parser := ParserForName("qwen3.5")
+	if parser == nil {
+		t.Fatal("expected qwen3.5 parser")
+	}
+
+	reporter, ok := parser.(ThinkingStateReporter)
+	if !ok {
+		t.Fatal("expected qwen3.5 parser to implement ThinkingStateReporter")
+	}
+
+	tools := []api.Tool{
+		{
+			Function: api.ToolFunction{
+				Name: "get_weather",
+				Parameters: api.ToolFunctionParameters{
+					Properties: func() *api.ToolPropertiesMap {
+						props := api.NewToolPropertiesMap()
+						props.Set("location", api.ToolProperty{Type: api.PropertyType{"string"}})
+						return props
+					}(),
+				},
+			},
+		},
+	}
+
+	parser.Init(tools, nil, &api.ThinkValue{Value: true})
+	// The model omits </think> and goes straight into a tool call; eat() closes
+	// thinking on its behalf, so the turn must not look like unclosed thinking.
+	_, _, calls, err := parser.Add("Deciding...<tool_call><function=get_weather><parameter=location>\nSan Francisco\n</parameter></function></tool_call>", true)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if reporter.UnclosedThinking() {
+		t.Fatal("expected UnclosedThinking to be false once thinking was closed for a tool call")
+	}
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -2832,6 +2832,22 @@ func (s *Server) ChatHandler(c *gin.Context) {
 						return
 					}
 
+					// Some thinking models stop without ever emitting a closing thinking
+					// tag. The parser then classifies the whole generation as thinking and
+					// Content stays empty, so every consumer that keys off Content drops
+					// the answer: /v1/responses emits no message item at all when
+					// streaming, and a message item holding an empty string when not.
+					// Only do this when generation stopped on its own -- a length-capped
+					// or disconnected stream really does hold an unfinished thought, which
+					// should not be promoted to a final answer.
+					if r.Done && r.DoneReason == llm.DoneReasonStop &&
+						res.Message.Content == "" && len(res.Message.ToolCalls) == 0 && tb.Len() > 0 {
+						if reporter, ok := builtinParser.(parsers.ThinkingStateReporter); ok && reporter.UnclosedThinking() {
+							slog.Log(context.TODO(), logutil.LevelTrace, "promoting unclosed thinking to content", "parser", m.Config.Parser, "len", tb.Len())
+							res.Message.Content = tb.String()
+						}
+					}
+
 					if res.Message.Content != "" || res.Message.Thinking != "" || len(res.Message.ToolCalls) > 0 || r.Done || len(res.Logprobs) > 0 {
 						slog.Log(context.TODO(), logutil.LevelTrace, "builtin parser output", "parser", m.Config.Parser, "content", content, "thinking", thinking, "toolCalls", toolCalls, "done", r.Done)
 						ch <- res


### PR DESCRIPTION
When a thinking model stops without ever emitting a closing thinking tag, the
final answer is dropped entirely.

`Qwen35Parser.Init` starts in `qwen35ParserStateCollectingThinking` when thinking
is enabled, because the prompt has already opened the thinking block and the model
is not expected to emit `<think>` itself. If the model then finishes without
emitting `</think>`, the state machine never leaves `CollectingThinking`, so the
entire generation — including the final answer — is classified as thinking and
`Message.Content` stays empty.

Everything downstream keys off `Content`, so the answer is lost:

- `/v1/responses`, streaming: `ResponsesStreamConverter` emits only
  `response.reasoning_summary_text.*` and **no `message` item at all**
- `/v1/responses`, non-streaming: `openai.ToResponse` produces a `message` item
  whose `output_text` is the **empty string** — arguably worse, since clients see
  a well-formed but blank reply and do not retry
- `/v1/chat/completions`: `content` is `""` with the whole answer in `reasoning`

`eat()` already compensates for this model behaviour in the sibling case — when
the tag is omitted and a `<tool_call>` follows, it closes thinking on the model's
behalf, with a comment saying `qwen3.5:9b model forgets sometimes to use </think>
tag before the <tool_call> block starts`. This PR covers the other half: the tag
is omitted and the *final answer* follows.

### Reproduction

Ollama 0.32.14, `qwen3.8:latest` (`parser=qwen3.5`), a ~96k-token turn ending in a
final summary, via `/v1/responses` with `reasoning: {effort: "medium"}`:

| | before | after |
|---|---|---|
| `response.output_text.delta` (streaming) | 0 | 1 |
| `response.completed` → `output` | `['reasoning']` | `['reasoning', 'message']` |
| `message.content[0].text` (non-streaming) | `""` | 1516 chars |

The generation ends with `status: "completed"` and `incomplete_details: null`, and
the recovered text is a complete, well-formed answer — this is a model that
finished normally and merely omitted the closing tag, not a truncated one.

Observed through Codex CLI pointed at a local Ollama: the TUI streamed the
reasoning and then displayed nothing, because `last_agent_message` was `null`.

### Approach

The distinction that matters is *why* generation stopped, and that is not visible
from `Add`'s return values:

- stopped on its own, tag omitted → the thinking buffer holds a finished answer
- stopped on a length cap or a closed connection → it holds an unfinished thought,
  which should not be promoted

So the promotion is gated on `DoneReason == DoneReasonStop` and lives in
`ChatHandler`, where `DoneReason` is available, rather than inside the parser.
The parser only reports its state through a new optional interface:

```go
type ThinkingStateReporter interface {
	UnclosedThinking() bool
}
```

This keeps `Add`'s behaviour unchanged, so
`TestQwen35ParserThinkingTruncatedWithoutCloseTag` and every other existing test
still hold: a truncated stream still yields empty content.

The promotion also cannot fire on a tool-call turn — `UnclosedThinking()` is only
true while no closing tag has been seen, and `eat()` closes thinking as soon as it
sees `<tool_call>`, so "unclosed thinking" and "parsed a tool call" are mutually
exclusive by construction. The guard additionally requires
`len(res.Message.ToolCalls) == 0` and `res.Message.Content == ""`.

Only `Qwen35Parser` implements the interface here; other parsers are unaffected
because the call site type-asserts. Related: #17987, #18009.

### Tests

Three new tests in `model/parsers/qwen35_test.go`, no existing test modified:

- `UnclosedThinking()` stays true when no closing tag is ever seen
- it is cleared by an explicit `</think>`
- it is cleared when `eat()` closes thinking for a `<tool_call>`

`go build ./...`, `go vet ./model/parsers/ ./server/`, `gofmt -l` and
`go test ./model/parsers/` all pass. The fix was also built and run against the
real workload above on an RX 7900 XTX, verified across streaming, non-streaming
and a full agentic session with tool calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
