### PR TITLE
x/mlxrunner: enforce the configured num_ctx instead of always using the architecture max

### DIFF
--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -34,7 +34,7 @@ type Client struct {
 	port              int
 	modelName         string
 	contextLength     atomic.Int64
-	softContextLength int // recommended limit to avoid poor performance
+	softContextLength int // configured num_ctx; enforced as a hard cap on the subprocess, 0 means use the architecture max
 	memory            atomic.Uint64
 	done              chan struct{}
 	doneErr           error // valid after done is closed
@@ -322,8 +322,12 @@ func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 		exe = eval
 	}
 
-	// Spawn subprocess: ollama runner --mlx-engine --model <name> --port <port>
-	cmd := exec.Command(exe, "runner", "--mlx-engine", "--model", c.modelName, "--port", strconv.Itoa(port))
+	// Spawn subprocess: ollama runner --mlx-engine --model <name> --port <port> [--num-ctx <n>]
+	runnerArgs := []string{"runner", "--mlx-engine", "--model", c.modelName, "--port", strconv.Itoa(port)}
+	if c.softContextLength > 0 {
+		runnerArgs = append(runnerArgs, "--num-ctx", strconv.Itoa(c.softContextLength))
+	}
+	cmd := exec.Command(exe, runnerArgs...)
 	cmd.Env = os.Environ()
 
 	// Set library path environment variable for MLX libraries

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -56,7 +56,21 @@ type Runner struct {
 	spec *speculation
 }
 
-func (r *Runner) Load(modelName string) error {
+// effectiveContextLength returns the context length the runner should
+// enforce: numCtx if it's a positive value smaller than the architecture's
+// max context (archMax), otherwise archMax unchanged.
+func effectiveContextLength(archMax, numCtx int) int {
+	if numCtx > 0 && numCtx < archMax {
+		return numCtx
+	}
+	return archMax
+}
+
+// Load loads modelName and prepares the runner to serve requests. numCtx, if
+// positive and smaller than the architecture's max context, clamps the
+// runner's effective context length; zero or negative leaves it at the
+// architecture max.
+func (r *Runner) Load(modelName string, numCtx int) error {
 	root, err := model.Open(modelName)
 	if err != nil {
 		return err
@@ -122,7 +136,7 @@ func (r *Runner) Load(modelName string) error {
 
 	r.Model = m
 	r.Tokenizer = m.Tokenizer()
-	r.contextLength = m.MaxContextLength()
+	r.contextLength = effectiveContextLength(m.MaxContextLength(), numCtx)
 	caches := m.NewCaches()
 	draftCaches := newDraftCaches(draftModel)
 	r.cache = newPrefixCache(slices.Concat(caches, draftCaches))

--- a/x/mlxrunner/runner_test.go
+++ b/x/mlxrunner/runner_test.go
@@ -1,0 +1,25 @@
+package mlxrunner
+
+import "testing"
+
+func TestEffectiveContextLength(t *testing.T) {
+	cases := []struct {
+		name            string
+		archMax, numCtx int
+		want            int
+	}{
+		{"num_ctx unset uses arch max", 262144, 0, 262144},
+		{"negative num_ctx uses arch max", 262144, -1, 262144},
+		{"num_ctx smaller than arch max is enforced", 262144, 65536, 65536},
+		{"num_ctx larger than arch max is clamped to arch max", 4096, 65536, 4096},
+		{"num_ctx equal to arch max is a no-op", 65536, 65536, 65536},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := effectiveContextLength(tt.archMax, tt.numCtx); got != tt.want {
+				t.Errorf("effectiveContextLength(%d, %d) = %d, want %d", tt.archMax, tt.numCtx, got, tt.want)
+			}
+		})
+	}
+}

--- a/x/mlxrunner/server.go
+++ b/x/mlxrunner/server.go
@@ -28,11 +28,13 @@ func Execute(args []string) error {
 	var (
 		modelName string
 		port      int
+		numCtx    int
 	)
 
 	flagSet := flag.NewFlagSet("mlxrunner", flag.ExitOnError)
 	flagSet.StringVar(&modelName, "model", "", "Model name")
 	flagSet.IntVar(&port, "port", 0, "Port to listen on")
+	flagSet.IntVar(&numCtx, "num-ctx", 0, "Context length to enforce; 0 uses the architecture's max")
 	_ = flagSet.Bool("verbose", false, "Enable debug logging")
 	flagSet.Parse(args)
 
@@ -66,7 +68,7 @@ func Execute(args []string) error {
 	}
 
 	if err := worker.Do(context.Background(), func() error {
-		return runner.Load(modelName)
+		return runner.Load(modelName, numCtx)
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Problem

Fixes #18125.

`Runner.Load` in `x/mlxrunner/runner.go` always set `contextLength = m.MaxContextLength()` (the architecture's absolute max), with no way to constrain it further. `Client.Load` in `x/mlxrunner/client.go` spawns the `mlx-engine` subprocess with only `--model` and `--port` — the `softContextLength` the scheduler already resolved from the Modelfile/request/env (`mlxrunner.NewClient(modelName, req.opts.NumCtx)`, see `server/sched.go`) was stored on the `Client` purely for the `/api/ps` `context_length` field and never reached the subprocess doing the actual work.

Since the prefill length check (`pipeline.go`: `len(tokens) >= r.contextLength`), the generation cap, the sampler's allocation size, and the subprocess's own `/v1/status` `ContextLength` all key off `Runner.contextLength`, a Modelfile `num_ctx` smaller than the architecture max was silently unenforced end-to-end: `ollama show`/`/api/ps` reported the configured value, but the runner itself always used the architecture max. A prompt between the two limits was accepted and run through a full prefill instead of being rejected, and on long enough prompts this triggers the Metal command-buffer watchdog panic described in the issue (`kIOGPUCommandBufferCallbackErrorImpactingInteractivity`).

## Fix

- Added a `--num-ctx` flag to the `mlx-engine` runner subcommand (`server.go`), defaulting to 0 (architecture max, unchanged behavior when unset).
- `client.go`'s subprocess spawn now passes `--num-ctx <softContextLength>` whenever it's set, so the value the scheduler already computed actually reaches the runner.
- `Runner.Load` now takes `numCtx` and clamps `contextLength` via a small `effectiveContextLength(archMax, numCtx)` helper when `numCtx` is positive and smaller than the architecture max.

This is a single source-of-truth fix: everything downstream that already reads `r.contextLength` (prefill validation, generation cap, sampler sizing, `/v1/status`) picks up the correct, enforced value with no further changes needed.

Out of scope: the separate upstream MLX transient-allocation memory behavior mentioned in the issue thread (linked to `ml-explore/mlx-lm`/`ml-explore/mlx` issues) — this PR only addresses the missing `num_ctx` enforcement, which is what let oversized prompts reach prefill in the first place.

## Testing

- Added `TestEffectiveContextLength` (table-driven) covering unset/negative/smaller/larger/equal `num_ctx` vs. architecture max.
- `go test ./x/mlxrunner/...` passes (includes existing pipeline/grammar/cache/sample/xgrammar suites, run with real MLX on Apple Silicon).
- `go vet ./...`, `gofmt -l` clean.
- `go build ./x/... ./server/... ./cmd/...` succeeds.