### PR TITLE
convert: resolve torch model paths through the supplied fs.FS

### DIFF
--- a/convert/reader_torch.go
+++ b/convert/reader_torch.go
@@ -1,8 +1,10 @@
 package convert
 
 import (
+	"fmt"
 	"io"
 	"io/fs"
+	"os"
 	"strings"
 
 	"github.com/nlpodyssey/gopickle/pytorch"
@@ -12,7 +14,16 @@ import (
 func parseTorch(fsys fs.FS, replacer *strings.Replacer, ps ...string) ([]Tensor, error) {
 	var ts []Tensor
 	for _, p := range ps {
-		pt, err := pytorch.Load(p)
+		// gopickle's pytorch.Load only accepts an OS filename; it has no
+		// fs.FS-aware alternative. Recover the real OS path from fsys rather
+		// than passing p through unchanged, which would resolve against the
+		// process's working directory instead of fsys.
+		osPath, err := resolveOSPath(fsys, p)
+		if err != nil {
+			return nil, err
+		}
+
+		pt, err := pytorch.Load(osPath)
 		if err != nil {
 			return nil, err
 		}
@@ -36,6 +47,24 @@ func parseTorch(fsys fs.FS, replacer *strings.Replacer, ps ...string) ([]Tensor,
 	}
 
 	return ts, nil
+}
+
+// resolveOSPath recovers the real OS filename backing name in fsys. It only
+// works for OS-backed filesystems (e.g. os.DirFS, the only kind ConvertModel
+// passes in), since fsys.Open returns the concrete *os.File in that case.
+func resolveOSPath(fsys fs.FS, name string) (string, error) {
+	f, err := fsys.Open(name)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	osFile, ok := f.(*os.File)
+	if !ok {
+		return "", fmt.Errorf("%s: torch format requires an OS-backed filesystem", name)
+	}
+
+	return osFile.Name(), nil
 }
 
 type torch struct {

--- a/convert/reader_torch_test.go
+++ b/convert/reader_torch_test.go
@@ -1,0 +1,40 @@
+package convert
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestParseTorchUsesSuppliedFS ensures parseTorch resolves the given path
+// against fsys, not against the process's working directory. It chdirs
+// somewhere the file doesn't exist, so if parseTorch ever regresses to
+// passing the fs-relative path straight to gopickle, this fails with a
+// "file does not exist" error instead of a pickle-decoding error.
+func TestParseTorchUsesSuppliedFS(t *testing.T) {
+	dir := t.TempDir()
+	name := "pytorch_model.bin"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte("not a real pickle file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Chdir(t.TempDir())
+
+	_, err := parseTorch(os.DirFS(dir), strings.NewReplacer(), name)
+	if err == nil {
+		t.Fatal("expected an error decoding a bogus pickle file, got nil")
+	}
+	if strings.Contains(err.Error(), "no such file") {
+		t.Fatalf("parseTorch resolved %q against the working directory instead of the supplied fs.FS: %v", name, err)
+	}
+}
+
+func TestParseTorchMissingFile(t *testing.T) {
+	dir := t.TempDir()
+
+	_, err := parseTorch(os.DirFS(dir), strings.NewReplacer(), "missing.bin")
+	if err == nil {
+		t.Fatal("expected an error for a missing file, got nil")
+	}
+}


### PR DESCRIPTION
## Problem

`parseTorch` in `convert/reader_torch.go` passes the fs-relative path straight to gopickle's `pytorch.Load(p)`. `pytorch.Load` has no `fs.FS` awareness — it treats `p` as an OS path resolved against the process's working directory, not against the `fs.FS` the caller supplied (always `os.DirFS(tmpDir)` in production, via `server/create.go`). This silently produces wrong results (or a confusing "no such file" error) whenever the process's CWD isn't the model directory, unlike `parseSafetensors`, which correctly stays inside the given `fs.FS`.

Fixes #18184.

## Fix

gopickle has no `fs.FS`-aware loader and only accepts an OS filename, so there's no way to avoid handing it a real OS path. `os.DirFS`'s `Open` is implemented as a thin wrapper over `os.Open` (see `$GOROOT/src/os/file.go`), so it always returns the concrete `*os.File` as the `fs.File` value. `parseTorch` now opens the file through the supplied `fsys`, type-asserts the result to `*os.File`, and uses `.Name()` to recover the real OS path before calling `pytorch.Load`. This only works for OS-backed filesystems, which matches every current caller, and now fails with an explicit, descriptive error instead of a silent wrong-directory read if that ever changes.

`parseTorch`'s signature is unchanged, so the shared dispatch table in `reader.go` needed no changes.

## Testing

- Added `TestParseTorchUsesSuppliedFS`, which chdirs to an empty directory and confirms `parseTorch` still finds the file via the supplied `fs.FS` (verified this test fails with the pre-fix code, reproducing the exact "no such file" error from the issue).
- Added `TestParseTorchMissingFile` for the still-missing-file case.
- `go test ./convert/...`, `go test ./server/...`, `go vet ./convert/...`, `gofmt -l` all pass.
- `go build ./convert/... ./server/... ./cmd/...` succeeds.