### PR TITLE
server: don't downgrade context for requests that don't specify num_ctx

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -1396,7 +1396,11 @@ func (runner *runnerRef) needsReload(ctx context.Context, req *LlmRequest) bool 
 	optsExisting := runner.Options.Runner
 	optsNew := req.opts.Runner
 	optsNew.NumCtx = effectiveContext(optsNew.NumCtx, runner.trainContext)
-	if runner.numCtxAuto && req.numCtxAuto {
+	// A request that doesn't ask for a specific num_ctx should keep whatever
+	// is already loaded rather than reload down to today's automatic default,
+	// regardless of whether that loaded context was itself auto-derived or
+	// came from an earlier explicit request.
+	if req.numCtxAuto {
 		optsNew.NumCtx = optsExisting.NumCtx
 	}
 	if runner.numBatchAuto && req.numBatchAuto {

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -954,6 +954,35 @@ func TestSchedNeedsReloadIgnoresAutomaticNumCtxClamp(t *testing.T) {
 	require.True(t, runner.needsReload(ctx, req))
 }
 
+// TestSchedNeedsReloadKeepsExplicitContextForAutoRequest guards against a
+// regression where a request that omits num_ctx (e.g. a warm-up call) forced
+// a reload down to the automatic default even though the runner was already
+// loaded with a larger, explicitly requested context.
+func TestSchedNeedsReloadKeepsExplicitContextForAutoRequest(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer done()
+
+	llm := &mockLlm{vramByGPU: map[ml.DeviceID]uint64{}}
+	opts := api.DefaultOptions()
+	opts.NumCtx = 8192
+	model := &Model{}
+	runner := &runnerRef{
+		model:       model,
+		Options:     &opts,
+		llama:       llm,
+		numParallel: 1,
+		numCtxAuto:  false,
+	}
+	req := &LlmRequest{
+		model:      model,
+		opts:       api.DefaultOptions(),
+		numCtxAuto: true,
+	}
+	req.opts.NumCtx = 4096
+
+	require.False(t, runner.needsReload(ctx, req))
+}
+
 func TestSchedNeedsReloadUsesEffectiveAutomaticContextShift(t *testing.T) {
 	ctx, done := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer done()


### PR DESCRIPTION
## Problem

Fixes #18129.

`runnerRef.needsReload` only carries the currently loaded `num_ctx` forward when *both* the loaded runner and the incoming request have an automatic (non-explicit) context:

```go
if runner.numCtxAuto && req.numCtxAuto {
    optsNew.NumCtx = optsExisting.NumCtx
}
```

That covers the case this was originally written for (avoiding reload-thrash from automatic VRAM-tier sizing noise between two automatic requests, see `TestSchedNeedsReloadIgnoresAutomaticNumCtxClamp`). It doesn't cover the case reported in #18129: a runner loaded with an **explicit** `num_ctx` (`runner.numCtxAuto == false`), followed by a request that omits `num_ctx` entirely (`req.numCtxAuto == true`) — e.g. a lightweight warm-up call. Since the condition requires both sides to be automatic, the request's fallback default is treated as a real option change, forcing a reload down to that default. The next "real" request specifying the original `num_ctx` then forces a third reload back up, paying two full model-load costs for a warm-up that should have been a no-op.

## Fix

A request that doesn't ask for a specific `num_ctx` has no basis for preferring today's automatic default over whatever's already loaded, independent of how the loaded context was chosen. Narrowed the condition to only check the incoming request:

```go
if req.numCtxAuto {
    optsNew.NumCtx = optsExisting.NumCtx
}
```

This still reloads whenever the request (or model, or env) explicitly asks for a different context, and still avoids reload-thrash in the original automatic-vs-automatic case; it additionally stops the spontaneous explicit-context-loaded + automatic-request reload described in the issue.

## Testing

- Added `TestSchedNeedsReloadKeepsExplicitContextForAutoRequest`, mirroring the existing `TestSchedNeedsReloadIgnoresAutomaticNumCtxClamp` style, covering the explicit-runner/automatic-request case. Verified it fails against the pre-fix code with the exact false-positive reload the issue describes.
- `go test ./server/...` and `go test ./server/... -race -run TestSched` both pass, including all pre-existing `numCtxAuto`/`numBatchAuto`/`useMMapAuto` tests.
- `go vet ./server/...`, `gofmt -l` clean.