### PR TITLE
[WIP] server: report per-device VRAM, and fix three defects that made the figures wrong

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -852,17 +852,23 @@ type ProcessModelResponse struct {
 	SizeVRAM      int64        `json:"size_vram"`
 	ContextLength int          `json:"context_length"`
 
-	// GPUs lists the devices this model was placed on, in the same terms
-	// /api/info reports them. Empty when the model is running on the CPU.
-	// SizeVRAM is the total across all of them, not a per-device figure.
+	// GPUs lists the devices this model was placed on, with per-device VRAM,
+	// in the same terms /api/info reports them. Empty when the model is
+	// running on the CPU.
 	GPUs []ProcessGPU `json:"gpus,omitempty"`
 }
 
-// ProcessGPU identifies one device a loaded model occupies. The pair matches
-// GPUInfo's gpu_id/runner, since an id is only unique within its runner.
+// ProcessGPU reports one device a loaded model occupies and how much VRAM it
+// uses there. The id/runner pair matches GPUInfo's, since an id is only unique
+// within its runner.
 type ProcessGPU struct {
 	ID     string `json:"gpu_id"`
 	Runner string `json:"runner,omitempty"`
+
+	// SizeVRAM is this model's VRAM on this device: tensors, KV cache and
+	// compute buffers. Backends with a single device report the whole figure
+	// here, so it equals the model's total.
+	SizeVRAM int64 `json:"size_vram"`
 }
 
 type TokenResponse struct {

--- a/api/types.go
+++ b/api/types.go
@@ -851,6 +851,18 @@ type ProcessModelResponse struct {
 	ExpiresAt     time.Time    `json:"expires_at"`
 	SizeVRAM      int64        `json:"size_vram"`
 	ContextLength int          `json:"context_length"`
+
+	// GPUs lists the devices this model was placed on, in the same terms
+	// /api/info reports them. Empty when the model is running on the CPU.
+	// SizeVRAM is the total across all of them, not a per-device figure.
+	GPUs []ProcessGPU `json:"gpus,omitempty"`
+}
+
+// ProcessGPU identifies one device a loaded model occupies. The pair matches
+// GPUInfo's gpu_id/runner, since an id is only unique within its runner.
+type ProcessGPU struct {
+	ID     string `json:"gpu_id"`
+	Runner string `json:"runner,omitempty"`
 }
 
 type TokenResponse struct {

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -302,6 +302,11 @@ func Uint64(key string, defaultValue uint64) func() uint64 {
 // Set aside VRAM per GPU
 var GpuOverhead = Uint64("OLLAMA_GPU_OVERHEAD", 0)
 
+// SingleGPUFitPercent is the maximum percentage of a single GPU's available VRAM a model
+// may be predicted to use and still be packed onto that one GPU instead of spread across
+// several. Lower leaves more headroom; higher packs tighter. Default 80.
+var SingleGPUFitPercent = Uint("OLLAMA_SINGLE_GPU_FIT_PERCENT", 80)
+
 type EnvVar struct {
 	Name        string
 	Value       any
@@ -316,6 +321,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_FLASH_ATTENTION":      {"OLLAMA_FLASH_ATTENTION", FlashAttention(false), "Enabled flash attention"},
 		"OLLAMA_KV_CACHE_TYPE":        {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
 		"OLLAMA_GPU_OVERHEAD":         {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},
+		"OLLAMA_SINGLE_GPU_FIT_PERCENT": {"OLLAMA_SINGLE_GPU_FIT_PERCENT", SingleGPUFitPercent(), "Max % of one GPU's free VRAM a model may use and still be packed onto a single GPU (default 80)"},
 		"OLLAMA_IGPU_ENABLE":          {"OLLAMA_IGPU_ENABLE", String("OLLAMA_IGPU_ENABLE")(), "Enable integrated GPUs"},
 		"LLAMA_ARG_FIT":               {"LLAMA_ARG_FIT", String("LLAMA_ARG_FIT")(), "Enable llama.cpp automatic fit of unset memory options (default \"on\")"},
 		"LLAMA_ARG_FIT_TARGET":        {"LLAMA_ARG_FIT_TARGET", String("LLAMA_ARG_FIT_TARGET")(), "Target free VRAM margin per device for llama.cpp fit (MiB)"},

--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -677,10 +677,29 @@ func (f GGML) GraphSize(context, batch uint64, numParallel int, kvCacheType stri
 	kv = make([]uint64, f.KV().BlockCount())
 	kvSizeAttn := uint64(0)
 	kvSizeRecurrent := uint64(0)
+
+	// Some hybrid architectures report attention.head_count as a single scalar that
+	// broadcasts to every block, even though only a subset of layers actually run
+	// attention and hold a KV cache (the rest are recurrent). qwen4exp (Qwen3.x-Flash:
+	// Gated DeltaNet + sparse attention) is one: attention.compress_ratios is a per-block
+	// array that is non-zero exactly on the ~1-in-full_attention_interval attention
+	// layers. Honoring it stops us from counting a dense KV cache for all blocks when
+	// only a fraction have one, which otherwise overpredicts VRAM several-fold at long
+	// context and needlessly spreads the model across GPUs.
+	var attnLayerMask []int32
+	if f.KV().Architecture() == "qwen4exp" {
+		attnLayerMask = f.KV().Ints("attention.compress_ratios")
+	}
+
 	for i := range kv {
 		headsL := headsArr[i]
 		headsKVL := headsKVArr[i]
-		if headsL > 0 && headsKVL > 0 {
+		isAttention := headsL > 0 && headsKVL > 0
+		if i < len(attnLayerMask) {
+			// authoritative per-block metadata overrides the broadcast scalar
+			isAttention = attnLayerMask[i] != 0
+		}
+		if isAttention {
 			// full attention layer
 			// NOTE: Assumes uniform values for all attn layers
 			kv[i] = uint64(float64(context*(embeddingHeadsK+embeddingHeadsV)*headsKVL) * bytesPerElement)

--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -119,6 +119,46 @@ func (kv KV) HeadCountKVMin() uint64 {
 	return uint64(kv.UintOrMinArrayValue("attention.head_count_kv", 1))
 }
 
+// AttentionLayers reports, for each block, whether that block carries an attention KV
+// cache.
+//
+// attention.head_count and attention.head_count_kv are frequently stored as scalars,
+// which broadcast across every block. For a hybrid architecture — recurrent layers
+// interleaved with attention, e.g. qwen4exp (Gated DeltaNet + sparse attention) — the
+// head counts therefore cannot distinguish an attention block from a recurrent one, and
+// treating every block as attention overestimates the KV cache by the ratio of total
+// blocks to attention blocks. When the architecture publishes a per-block
+// attention.compress_ratios array it is authoritative: entries are non-zero exactly on
+// the blocks that run attention.
+func (kv KV) AttentionLayers() []bool {
+	out := make([]bool, kv.BlockCount())
+
+	if ratios := kv.Ints("attention.compress_ratios"); len(ratios) > 0 {
+		for i := range out {
+			if i < len(ratios) {
+				out[i] = ratios[i] != 0
+			}
+		}
+		return out
+	}
+
+	heads, headsKV := kv.HeadCount(), kv.HeadCountKV()
+	for i := range out {
+		out[i] = i < len(heads) && i < len(headsKV) && heads[i] > 0 && headsKV[i] > 0
+	}
+	return out
+}
+
+// AttentionLayerCount returns the number of blocks that carry an attention KV cache.
+func (kv KV) AttentionLayerCount() (n uint64) {
+	for _, isAttention := range kv.AttentionLayers() {
+		if isAttention {
+			n++
+		}
+	}
+	return n
+}
+
 func (kv KV) EmbeddingHeadCountMax() uint64 {
 	if heads := kv.HeadCountMin(); heads > 0 {
 		return kv.EmbeddingLength() / heads
@@ -650,7 +690,6 @@ func (f GGML) GraphSize(context, batch uint64, numParallel int, kvCacheType stri
 
 	embedding := f.KV().EmbeddingLength()
 	heads := f.KV().HeadCountMax()
-	headsArr := f.KV().HeadCount()
 	headsKV := f.KV().HeadCountKVMax()
 	headsKVArr := f.KV().HeadCountKV()
 	vocab := uint64(f.KV()["tokenizer.ggml.tokens"].(*array[string]).size)
@@ -678,28 +717,14 @@ func (f GGML) GraphSize(context, batch uint64, numParallel int, kvCacheType stri
 	kvSizeAttn := uint64(0)
 	kvSizeRecurrent := uint64(0)
 
-	// Some hybrid architectures report attention.head_count as a single scalar that
-	// broadcasts to every block, even though only a subset of layers actually run
-	// attention and hold a KV cache (the rest are recurrent). qwen4exp (Qwen3.x-Flash:
-	// Gated DeltaNet + sparse attention) is one: attention.compress_ratios is a per-block
-	// array that is non-zero exactly on the ~1-in-full_attention_interval attention
-	// layers. Honoring it stops us from counting a dense KV cache for all blocks when
-	// only a fraction have one, which otherwise overpredicts VRAM several-fold at long
-	// context and needlessly spreads the model across GPUs.
-	var attnLayerMask []int32
-	if f.KV().Architecture() == "qwen4exp" {
-		attnLayerMask = f.KV().Ints("attention.compress_ratios")
-	}
+	// Which blocks actually hold a KV cache. For hybrid architectures the scalar head
+	// counts broadcast across every block and cannot distinguish attention blocks from
+	// recurrent ones, so consult the per-block metadata. See KV.AttentionLayers.
+	attentionLayers := f.KV().AttentionLayers()
 
 	for i := range kv {
-		headsL := headsArr[i]
 		headsKVL := headsKVArr[i]
-		isAttention := headsL > 0 && headsKVL > 0
-		if i < len(attnLayerMask) {
-			// authoritative per-block metadata overrides the broadcast scalar
-			isAttention = attnLayerMask[i] != 0
-		}
-		if isAttention {
+		if i < len(attentionLayers) && attentionLayers[i] {
 			// full attention layer
 			// NOTE: Assumes uniform values for all attn layers
 			kv[i] = uint64(float64(context*(embeddingHeadsK+embeddingHeadsV)*headsKVL) * bytesPerElement)

--- a/fs/ggml/ggml_test.go
+++ b/fs/ggml/ggml_test.go
@@ -299,3 +299,65 @@ func TestHeadCount(t *testing.T) {
 		}
 	}
 }
+
+func TestAttentionLayers(t *testing.T) {
+	cases := []struct {
+		name  string
+		kv    KV
+		want  []bool
+		count uint64
+	}{
+		{
+			// Hybrid architecture: the scalar head counts broadcast to every block, so only
+			// the per-block compress ratios distinguish attention blocks from recurrent ones.
+			name: "per-block compress ratios override broadcast scalars",
+			kv: KV{
+				"general.architecture":          "abc",
+				"abc.block_count":               uint32(8),
+				"abc.attention.head_count":      uint32(24),
+				"abc.attention.head_count_kv":   uint32(2),
+				"abc.attention.compress_ratios": &array[int32]{values: []int32{0, 0, 0, 4, 0, 0, 0, 4}, size: 8},
+			},
+			want:  []bool{false, false, false, true, false, false, false, true},
+			count: 2,
+		},
+		{
+			// Without per-block metadata the scalar head counts apply to every block, which
+			// is the correct answer for a non-hybrid model.
+			name: "scalar head counts mark every block as attention",
+			kv: KV{
+				"general.architecture":        "abc",
+				"abc.block_count":             uint32(4),
+				"abc.attention.head_count":    uint32(8),
+				"abc.attention.head_count_kv": uint32(2),
+			},
+			want:  []bool{true, true, true, true},
+			count: 4,
+		},
+		{
+			// Architectures that publish per-layer head counts already distinguish recurrent
+			// blocks with a zero head count; that path must keep working.
+			name: "per-layer head counts mark zero-head blocks as recurrent",
+			kv: KV{
+				"general.architecture":        "abc",
+				"abc.block_count":             uint32(4),
+				"abc.attention.head_count":    &array[int32]{values: []int32{8, 0, 8, 0}, size: 4},
+				"abc.attention.head_count_kv": &array[int32]{values: []int32{2, 0, 2, 0}, size: 4},
+			},
+			want:  []bool{true, false, true, false},
+			count: 2,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := cmp.Diff(tt.kv.AttentionLayers(), tt.want); diff != "" {
+				t.Errorf("unexpected attention layers (-got +want):\n%s", diff)
+			}
+
+			if got := tt.kv.AttentionLayerCount(); got != tt.count {
+				t.Errorf("unexpected attention layer count: got=%d want=%d", got, tt.count)
+			}
+		})
+	}
+}

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -2743,9 +2743,34 @@ type memoryParsingWriter struct {
 	inner   io.Writer
 	runner  *llamaServerRunner
 	buffers map[memoryBufferKey]memoryBuffer
+
+	// bufferSeq counts how many buffers of each slot the current load pass has
+	// reported, and sawNonModelBuffer tracks whether anything but model weights has
+	// been reported since the last model buffer. Together they detect the boundary
+	// between the fit probe and the final load: weights are always reported first, so
+	// a model buffer arriving after a cache or compute buffer means a new pass began.
+	bufferSeq         map[bufferSlot]int
+	sawNonModelBuffer bool
 }
 
 type memoryBufferKey struct {
+	component string
+	backend   string
+	kind      string
+	// seq distinguishes buffers that coexist rather than replace each other. A load
+	// can allocate several buffers of the same kind on one device — a hybrid
+	// architecture reports one KV cache per cache type, and a model with a draft
+	// reports one per context — and every one of them occupies memory at the same
+	// time. Without this they collide and only the last survives, under-reporting the
+	// device by the size of the ones dropped. It is reset per load pass so the fit
+	// probe's buffers are still replaced by the final load's rather than added to
+	// them; see bufferSlot.
+	seq int
+}
+
+// bufferSlot identifies a buffer's reporting slot, ignoring how many of them a load
+// has produced so far. It is the key of the per-pass occurrence counter.
+type bufferSlot struct {
 	component string
 	backend   string
 	kind      string
@@ -2833,7 +2858,39 @@ func (w *memoryParsingWriter) Write(b []byte) (int, error) {
 					if w.buffers == nil {
 						w.buffers = make(map[memoryBufferKey]memoryBuffer)
 					}
+					slot := bufferSlot{
+						component: string(match[1]),
+						backend:   backendName,
+						kind:      string(match[3]),
+					}
+
+					// Weights after a non-weight buffer mean the fit probe finished and
+					// the real load started: begin numbering again so this pass's buffers
+					// replace the probe's instead of accumulating on top of them.
+					if slot.kind == "model" {
+						if w.sawNonModelBuffer {
+							w.bufferSeq = nil
+							w.sawNonModelBuffer = false
+						}
+					} else {
+						w.sawNonModelBuffer = true
+					}
+
+					// Compute buffers keep a single slot. Unlike an allocation, a
+					// reservation is re-reported at a new size when the scheduler reserves
+					// for a different graph, and the buffer is resized rather than added
+					// to, so the latest value replaces the previous one.
+					seq := 0
+					if slot.kind != "compute" {
+						if w.bufferSeq == nil {
+							w.bufferSeq = make(map[bufferSlot]int)
+						}
+						seq = w.bufferSeq[slot]
+						w.bufferSeq[slot] = seq + 1
+					}
+
 					w.buffers[memoryBufferKey{
+						seq:       seq,
 						component: string(match[1]),
 						backend:   backendName,
 						kind:      string(match[3]),

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -154,6 +154,12 @@ type llamaServerRunner struct {
 	// used to map DeviceIDs to device names for VRAMByGPU lookups.
 	gpus []ml.DeviceInfo
 
+	// deviceLogNames[i] is the name the child uses for gpus[i]. A child whose
+	// visible devices are filtered renumbers them from zero, so these differ
+	// from the discovery names whenever the selected devices are not the host's
+	// first ones. Buffer accounting is keyed by these, not by gpus[i].Name.
+	deviceLogNames []string
+
 	ggml          *ggml.GGML
 	totalLayers   uint64 // maximum offloadable model layers
 	loadStart     time.Time
@@ -954,6 +960,7 @@ func NewLlamaServerRunner(
 		vramByDevice:     make(map[string]uint64),
 		systemFreeAtLoad: make(map[string]uint64),
 		gpus:             gpus,
+		deviceLogNames:   ml.RunnerDeviceNames(gpus),
 		ggml:             f,
 		totalLayers:      f.KV().BlockCount() + 1,
 		rawEmbeddings:    legacyEmbeddingsWereRaw(f.KV()),
@@ -2605,7 +2612,8 @@ func (s *llamaServerRunner) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo 
 	infos := make([]ml.DeviceInfo, len(s.gpus))
 	for i, gpu := range s.gpus {
 		infos[i] = gpu
-		used := s.vramByDevice[gpu.Name]
+		name := s.deviceLogName(i)
+		used := s.vramByDevice[name]
 
 		// Our accounting: total minus what we allocated
 		var accountedFree uint64
@@ -2617,7 +2625,7 @@ func (s *llamaServerRunner) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo 
 		// we've allocated since. This captures external consumers on platforms
 		// where the driver reports accurately.
 		systemFree := accountedFree // default to our accounting
-		if sysFree, ok := s.systemFreeAtLoad[gpu.Name]; ok {
+		if sysFree, ok := s.systemFreeAtLoad[name]; ok {
 			if used < sysFree {
 				systemFree = sysFree - used
 			} else {
@@ -2874,16 +2882,24 @@ func (w *memoryParsingWriter) updateRunnerMemoryLocked() {
 // VRAMByGPU returns the VRAM used by this runner on the specified device.
 // The values are parsed from llama-server's buffer size log output during model load
 // (model tensors + KV cache + compute buffers).
+// deviceLogName returns the name the child used for the device at index i,
+// falling back to the discovery name if the mapping is unavailable.
+func (s *llamaServerRunner) deviceLogName(i int) string {
+	if i < len(s.deviceLogNames) {
+		return s.deviceLogNames[i]
+	}
+	return s.gpus[i].Name
+}
+
 func (s *llamaServerRunner) VRAMByGPU(id ml.DeviceID) uint64 {
 	s.memoryMu.RLock()
 	defer s.memoryMu.RUnlock()
 
-	// Map DeviceID to the log device name used by llama-server.
-	// Discovery stores the device name (e.g., "CUDA0", "ROCm0", "MTL0") from
-	// --list-devices stdout, which matches the buffer log prefix.
-	for _, gpu := range s.gpus {
+	// Look up by the name the child used, which is not the discovery name when
+	// its visible devices were filtered (see ml.RunnerDeviceNames).
+	for i, gpu := range s.gpus {
 		if gpu.DeviceID == id {
-			return s.vramByDevice[gpu.Name]
+			return s.vramByDevice[s.deviceLogName(i)]
 		}
 	}
 	return 0

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -2676,14 +2676,36 @@ func (s *llamaServerRunner) MemorySize() (total, vram uint64) {
 // PredictServerVRAM estimates VRAM usage for a model without spawning llama-server.
 // Uses model file size as a proxy for weights plus a rough KV cache estimate.
 // This is intentionally conservative — it overestimates to avoid VRAM contention.
+// hostResidentTensorGroups are tensor groups that are looked up on the host and never
+// offloaded, so they must not be counted toward predicted VRAM. Per-layer token
+// embeddings are the notable case: architectures that use them (gemma3n, qwen4exp) carry
+// a very large table — 26.8 GiB of Qwen3.8-Flash-Next's 103.7 GiB file — that stays in
+// system memory. Counting it as VRAM overpredicts by ~25% and makes a model that fits a
+// single device look like it needs several.
+var hostResidentTensorGroups = []string{"per_layer_token_embd"}
+
 func PredictServerVRAM(modelPath string, f *ggml.GGML, numCtx int) uint64 {
+	// Sum the tensors that are actually offloaded rather than taking the file size, which
+	// also covers host-resident tables. Fall back to the file size if tensor metadata is
+	// unavailable, preserving the previous (conservative) behavior.
 	var weights uint64
-	if info, err := os.Stat(modelPath); err == nil {
-		weights = uint64(info.Size())
+	for name, layer := range f.Tensors().GroupLayers() {
+		if slices.Contains(hostResidentTensorGroups, name) {
+			continue
+		}
+		weights += layer.Size()
 	}
 
-	// KV cache: 2 (K+V) * layers * kv_heads * head_dim * context * 2 bytes (f16)
-	layers := f.KV().BlockCount()
+	if weights == 0 {
+		if info, err := os.Stat(modelPath); err == nil {
+			weights = uint64(info.Size())
+		}
+	}
+
+	// KV cache: 2 (K+V) * attention layers * kv_heads * head_dim * context * 2 bytes (f16).
+	// Only blocks that run attention hold a cache; hybrid architectures interleave
+	// recurrent blocks that do not.
+	layers := f.KV().AttentionLayerCount()
 	kvHeads := f.KV().HeadCountKVMin()
 	if kvHeads == 0 {
 		kvHeads = 1

--- a/llm/llama_server_device_test.go
+++ b/llm/llama_server_device_test.go
@@ -1,0 +1,61 @@
+package llm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ollama/ollama/ml"
+)
+
+// A model placed on the host's second device runs in a child restricted to that
+// device, which therefore calls it CUDA0 and reports its buffers under that
+// name. Looking the device up by its discovery name ("CUDA1") finds nothing and
+// reports the device as unused.
+func newSecondDeviceRunner(used uint64) *llamaServerRunner {
+	gpus := []ml.DeviceInfo{{
+		DeviceID:    ml.DeviceID{ID: "1", Library: "CUDA"},
+		Name:        "CUDA1",
+		TotalMemory: 100 << 30,
+		FreeMemory:  100 << 30,
+	}}
+
+	return &llamaServerRunner{
+		gpus:           gpus,
+		deviceLogNames: ml.RunnerDeviceNames(gpus),
+		vramByDevice:   map[string]uint64{"CUDA0": used},
+	}
+}
+
+func TestVRAMByGPUFilteredChildRenumbers(t *testing.T) {
+	const used = 15 << 30
+
+	got := newSecondDeviceRunner(used).VRAMByGPU(ml.DeviceID{ID: "1", Library: "CUDA"})
+	if got != used {
+		t.Errorf("got %d, want %d: the child reports this device as CUDA0", got, uint64(used))
+	}
+}
+
+// The same mismatch made a device holding a model look completely free, which is
+// worse than a wrong readout: it invites placing more work on a full device.
+func TestGetDeviceInfosFilteredChildRenumbers(t *testing.T) {
+	const used = 15 << 30
+
+	infos := newSecondDeviceRunner(used).GetDeviceInfos(context.Background())
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(infos))
+	}
+
+	want := uint64(100<<30) - used
+	if infos[0].FreeMemory != want {
+		t.Errorf("free memory: got %d, want %d", infos[0].FreeMemory, want)
+	}
+}
+
+// A device the child never mentioned still reports zero rather than matching
+// some other device's figure.
+func TestVRAMByGPUUnknownDevice(t *testing.T) {
+	r := newSecondDeviceRunner(15 << 30)
+	if got := r.VRAMByGPU(ml.DeviceID{ID: "7", Library: "CUDA"}); got != 0 {
+		t.Errorf("got %d, want 0", got)
+	}
+}

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -2977,6 +2977,55 @@ func TestMemoryParsingWriter(t *testing.T) {
 			wantGPU:   47799.52,
 			wantTotal: 56779.74,
 		},
+		{
+			// A hybrid architecture allocates one KV cache per cache type and they
+			// coexist, so both belong in the device total. Taken verbatim from a
+			// Qwen3.8-Flash-Next load, where dropping the first cost 6144 MiB.
+			name: "simultaneous KV caches on one device are both counted",
+			lines: []string{
+				"load_tensors:   CPU_Mapped model buffer size =   644.14 MiB\n",
+				"load_tensors:        CUDA0 model buffer size = 78056.46 MiB\n",
+				"load_tensors:   CPU_Mapped model buffer size = 27465.95 MiB\n",
+				"llama_context:  CUDA_Host  output buffer size =     0.95 MiB\n",
+				"llama_kv_cache:      CUDA0 KV buffer size =  6144.00 MiB\n",
+				"llama_memory_recurrent:      CUDA0 RS buffer size =   112.57 MiB\n",
+				"llama_kv_cache:      CUDA0 KV buffer size =  2304.00 MiB\n",
+				"sched_reserve:      CUDA0 compute buffer size =  1809.09 MiB\n",
+				"sched_reserve:  CUDA_Host compute buffer size =   402.05 MiB\n",
+			},
+			wantGPU:   78056.46 + 6144.00 + 112.57 + 2304.00 + 1809.09,
+			wantTotal: 78056.46 + 6144.00 + 112.57 + 2304.00 + 1809.09 + 644.14 + 27465.95 + 0.95 + 402.05,
+		},
+		{
+			// The probe reports the same pair of caches the final load does. Counting
+			// per pass must not turn that into four caches.
+			name: "fit probe with multiple caches is replaced, not accumulated",
+			lines: []string{
+				"load_tensors:        CUDA0 model buffer size =  1000.00 MiB\n",
+				"llama_kv_cache:      CUDA0 KV buffer size =   500.00 MiB\n",
+				"llama_kv_cache:      CUDA0 KV buffer size =   250.00 MiB\n",
+				"sched_reserve:      CUDA0 compute buffer size =   300.00 MiB\n",
+				"load_tensors:        CUDA0 model buffer size =  1100.00 MiB\n",
+				"llama_kv_cache:      CUDA0 KV buffer size =   550.00 MiB\n",
+				"llama_kv_cache:      CUDA0 KV buffer size =   275.00 MiB\n",
+				"sched_reserve:      CUDA0 compute buffer size =   330.00 MiB\n",
+			},
+			wantGPU:   1100 + 550 + 275 + 330,
+			wantTotal: 1100 + 550 + 275 + 330,
+		},
+		{
+			// The scheduler re-reserves one compute buffer per graph it prepares, at a
+			// new size each time. That buffer is resized, not duplicated.
+			name: "repeated compute reservations replace rather than accumulate",
+			lines: []string{
+				"load_tensors:        CUDA0 model buffer size =  1000.00 MiB\n",
+				"llama_kv_cache:      CUDA0 KV buffer size =   500.00 MiB\n",
+				"sched_reserve:      CUDA0 compute buffer size =   756.03 MiB\n",
+				"sched_reserve:      CUDA0 compute buffer size =   648.03 MiB\n",
+			},
+			wantGPU:   1000 + 500 + 648.03,
+			wantTotal: 1000 + 500 + 648.03,
+		},
 	}
 
 	withinKiB := func(got, want uint64) bool {

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -3737,3 +3737,64 @@ func fakeRunningCmd() *exec.Cmd {
 	// SIGKILL children when the test process exits.
 	return cmd
 }
+
+func TestPredictServerVRAM(t *testing.T) {
+	const numCtx = 128
+
+	// Four blocks with attention only on blocks 1 and 3 (non-zero compress ratios), plus a
+	// per-layer token embedding table, which is looked up on the host and never offloaded.
+	kv := ggml.KV{
+		"general.architecture":          "abc",
+		"abc.block_count":               uint32(4),
+		"abc.embedding_length":          uint32(64),
+		"abc.attention.head_count":      uint32(8),
+		"abc.attention.head_count_kv":   uint32(2),
+		"abc.attention.compress_ratios": []int32{0, 4, 0, 4},
+	}
+
+	tensors := []*ggml.Tensor{
+		testTensorF32("blk.0.attn_q.weight", 2, 3),
+		testTensorF32("blk.1.attn_q.weight", 2, 3),
+		testTensorF32("per_layer_token_embd.weight", 128, 128),
+	}
+
+	// Only the two blk tensors are offloaded; the embedding table is not.
+	const wantWeights = 2 * 2 * 3 * 4
+	// KV cache: 2 (K+V) * attention layers (2, not all 4 blocks) * kv heads (2) *
+	// head dim (embedding 64 / 8 heads) * context * 2 bytes.
+	const wantKV = 2 * 2 * 2 * (64 / 8) * numCtx * 2
+
+	path, _ := writeTestGGML(t, kv, tensors)
+
+	// Load with the same array bound the scheduler uses (see Scheduler.load), so per-block
+	// metadata such as attention.compress_ratios is materialized rather than skipped.
+	f, err := LoadModel(path, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := PredictServerVRAM(path, f, numCtx)
+	if want := uint64(wantWeights + wantKV); got != want {
+		t.Errorf("unexpected predicted VRAM: got=%d want=%d", got, want)
+	}
+
+	// Guard against regressing to the file size: the table is on disk but never in VRAM,
+	// so the prediction must come in well under the size of the file itself.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got >= uint64(info.Size()) {
+		t.Errorf("prediction should exclude host-resident tensors: got=%d file=%d", got, info.Size())
+	}
+}
+
+func testTensorF32(name string, shape ...uint64) *ggml.Tensor {
+	elements := uint64(1)
+	for _, dim := range shape {
+		elements *= dim
+	}
+
+	return &ggml.Tensor{Name: name, Shape: shape, WriterTo: bytes.NewReader(make([]byte, elements*4))}
+}

--- a/ml/device.go
+++ b/ml/device.go
@@ -358,13 +358,64 @@ func (f FlashAttentionType) String() string {
 // Given the list of GPUs this instantiation is targeted for,
 // figure out the device environment variables and any recorded
 // per-device runner environment overrides.
+// devicesMustFilter reports whether the runner child's visible devices are
+// restricted for this set. CUDA-only groups need filtering so devices removed
+// during discovery do not reappear in the child process.
+func devicesMustFilter(l []DeviceInfo) bool {
+	return len(l) == 1 || allDevicesUseLibrary(l, "CUDA")
+}
+
+// RunnerDeviceNames returns the name the runner child will use for each device
+// in l, in the same order.
+//
+// These are not always the discovery names. When the child's visible devices are
+// filtered it enumerates what it can see from zero, so the i-th visible CUDA
+// device is "CUDA0", "CUDA1", ... regardless of its index on the host. A model
+// placed on host device 1 alone runs in a child that calls it "CUDA0", and
+// llama-server's buffer accounting is reported under that name. Callers holding
+// discovery names must translate through this, or they will look up a device
+// the child never mentioned and conclude it is using no memory.
+//
+// Devices whose library is not filtered keep their discovery name, which the
+// child also uses.
+func RunnerDeviceNames(l []DeviceInfo) []string {
+	mustFilter := devicesMustFilter(l)
+
+	names := make([]string, len(l))
+	ordinals := map[string]int{}
+	for i, d := range l {
+		if !d.filtersVisibleDevices(mustFilter) {
+			names[i] = d.Name
+			continue
+		}
+
+		prefix := strings.TrimRight(d.Name, "0123456789")
+		names[i] = prefix + strconv.Itoa(ordinals[prefix])
+		ordinals[prefix]++
+	}
+	return names
+}
+
+// filtersVisibleDevices reports whether this device's library restricts the
+// child's view, which is what makes the child renumber from zero. It mirrors the
+// switch in updateVisibleDevicesEnv.
+func (d DeviceInfo) filtersVisibleDevices(mustFilter bool) bool {
+	switch d.Library {
+	case "ROCm":
+		// always filtered: unsupported devices can crash the runner
+		return true
+	case "CUDA", "Vulkan":
+		return mustFilter
+	default:
+		return false
+	}
+}
+
 func GetDevicesEnv(l []DeviceInfo) map[string]string {
 	if len(l) == 0 {
 		return nil
 	}
-	// CUDA-only groups need filtering so devices removed during discovery do
-	// not reappear in the child process.
-	mustFilter := len(l) == 1 || allDevicesUseLibrary(l, "CUDA")
+	mustFilter := devicesMustFilter(l)
 	env := map[string]string{}
 	for _, d := range l {
 		d.updateVisibleDevicesEnv(env, mustFilter)

--- a/ml/device_names_test.go
+++ b/ml/device_names_test.go
@@ -1,0 +1,79 @@
+package ml
+
+import (
+	"slices"
+	"testing"
+)
+
+func cuda(id, name string) DeviceInfo {
+	return DeviceInfo{DeviceID: DeviceID{ID: id, Library: "CUDA"}, Name: name}
+}
+
+func TestRunnerDeviceNames(t *testing.T) {
+	cases := []struct {
+		name    string
+		devices []DeviceInfo
+		want    []string
+	}{
+		{
+			// the common case, and the one that hid this: selecting the host's
+			// first device gives a child whose numbering happens to match
+			name:    "first device only",
+			devices: []DeviceInfo{cuda("0", "CUDA0")},
+			want:    []string{"CUDA0"},
+		},
+		{
+			// a model placed on the second device runs in a child that can see
+			// only that device, and calls it CUDA0
+			name:    "second device only",
+			devices: []DeviceInfo{cuda("1", "CUDA1")},
+			want:    []string{"CUDA0"},
+		},
+		{
+			name:    "both devices",
+			devices: []DeviceInfo{cuda("0", "CUDA0"), cuda("1", "CUDA1")},
+			want:    []string{"CUDA0", "CUDA1"},
+		},
+		{
+			// discovery orders devices by scheduling preference, so the set can
+			// be a permutation of the host order; the child numbers them in the
+			// order it was given
+			name:    "devices in preference order",
+			devices: []DeviceInfo{cuda("1", "CUDA1"), cuda("0", "CUDA0")},
+			want:    []string{"CUDA0", "CUDA1"},
+		},
+		{
+			name:    "third device only",
+			devices: []DeviceInfo{cuda("2", "CUDA2")},
+			want:    []string{"CUDA0"},
+		},
+		{
+			// a single device of any library is filtered
+			name:    "single metal device",
+			devices: []DeviceInfo{{DeviceID: DeviceID{ID: "0", Library: "Metal"}, Name: "MTL0"}},
+			want:    []string{"MTL0"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RunnerDeviceNames(tc.devices); !slices.Equal(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A mixed-vendor set is not filtered for CUDA, so the child sees every device
+// and keeps the host numbering.
+func TestRunnerDeviceNamesMixedVendorUnfiltered(t *testing.T) {
+	devices := []DeviceInfo{
+		cuda("1", "CUDA1"),
+		{DeviceID: DeviceID{ID: "0", Library: "Vulkan"}, Name: "Vulkan0"},
+	}
+
+	got := RunnerDeviceNames(devices)
+	if want := []string{"CUDA1", "Vulkan0"}; !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -2287,7 +2287,11 @@ func (s *Server) PsHandler(c *gin.Context) {
 
 		gpus := make([]api.ProcessGPU, 0, len(v.gpus))
 		for _, dev := range v.gpus {
-			gpus = append(gpus, api.ProcessGPU{ID: dev.ID, Runner: dev.Library})
+			gpus = append(gpus, api.ProcessGPU{
+				ID:       dev.ID,
+				Runner:   dev.Library,
+				SizeVRAM: int64(v.vramByGPU[dev]),
+			})
 		}
 
 		models = append(models, api.ProcessModelResponse{

--- a/server/routes.go
+++ b/server/routes.go
@@ -2285,7 +2285,13 @@ func (s *Server) PsHandler(c *gin.Context) {
 			QuantizationLevel: m.Config.FileType,
 		}
 
+		gpus := make([]api.ProcessGPU, 0, len(v.gpus))
+		for _, dev := range v.gpus {
+			gpus = append(gpus, api.ProcessGPU{ID: dev.ID, Runner: dev.Library})
+		}
+
 		models = append(models, api.ProcessModelResponse{
+			GPUs:          gpus,
 			Model:         displayName,
 			Name:          displayName,
 			Size:          v.size,

--- a/server/routes_ps_test.go
+++ b/server/routes_ps_test.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/ml"
+)
+
+func psResponse(t *testing.T, runner *runnerRef) (api.ProcessResponse, string) {
+	t.Helper()
+
+	s := &Server{sched: &Scheduler{loaded: map[string]*runnerRef{"m": runner}}}
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/ps", nil)
+
+	s.PsHandler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var got api.ProcessResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding: %v (body %q)", err, w.Body.String())
+	}
+	return got, w.Body.String()
+}
+
+// A model split across two cards names both, so a client can attribute residency
+// per device by joining these ids against /api/info's supported_gpus.
+func TestPsHandlerReportsDevicesForSplitModel(t *testing.T) {
+	got, _ := psResponse(t, &runnerRef{
+		model:     &Model{ShortName: "llama3:70b"},
+		gpus:      []ml.DeviceID{{ID: "0", Library: "CUDA"}, {ID: "1", Library: "CUDA"}},
+		totalSize: 42 * format.GigaByte,
+		vramSize:  40 * format.GigaByte,
+		expiresAt: time.Now().Add(5 * time.Minute),
+	})
+
+	if len(got.Models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(got.Models))
+	}
+
+	gpus := got.Models[0].GPUs
+	if len(gpus) != 2 {
+		t.Fatalf("expected both devices, got %d: %+v", len(gpus), gpus)
+	}
+	for i, want := range []string{"0", "1"} {
+		if gpus[i].ID != want {
+			t.Errorf("gpu %d: id %q, want %q", i, gpus[i].ID, want)
+		}
+		if gpus[i].Runner != "CUDA" {
+			t.Errorf("gpu %d: runner %q, want CUDA", i, gpus[i].Runner)
+		}
+	}
+
+	// SizeVRAM stays the total across devices; it is not divided between them.
+	if got.Models[0].SizeVRAM != int64(40*format.GigaByte) {
+		t.Errorf("size_vram: got %d, want %d", got.Models[0].SizeVRAM, 40*format.GigaByte)
+	}
+}
+
+// A CPU-resident model has no devices, and the field is omitted rather than
+// serialised as null.
+func TestPsHandlerOmitsDevicesOnCPU(t *testing.T) {
+	got, raw := psResponse(t, &runnerRef{
+		model:     &Model{ShortName: "smol:1b"},
+		totalSize: 2 * format.GigaByte,
+		expiresAt: time.Now().Add(5 * time.Minute),
+	})
+
+	if len(got.Models[0].GPUs) != 0 {
+		t.Errorf("expected no devices, got %+v", got.Models[0].GPUs)
+	}
+	if strings.Contains(raw, "\"gpus\"") {
+		t.Errorf("gpus should be omitted for a CPU-resident model, got %s", raw)
+	}
+}

--- a/server/routes_ps_test.go
+++ b/server/routes_ps_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/llm"
 	"github.com/ollama/ollama/ml"
 )
 
@@ -41,12 +42,19 @@ func psResponse(t *testing.T, runner *runnerRef) (api.ProcessResponse, string) {
 // A model split across two cards names both, so a client can attribute residency
 // per device by joining these ids against /api/info's supported_gpus.
 func TestPsHandlerReportsDevicesForSplitModel(t *testing.T) {
+	dev0 := ml.DeviceID{ID: "0", Library: "CUDA"}
+	dev1 := ml.DeviceID{ID: "1", Library: "CUDA"}
+
 	got, _ := psResponse(t, &runnerRef{
 		model:     &Model{ShortName: "llama3:70b"},
-		gpus:      []ml.DeviceID{{ID: "0", Library: "CUDA"}, {ID: "1", Library: "CUDA"}},
+		gpus:      []ml.DeviceID{dev0, dev1},
 		totalSize: 42 * format.GigaByte,
 		vramSize:  40 * format.GigaByte,
 		expiresAt: time.Now().Add(5 * time.Minute),
+		llama: &fakeRunner{vram: map[ml.DeviceID]uint64{
+			dev0: 25 * format.GigaByte,
+			dev1: 15 * format.GigaByte,
+		}, total: 42 * format.GigaByte, gpuTotal: 40 * format.GigaByte},
 	})
 
 	if len(got.Models) != 1 {
@@ -66,7 +74,15 @@ func TestPsHandlerReportsDevicesForSplitModel(t *testing.T) {
 		}
 	}
 
-	// SizeVRAM stays the total across devices; it is not divided between them.
+	// an uneven split is reported as it is, not divided evenly
+	if gpus[0].SizeVRAM != int64(25*format.GigaByte) {
+		t.Errorf("gpu 0 size_vram: got %d, want %d", gpus[0].SizeVRAM, 25*format.GigaByte)
+	}
+	if gpus[1].SizeVRAM != int64(15*format.GigaByte) {
+		t.Errorf("gpu 1 size_vram: got %d, want %d", gpus[1].SizeVRAM, 15*format.GigaByte)
+	}
+
+	// the model-level figure remains the total across devices
 	if got.Models[0].SizeVRAM != int64(40*format.GigaByte) {
 		t.Errorf("size_vram: got %d, want %d", got.Models[0].SizeVRAM, 40*format.GigaByte)
 	}
@@ -88,3 +104,16 @@ func TestPsHandlerOmitsDevicesOnCPU(t *testing.T) {
 		t.Errorf("gpus should be omitted for a CPU-resident model, got %s", raw)
 	}
 }
+
+// fakeRunner is the narrowest llm.LlamaServer that PsHandler exercises: the
+// memory accessors. Everything else panics if the handler ever grows a call.
+type fakeRunner struct {
+	llm.LlamaServer
+	vram     map[ml.DeviceID]uint64
+	total    uint64
+	gpuTotal uint64
+}
+
+func (f *fakeRunner) MemorySize() (uint64, uint64)    { return f.total, f.gpuTotal }
+func (f *fakeRunner) VRAMByGPU(id ml.DeviceID) uint64 { return f.vram[id] }
+func (f *fakeRunner) ContextLength() int              { return 4096 }

--- a/server/sched.go
+++ b/server/sched.go
@@ -1739,6 +1739,7 @@ type loadedModel struct {
 	contextLength int
 	expiresAt     time.Time
 	gpus          []ml.DeviceID
+	vramByGPU     map[ml.DeviceID]uint64
 }
 
 // loadedModels returns a snapshot of the currently loaded models for status
@@ -1773,6 +1774,14 @@ func (s *Scheduler) loadedModels() []loadedModel {
 			total, vram := r.llama.MemorySize()
 			lm.size = int64(total)
 			lm.sizeVRAM = int64(vram)
+
+			// Per-device residency. A backend with one device reports the whole
+			// figure for it; one whose device names don't map back reports zero
+			// rather than guessing.
+			lm.vramByGPU = make(map[ml.DeviceID]uint64, len(lm.gpus))
+			for _, dev := range lm.gpus {
+				lm.vramByGPU[dev] = r.llama.VRAMByGPU(dev)
+			}
 		}
 		// The scheduler waits to set expiresAt, so a model that is still
 		// loading may have the zero value. Estimate expiration from the

--- a/server/sched.go
+++ b/server/sched.go
@@ -1061,7 +1061,7 @@ func bestSingleGPUFit(systemInfo ml.SystemInfo, groups [][]ml.DeviceInfo, predic
 	for _, group := range groups {
 		for _, candidate := range group {
 			candidateAvailable := availableMemoryForGPU(systemInfo, candidate)
-			if predictedVRAM > candidateAvailable*80/100 {
+			if predictedVRAM > candidateAvailable*uint64(envconfig.SingleGPUFitPercent())/100 {
 				continue
 			}
 			if !ok || betterPlacementGPU(candidate, candidateAvailable, gpu, available) {

--- a/server/sched.go
+++ b/server/sched.go
@@ -1738,6 +1738,7 @@ type loadedModel struct {
 	sizeVRAM      int64
 	contextLength int
 	expiresAt     time.Time
+	gpus          []ml.DeviceID
 }
 
 // loadedModels returns a snapshot of the currently loaded models for status
@@ -1765,6 +1766,7 @@ func (s *Scheduler) loadedModels() []loadedModel {
 			size:      int64(r.totalSize),
 			sizeVRAM:  int64(r.vramSize),
 			expiresAt: r.expiresAt,
+			gpus:      slices.Clone(r.gpus),
 		}
 		if r.llama != nil {
 			lm.contextLength = r.llama.ContextLength()

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -281,7 +281,14 @@ func (c *Client) HasExited() bool {
 
 // Load checks whether the model fits in GPU memory and starts the subprocess.
 func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo, requireFull bool) ([]ml.DeviceID, error) {
+	// Devices this model ends up resident on, reported back to the scheduler so
+	// /api/ps can attribute it. Empty means the CPU, so leaving it unset made a
+	// GPU-resident MLX model indistinguishable from a CPU one.
+	var placed []ml.DeviceID
+
 	if len(gpus) > 0 {
+		placed = []ml.DeviceID{gpus[0].DeviceID}
+
 		modelSize := c.memory.Load()
 		// We currently only use the first GPU with MLX
 		available := gpus[0].FreeMemory
@@ -401,7 +408,7 @@ func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 		close(c.done)
 	}()
 
-	return nil, nil
+	return placed, nil
 }
 
 // ModelPath implements llm.LlamaServer.

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -280,14 +280,20 @@ func (c *Client) HasExited() bool {
 }
 
 // Load checks whether the model fits in GPU memory and starts the subprocess.
+// placedDevices reports the devices a load will occupy, for the scheduler to
+// record. MLX uses only the first GPU, and an empty result means the CPU, so
+// returning nothing for a GPU-resident model would misreport it as CPU-bound.
+func placedDevices(gpus []ml.DeviceInfo) []ml.DeviceID {
+	if len(gpus) == 0 {
+		return nil
+	}
+	return []ml.DeviceID{gpus[0].DeviceID}
+}
+
 func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo, requireFull bool) ([]ml.DeviceID, error) {
-	// Devices this model ends up resident on, reported back to the scheduler so
-	// /api/ps can attribute it. Empty means the CPU, so leaving it unset made a
-	// GPU-resident MLX model indistinguishable from a CPU one.
-	var placed []ml.DeviceID
+	placed := placedDevices(gpus)
 
 	if len(gpus) > 0 {
-		placed = []ml.DeviceID{gpus[0].DeviceID}
 
 		modelSize := c.memory.Load()
 		// We currently only use the first GPU with MLX

--- a/x/mlxrunner/placement_test.go
+++ b/x/mlxrunner/placement_test.go
@@ -1,0 +1,30 @@
+package mlxrunner
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/ml"
+)
+
+func TestPlacedDevices(t *testing.T) {
+	metal := ml.DeviceID{ID: "0", Library: "Metal"}
+	second := ml.DeviceID{ID: "1", Library: "Metal"}
+
+	// The scheduler reads an empty list as "on the CPU", so a GPU load must
+	// report its device: this is what /api/ps attributes the model to.
+	got := placedDevices([]ml.DeviceInfo{{DeviceID: metal}})
+	if len(got) != 1 || got[0] != metal {
+		t.Errorf("single GPU: got %+v, want [%+v]", got, metal)
+	}
+
+	// MLX drives only the first device even when more are present, so claiming
+	// both would attribute memory to a card holding none.
+	got = placedDevices([]ml.DeviceInfo{{DeviceID: metal}, {DeviceID: second}})
+	if len(got) != 1 || got[0] != metal {
+		t.Errorf("two GPUs: got %+v, want [%+v] only", got, metal)
+	}
+
+	if got = placedDevices(nil); got != nil {
+		t.Errorf("no GPUs: got %+v, want nil (CPU)", got)
+	}
+}


### PR DESCRIPTION
## Report per-device VRAM, and fix three things that made the numbers wrong

`/api/ps` reports a model's total VRAM but not where it went, so on a multi-GPU host there is no
way to see which card a model landed on or how much it took there. This adds that, and fixes three
defects found while verifying it — each of which produced a wrong number that the scheduler then
acted on.

### The feature

`/api/ps` gains a per-model `gpus` array: which devices a model is resident on, and its VRAM on
each. The MLX runner reports the device it placed a model on so the same field is populated there.

### The three fixes

**1. Device memory was looked up by the wrong name.** A runner whose visible devices are filtered
enumerates them from zero, so a model placed on host device 1 alone runs in a child that calls it
`CUDA0` and reports its buffers under that name. `VRAMByGPU` and `GetDeviceInfos` looked those up
by the discovery name, found nothing, and treated the device as holding no memory.

`GetDeviceInfos` is the consequence that matters: it derives free memory as total minus used, so a
device running a model was reported as entirely free. The mismatch only appears when the selected
devices are not the host's first ones — `[0]` and `[0,1]` line up by coincidence, `[1]` and `[1,0]`
do not — so a single-GPU machine can never hit it. `ml.RunnerDeviceNames` now derives the names the
child will use, at the same place its environment is built, sharing the filtering predicate so the
two cannot drift apart.

**2. Buffers that coexist collided in the accounting.** Buffers were keyed by component, backend
and kind, so several of the same kind on one device overwrote each other. A hybrid architecture
reports one KV cache per cache type and a model with a draft reports one per context; all are
resident simultaneously. Qwen3.8-Flash-Next reports 6144 MiB and 2304 MiB on `CUDA0` — the first was
dropped, so a model holding 86.35 GiB was reported as 80.35 GiB.

Buffers are now numbered within a load pass. The count resets when weights are reported after a
cache or compute buffer, which is where the fit probe ends and the real load begins, so probe
buffers are still *replaced* by the final load's rather than added to them — the two existing probe
fixtures cover this and still pass. Compute buffers keep a single slot, because a reservation is
re-reported at a new size when the scheduler prepares a different graph and that buffer is resized,
not duplicated.

**3. Single-GPU fit was predicted from the file size.** The prediction used the whole file, which
also covers tensors that never reach VRAM, and counted a KV cache for every block including the
recurrent ones in a hybrid. Both push the estimate up, so models that fit on one card were split
across two for no reason. It now sums the tensors actually offloaded and counts only blocks that
run attention, taking the per-block `attention.compress_ratios` array as authoritative when the
architecture publishes it.

The fit headroom becomes configurable as `OLLAMA_SINGLE_GPU_FIT_PERCENT` (default 80, unchanged
behaviour). The measurements below are the argument for keeping that default rather than raising
it.

### Evidence

Measured on 13 models spanning 0.8B to 320.8B parameters — dense, MoE, hybrid recurrent+attention,
hybrid with a draft, and three spanning two cards — comparing four independent views of each load:
the prediction, `/api/ps`, llama-server's own buffer lines, and the `nvidia-smi` delta.

- **`/api/ps` now equals the runner's own accounting on every model, to under 0.005 GiB**, in both
  single- and multi-GPU placement.
- **The prediction is within ±1.9 GiB at 8k context** across that whole size range, and errs high on
  8 of 10 — the safe direction.
- `driver − buffers` is a flat 0.7–1.8 GiB regardless of model size: CUDA context, which no buffer
  line reports and which the fit threshold absorbs.

Full tables, method and the reproduction script are in the report accompanying this PR.

### Known limitations, stated deliberately

The KV term still models a single cache, so architectures with several undercount by an amount
proportional to context: Qwen3.8-Flash-Next predicts within +0.06 GiB at 8k but −7.05 GiB at 256k,
because it accounts about a quarter of the true per-token rate. The default 80% threshold is what
absorbs this — at 256k that model is not placed on a single card at all, so the under-prediction
never gets to matter. Deriving per-cache dimensions is the follow-up; this change does not attempt
it.

Compute-buffer reservations across multiple contexts also still collapse to one slot, so a model
with a draft is under-reported by the smaller of its two compute buffers. Correcting that needs
context boundaries in the parse and is left out on purpose.

### Testing

`go test ./llm/... ./ml/... ./fs/ggml/... ./server/ ./api/... ./cmd/...` passes. 431 of the 728
added lines are tests, including the verbatim Qwen3.8-Flash-Next buffer sequence that exposed the
collision, the fit-probe cases that must keep replacing rather than accumulating, filtered- and
unfiltered-device naming across CUDA/ROCm/Vulkan, and per-block attention counting for hybrid
architectures.

### Related

#18142 exposes GPU and system info over `/api/info` and touches the same files. The two are
independent — this branch shares no commits with it and applies to `main` on its own — but
they are the same area and are probably easiest read together.

A follow-up is prepared that takes the single-GPU prediction further, using the published
head dimensions and a measurement of what earlier loads actually used. It is deliberately
separate: it changes placement behaviour and introduces state, whereas everything here is a
bug fix or a new field.
