### PR TITLE
convert: resolve fs.FS path in parseTorch and parse thinking tags when think is false

### DIFF
--- a/convert/reader_torch.go
+++ b/convert/reader_torch.go
@@ -3,6 +3,7 @@ package convert
 import (
 	"io"
 	"io/fs"
+	"os"
 	"strings"
 
 	"github.com/nlpodyssey/gopickle/pytorch"
@@ -12,7 +13,33 @@ import (
 func parseTorch(fsys fs.FS, replacer *strings.Replacer, ps ...string) ([]Tensor, error) {
 	var ts []Tensor
 	for _, p := range ps {
-		pt, err := pytorch.Load(p)
+		f, err := fsys.Open(p)
+		if err != nil {
+			return nil, err
+		}
+
+		filePath := p
+		if osFile, ok := f.(*os.File); ok {
+			filePath = osFile.Name()
+			_ = f.Close()
+		} else {
+			tmp, err := os.CreateTemp("", "ollama-torch-*.bin")
+			if err != nil {
+				_ = f.Close()
+				return nil, err
+			}
+			defer os.Remove(tmp.Name())
+			if _, err := io.Copy(tmp, f); err != nil {
+				_ = f.Close()
+				_ = tmp.Close()
+				return nil, err
+			}
+			_ = f.Close()
+			_ = tmp.Close()
+			filePath = tmp.Name()
+		}
+
+		pt, err := pytorch.Load(filePath)
 		if err != nil {
 			return nil, err
 		}

--- a/convert/reader_torch_test.go
+++ b/convert/reader_torch_test.go
@@ -1,0 +1,45 @@
+package convert
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"testing/fstest"
+)
+
+func TestParseTorchResolvesFSPath(t *testing.T) {
+	// Test with os.DirFS where files are outside the current working directory
+	dir := t.TempDir()
+	testFile := "pytorch_model.bin"
+	if err := os.WriteFile(filepath.Join(dir, testFile), []byte("dummy invalid pickle"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := parseTorch(os.DirFS(dir), strings.NewReplacer(), testFile)
+	if err == nil {
+		t.Fatal("expected error parsing dummy pickle content, got nil")
+	}
+	// The file should be found on disk and opened, so it must not fail with "no such file or directory"
+	if strings.Contains(err.Error(), "no such file") || strings.Contains(err.Error(), "The system cannot find the file specified") {
+		t.Fatalf("expected file to be found in fs.FS, but got: %v", err)
+	}
+}
+
+func TestParseTorchFallbackWithMapFS(t *testing.T) {
+	// Test with in-memory fs.FS (MapFS) to verify temporary file copy fallback
+	mapFS := fstest.MapFS{
+		"pytorch_model.bin": &fstest.MapFile{
+			Data: []byte("dummy invalid pickle"),
+			Mode: 0o644,
+		},
+	}
+
+	_, err := parseTorch(mapFS, strings.NewReplacer(), "pytorch_model.bin")
+	if err == nil {
+		t.Fatal("expected error parsing dummy pickle content, got nil")
+	}
+	if strings.Contains(err.Error(), "no such file") || strings.Contains(err.Error(), "The system cannot find the file specified") {
+		t.Fatalf("expected file to be found in MapFS, but got: %v", err)
+	}
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -638,7 +638,7 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 	var thinkingState *thinking.Parser
 	if builtinParser == nil {
 		openingTag, closingTag := thinking.InferTags(m.Template.Template)
-		if req.Think != nil && req.Think.Bool() && openingTag != "" && closingTag != "" {
+		if openingTag != "" && closingTag != "" {
 			thinkingState = &thinking.Parser{
 				OpeningTag: openingTag,
 				ClosingTag: closingTag,
@@ -2722,7 +2722,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 
 	var thinkingState *thinking.Parser
 	openingTag, closingTag := thinking.InferTags(m.Template.Template)
-	if req.Think != nil && req.Think.Bool() && openingTag != "" && closingTag != "" {
+	if openingTag != "" && closingTag != "" {
 		thinkingState = &thinking.Parser{
 			OpeningTag: openingTag,
 			ClosingTag: closingTag,

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -2455,9 +2455,7 @@ func TestChatWithPromptEndingInThinkTag(t *testing.T) {
 					{Role: "user", Content: userContent},
 				},
 				Stream: &streamRequest,
-			}
-			if think {
-				req.Think = &api.ThinkValue{Value: think}
+				Think:  &api.ThinkValue{Value: think},
 			}
 
 			w := createRequest(t, s.ChatHandler, req)
@@ -2476,6 +2474,49 @@ func TestChatWithPromptEndingInThinkTag(t *testing.T) {
 
 			if resp.Message.Content != expectedContent {
 				t.Errorf("expected content %q, got %q", expectedContent, resp.Message.Content)
+			}
+		})
+	}
+
+	testGenerateRequest := func(t *testing.T, name string, prompt string, modelResponse string, expectedThinking string, expectedResponse string, think *bool) {
+		t.Run(name, func(t *testing.T) {
+			mock.CompletionResponse = llm.CompletionResponse{
+				Content:            modelResponse,
+				Done:               true,
+				DoneReason:         llm.DoneReasonStop,
+				PromptEvalCount:    1,
+				PromptEvalDuration: 1,
+				EvalCount:          1,
+				EvalDuration:       1,
+			}
+			mock.CompletionFn = nil
+
+			streamRequest := false
+			req := api.GenerateRequest{
+				Model:  "test-thinking",
+				Prompt: prompt,
+				Stream: &streamRequest,
+			}
+			if think != nil {
+				req.Think = &api.ThinkValue{Value: *think}
+			}
+
+			w := createRequest(t, s.GenerateHandler, req)
+			if w.Code != http.StatusOK {
+				t.Fatalf("expected status 200, got %d", w.Code)
+			}
+
+			var resp api.GenerateResponse
+			if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+				t.Fatal(err)
+			}
+
+			if resp.Thinking != expectedThinking {
+				t.Errorf("expected thinking %q, got %q", expectedThinking, resp.Thinking)
+			}
+
+			if resp.Response != expectedResponse {
+				t.Errorf("expected response %q, got %q", expectedResponse, resp.Response)
 			}
 		})
 	}
@@ -2501,6 +2542,43 @@ func TestChatWithPromptEndingInThinkTag(t *testing.T) {
 		"",
 		"The answer is 4.",
 		true)
+
+	testChatRequest(t, "chat with think: false does not leak thinking tags",
+		"Help me solve this problem",
+		" Let me think about this step by step... </think> The answer is 42.",
+		"Let me think about this step by step... ",
+		"The answer is 42.",
+		false)
+
+	thinkFalse := false
+	thinkTrue := true
+	testGenerateRequest(t, "generate with think: false does not leak thinking tags",
+		"What is 2+2?",
+		" Let me think about this step by step... </think> The answer is 4.",
+		"Let me think about this step by step... ",
+		"The answer is 4.",
+		&thinkFalse)
+
+	testGenerateRequest(t, "generate with think: false and empty thinking content",
+		"What is 2+2?",
+		"</think> The answer is 4.",
+		"",
+		"The answer is 4.",
+		&thinkFalse)
+
+	testGenerateRequest(t, "generate with think: true parses thinking",
+		"What is 2+2?",
+		" Let me think about this step by step... </think> The answer is 4.",
+		"Let me think about this step by step... ",
+		"The answer is 4.",
+		&thinkTrue)
+
+	testGenerateRequest(t, "generate with think omitted defaults to parsing thinking",
+		"What is 2+2?",
+		" Let me think about this step by step... </think> The answer is 4.",
+		"Let me think about this step by step... ",
+		"The answer is 4.",
+		nil)
 
 	// Test streaming response with template-added <think>
 	t.Run("streaming with thinking", func(t *testing.T) {


### PR DESCRIPTION
This PR resolves two open issues:

### 1. Fixes #18184: `convert: parseTorch ignores fs.FS and resolves paths against working directory`
`parseTorch` received an `fs.FS` argument, but passed the relative filename `p` directly to `pytorch.Load(p)`, which resolved relative to the current working directory. We now resolve files via `fsys.Open(p)`:
- For `*os.File` (such as `os.DirFS`), retrieve the resolved OS path via `osFile.Name()` with zero extra disk I/O.
- For in-memory/custom filesystems, stage to a temporary file via `os.CreateTemp`.
- Added unit tests in `convert/reader_torch_test.go` covering both `os.DirFS` and `fstest.MapFS`.

### 2. Fixes #18044: `/api/generate ignores think: false and leaks raw <think> into response`
`thinkingState` was previously not instantiated when `think: false` was passed because it was gated on `req.Think.Bool()`. When thinking models (such as DeepSeek-R1) emitted `<think>...</think>`, raw tokens leaked into `response` or `content`.
- Initialized `thinkingState` whenever thinking tags exist in the model template (`openingTag != "" && closingTag != ""`).
- Added test cases in `server/routes_generate_test.go` verifying that `/api/generate` and `/api/chat` with `think: false` do not leak thinking tags into `response` or `content`.