### PR TITLE
[WIP] llm: predict single-GPU VRAM from published head dimensions and measured loads

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -852,17 +852,23 @@ type ProcessModelResponse struct {
 	SizeVRAM      int64        `json:"size_vram"`
 	ContextLength int          `json:"context_length"`
 
-	// GPUs lists the devices this model was placed on, in the same terms
-	// /api/info reports them. Empty when the model is running on the CPU.
-	// SizeVRAM is the total across all of them, not a per-device figure.
+	// GPUs lists the devices this model was placed on, with per-device VRAM,
+	// in the same terms /api/info reports them. Empty when the model is
+	// running on the CPU.
 	GPUs []ProcessGPU `json:"gpus,omitempty"`
 }
 
-// ProcessGPU identifies one device a loaded model occupies. The pair matches
-// GPUInfo's gpu_id/runner, since an id is only unique within its runner.
+// ProcessGPU reports one device a loaded model occupies and how much VRAM it
+// uses there. The id/runner pair matches GPUInfo's, since an id is only unique
+// within its runner.
 type ProcessGPU struct {
 	ID     string `json:"gpu_id"`
 	Runner string `json:"runner,omitempty"`
+
+	// SizeVRAM is this model's VRAM on this device: tensors, KV cache and
+	// compute buffers. Backends with a single device report the whole figure
+	// here, so it equals the model's total.
+	SizeVRAM int64 `json:"size_vram"`
 }
 
 type TokenResponse struct {

--- a/api/types.go
+++ b/api/types.go
@@ -851,6 +851,18 @@ type ProcessModelResponse struct {
 	ExpiresAt     time.Time    `json:"expires_at"`
 	SizeVRAM      int64        `json:"size_vram"`
 	ContextLength int          `json:"context_length"`
+
+	// GPUs lists the devices this model was placed on, in the same terms
+	// /api/info reports them. Empty when the model is running on the CPU.
+	// SizeVRAM is the total across all of them, not a per-device figure.
+	GPUs []ProcessGPU `json:"gpus,omitempty"`
+}
+
+// ProcessGPU identifies one device a loaded model occupies. The pair matches
+// GPUInfo's gpu_id/runner, since an id is only unique within its runner.
+type ProcessGPU struct {
+	ID     string `json:"gpu_id"`
+	Runner string `json:"runner,omitempty"`
 }
 
 type TokenResponse struct {

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -302,6 +302,11 @@ func Uint64(key string, defaultValue uint64) func() uint64 {
 // Set aside VRAM per GPU
 var GpuOverhead = Uint64("OLLAMA_GPU_OVERHEAD", 0)
 
+// SingleGPUFitPercent is the maximum percentage of a single GPU's available VRAM a model
+// may be predicted to use and still be packed onto that one GPU instead of spread across
+// several. Lower leaves more headroom; higher packs tighter. Default 80.
+var SingleGPUFitPercent = Uint("OLLAMA_SINGLE_GPU_FIT_PERCENT", 80)
+
 type EnvVar struct {
 	Name        string
 	Value       any
@@ -316,6 +321,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_FLASH_ATTENTION":      {"OLLAMA_FLASH_ATTENTION", FlashAttention(false), "Enabled flash attention"},
 		"OLLAMA_KV_CACHE_TYPE":        {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
 		"OLLAMA_GPU_OVERHEAD":         {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},
+		"OLLAMA_SINGLE_GPU_FIT_PERCENT": {"OLLAMA_SINGLE_GPU_FIT_PERCENT", SingleGPUFitPercent(), "Max % of one GPU's free VRAM a model may use and still be packed onto a single GPU (default 80)"},
 		"OLLAMA_IGPU_ENABLE":          {"OLLAMA_IGPU_ENABLE", String("OLLAMA_IGPU_ENABLE")(), "Enable integrated GPUs"},
 		"LLAMA_ARG_FIT":               {"LLAMA_ARG_FIT", String("LLAMA_ARG_FIT")(), "Enable llama.cpp automatic fit of unset memory options (default \"on\")"},
 		"LLAMA_ARG_FIT_TARGET":        {"LLAMA_ARG_FIT_TARGET", String("LLAMA_ARG_FIT_TARGET")(), "Target free VRAM margin per device for llama.cpp fit (MiB)"},

--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -677,10 +677,29 @@ func (f GGML) GraphSize(context, batch uint64, numParallel int, kvCacheType stri
 	kv = make([]uint64, f.KV().BlockCount())
 	kvSizeAttn := uint64(0)
 	kvSizeRecurrent := uint64(0)
+
+	// Some hybrid architectures report attention.head_count as a single scalar that
+	// broadcasts to every block, even though only a subset of layers actually run
+	// attention and hold a KV cache (the rest are recurrent). qwen4exp (Qwen3.x-Flash:
+	// Gated DeltaNet + sparse attention) is one: attention.compress_ratios is a per-block
+	// array that is non-zero exactly on the ~1-in-full_attention_interval attention
+	// layers. Honoring it stops us from counting a dense KV cache for all blocks when
+	// only a fraction have one, which otherwise overpredicts VRAM several-fold at long
+	// context and needlessly spreads the model across GPUs.
+	var attnLayerMask []int32
+	if f.KV().Architecture() == "qwen4exp" {
+		attnLayerMask = f.KV().Ints("attention.compress_ratios")
+	}
+
 	for i := range kv {
 		headsL := headsArr[i]
 		headsKVL := headsKVArr[i]
-		if headsL > 0 && headsKVL > 0 {
+		isAttention := headsL > 0 && headsKVL > 0
+		if i < len(attnLayerMask) {
+			// authoritative per-block metadata overrides the broadcast scalar
+			isAttention = attnLayerMask[i] != 0
+		}
+		if isAttention {
 			// full attention layer
 			// NOTE: Assumes uniform values for all attn layers
 			kv[i] = uint64(float64(context*(embeddingHeadsK+embeddingHeadsV)*headsKVL) * bytesPerElement)

--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -159,6 +159,36 @@ func (kv KV) AttentionLayerCount() (n uint64) {
 	return n
 }
 
+// KVCacheBytesPerToken reports how many bytes of attention KV cache one token of context
+// occupies, summed over the blocks that actually run attention.
+//
+// Each such block holds a key and a value vector per KV head, so its width is
+// head_count_kv * (key_length + value_length). key_length and value_length are read from
+// the model rather than derived as embedding_length/head_count: architectures increasingly
+// set a head dimension that is not that ratio, and deriving it is then wrong by whatever
+// factor separates the two. Qwen3.8-Flash-Next publishes key_length 256 against an implied
+// 2560/24, so the derived figure is off by more than 2x.
+//
+// Elements are assumed to be 2 bytes, matching the default f16 cache. A quantized cache is
+// smaller, so this is an upper bound for one.
+//
+// This covers the caches the metadata describes. An architecture that allocates a further
+// cache the metadata does not describe uses more than this, and the shortfall grows with
+// context; measuring a load is the only way to capture that.
+func (kv KV) KVCacheBytesPerToken() uint64 {
+	headsKV := kv.HeadCountKV()
+	width := kv.EmbeddingHeadCountK() + kv.EmbeddingHeadCountV()
+
+	var total uint64
+	for i, isAttention := range kv.AttentionLayers() {
+		if !isAttention || i >= len(headsKV) {
+			continue
+		}
+		total += headsKV[i] * width * 2
+	}
+	return total
+}
+
 func (kv KV) EmbeddingHeadCountMax() uint64 {
 	if heads := kv.HeadCountMin(); heads > 0 {
 		return kv.EmbeddingLength() / heads

--- a/fs/ggml/ggml.go
+++ b/fs/ggml/ggml.go
@@ -119,6 +119,46 @@ func (kv KV) HeadCountKVMin() uint64 {
 	return uint64(kv.UintOrMinArrayValue("attention.head_count_kv", 1))
 }
 
+// AttentionLayers reports, for each block, whether that block carries an attention KV
+// cache.
+//
+// attention.head_count and attention.head_count_kv are frequently stored as scalars,
+// which broadcast across every block. For a hybrid architecture — recurrent layers
+// interleaved with attention, e.g. qwen4exp (Gated DeltaNet + sparse attention) — the
+// head counts therefore cannot distinguish an attention block from a recurrent one, and
+// treating every block as attention overestimates the KV cache by the ratio of total
+// blocks to attention blocks. When the architecture publishes a per-block
+// attention.compress_ratios array it is authoritative: entries are non-zero exactly on
+// the blocks that run attention.
+func (kv KV) AttentionLayers() []bool {
+	out := make([]bool, kv.BlockCount())
+
+	if ratios := kv.Ints("attention.compress_ratios"); len(ratios) > 0 {
+		for i := range out {
+			if i < len(ratios) {
+				out[i] = ratios[i] != 0
+			}
+		}
+		return out
+	}
+
+	heads, headsKV := kv.HeadCount(), kv.HeadCountKV()
+	for i := range out {
+		out[i] = i < len(heads) && i < len(headsKV) && heads[i] > 0 && headsKV[i] > 0
+	}
+	return out
+}
+
+// AttentionLayerCount returns the number of blocks that carry an attention KV cache.
+func (kv KV) AttentionLayerCount() (n uint64) {
+	for _, isAttention := range kv.AttentionLayers() {
+		if isAttention {
+			n++
+		}
+	}
+	return n
+}
+
 func (kv KV) EmbeddingHeadCountMax() uint64 {
 	if heads := kv.HeadCountMin(); heads > 0 {
 		return kv.EmbeddingLength() / heads
@@ -650,7 +690,6 @@ func (f GGML) GraphSize(context, batch uint64, numParallel int, kvCacheType stri
 
 	embedding := f.KV().EmbeddingLength()
 	heads := f.KV().HeadCountMax()
-	headsArr := f.KV().HeadCount()
 	headsKV := f.KV().HeadCountKVMax()
 	headsKVArr := f.KV().HeadCountKV()
 	vocab := uint64(f.KV()["tokenizer.ggml.tokens"].(*array[string]).size)
@@ -678,28 +717,14 @@ func (f GGML) GraphSize(context, batch uint64, numParallel int, kvCacheType stri
 	kvSizeAttn := uint64(0)
 	kvSizeRecurrent := uint64(0)
 
-	// Some hybrid architectures report attention.head_count as a single scalar that
-	// broadcasts to every block, even though only a subset of layers actually run
-	// attention and hold a KV cache (the rest are recurrent). qwen4exp (Qwen3.x-Flash:
-	// Gated DeltaNet + sparse attention) is one: attention.compress_ratios is a per-block
-	// array that is non-zero exactly on the ~1-in-full_attention_interval attention
-	// layers. Honoring it stops us from counting a dense KV cache for all blocks when
-	// only a fraction have one, which otherwise overpredicts VRAM several-fold at long
-	// context and needlessly spreads the model across GPUs.
-	var attnLayerMask []int32
-	if f.KV().Architecture() == "qwen4exp" {
-		attnLayerMask = f.KV().Ints("attention.compress_ratios")
-	}
+	// Which blocks actually hold a KV cache. For hybrid architectures the scalar head
+	// counts broadcast across every block and cannot distinguish attention blocks from
+	// recurrent ones, so consult the per-block metadata. See KV.AttentionLayers.
+	attentionLayers := f.KV().AttentionLayers()
 
 	for i := range kv {
-		headsL := headsArr[i]
 		headsKVL := headsKVArr[i]
-		isAttention := headsL > 0 && headsKVL > 0
-		if i < len(attnLayerMask) {
-			// authoritative per-block metadata overrides the broadcast scalar
-			isAttention = attnLayerMask[i] != 0
-		}
-		if isAttention {
+		if i < len(attentionLayers) && attentionLayers[i] {
 			// full attention layer
 			// NOTE: Assumes uniform values for all attn layers
 			kv[i] = uint64(float64(context*(embeddingHeadsK+embeddingHeadsV)*headsKVL) * bytesPerElement)

--- a/fs/ggml/ggml_test.go
+++ b/fs/ggml/ggml_test.go
@@ -361,3 +361,90 @@ func TestAttentionLayers(t *testing.T) {
 		})
 	}
 }
+
+func TestKVCacheBytesPerToken(t *testing.T) {
+	cases := []struct {
+		name string
+		kv   KV
+		want uint64
+	}{
+		{
+			// Qwen3.8-Flash-Next: 48 blocks with attention on every fourth, 2 KV heads, and
+			// a published head dimension of 256 that is nothing like embedding_length /
+			// head_count (2560/24 = 106). Deriving the dimension instead of reading it is
+			// wrong by more than 2x here. Verified against the runtime, which reports
+			// 6144 MiB of cache over 262144 cells: 6144 MiB / 262144 = 24576 bytes.
+			name: "published key and value lengths are used",
+			kv: KV{
+				"general.architecture":          "abc",
+				"abc.block_count":               uint32(48),
+				"abc.embedding_length":          uint32(2560),
+				"abc.attention.head_count":      uint32(24),
+				"abc.attention.head_count_kv":   uint32(2),
+				"abc.attention.key_length":      uint32(256),
+				"abc.attention.value_length":    uint32(256),
+				"abc.attention.compress_ratios": &array[int32]{values: repeatRatios(48, 4), size: 48},
+			},
+			want: 12 * 2 * (256 + 256) * 2,
+		},
+		{
+			// Without published dimensions the head dimension is embedding_length divided by
+			// the head count, which is the historical behaviour and still correct for the
+			// architectures that do not publish it.
+			name: "head dimension is derived when not published",
+			kv: KV{
+				"general.architecture":        "abc",
+				"abc.block_count":             uint32(4),
+				"abc.embedding_length":        uint32(64),
+				"abc.attention.head_count":    uint32(8),
+				"abc.attention.head_count_kv": uint32(2),
+			},
+			want: 4 * 2 * (8 + 8) * 2,
+		},
+		{
+			// Recurrent blocks hold no attention cache, so a hybrid must not be charged for
+			// all of its blocks.
+			name: "recurrent blocks contribute nothing",
+			kv: KV{
+				"general.architecture":          "abc",
+				"abc.block_count":               uint32(8),
+				"abc.embedding_length":          uint32(64),
+				"abc.attention.head_count":      uint32(8),
+				"abc.attention.head_count_kv":   uint32(2),
+				"abc.attention.compress_ratios": &array[int32]{values: []int32{0, 0, 0, 4, 0, 0, 0, 4}, size: 8},
+			},
+			want: 2 * 2 * (8 + 8) * 2,
+		},
+		{
+			// Per-layer KV head counts vary across blocks and each block must be charged its
+			// own width rather than a single representative value.
+			name: "per-layer kv head counts are summed individually",
+			kv: KV{
+				"general.architecture":        "abc",
+				"abc.block_count":             uint32(3),
+				"abc.embedding_length":        uint32(64),
+				"abc.attention.head_count":    &array[uint32]{values: []uint32{8, 8, 8}, size: 3},
+				"abc.attention.head_count_kv": &array[uint32]{values: []uint32{1, 2, 4}, size: 3},
+			},
+			want: (1 + 2 + 4) * (8 + 8) * 2,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.kv.KVCacheBytesPerToken(); got != tt.want {
+				t.Errorf("KVCacheBytesPerToken() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// repeatRatios builds a per-block compress ratio array with a non-zero entry on every
+// nth block, matching how hybrid architectures interleave attention.
+func repeatRatios(blocks, interval int) []int32 {
+	out := make([]int32, blocks)
+	for i := interval - 1; i < blocks; i += interval {
+		out[i] = int32(interval)
+	}
+	return out
+}

--- a/fs/ggml/ggml_test.go
+++ b/fs/ggml/ggml_test.go
@@ -299,3 +299,65 @@ func TestHeadCount(t *testing.T) {
 		}
 	}
 }
+
+func TestAttentionLayers(t *testing.T) {
+	cases := []struct {
+		name  string
+		kv    KV
+		want  []bool
+		count uint64
+	}{
+		{
+			// Hybrid architecture: the scalar head counts broadcast to every block, so only
+			// the per-block compress ratios distinguish attention blocks from recurrent ones.
+			name: "per-block compress ratios override broadcast scalars",
+			kv: KV{
+				"general.architecture":          "abc",
+				"abc.block_count":               uint32(8),
+				"abc.attention.head_count":      uint32(24),
+				"abc.attention.head_count_kv":   uint32(2),
+				"abc.attention.compress_ratios": &array[int32]{values: []int32{0, 0, 0, 4, 0, 0, 0, 4}, size: 8},
+			},
+			want:  []bool{false, false, false, true, false, false, false, true},
+			count: 2,
+		},
+		{
+			// Without per-block metadata the scalar head counts apply to every block, which
+			// is the correct answer for a non-hybrid model.
+			name: "scalar head counts mark every block as attention",
+			kv: KV{
+				"general.architecture":        "abc",
+				"abc.block_count":             uint32(4),
+				"abc.attention.head_count":    uint32(8),
+				"abc.attention.head_count_kv": uint32(2),
+			},
+			want:  []bool{true, true, true, true},
+			count: 4,
+		},
+		{
+			// Architectures that publish per-layer head counts already distinguish recurrent
+			// blocks with a zero head count; that path must keep working.
+			name: "per-layer head counts mark zero-head blocks as recurrent",
+			kv: KV{
+				"general.architecture":        "abc",
+				"abc.block_count":             uint32(4),
+				"abc.attention.head_count":    &array[int32]{values: []int32{8, 0, 8, 0}, size: 4},
+				"abc.attention.head_count_kv": &array[int32]{values: []int32{2, 0, 2, 0}, size: 4},
+			},
+			want:  []bool{true, false, true, false},
+			count: 2,
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if diff := cmp.Diff(tt.kv.AttentionLayers(), tt.want); diff != "" {
+				t.Errorf("unexpected attention layers (-got +want):\n%s", diff)
+			}
+
+			if got := tt.kv.AttentionLayerCount(); got != tt.count {
+				t.Errorf("unexpected attention layer count: got=%d want=%d", got, tt.count)
+			}
+		})
+	}
+}

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -2743,9 +2743,34 @@ type memoryParsingWriter struct {
 	inner   io.Writer
 	runner  *llamaServerRunner
 	buffers map[memoryBufferKey]memoryBuffer
+
+	// bufferSeq counts how many buffers of each slot the current load pass has
+	// reported, and sawNonModelBuffer tracks whether anything but model weights has
+	// been reported since the last model buffer. Together they detect the boundary
+	// between the fit probe and the final load: weights are always reported first, so
+	// a model buffer arriving after a cache or compute buffer means a new pass began.
+	bufferSeq         map[bufferSlot]int
+	sawNonModelBuffer bool
 }
 
 type memoryBufferKey struct {
+	component string
+	backend   string
+	kind      string
+	// seq distinguishes buffers that coexist rather than replace each other. A load
+	// can allocate several buffers of the same kind on one device — a hybrid
+	// architecture reports one KV cache per cache type, and a model with a draft
+	// reports one per context — and every one of them occupies memory at the same
+	// time. Without this they collide and only the last survives, under-reporting the
+	// device by the size of the ones dropped. It is reset per load pass so the fit
+	// probe's buffers are still replaced by the final load's rather than added to
+	// them; see bufferSlot.
+	seq int
+}
+
+// bufferSlot identifies a buffer's reporting slot, ignoring how many of them a load
+// has produced so far. It is the key of the per-pass occurrence counter.
+type bufferSlot struct {
 	component string
 	backend   string
 	kind      string
@@ -2833,7 +2858,39 @@ func (w *memoryParsingWriter) Write(b []byte) (int, error) {
 					if w.buffers == nil {
 						w.buffers = make(map[memoryBufferKey]memoryBuffer)
 					}
+					slot := bufferSlot{
+						component: string(match[1]),
+						backend:   backendName,
+						kind:      string(match[3]),
+					}
+
+					// Weights after a non-weight buffer mean the fit probe finished and
+					// the real load started: begin numbering again so this pass's buffers
+					// replace the probe's instead of accumulating on top of them.
+					if slot.kind == "model" {
+						if w.sawNonModelBuffer {
+							w.bufferSeq = nil
+							w.sawNonModelBuffer = false
+						}
+					} else {
+						w.sawNonModelBuffer = true
+					}
+
+					// Compute buffers keep a single slot. Unlike an allocation, a
+					// reservation is re-reported at a new size when the scheduler reserves
+					// for a different graph, and the buffer is resized rather than added
+					// to, so the latest value replaces the previous one.
+					seq := 0
+					if slot.kind != "compute" {
+						if w.bufferSeq == nil {
+							w.bufferSeq = make(map[bufferSlot]int)
+						}
+						seq = w.bufferSeq[slot]
+						w.bufferSeq[slot] = seq + 1
+					}
+
 					w.buffers[memoryBufferKey{
+						seq:       seq,
 						component: string(match[1]),
 						backend:   backendName,
 						kind:      string(match[3]),

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -154,6 +154,12 @@ type llamaServerRunner struct {
 	// used to map DeviceIDs to device names for VRAMByGPU lookups.
 	gpus []ml.DeviceInfo
 
+	// deviceLogNames[i] is the name the child uses for gpus[i]. A child whose
+	// visible devices are filtered renumbers them from zero, so these differ
+	// from the discovery names whenever the selected devices are not the host's
+	// first ones. Buffer accounting is keyed by these, not by gpus[i].Name.
+	deviceLogNames []string
+
 	ggml          *ggml.GGML
 	totalLayers   uint64 // maximum offloadable model layers
 	loadStart     time.Time
@@ -954,6 +960,7 @@ func NewLlamaServerRunner(
 		vramByDevice:     make(map[string]uint64),
 		systemFreeAtLoad: make(map[string]uint64),
 		gpus:             gpus,
+		deviceLogNames:   ml.RunnerDeviceNames(gpus),
 		ggml:             f,
 		totalLayers:      f.KV().BlockCount() + 1,
 		rawEmbeddings:    legacyEmbeddingsWereRaw(f.KV()),
@@ -2605,7 +2612,8 @@ func (s *llamaServerRunner) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo 
 	infos := make([]ml.DeviceInfo, len(s.gpus))
 	for i, gpu := range s.gpus {
 		infos[i] = gpu
-		used := s.vramByDevice[gpu.Name]
+		name := s.deviceLogName(i)
+		used := s.vramByDevice[name]
 
 		// Our accounting: total minus what we allocated
 		var accountedFree uint64
@@ -2617,7 +2625,7 @@ func (s *llamaServerRunner) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo 
 		// we've allocated since. This captures external consumers on platforms
 		// where the driver reports accurately.
 		systemFree := accountedFree // default to our accounting
-		if sysFree, ok := s.systemFreeAtLoad[gpu.Name]; ok {
+		if sysFree, ok := s.systemFreeAtLoad[name]; ok {
 			if used < sysFree {
 				systemFree = sysFree - used
 			} else {
@@ -2874,16 +2882,24 @@ func (w *memoryParsingWriter) updateRunnerMemoryLocked() {
 // VRAMByGPU returns the VRAM used by this runner on the specified device.
 // The values are parsed from llama-server's buffer size log output during model load
 // (model tensors + KV cache + compute buffers).
+// deviceLogName returns the name the child used for the device at index i,
+// falling back to the discovery name if the mapping is unavailable.
+func (s *llamaServerRunner) deviceLogName(i int) string {
+	if i < len(s.deviceLogNames) {
+		return s.deviceLogNames[i]
+	}
+	return s.gpus[i].Name
+}
+
 func (s *llamaServerRunner) VRAMByGPU(id ml.DeviceID) uint64 {
 	s.memoryMu.RLock()
 	defer s.memoryMu.RUnlock()
 
-	// Map DeviceID to the log device name used by llama-server.
-	// Discovery stores the device name (e.g., "CUDA0", "ROCm0", "MTL0") from
-	// --list-devices stdout, which matches the buffer log prefix.
-	for _, gpu := range s.gpus {
+	// Look up by the name the child used, which is not the discovery name when
+	// its visible devices were filtered (see ml.RunnerDeviceNames).
+	for i, gpu := range s.gpus {
 		if gpu.DeviceID == id {
-			return s.vramByDevice[gpu.Name]
+			return s.vramByDevice[s.deviceLogName(i)]
 		}
 	}
 	return 0

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -2676,14 +2676,36 @@ func (s *llamaServerRunner) MemorySize() (total, vram uint64) {
 // PredictServerVRAM estimates VRAM usage for a model without spawning llama-server.
 // Uses model file size as a proxy for weights plus a rough KV cache estimate.
 // This is intentionally conservative — it overestimates to avoid VRAM contention.
+// hostResidentTensorGroups are tensor groups that are looked up on the host and never
+// offloaded, so they must not be counted toward predicted VRAM. Per-layer token
+// embeddings are the notable case: architectures that use them (gemma3n, qwen4exp) carry
+// a very large table — 26.8 GiB of Qwen3.8-Flash-Next's 103.7 GiB file — that stays in
+// system memory. Counting it as VRAM overpredicts by ~25% and makes a model that fits a
+// single device look like it needs several.
+var hostResidentTensorGroups = []string{"per_layer_token_embd"}
+
 func PredictServerVRAM(modelPath string, f *ggml.GGML, numCtx int) uint64 {
+	// Sum the tensors that are actually offloaded rather than taking the file size, which
+	// also covers host-resident tables. Fall back to the file size if tensor metadata is
+	// unavailable, preserving the previous (conservative) behavior.
 	var weights uint64
-	if info, err := os.Stat(modelPath); err == nil {
-		weights = uint64(info.Size())
+	for name, layer := range f.Tensors().GroupLayers() {
+		if slices.Contains(hostResidentTensorGroups, name) {
+			continue
+		}
+		weights += layer.Size()
 	}
 
-	// KV cache: 2 (K+V) * layers * kv_heads * head_dim * context * 2 bytes (f16)
-	layers := f.KV().BlockCount()
+	if weights == 0 {
+		if info, err := os.Stat(modelPath); err == nil {
+			weights = uint64(info.Size())
+		}
+	}
+
+	// KV cache: 2 (K+V) * attention layers * kv_heads * head_dim * context * 2 bytes (f16).
+	// Only blocks that run attention hold a cache; hybrid architectures interleave
+	// recurrent blocks that do not.
+	layers := f.KV().AttentionLayerCount()
 	kvHeads := f.KV().HeadCountKVMin()
 	if kvHeads == 0 {
 		kvHeads = 1

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -2696,7 +2696,7 @@ var hostResidentTensorGroups = []string{"per_layer_token_embd"}
 // The split exists so that a measured load can be extrapolated: VRAMCalibration anchors on
 // what a model actually used and needs a slope to move away from that point. Callers that
 // only want a number for one context length should use PredictServerVRAM.
-func PredictServerVRAMParts(modelPath string, f *ggml.GGML) (weights, bytesPerToken uint64) {
+func PredictServerVRAMParts(modelPath string, projectorPaths []string, f *ggml.GGML) (weights, bytesPerToken uint64) {
 	// Sum the tensors that are actually offloaded rather than taking the file size, which
 	// also covers host-resident tables. Fall back to the file size if tensor metadata is
 	// unavailable, preserving the previous (conservative) behavior.
@@ -2714,12 +2714,27 @@ func PredictServerVRAMParts(modelPath string, f *ggml.GGML) (weights, bytesPerTo
 		}
 	}
 
+	// A projector is a separate file the runner loads alongside the weights, so it is
+	// absent from the model's own tensors. Its size is counted here because the memory has
+	// to be found somewhere, and counting it is the conservative direction: ollama declines
+	// to offload it under pressure, in which case this over-predicts rather than placing a
+	// model that then cannot fit.
+	//
+	// The file is very close to what the projector occupies before an image arrives; the
+	// runner reserves more than this for the largest image it will accept, and that figure
+	// is only known once it has loaded. A measured load supplies it thereafter.
+	for _, path := range projectorPaths {
+		if info, err := os.Stat(path); err == nil {
+			weights += uint64(info.Size())
+		}
+	}
+
 	return weights, f.KV().KVCacheBytesPerToken()
 }
 
 // PredictServerVRAM estimates VRAM usage for a model at a given context length.
-func PredictServerVRAM(modelPath string, f *ggml.GGML, numCtx int) uint64 {
-	weights, bytesPerToken := PredictServerVRAMParts(modelPath, f)
+func PredictServerVRAM(modelPath string, projectorPaths []string, f *ggml.GGML, numCtx int) uint64 {
+	weights, bytesPerToken := PredictServerVRAMParts(modelPath, projectorPaths, f)
 	return weights + bytesPerToken*uint64(max(numCtx, 0))
 }
 
@@ -2747,6 +2762,29 @@ type memoryParsingWriter struct {
 	// a model buffer arriving after a cache or compute buffer means a new pass began.
 	bufferSeq         map[bufferSlot]int
 	sawNonModelBuffer bool
+
+	// clipBackend is the backend the projector was placed on and mmprojBytes is what it
+	// occupies. They are reported on separate lines whose order is not guaranteed -- the
+	// size is reported first in practice -- so each is recorded as it arrives and the
+	// attribution is made once both are known.
+	clipBackend string
+	mmprojBytes uint64
+}
+
+// noteProjectorLocked attributes the projector's memory to the device holding it, once both
+// the device and the size are known.
+func (w *memoryParsingWriter) noteProjectorLocked() {
+	if w.clipBackend == "" || w.mmprojBytes == 0 {
+		return
+	}
+	if w.buffers == nil {
+		w.buffers = make(map[memoryBufferKey]memoryBuffer)
+	}
+	// One slot: the projector is reported as a total rather than per buffer, and a repeat
+	// report replaces rather than adds. The kind is its own so that it takes no part in the
+	// load-pass numbering the buffer-size lines use.
+	w.buffers[memoryBufferKey{component: "mtmd", backend: w.clipBackend, kind: "mmproj"}] = memoryBuffer{bytes: w.mmprojBytes}
+	w.updateRunnerMemoryLocked()
 }
 
 type memoryBufferKey struct {
@@ -2786,6 +2824,25 @@ var deviceFreeRegex = regexp.MustCompile(`using device (\S+)\s+\(.*\)\s+-\s+(\d+
 // bufferSizeRegex matches llama-server buffer size lines and captures the
 // component so repeated fit/probe values can be replaced by the final load.
 var bufferSizeRegex = regexp.MustCompile(`(?m)(?:^|\n)[^\n:]*?([A-Za-z_][A-Za-z0-9_]*):\s+(\S+)\s+(model|KV|compute|output|RS)\s+buffer size\s*=\s*([\d.]+)\s*MiB`)
+
+// clipBackendRegex captures the backend a multimodal projector was placed on:
+//
+//	clip_ctx: CLIP using CUDA0 backend
+//	clip_ctx: CLIP using CPU backend
+//
+// This is what distinguishes a projector that occupies VRAM from one that does not. Ollama
+// declines to offload it under memory pressure, and the line reports the outcome.
+var clipBackendRegex = regexp.MustCompile(`clip_ctx:\s+CLIP using (\S+) backend`)
+
+// mmprojMemoryRegex captures the projector's memory, which llama-server reports on its own
+// rather than through the buffer-size lines every other allocation uses:
+//
+//	srv load_model: [mtmd] estimated worst-case memory usage of mmproj is 1135.13 MiB
+//
+// It is a worst-case figure, covering the largest image the projector will accept, so it is
+// larger than what a projector holds before any image arrives. That is the right figure to
+// hold a device to: the memory has to be there when an image does arrive.
+var mmprojMemoryRegex = regexp.MustCompile(`\[mtmd\][^\n]*?mmproj is\s+([\d.]+)\s*MiB`)
 
 var (
 	offloadedLayersRegex      = regexp.MustCompile(`offloaded\s+(\d+)/(\d+)\s+layers to GPU`)
@@ -2846,6 +2903,16 @@ func (w *memoryParsingWriter) Write(b []byte) (int, error) {
 				overflowing, err := strconv.ParseUint(string(match[1]), 10, 64)
 				if err == nil && overflowing > 0 {
 					w.runner.gpuLayerOverflow += int(overflowing)
+				}
+			}
+			if match := clipBackendRegex.FindSubmatch(b); match != nil {
+				w.clipBackend = string(match[1])
+				w.noteProjectorLocked()
+			}
+			for _, match := range mmprojMemoryRegex.FindAllSubmatch(b, -1) {
+				if mib, err := strconv.ParseFloat(string(match[1]), 64); err == nil {
+					w.mmprojBytes = uint64(mib * 1024 * 1024)
+					w.noteProjectorLocked()
 				}
 			}
 			for _, match := range bufferSizeRegex.FindAllSubmatch(b, -1) {

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -2681,9 +2681,6 @@ func (s *llamaServerRunner) MemorySize() (total, vram uint64) {
 	return total, vram
 }
 
-// PredictServerVRAM estimates VRAM usage for a model without spawning llama-server.
-// Uses model file size as a proxy for weights plus a rough KV cache estimate.
-// This is intentionally conservative — it overestimates to avoid VRAM contention.
 // hostResidentTensorGroups are tensor groups that are looked up on the host and never
 // offloaded, so they must not be counted toward predicted VRAM. Per-layer token
 // embeddings are the notable case: architectures that use them (gemma3n, qwen4exp) carry
@@ -2692,11 +2689,18 @@ func (s *llamaServerRunner) MemorySize() (total, vram uint64) {
 // single device look like it needs several.
 var hostResidentTensorGroups = []string{"per_layer_token_embd"}
 
-func PredictServerVRAM(modelPath string, f *ggml.GGML, numCtx int) uint64 {
+// PredictServerVRAMParts estimates VRAM usage for a model without spawning llama-server,
+// split into the part that does not depend on context and the rate at which the rest grows
+// with it.
+//
+// The split exists so that a measured load can be extrapolated: VRAMCalibration anchors on
+// what a model actually used and needs a slope to move away from that point. Callers that
+// only want a number for one context length should use PredictServerVRAM.
+func PredictServerVRAMParts(modelPath string, f *ggml.GGML) (weights, bytesPerToken uint64) {
 	// Sum the tensors that are actually offloaded rather than taking the file size, which
 	// also covers host-resident tables. Fall back to the file size if tensor metadata is
 	// unavailable, preserving the previous (conservative) behavior.
-	var weights uint64
+
 	for name, layer := range f.Tensors().GroupLayers() {
 		if slices.Contains(hostResidentTensorGroups, name) {
 			continue
@@ -2710,21 +2714,13 @@ func PredictServerVRAM(modelPath string, f *ggml.GGML, numCtx int) uint64 {
 		}
 	}
 
-	// KV cache: 2 (K+V) * attention layers * kv_heads * head_dim * context * 2 bytes (f16).
-	// Only blocks that run attention hold a cache; hybrid architectures interleave
-	// recurrent blocks that do not.
-	layers := f.KV().AttentionLayerCount()
-	kvHeads := f.KV().HeadCountKVMin()
-	if kvHeads == 0 {
-		kvHeads = 1
-	}
-	headDim := uint64(0)
-	if f.KV().HeadCountMax() > 0 {
-		headDim = f.KV().EmbeddingLength() / f.KV().HeadCountMax()
-	}
-	kvCache := 2 * layers * kvHeads * headDim * uint64(numCtx) * 2
+	return weights, f.KV().KVCacheBytesPerToken()
+}
 
-	return weights + kvCache
+// PredictServerVRAM estimates VRAM usage for a model at a given context length.
+func PredictServerVRAM(modelPath string, f *ggml.GGML, numCtx int) uint64 {
+	weights, bytesPerToken := PredictServerVRAMParts(modelPath, f)
+	return weights + bytesPerToken*uint64(max(numCtx, 0))
 }
 
 // memoryParsingWriter wraps an io.Writer and parses llama-server log output

--- a/llm/llama_server_device_test.go
+++ b/llm/llama_server_device_test.go
@@ -1,0 +1,61 @@
+package llm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ollama/ollama/ml"
+)
+
+// A model placed on the host's second device runs in a child restricted to that
+// device, which therefore calls it CUDA0 and reports its buffers under that
+// name. Looking the device up by its discovery name ("CUDA1") finds nothing and
+// reports the device as unused.
+func newSecondDeviceRunner(used uint64) *llamaServerRunner {
+	gpus := []ml.DeviceInfo{{
+		DeviceID:    ml.DeviceID{ID: "1", Library: "CUDA"},
+		Name:        "CUDA1",
+		TotalMemory: 100 << 30,
+		FreeMemory:  100 << 30,
+	}}
+
+	return &llamaServerRunner{
+		gpus:           gpus,
+		deviceLogNames: ml.RunnerDeviceNames(gpus),
+		vramByDevice:   map[string]uint64{"CUDA0": used},
+	}
+}
+
+func TestVRAMByGPUFilteredChildRenumbers(t *testing.T) {
+	const used = 15 << 30
+
+	got := newSecondDeviceRunner(used).VRAMByGPU(ml.DeviceID{ID: "1", Library: "CUDA"})
+	if got != used {
+		t.Errorf("got %d, want %d: the child reports this device as CUDA0", got, uint64(used))
+	}
+}
+
+// The same mismatch made a device holding a model look completely free, which is
+// worse than a wrong readout: it invites placing more work on a full device.
+func TestGetDeviceInfosFilteredChildRenumbers(t *testing.T) {
+	const used = 15 << 30
+
+	infos := newSecondDeviceRunner(used).GetDeviceInfos(context.Background())
+	if len(infos) != 1 {
+		t.Fatalf("expected 1 device, got %d", len(infos))
+	}
+
+	want := uint64(100<<30) - used
+	if infos[0].FreeMemory != want {
+		t.Errorf("free memory: got %d, want %d", infos[0].FreeMemory, want)
+	}
+}
+
+// A device the child never mentioned still reports zero rather than matching
+// some other device's figure.
+func TestVRAMByGPUUnknownDevice(t *testing.T) {
+	r := newSecondDeviceRunner(15 << 30)
+	if got := r.VRAMByGPU(ml.DeviceID{ID: "7", Library: "CUDA"}); got != 0 {
+		t.Errorf("got %d, want 0", got)
+	}
+}

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -2977,6 +2977,55 @@ func TestMemoryParsingWriter(t *testing.T) {
 			wantGPU:   47799.52,
 			wantTotal: 56779.74,
 		},
+		{
+			// A hybrid architecture allocates one KV cache per cache type and they
+			// coexist, so both belong in the device total. Taken verbatim from a
+			// Qwen3.8-Flash-Next load, where dropping the first cost 6144 MiB.
+			name: "simultaneous KV caches on one device are both counted",
+			lines: []string{
+				"load_tensors:   CPU_Mapped model buffer size =   644.14 MiB\n",
+				"load_tensors:        CUDA0 model buffer size = 78056.46 MiB\n",
+				"load_tensors:   CPU_Mapped model buffer size = 27465.95 MiB\n",
+				"llama_context:  CUDA_Host  output buffer size =     0.95 MiB\n",
+				"llama_kv_cache:      CUDA0 KV buffer size =  6144.00 MiB\n",
+				"llama_memory_recurrent:      CUDA0 RS buffer size =   112.57 MiB\n",
+				"llama_kv_cache:      CUDA0 KV buffer size =  2304.00 MiB\n",
+				"sched_reserve:      CUDA0 compute buffer size =  1809.09 MiB\n",
+				"sched_reserve:  CUDA_Host compute buffer size =   402.05 MiB\n",
+			},
+			wantGPU:   78056.46 + 6144.00 + 112.57 + 2304.00 + 1809.09,
+			wantTotal: 78056.46 + 6144.00 + 112.57 + 2304.00 + 1809.09 + 644.14 + 27465.95 + 0.95 + 402.05,
+		},
+		{
+			// The probe reports the same pair of caches the final load does. Counting
+			// per pass must not turn that into four caches.
+			name: "fit probe with multiple caches is replaced, not accumulated",
+			lines: []string{
+				"load_tensors:        CUDA0 model buffer size =  1000.00 MiB\n",
+				"llama_kv_cache:      CUDA0 KV buffer size =   500.00 MiB\n",
+				"llama_kv_cache:      CUDA0 KV buffer size =   250.00 MiB\n",
+				"sched_reserve:      CUDA0 compute buffer size =   300.00 MiB\n",
+				"load_tensors:        CUDA0 model buffer size =  1100.00 MiB\n",
+				"llama_kv_cache:      CUDA0 KV buffer size =   550.00 MiB\n",
+				"llama_kv_cache:      CUDA0 KV buffer size =   275.00 MiB\n",
+				"sched_reserve:      CUDA0 compute buffer size =   330.00 MiB\n",
+			},
+			wantGPU:   1100 + 550 + 275 + 330,
+			wantTotal: 1100 + 550 + 275 + 330,
+		},
+		{
+			// The scheduler re-reserves one compute buffer per graph it prepares, at a
+			// new size each time. That buffer is resized, not duplicated.
+			name: "repeated compute reservations replace rather than accumulate",
+			lines: []string{
+				"load_tensors:        CUDA0 model buffer size =  1000.00 MiB\n",
+				"llama_kv_cache:      CUDA0 KV buffer size =   500.00 MiB\n",
+				"sched_reserve:      CUDA0 compute buffer size =   756.03 MiB\n",
+				"sched_reserve:      CUDA0 compute buffer size =   648.03 MiB\n",
+			},
+			wantGPU:   1000 + 500 + 648.03,
+			wantTotal: 1000 + 500 + 648.03,
+		},
 	}
 
 	withinKiB := func(got, want uint64) bool {

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -3014,6 +3014,57 @@ func TestMemoryParsingWriter(t *testing.T) {
 			wantTotal: 1100 + 550 + 275 + 330,
 		},
 		{
+			// A projector is reported on its own line rather than as a buffer, and it is
+			// real VRAM when the runner placed it on a device.
+			name: "an offloaded projector counts toward the device",
+			lines: []string{
+				"load_tensors:        CUDA0 model buffer size =  1000.00 MiB\n",
+				"llama_kv_cache:      CUDA0 KV buffer size =   500.00 MiB\n",
+				// The size is reported before the backend it belongs to, so the
+				// attribution cannot depend on seeing them in a fixed order.
+				"srv    load_model: [mtmd] estimated worst-case memory usage of mmproj is 1135.13 MiB (took 25.80 ms)\n",
+				"clip_ctx: CLIP using CUDA0 backend\n",
+			},
+			wantGPU:   1000 + 500 + 1135.13,
+			wantTotal: 1000 + 500 + 1135.13,
+		},
+		{
+			// Ollama declines to offload the projector under memory pressure. It still
+			// occupies memory, but not on the device, and counting it there would reserve
+			// VRAM nothing is using.
+			name: "a projector left on the host does not count toward the device",
+			lines: []string{
+				"load_tensors:        CUDA0 model buffer size =  1000.00 MiB\n",
+				"llama_kv_cache:      CUDA0 KV buffer size =   500.00 MiB\n",
+				"srv    load_model: [mtmd] estimated worst-case memory usage of mmproj is 1135.13 MiB (took 25.80 ms)\n",
+				"clip_ctx: CLIP using CPU backend\n",
+			},
+			wantGPU:   1000 + 500,
+			wantTotal: 1000 + 500 + 1135.13,
+		},
+		{
+			// Reported once per load; a repeat replaces rather than doubling.
+			name: "a re-reported projector replaces its previous figure",
+			lines: []string{
+				"clip_ctx: CLIP using CUDA0 backend\n",
+				"srv    load_model: [mtmd] estimated worst-case memory usage of mmproj is 1135.13 MiB (took 25.80 ms)\n",
+				"srv    load_model: [mtmd] estimated worst-case memory usage of mmproj is 1161.02 MiB (took 24.38 ms)\n",
+			},
+			wantGPU:   1161.02,
+			wantTotal: 1161.02,
+		},
+		{
+			// Without a backend line there is nothing to attribute the figure to, so it is
+			// left out rather than guessed onto a device.
+			name: "a projector with no backend reported is ignored",
+			lines: []string{
+				"load_tensors:        CUDA0 model buffer size =  1000.00 MiB\n",
+				"srv    load_model: [mtmd] estimated worst-case memory usage of mmproj is 1135.13 MiB (took 25.80 ms)\n",
+			},
+			wantGPU:   1000,
+			wantTotal: 1000,
+		},
+		{
 			// The scheduler re-reserves one compute buffer per graph it prepares, at a
 			// new size each time. That buffer is resized, not duplicated.
 			name: "repeated compute reservations replace rather than accumulate",
@@ -3822,7 +3873,7 @@ func TestPredictServerVRAM(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := PredictServerVRAM(path, f, numCtx)
+	got := PredictServerVRAM(path, nil, f, numCtx)
 	if want := uint64(wantWeights + wantKV); got != want {
 		t.Errorf("unexpected predicted VRAM: got=%d want=%d", got, want)
 	}
@@ -3846,4 +3897,43 @@ func testTensorF32(name string, shape ...uint64) *ggml.Tensor {
 	}
 
 	return &ggml.Tensor{Name: name, Shape: shape, WriterTo: bytes.NewReader(make([]byte, elements*4))}
+}
+
+// A projector lives in its own file, so it contributes nothing to the model's tensors and
+// has to be added explicitly or a vision model is predicted as though it were text-only.
+func TestPredictServerVRAMCountsProjectors(t *testing.T) {
+	const numCtx = 128
+
+	kv := ggml.KV{
+		"general.architecture":        "abc",
+		"abc.block_count":             uint32(2),
+		"abc.embedding_length":        uint32(64),
+		"abc.attention.head_count":    uint32(8),
+		"abc.attention.head_count_kv": uint32(2),
+	}
+	path, _ := writeTestGGML(t, kv, []*ggml.Tensor{testTensorF32("blk.0.attn_q.weight", 2, 3)})
+
+	f, err := LoadModel(path, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	proj := filepath.Join(t.TempDir(), "mmproj-F16.gguf")
+	const projSize = 900 * 1024 * 1024
+	if err := os.WriteFile(proj, make([]byte, projSize), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	withoutProjector := PredictServerVRAM(path, nil, f, numCtx)
+	withProjector := PredictServerVRAM(path, []string{proj}, f, numCtx)
+
+	if got := withProjector - withoutProjector; got != projSize {
+		t.Errorf("projector contribution: got=%d want=%d", got, projSize)
+	}
+
+	// A path that cannot be read must not abort the prediction: an unreadable projector is
+	// a reason to predict slightly low, not to refuse to place the model.
+	if got := PredictServerVRAM(path, []string{"/nonexistent/mmproj.gguf"}, f, numCtx); got != withoutProjector {
+		t.Errorf("missing projector changed the prediction: got=%d want=%d", got, withoutProjector)
+	}
 }

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -3737,3 +3737,64 @@ func fakeRunningCmd() *exec.Cmd {
 	// SIGKILL children when the test process exits.
 	return cmd
 }
+
+func TestPredictServerVRAM(t *testing.T) {
+	const numCtx = 128
+
+	// Four blocks with attention only on blocks 1 and 3 (non-zero compress ratios), plus a
+	// per-layer token embedding table, which is looked up on the host and never offloaded.
+	kv := ggml.KV{
+		"general.architecture":          "abc",
+		"abc.block_count":               uint32(4),
+		"abc.embedding_length":          uint32(64),
+		"abc.attention.head_count":      uint32(8),
+		"abc.attention.head_count_kv":   uint32(2),
+		"abc.attention.compress_ratios": []int32{0, 4, 0, 4},
+	}
+
+	tensors := []*ggml.Tensor{
+		testTensorF32("blk.0.attn_q.weight", 2, 3),
+		testTensorF32("blk.1.attn_q.weight", 2, 3),
+		testTensorF32("per_layer_token_embd.weight", 128, 128),
+	}
+
+	// Only the two blk tensors are offloaded; the embedding table is not.
+	const wantWeights = 2 * 2 * 3 * 4
+	// KV cache: 2 (K+V) * attention layers (2, not all 4 blocks) * kv heads (2) *
+	// head dim (embedding 64 / 8 heads) * context * 2 bytes.
+	const wantKV = 2 * 2 * 2 * (64 / 8) * numCtx * 2
+
+	path, _ := writeTestGGML(t, kv, tensors)
+
+	// Load with the same array bound the scheduler uses (see Scheduler.load), so per-block
+	// metadata such as attention.compress_ratios is materialized rather than skipped.
+	f, err := LoadModel(path, 1024)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := PredictServerVRAM(path, f, numCtx)
+	if want := uint64(wantWeights + wantKV); got != want {
+		t.Errorf("unexpected predicted VRAM: got=%d want=%d", got, want)
+	}
+
+	// Guard against regressing to the file size: the table is on disk but never in VRAM,
+	// so the prediction must come in well under the size of the file itself.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got >= uint64(info.Size()) {
+		t.Errorf("prediction should exclude host-resident tensors: got=%d file=%d", got, info.Size())
+	}
+}
+
+func testTensorF32(name string, shape ...uint64) *ggml.Tensor {
+	elements := uint64(1)
+	for _, dim := range shape {
+		elements *= dim
+	}
+
+	return &ggml.Tensor{Name: name, Shape: shape, WriterTo: bytes.NewReader(make([]byte, elements*4))}
+}

--- a/llm/vram_calibration.go
+++ b/llm/vram_calibration.go
@@ -16,8 +16,15 @@ const maxCalibrationSamples = 8
 // consulted — that is how a sample is invalidated when the thing it described changes.
 // ModelSize is included because a path can be rewritten to hold different weights.
 type CalibrationKey struct {
-	Model          string
-	ModelSize      uint64
+	Model     string
+	ModelSize uint64
+
+	// Projectors identifies the multimodal projectors loaded alongside the weights. Two
+	// models can share a weights blob and differ only by a projector -- ollama stores the
+	// projector as its own layer, so a vision variant and a text-only one of the same model
+	// have identical Model and ModelSize -- and the projector occupies VRAM, so their loads
+	// are not comparable.
+	Projectors     string
 	KVCacheType    string
 	FlashAttention bool
 	NumBatch       int

--- a/llm/vram_calibration.go
+++ b/llm/vram_calibration.go
@@ -1,0 +1,195 @@
+package llm
+
+import (
+	"math"
+	"sync"
+)
+
+// maxCalibrationSamples bounds how many context lengths are remembered per key. A straight
+// line needs two; the rest are kept so a fit is not dominated by one unusual load.
+const maxCalibrationSamples = 8
+
+// CalibrationKey identifies loads whose memory use is comparable.
+//
+// Everything that moves the curve belongs in here. Samples are looked up by the whole key,
+// so changing any of these selects a different bucket and the old samples stop being
+// consulted — that is how a sample is invalidated when the thing it described changes.
+// ModelSize is included because a path can be rewritten to hold different weights.
+type CalibrationKey struct {
+	Model          string
+	ModelSize      uint64
+	KVCacheType    string
+	FlashAttention bool
+	NumBatch       int
+	NumParallel    int
+	NumGPU         int
+}
+
+type calibrationSample struct {
+	numCtx int
+	vram   uint64
+}
+
+// VRAMCalibration remembers how much VRAM a model actually used, so that a later load of
+// the same model can be predicted from measurement rather than from metadata alone.
+//
+// Measured VRAM is close to linear in context length: across two architectures at four
+// context lengths, the residual of a straight-line fit stayed under 30 MiB. Two loads at
+// different context lengths are therefore enough to predict a third, including behaviour
+// the metadata does not describe.
+//
+// That matters because the metadata prediction models one KV cache of the published
+// dimensions. An architecture that allocates several caches, or whose compute buffers grow
+// with context, uses more than that, by an amount proportional to context — and in the
+// direction that overcommits a device. A measurement covers all of it without needing to
+// know which effect produced it.
+//
+// The zero value is not usable; call NewVRAMCalibration.
+type VRAMCalibration struct {
+	mu      sync.Mutex
+	samples map[CalibrationKey][]calibrationSample
+}
+
+func NewVRAMCalibration() *VRAMCalibration {
+	return &VRAMCalibration{samples: make(map[CalibrationKey][]calibrationSample)}
+}
+
+// Record stores what a completed load actually used. A second measurement at a context
+// length already recorded replaces it rather than being added alongside, so a key always
+// reflects the most recent load at each context length.
+func (c *VRAMCalibration) Record(key CalibrationKey, numCtx int, vram uint64) {
+	if c == nil || numCtx <= 0 || vram == 0 {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	samples := c.samples[key]
+	for i := range samples {
+		if samples[i].numCtx == numCtx {
+			samples[i].vram = vram
+			return
+		}
+	}
+
+	samples = append(samples, calibrationSample{numCtx: numCtx, vram: vram})
+	if len(samples) > maxCalibrationSamples {
+		samples = samples[len(samples)-maxCalibrationSamples:]
+	}
+	c.samples[key] = samples
+}
+
+// Predict estimates VRAM for a load at numCtx, preferring measurement over metadata.
+//
+// base and bytesPerToken are the metadata prediction, used as the prior: with no samples
+// it is returned unchanged, and with a single sample it supplies the slope through that
+// measured point. The second return reports whether measurement was used, which is worth
+// logging — a prediction backed by a sample deserves different trust than one that is not.
+func (c *VRAMCalibration) Predict(key CalibrationKey, numCtx int, base, bytesPerToken uint64) (uint64, bool) {
+	prior := addScaled(base, bytesPerToken, max(numCtx, 0))
+	if c == nil || numCtx <= 0 {
+		return prior, false
+	}
+
+	c.mu.Lock()
+	samples := append([]calibrationSample(nil), c.samples[key]...)
+	c.mu.Unlock()
+
+	switch {
+	case len(samples) == 0:
+		return prior, false
+
+	case !hasDistinctContexts(samples):
+		// One measured point, so the slope has to come from the prior. Anchoring on the
+		// measurement still corrects the whole context-independent part, which is the
+		// larger of the two terms for every model of consequence.
+		s := samples[0]
+		return addScaled(s.vram, bytesPerToken, numCtx-s.numCtx), true
+
+	default:
+		intercept, slope := leastSquares(samples)
+		if slope < 0 {
+			// Memory does not shrink as context grows; a negative slope means the samples
+			// disagree for some reason this model cannot express, so fall back rather than
+			// extrapolate a nonsense line.
+			return prior, false
+		}
+		return clampFloat(intercept + slope*float64(numCtx)), true
+	}
+}
+
+func hasDistinctContexts(samples []calibrationSample) bool {
+	for _, s := range samples[1:] {
+		if s.numCtx != samples[0].numCtx {
+			return true
+		}
+	}
+	return false
+}
+
+// leastSquares fits vram = intercept + slope*numCtx over the samples.
+func leastSquares(samples []calibrationSample) (intercept, slope float64) {
+	n := float64(len(samples))
+	var sumX, sumY float64
+	for _, s := range samples {
+		sumX += float64(s.numCtx)
+		sumY += float64(s.vram)
+	}
+	meanX, meanY := sumX/n, sumY/n
+
+	var num, den float64
+	for _, s := range samples {
+		dx := float64(s.numCtx) - meanX
+		num += dx * (float64(s.vram) - meanY)
+		den += dx * dx
+	}
+	if den == 0 {
+		return meanY, 0
+	}
+	slope = num / den
+	return meanY - slope*meanX, slope
+}
+
+// addScaled returns base + perToken*tokens, saturating instead of wrapping. tokens may be
+// negative, which is how a single sample is extrapolated down to a shorter context. These
+// are sizes in bytes, so a result that would go below zero or past the width of the type is
+// meaningless either way; saturating keeps a nonsense input from becoming a plausible-
+// looking number.
+func addScaled(base, perToken uint64, tokens int) uint64 {
+	if tokens == 0 || perToken == 0 {
+		return base
+	}
+
+	magnitude := uint64(tokens)
+	if tokens < 0 {
+		magnitude = uint64(-tokens)
+	}
+
+	product := perToken * magnitude
+	if product/magnitude != perToken {
+		product = math.MaxUint64
+	}
+
+	if tokens < 0 {
+		if product > base {
+			return 0
+		}
+		return base - product
+	}
+	if base > math.MaxUint64-product {
+		return math.MaxUint64
+	}
+	return base + product
+}
+
+func clampFloat(v float64) uint64 {
+	switch {
+	case math.IsNaN(v), v <= 0:
+		return 0
+	case v >= math.MaxUint64:
+		return math.MaxUint64
+	default:
+		return uint64(v)
+	}
+}

--- a/llm/vram_calibration_test.go
+++ b/llm/vram_calibration_test.go
@@ -90,6 +90,7 @@ func TestCalibrationKeyChangeInvalidates(t *testing.T) {
 	changed := map[string]func(*CalibrationKey){
 		"model":           func(k *CalibrationKey) { k.Model = "/models/other.gguf" },
 		"model size":      func(k *CalibrationKey) { k.ModelSize = 5678 },
+		"projector":       func(k *CalibrationKey) { k.Projectors = "/blobs/sha256-abc" },
 		"kv cache type":   func(k *CalibrationKey) { k.KVCacheType = "q8_0" },
 		"flash attention": func(k *CalibrationKey) { k.FlashAttention = true },
 		"num batch":       func(k *CalibrationKey) { k.NumBatch = 512 },

--- a/llm/vram_calibration_test.go
+++ b/llm/vram_calibration_test.go
@@ -1,0 +1,228 @@
+package llm
+
+import "testing"
+
+const (
+	mib = 1024 * 1024
+	gib = 1024 * mib
+)
+
+func testKey() CalibrationKey {
+	return CalibrationKey{Model: "/models/test.gguf", ModelSize: 1234, NumParallel: 1, NumGPU: 1}
+}
+
+// withinMiB keeps the assertions readable: these are memory sizes, and agreement to the
+// byte is neither achievable from a least-squares fit nor required by the caller.
+func withinMiB(got, want uint64, mibs float64) bool {
+	diff := float64(got) - float64(want)
+	if diff < 0 {
+		diff = -diff
+	}
+	return diff <= mibs*mib
+}
+
+func TestCalibrationFallsBackToPriorWithoutSamples(t *testing.T) {
+	c := NewVRAMCalibration()
+
+	got, calibrated := c.Predict(testKey(), 8192, 10*gib, 1024)
+	if calibrated {
+		t.Error("reported a calibrated prediction with no samples recorded")
+	}
+	if want := uint64(10*gib + 8192*1024); got != want {
+		t.Errorf("prior not returned unchanged: got=%d want=%d", got, want)
+	}
+}
+
+func TestCalibrationFitsTwoSamples(t *testing.T) {
+	c := NewVRAMCalibration()
+	key := testKey()
+
+	// 20 GiB of weights plus exactly 2048 bytes per token.
+	c.Record(key, 8192, 20*gib+8192*2048)
+	c.Record(key, 32768, 20*gib+32768*2048)
+
+	for _, numCtx := range []int{4096, 16384, 65536, 262144} {
+		got, calibrated := c.Predict(key, numCtx, 999*gib, 1)
+		if !calibrated {
+			t.Fatalf("ctx %d: fell back to the prior despite two samples", numCtx)
+		}
+		want := uint64(20*gib + numCtx*2048)
+		if !withinMiB(got, want, 1) {
+			t.Errorf("ctx %d: got=%d want=%d", numCtx, got, want)
+		}
+	}
+}
+
+// The prior is deliberately absurd in the test above and here: a calibrated prediction
+// must not be influenced by it at all.
+func TestCalibrationSingleSampleUsesPriorSlopeThroughMeasuredPoint(t *testing.T) {
+	c := NewVRAMCalibration()
+	key := testKey()
+	c.Record(key, 8192, 30*gib)
+
+	// One sample fixes the intercept; the slope has to come from the prior.
+	got, calibrated := c.Predict(key, 16384, 999*gib, 4096)
+	if !calibrated {
+		t.Fatal("a single sample should still beat the prior")
+	}
+	if want := uint64(30*gib + 8192*4096); got != want {
+		t.Errorf("got=%d want=%d", got, want)
+	}
+
+	// And it must extrapolate downwards as well, without underflowing.
+	got, _ = c.Predict(key, 1024, 999*gib, 4096)
+	if want := uint64(30*gib - 7168*4096); got != want {
+		t.Errorf("downward: got=%d want=%d", got, want)
+	}
+	if got, _ := c.Predict(key, 1, 0, 1<<62); got != 0 {
+		t.Errorf("expected underflow to clamp at 0, got %d", got)
+	}
+}
+
+func TestCalibrationKeyChangeInvalidates(t *testing.T) {
+	c := NewVRAMCalibration()
+	key := testKey()
+	c.Record(key, 8192, 20*gib+8192*2048)
+	c.Record(key, 32768, 20*gib+32768*2048)
+
+	// Each of these describes a load whose memory use is not comparable, so each must miss
+	// the samples above rather than silently applying them.
+	changed := map[string]func(*CalibrationKey){
+		"model":           func(k *CalibrationKey) { k.Model = "/models/other.gguf" },
+		"model size":      func(k *CalibrationKey) { k.ModelSize = 5678 },
+		"kv cache type":   func(k *CalibrationKey) { k.KVCacheType = "q8_0" },
+		"flash attention": func(k *CalibrationKey) { k.FlashAttention = true },
+		"num batch":       func(k *CalibrationKey) { k.NumBatch = 512 },
+		"num parallel":    func(k *CalibrationKey) { k.NumParallel = 4 },
+		"num gpu":         func(k *CalibrationKey) { k.NumGPU = 2 },
+	}
+
+	for name, mutate := range changed {
+		t.Run(name, func(t *testing.T) {
+			other := testKey()
+			mutate(&other)
+			if _, calibrated := c.Predict(other, 8192, 10*gib, 1024); calibrated {
+				t.Errorf("%s changed but the old samples were still applied", name)
+			}
+		})
+	}
+
+	if _, calibrated := c.Predict(key, 8192, 10*gib, 1024); !calibrated {
+		t.Error("the original key stopped resolving to its own samples")
+	}
+}
+
+func TestCalibrationRecordReplacesSameContext(t *testing.T) {
+	c := NewVRAMCalibration()
+	key := testKey()
+
+	c.Record(key, 8192, 40*gib)
+	c.Record(key, 8192, 50*gib) // the model changed underneath, or the first load was odd
+	c.Record(key, 16384, 50*gib+8192*2048)
+
+	got, calibrated := c.Predict(key, 8192, 999*gib, 1)
+	if !calibrated {
+		t.Fatal("expected a calibrated prediction")
+	}
+	if !withinMiB(got, 50*gib, 1) {
+		t.Errorf("stale sample was not replaced: got=%d want≈%d", got, uint64(50*gib))
+	}
+}
+
+func TestCalibrationIgnoresUnusableInput(t *testing.T) {
+	c := NewVRAMCalibration()
+	key := testKey()
+
+	c.Record(key, 0, 40*gib)  // no context length to attribute it to
+	c.Record(key, 8192, 0)    // a load that reported nothing
+	c.Record(key, -1, 40*gib) // nonsense
+
+	if _, calibrated := c.Predict(key, 8192, 10*gib, 1024); calibrated {
+		t.Error("unusable samples were recorded")
+	}
+
+	// A nil store is usable and simply never calibrates, so callers need no nil check.
+	var nilStore *VRAMCalibration
+	nilStore.Record(key, 8192, 40*gib)
+	if got, calibrated := nilStore.Predict(key, 8192, 10*gib, 1024); calibrated || got != uint64(10*gib+8192*1024) {
+		t.Errorf("nil store: got=%d calibrated=%v", got, calibrated)
+	}
+}
+
+func TestCalibrationRejectsNegativeSlope(t *testing.T) {
+	c := NewVRAMCalibration()
+	key := testKey()
+
+	// Memory does not shrink as context grows. Samples that say otherwise describe
+	// something this model cannot express, so the prior is safer than the line.
+	c.Record(key, 8192, 40*gib)
+	c.Record(key, 32768, 30*gib)
+
+	got, calibrated := c.Predict(key, 262144, 50*gib, 1024)
+	if calibrated {
+		t.Error("extrapolated a negative slope instead of falling back")
+	}
+	if want := uint64(50*gib + 262144*1024); got != want {
+		t.Errorf("got=%d want=%d", got, want)
+	}
+}
+
+func TestCalibrationBoundsSampleCount(t *testing.T) {
+	c := NewVRAMCalibration()
+	key := testKey()
+
+	for i := 1; i <= maxCalibrationSamples+5; i++ {
+		c.Record(key, i*1024, uint64(20*gib+i*1024*2048))
+	}
+
+	c.mu.Lock()
+	n := len(c.samples[key])
+	c.mu.Unlock()
+	if n != maxCalibrationSamples {
+		t.Errorf("sample count not bounded: got=%d want=%d", n, maxCalibrationSamples)
+	}
+
+	// Dropping the oldest must not disturb the fit, since the line is the same.
+	got, calibrated := c.Predict(key, 100*1024, 999*gib, 1)
+	if !calibrated {
+		t.Fatal("expected a calibrated prediction")
+	}
+	if want := uint64(20*gib + 100*1024*2048); !withinMiB(got, want, 1) {
+		t.Errorf("got=%d want=%d", got, want)
+	}
+}
+
+// TestCalibrationAgainstMeasuredCurve uses VRAM actually measured on a two-card host, to
+// check that calibrating from the two cheapest loads predicts the expensive ones. The
+// metadata prediction is 7.05 GiB low at the longest context because it models one KV
+// cache and this architecture allocates two; the point of calibrating is that the shortfall
+// does not have to be understood to be corrected.
+func TestCalibrationAgainstMeasuredCurve(t *testing.T) {
+	measured := []struct {
+		numCtx int
+		vram   float64 // GiB, from llama-server's own buffer accounting
+	}{
+		{8192, 76.84},
+		{32768, 77.71},
+		{131072, 81.41},
+		{262144, 86.35},
+	}
+
+	c := NewVRAMCalibration()
+	key := testKey()
+	for _, m := range measured[:2] {
+		c.Record(key, m.numCtx, uint64(m.vram*gib))
+	}
+
+	for _, m := range measured[2:] {
+		got, calibrated := c.Predict(key, m.numCtx, 76*gib, 10138)
+		if !calibrated {
+			t.Fatalf("ctx %d: expected a calibrated prediction", m.numCtx)
+		}
+		want := uint64(m.vram * gib)
+		if !withinMiB(got, want, 600) {
+			t.Errorf("ctx %d: got=%.2f GiB want=%.2f GiB (off by %.0f MiB)",
+				m.numCtx, float64(got)/gib, m.vram, (float64(got)-float64(want))/mib)
+		}
+	}
+}

--- a/ml/device.go
+++ b/ml/device.go
@@ -358,13 +358,64 @@ func (f FlashAttentionType) String() string {
 // Given the list of GPUs this instantiation is targeted for,
 // figure out the device environment variables and any recorded
 // per-device runner environment overrides.
+// devicesMustFilter reports whether the runner child's visible devices are
+// restricted for this set. CUDA-only groups need filtering so devices removed
+// during discovery do not reappear in the child process.
+func devicesMustFilter(l []DeviceInfo) bool {
+	return len(l) == 1 || allDevicesUseLibrary(l, "CUDA")
+}
+
+// RunnerDeviceNames returns the name the runner child will use for each device
+// in l, in the same order.
+//
+// These are not always the discovery names. When the child's visible devices are
+// filtered it enumerates what it can see from zero, so the i-th visible CUDA
+// device is "CUDA0", "CUDA1", ... regardless of its index on the host. A model
+// placed on host device 1 alone runs in a child that calls it "CUDA0", and
+// llama-server's buffer accounting is reported under that name. Callers holding
+// discovery names must translate through this, or they will look up a device
+// the child never mentioned and conclude it is using no memory.
+//
+// Devices whose library is not filtered keep their discovery name, which the
+// child also uses.
+func RunnerDeviceNames(l []DeviceInfo) []string {
+	mustFilter := devicesMustFilter(l)
+
+	names := make([]string, len(l))
+	ordinals := map[string]int{}
+	for i, d := range l {
+		if !d.filtersVisibleDevices(mustFilter) {
+			names[i] = d.Name
+			continue
+		}
+
+		prefix := strings.TrimRight(d.Name, "0123456789")
+		names[i] = prefix + strconv.Itoa(ordinals[prefix])
+		ordinals[prefix]++
+	}
+	return names
+}
+
+// filtersVisibleDevices reports whether this device's library restricts the
+// child's view, which is what makes the child renumber from zero. It mirrors the
+// switch in updateVisibleDevicesEnv.
+func (d DeviceInfo) filtersVisibleDevices(mustFilter bool) bool {
+	switch d.Library {
+	case "ROCm":
+		// always filtered: unsupported devices can crash the runner
+		return true
+	case "CUDA", "Vulkan":
+		return mustFilter
+	default:
+		return false
+	}
+}
+
 func GetDevicesEnv(l []DeviceInfo) map[string]string {
 	if len(l) == 0 {
 		return nil
 	}
-	// CUDA-only groups need filtering so devices removed during discovery do
-	// not reappear in the child process.
-	mustFilter := len(l) == 1 || allDevicesUseLibrary(l, "CUDA")
+	mustFilter := devicesMustFilter(l)
 	env := map[string]string{}
 	for _, d := range l {
 		d.updateVisibleDevicesEnv(env, mustFilter)

--- a/ml/device_names_test.go
+++ b/ml/device_names_test.go
@@ -1,0 +1,79 @@
+package ml
+
+import (
+	"slices"
+	"testing"
+)
+
+func cuda(id, name string) DeviceInfo {
+	return DeviceInfo{DeviceID: DeviceID{ID: id, Library: "CUDA"}, Name: name}
+}
+
+func TestRunnerDeviceNames(t *testing.T) {
+	cases := []struct {
+		name    string
+		devices []DeviceInfo
+		want    []string
+	}{
+		{
+			// the common case, and the one that hid this: selecting the host's
+			// first device gives a child whose numbering happens to match
+			name:    "first device only",
+			devices: []DeviceInfo{cuda("0", "CUDA0")},
+			want:    []string{"CUDA0"},
+		},
+		{
+			// a model placed on the second device runs in a child that can see
+			// only that device, and calls it CUDA0
+			name:    "second device only",
+			devices: []DeviceInfo{cuda("1", "CUDA1")},
+			want:    []string{"CUDA0"},
+		},
+		{
+			name:    "both devices",
+			devices: []DeviceInfo{cuda("0", "CUDA0"), cuda("1", "CUDA1")},
+			want:    []string{"CUDA0", "CUDA1"},
+		},
+		{
+			// discovery orders devices by scheduling preference, so the set can
+			// be a permutation of the host order; the child numbers them in the
+			// order it was given
+			name:    "devices in preference order",
+			devices: []DeviceInfo{cuda("1", "CUDA1"), cuda("0", "CUDA0")},
+			want:    []string{"CUDA0", "CUDA1"},
+		},
+		{
+			name:    "third device only",
+			devices: []DeviceInfo{cuda("2", "CUDA2")},
+			want:    []string{"CUDA0"},
+		},
+		{
+			// a single device of any library is filtered
+			name:    "single metal device",
+			devices: []DeviceInfo{{DeviceID: DeviceID{ID: "0", Library: "Metal"}, Name: "MTL0"}},
+			want:    []string{"MTL0"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := RunnerDeviceNames(tc.devices); !slices.Equal(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A mixed-vendor set is not filtered for CUDA, so the child sees every device
+// and keeps the host numbering.
+func TestRunnerDeviceNamesMixedVendorUnfiltered(t *testing.T) {
+	devices := []DeviceInfo{
+		cuda("1", "CUDA1"),
+		{DeviceID: DeviceID{ID: "0", Library: "Vulkan"}, Name: "Vulkan0"},
+	}
+
+	got := RunnerDeviceNames(devices)
+	if want := []string{"CUDA1", "Vulkan0"}; !slices.Equal(got, want) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}

--- a/server/routes.go
+++ b/server/routes.go
@@ -2287,7 +2287,11 @@ func (s *Server) PsHandler(c *gin.Context) {
 
 		gpus := make([]api.ProcessGPU, 0, len(v.gpus))
 		for _, dev := range v.gpus {
-			gpus = append(gpus, api.ProcessGPU{ID: dev.ID, Runner: dev.Library})
+			gpus = append(gpus, api.ProcessGPU{
+				ID:       dev.ID,
+				Runner:   dev.Library,
+				SizeVRAM: int64(v.vramByGPU[dev]),
+			})
 		}
 
 		models = append(models, api.ProcessModelResponse{

--- a/server/routes.go
+++ b/server/routes.go
@@ -2285,7 +2285,13 @@ func (s *Server) PsHandler(c *gin.Context) {
 			QuantizationLevel: m.Config.FileType,
 		}
 
+		gpus := make([]api.ProcessGPU, 0, len(v.gpus))
+		for _, dev := range v.gpus {
+			gpus = append(gpus, api.ProcessGPU{ID: dev.ID, Runner: dev.Library})
+		}
+
 		models = append(models, api.ProcessModelResponse{
+			GPUs:          gpus,
 			Model:         displayName,
 			Name:          displayName,
 			Size:          v.size,

--- a/server/routes_ps_test.go
+++ b/server/routes_ps_test.go
@@ -1,0 +1,90 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/ml"
+)
+
+func psResponse(t *testing.T, runner *runnerRef) (api.ProcessResponse, string) {
+	t.Helper()
+
+	s := &Server{sched: &Scheduler{loaded: map[string]*runnerRef{"m": runner}}}
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/ps", nil)
+
+	s.PsHandler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var got api.ProcessResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding: %v (body %q)", err, w.Body.String())
+	}
+	return got, w.Body.String()
+}
+
+// A model split across two cards names both, so a client can attribute residency
+// per device by joining these ids against /api/info's supported_gpus.
+func TestPsHandlerReportsDevicesForSplitModel(t *testing.T) {
+	got, _ := psResponse(t, &runnerRef{
+		model:     &Model{ShortName: "llama3:70b"},
+		gpus:      []ml.DeviceID{{ID: "0", Library: "CUDA"}, {ID: "1", Library: "CUDA"}},
+		totalSize: 42 * format.GigaByte,
+		vramSize:  40 * format.GigaByte,
+		expiresAt: time.Now().Add(5 * time.Minute),
+	})
+
+	if len(got.Models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(got.Models))
+	}
+
+	gpus := got.Models[0].GPUs
+	if len(gpus) != 2 {
+		t.Fatalf("expected both devices, got %d: %+v", len(gpus), gpus)
+	}
+	for i, want := range []string{"0", "1"} {
+		if gpus[i].ID != want {
+			t.Errorf("gpu %d: id %q, want %q", i, gpus[i].ID, want)
+		}
+		if gpus[i].Runner != "CUDA" {
+			t.Errorf("gpu %d: runner %q, want CUDA", i, gpus[i].Runner)
+		}
+	}
+
+	// SizeVRAM stays the total across devices; it is not divided between them.
+	if got.Models[0].SizeVRAM != int64(40*format.GigaByte) {
+		t.Errorf("size_vram: got %d, want %d", got.Models[0].SizeVRAM, 40*format.GigaByte)
+	}
+}
+
+// A CPU-resident model has no devices, and the field is omitted rather than
+// serialised as null.
+func TestPsHandlerOmitsDevicesOnCPU(t *testing.T) {
+	got, raw := psResponse(t, &runnerRef{
+		model:     &Model{ShortName: "smol:1b"},
+		totalSize: 2 * format.GigaByte,
+		expiresAt: time.Now().Add(5 * time.Minute),
+	})
+
+	if len(got.Models[0].GPUs) != 0 {
+		t.Errorf("expected no devices, got %+v", got.Models[0].GPUs)
+	}
+	if strings.Contains(raw, "\"gpus\"") {
+		t.Errorf("gpus should be omitted for a CPU-resident model, got %s", raw)
+	}
+}

--- a/server/routes_ps_test.go
+++ b/server/routes_ps_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/llm"
 	"github.com/ollama/ollama/ml"
 )
 
@@ -41,12 +42,19 @@ func psResponse(t *testing.T, runner *runnerRef) (api.ProcessResponse, string) {
 // A model split across two cards names both, so a client can attribute residency
 // per device by joining these ids against /api/info's supported_gpus.
 func TestPsHandlerReportsDevicesForSplitModel(t *testing.T) {
+	dev0 := ml.DeviceID{ID: "0", Library: "CUDA"}
+	dev1 := ml.DeviceID{ID: "1", Library: "CUDA"}
+
 	got, _ := psResponse(t, &runnerRef{
 		model:     &Model{ShortName: "llama3:70b"},
-		gpus:      []ml.DeviceID{{ID: "0", Library: "CUDA"}, {ID: "1", Library: "CUDA"}},
+		gpus:      []ml.DeviceID{dev0, dev1},
 		totalSize: 42 * format.GigaByte,
 		vramSize:  40 * format.GigaByte,
 		expiresAt: time.Now().Add(5 * time.Minute),
+		llama: &fakeRunner{vram: map[ml.DeviceID]uint64{
+			dev0: 25 * format.GigaByte,
+			dev1: 15 * format.GigaByte,
+		}, total: 42 * format.GigaByte, gpuTotal: 40 * format.GigaByte},
 	})
 
 	if len(got.Models) != 1 {
@@ -66,7 +74,15 @@ func TestPsHandlerReportsDevicesForSplitModel(t *testing.T) {
 		}
 	}
 
-	// SizeVRAM stays the total across devices; it is not divided between them.
+	// an uneven split is reported as it is, not divided evenly
+	if gpus[0].SizeVRAM != int64(25*format.GigaByte) {
+		t.Errorf("gpu 0 size_vram: got %d, want %d", gpus[0].SizeVRAM, 25*format.GigaByte)
+	}
+	if gpus[1].SizeVRAM != int64(15*format.GigaByte) {
+		t.Errorf("gpu 1 size_vram: got %d, want %d", gpus[1].SizeVRAM, 15*format.GigaByte)
+	}
+
+	// the model-level figure remains the total across devices
 	if got.Models[0].SizeVRAM != int64(40*format.GigaByte) {
 		t.Errorf("size_vram: got %d, want %d", got.Models[0].SizeVRAM, 40*format.GigaByte)
 	}
@@ -88,3 +104,16 @@ func TestPsHandlerOmitsDevicesOnCPU(t *testing.T) {
 		t.Errorf("gpus should be omitted for a CPU-resident model, got %s", raw)
 	}
 }
+
+// fakeRunner is the narrowest llm.LlamaServer that PsHandler exercises: the
+// memory accessors. Everything else panics if the handler ever grows a call.
+type fakeRunner struct {
+	llm.LlamaServer
+	vram     map[ml.DeviceID]uint64
+	total    uint64
+	gpuTotal uint64
+}
+
+func (f *fakeRunner) MemorySize() (uint64, uint64)    { return f.total, f.gpuTotal }
+func (f *fakeRunner) VRAMByGPU(id ml.DeviceID) uint64 { return f.vram[id] }
+func (f *fakeRunner) ContextLength() int              { return 4096 }

--- a/server/sched.go
+++ b/server/sched.go
@@ -121,6 +121,7 @@ func vramCalibrationKey(req *LlmRequest, gpus []ml.DeviceInfo, numParallel int) 
 	return llm.CalibrationKey{
 		Model:          req.model.ModelPath,
 		ModelSize:      modelFileSize(req.model.ModelPath),
+		Projectors:     strings.Join(req.model.ProjectorPaths, ","),
 		KVCacheType:    envconfig.KvCacheType(),
 		FlashAttention: llm.LlamaServerFlashAttention(gpus) == ml.FlashAttentionEnabled,
 		NumBatch:       req.opts.NumBatch,

--- a/server/sched.go
+++ b/server/sched.go
@@ -1739,6 +1739,7 @@ type loadedModel struct {
 	contextLength int
 	expiresAt     time.Time
 	gpus          []ml.DeviceID
+	vramByGPU     map[ml.DeviceID]uint64
 }
 
 // loadedModels returns a snapshot of the currently loaded models for status
@@ -1773,6 +1774,14 @@ func (s *Scheduler) loadedModels() []loadedModel {
 			total, vram := r.llama.MemorySize()
 			lm.size = int64(total)
 			lm.sizeVRAM = int64(vram)
+
+			// Per-device residency. A backend with one device reports the whole
+			// figure for it; one whose device names don't map back reports zero
+			// rather than guessing.
+			lm.vramByGPU = make(map[ml.DeviceID]uint64, len(lm.gpus))
+			for _, dev := range lm.gpus {
+				lm.vramByGPU[dev] = r.llama.VRAMByGPU(dev)
+			}
 		}
 		// The scheduler waits to set expiresAt, so a model that is still
 		// loading may have the zero value. Estimate expiration from the

--- a/server/sched.go
+++ b/server/sched.go
@@ -73,6 +73,10 @@ type Scheduler struct {
 	activeLoading llm.LlamaServer
 	loaded        map[string]*runnerRef
 
+	// vramCalibration remembers what earlier loads actually used, so a repeat load of a
+	// model is predicted from measurement instead of from metadata alone.
+	vramCalibration *llm.VRAMCalibration
+
 	loadFn          func(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, requireFull bool) bool
 	newServerFn     func(systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, model string, f *ggml.GGML, adapters []string, projectors []string, opts api.Options, numParallel int, config llm.LlamaServerConfig) (llm.LlamaServer, error)
 	getGpuFn        func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo
@@ -99,9 +103,38 @@ func InitScheduler(ctx context.Context) *Scheduler {
 		getGpuFn:        discover.GPUDevices,
 		getSystemInfoFn: discover.GetSystemInfo,
 		waitForRecovery: 5 * time.Second,
+		vramCalibration: llm.NewVRAMCalibration(),
 	}
 	sched.loadFn = sched.load
 	return sched
+}
+
+// vramCalibrationKey describes the inputs to a placement decision, so that a later
+// decision made from the same inputs can reuse what the earlier one measured.
+//
+// It deliberately describes the inputs rather than what the load ended up doing. The rest
+// of the pipeline is deterministic given these, so keying on them keeps the sample that a
+// load records addressable by the next load that would make the same decision — and any
+// change to them selects a different bucket, which is what stops a stale sample being
+// applied to a load it no longer describes.
+func vramCalibrationKey(req *LlmRequest, gpus []ml.DeviceInfo, numParallel int) llm.CalibrationKey {
+	return llm.CalibrationKey{
+		Model:          req.model.ModelPath,
+		ModelSize:      modelFileSize(req.model.ModelPath),
+		KVCacheType:    envconfig.KvCacheType(),
+		FlashAttention: llm.LlamaServerFlashAttention(gpus) == ml.FlashAttentionEnabled,
+		NumBatch:       req.opts.NumBatch,
+		NumParallel:    numParallel,
+		NumGPU:         len(gpus),
+	}
+}
+
+// predictLlamaServerVRAM estimates VRAM for a llama-server load, preferring a measurement
+// of an earlier load made from the same inputs over the metadata estimate.
+func predictLlamaServerVRAM(cal *llm.VRAMCalibration, req *LlmRequest, f *ggml.GGML, numCtx int, gpus []ml.DeviceInfo, numParallel int) uint64 {
+	weights, bytesPerToken := llm.PredictServerVRAMParts(req.model.ModelPath, f)
+	predicted, _ := cal.Predict(vramCalibrationKey(req, gpus, numParallel), numCtx, weights, bytesPerToken)
+	return predicted
 }
 
 // schedulerModelKey returns the scheduler map key for a model.
@@ -520,6 +553,11 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 	loadGpus := gpus
 	var launchOpts api.Options
 
+	// The context the prediction was made at, kept in scope so the measurement this load
+	// produces is recorded against the same value. req.opts.NumCtx is rewritten further
+	// down from what llama-server actually chose, so it cannot be recomputed later.
+	var predictedCtx int
+
 	if llama == nil {
 		var err error
 		if !req.model.IsMLX() {
@@ -532,8 +570,8 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 				return false
 			}
 
-			predictedCtx := effectiveLlamaServerContext(req.opts.NumCtx, f, numParallel)
-			predicted := llm.PredictServerVRAM(req.model.ModelPath, f, predictedCtx)
+			predictedCtx = effectiveLlamaServerContext(req.opts.NumCtx, f, numParallel)
+			predicted := predictLlamaServerVRAM(s.vramCalibration, req, f, predictedCtx, gpus, numParallel)
 			loadGpus, launchOpts = selectLlamaServerPlacement(systemInfo, gpus, predicted, req.opts)
 			availableForBatch, _, _ := availableMemoryForPlacement(systemInfo, loadGpus, launchOpts)
 			flashAttention := llm.LlamaServerFlashAttention(loadGpus)
@@ -647,7 +685,7 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 		s.loadedMu.Unlock()
 		otherLoaded := loadedCount > 0
 		if !req.oomRetryAttempted && llm.IsOutOfMemory(err) {
-			if oldNumCtx, effectiveNumCtx, newNumCtx, oldNumBatch, newNumBatch, ok := req.reduceAutoNumCtxForLoadOOM(f, numParallel, completion, systemInfo, loadGpus, launchOpts); ok {
+			if oldNumCtx, effectiveNumCtx, newNumCtx, oldNumBatch, newNumBatch, ok := req.reduceAutoNumCtxForLoadOOM(s.vramCalibration, f, numParallel, completion, systemInfo, loadGpus, launchOpts); ok {
 				req.oomRetryAttempted = true
 				slog.Warn("llama-server load failed; reducing automatic context and retrying once",
 					"model", req.model.ModelPath,
@@ -713,6 +751,8 @@ iGPUScan:
 		trainContext:    trainContext,
 	}
 	runner.numParallel = numParallel
+	runner.calibrationKey = vramCalibrationKey(req, gpus, numParallel)
+	runner.calibrationCtx = predictedCtx
 	runner.refMu.Lock() // hold lock until running or aborted
 
 	s.loadedMu.Lock()
@@ -743,6 +783,12 @@ iGPUScan:
 		}
 		runner.refCount++
 		runner.loading = false
+		// The load has finished, so llama-server has reported every buffer it allocated.
+		// Remember what it came to: the next load of this model made from the same inputs
+		// is predicted from this rather than from metadata.
+		if _, vram := llama.MemorySize(); vram > 0 {
+			s.vramCalibration.Record(runner.calibrationKey, runner.calibrationCtx, vram)
+		}
 		go func() {
 			<-req.ctx.Done()
 			slog.Debug("context for request finished")
@@ -754,7 +800,7 @@ iGPUScan:
 	return false
 }
 
-func (req *LlmRequest) reduceAutoNumCtxForLoadOOM(f *ggml.GGML, numParallel int, completion bool, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, launchOpts api.Options) (oldNumCtx, effectiveNumCtx, newNumCtx, oldNumBatch, newNumBatch int, ok bool) {
+func (req *LlmRequest) reduceAutoNumCtxForLoadOOM(cal *llm.VRAMCalibration, f *ggml.GGML, numParallel int, completion bool, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, launchOpts api.Options) (oldNumCtx, effectiveNumCtx, newNumCtx, oldNumBatch, newNumBatch int, ok bool) {
 	if !req.numCtxAuto {
 		return 0, 0, 0, 0, 0, false
 	}
@@ -775,7 +821,7 @@ func (req *LlmRequest) reduceAutoNumCtxForLoadOOM(f *ggml.GGML, numParallel int,
 
 	req.opts.NumCtx = newNumCtx
 	predictedCtx := effectiveLlamaServerContext(req.opts.NumCtx, f, numParallel)
-	predictedVRAM := llm.PredictServerVRAM(req.model.ModelPath, f, predictedCtx)
+	predictedVRAM := predictLlamaServerVRAM(cal, req, f, predictedCtx, gpus, numParallel)
 	available, _, _ := availableMemoryForPlacement(systemInfo, gpus, launchOpts)
 	req.applyAutomaticGenerationBatch(completion, predictedCtx, predictedVRAM, available, llm.LlamaServerFlashAttention(gpus), gpus)
 	newNumBatch = req.opts.NumBatch
@@ -1137,7 +1183,7 @@ func logSelectedGPUGroup(all, selected []ml.DeviceInfo) {
 
 func (s *Scheduler) applyLlamaServerMmapDefaults(req *LlmRequest, launchOpts api.Options, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, f *ggml.GGML, numParallel int) api.Options {
 	predictedCtx := effectiveLlamaServerContext(req.opts.NumCtx, f, numParallel)
-	predictedVRAM := llm.PredictServerVRAM(req.model.ModelPath, f, predictedCtx)
+	predictedVRAM := predictLlamaServerVRAM(s.vramCalibration, req, f, predictedCtx, gpus, numParallel)
 	availableVRAM, _, _ := availableMemoryForPlacement(systemInfo, gpus, launchOpts)
 
 	if reason := disableMmapDefaultReason(runtime.GOOS, req.opts, gpus, f.KV().BlockCount(), predictedVRAM, availableVRAM); reason != "" {
@@ -1201,7 +1247,7 @@ func (s *Scheduler) maybeDisableMmapForHostPressure(req *LlmRequest, launchOpts 
 	modelSize := modelFileSize(req.model.ModelPath)
 	loadedMmapSize := s.loadedMmapModelSizeLocked()
 	predictedCtx := effectiveLlamaServerContext(req.opts.NumCtx, f, numParallel)
-	predictedVRAM := llm.PredictServerVRAM(req.model.ModelPath, f, predictedCtx)
+	predictedVRAM := predictLlamaServerVRAM(s.vramCalibration, req, f, predictedCtx, gpus, numParallel)
 	availableVRAM, _, _ := availableMemoryForPlacement(systemInfo, gpus, launchOpts)
 	placementGpus := gpusForPlacement(gpus, launchOpts)
 
@@ -1339,8 +1385,15 @@ type runnerRef struct {
 	refMu    sync.Mutex
 	refCount uint // prevent unloading if > 0
 
-	llama        llm.LlamaServer
-	pid          int
+	llama llm.LlamaServer
+	pid   int
+
+	// calibrationKey and calibrationCtx are the inputs this load's prediction was made
+	// from, kept so its measurement is recorded under the key a later prediction from the
+	// same inputs will look up.
+	calibrationKey llm.CalibrationKey
+	calibrationCtx int
+
 	loading      bool          // True only during initial load, then false forever
 	gpus         []ml.DeviceID // Recorded at time of provisioning
 	discreteGPUs bool          // True if all devices are discrete GPUs - used to skip VRAM recovery check for iGPUs

--- a/server/sched.go
+++ b/server/sched.go
@@ -1061,7 +1061,7 @@ func bestSingleGPUFit(systemInfo ml.SystemInfo, groups [][]ml.DeviceInfo, predic
 	for _, group := range groups {
 		for _, candidate := range group {
 			candidateAvailable := availableMemoryForGPU(systemInfo, candidate)
-			if predictedVRAM > candidateAvailable*80/100 {
+			if predictedVRAM > candidateAvailable*uint64(envconfig.SingleGPUFitPercent())/100 {
 				continue
 			}
 			if !ok || betterPlacementGPU(candidate, candidateAvailable, gpu, available) {

--- a/server/sched.go
+++ b/server/sched.go
@@ -133,7 +133,7 @@ func vramCalibrationKey(req *LlmRequest, gpus []ml.DeviceInfo, numParallel int) 
 // predictLlamaServerVRAM estimates VRAM for a llama-server load, preferring a measurement
 // of an earlier load made from the same inputs over the metadata estimate.
 func predictLlamaServerVRAM(cal *llm.VRAMCalibration, req *LlmRequest, f *ggml.GGML, numCtx int, gpus []ml.DeviceInfo, numParallel int) uint64 {
-	weights, bytesPerToken := llm.PredictServerVRAMParts(req.model.ModelPath, f)
+	weights, bytesPerToken := llm.PredictServerVRAMParts(req.model.ModelPath, req.model.ProjectorPaths, f)
 	predicted, _ := cal.Predict(vramCalibrationKey(req, gpus, numParallel), numCtx, weights, bytesPerToken)
 	return predicted
 }

--- a/server/sched.go
+++ b/server/sched.go
@@ -1738,6 +1738,7 @@ type loadedModel struct {
 	sizeVRAM      int64
 	contextLength int
 	expiresAt     time.Time
+	gpus          []ml.DeviceID
 }
 
 // loadedModels returns a snapshot of the currently loaded models for status
@@ -1765,6 +1766,7 @@ func (s *Scheduler) loadedModels() []loadedModel {
 			size:      int64(r.totalSize),
 			sizeVRAM:  int64(r.vramSize),
 			expiresAt: r.expiresAt,
+			gpus:      slices.Clone(r.gpus),
 		}
 		if r.llama != nil {
 			lm.contextLength = r.llama.ContextLength()

--- a/server/sched.go
+++ b/server/sched.go
@@ -132,9 +132,15 @@ func vramCalibrationKey(req *LlmRequest, gpus []ml.DeviceInfo, numParallel int) 
 
 // predictLlamaServerVRAM estimates VRAM for a llama-server load, preferring a measurement
 // of an earlier load made from the same inputs over the metadata estimate.
-func predictLlamaServerVRAM(cal *llm.VRAMCalibration, req *LlmRequest, f *ggml.GGML, numCtx int, gpus []ml.DeviceInfo, numParallel int) uint64 {
+//
+// The key is passed in rather than derived here because the inputs it describes are not
+// all settled at once: placement and batch size are themselves chosen from a first
+// estimate. A caller that has settled them must pass the key describing what will
+// actually run, so that the measurement this load produces is filed where the next
+// prediction for the same load will look for it.
+func predictLlamaServerVRAM(cal *llm.VRAMCalibration, key llm.CalibrationKey, req *LlmRequest, f *ggml.GGML, numCtx int) uint64 {
 	weights, bytesPerToken := llm.PredictServerVRAMParts(req.model.ModelPath, req.model.ProjectorPaths, f)
-	predicted, _ := cal.Predict(vramCalibrationKey(req, gpus, numParallel), numCtx, weights, bytesPerToken)
+	predicted, _ := cal.Predict(key, numCtx, weights, bytesPerToken)
 	return predicted
 }
 
@@ -559,6 +565,11 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 	// down from what llama-server actually chose, so it cannot be recomputed later.
 	var predictedCtx int
 
+	// The key describing the load that will actually run. It cannot be rebuilt later:
+	// applyAutomaticGenerationBatch rewrites req.opts.NumBatch, so a key built before it
+	// and a key built after it are different keys for the same load.
+	var calibrationKey llm.CalibrationKey
+
 	if llama == nil {
 		var err error
 		if !req.model.IsMLX() {
@@ -572,12 +583,23 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 			}
 
 			predictedCtx = effectiveLlamaServerContext(req.opts.NumCtx, f, numParallel)
-			predicted := predictLlamaServerVRAM(s.vramCalibration, req, f, predictedCtx, gpus, numParallel)
+
+			// Placement and batch size are chosen from an estimate, and both change what
+			// the load costs, so the first prediction is made from the devices on offer
+			// and the batch requested. It decides the placement and nothing else.
+			bootstrapKey := vramCalibrationKey(req, gpus, numParallel)
+			predicted := predictLlamaServerVRAM(s.vramCalibration, bootstrapKey, req, f, predictedCtx)
 			loadGpus, launchOpts = selectLlamaServerPlacement(systemInfo, gpus, predicted, req.opts)
 			availableForBatch, _, _ := availableMemoryForPlacement(systemInfo, loadGpus, launchOpts)
 			flashAttention := llm.LlamaServerFlashAttention(loadGpus)
 			req.applyAutomaticGenerationBatch(completion, predictedCtx, predicted, availableForBatch, flashAttention, loadGpus)
 			launchOpts.NumBatch = req.opts.NumBatch
+
+			// Both are settled now, so this key describes the load that will run. It is
+			// used for the prediction the fit decision is made from and for the sample
+			// that load records, which is what makes the two meet.
+			calibrationKey = vramCalibrationKey(req, loadGpus, numParallel)
+			predicted = predictLlamaServerVRAM(s.vramCalibration, calibrationKey, req, f, predictedCtx)
 			predictedForLoad := predicted + generationBatchSurchargeForCompletion(completion, launchOpts.NumBatch)
 
 			// Pre-flight check: estimate whether the model fits in remaining memory.
@@ -752,7 +774,7 @@ iGPUScan:
 		trainContext:    trainContext,
 	}
 	runner.numParallel = numParallel
-	runner.calibrationKey = vramCalibrationKey(req, gpus, numParallel)
+	runner.calibrationKey = calibrationKey
 	runner.calibrationCtx = predictedCtx
 	runner.refMu.Lock() // hold lock until running or aborted
 
@@ -822,7 +844,7 @@ func (req *LlmRequest) reduceAutoNumCtxForLoadOOM(cal *llm.VRAMCalibration, f *g
 
 	req.opts.NumCtx = newNumCtx
 	predictedCtx := effectiveLlamaServerContext(req.opts.NumCtx, f, numParallel)
-	predictedVRAM := predictLlamaServerVRAM(cal, req, f, predictedCtx, gpus, numParallel)
+	predictedVRAM := predictLlamaServerVRAM(cal, vramCalibrationKey(req, gpus, numParallel), req, f, predictedCtx)
 	available, _, _ := availableMemoryForPlacement(systemInfo, gpus, launchOpts)
 	req.applyAutomaticGenerationBatch(completion, predictedCtx, predictedVRAM, available, llm.LlamaServerFlashAttention(gpus), gpus)
 	newNumBatch = req.opts.NumBatch
@@ -1184,7 +1206,7 @@ func logSelectedGPUGroup(all, selected []ml.DeviceInfo) {
 
 func (s *Scheduler) applyLlamaServerMmapDefaults(req *LlmRequest, launchOpts api.Options, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, f *ggml.GGML, numParallel int) api.Options {
 	predictedCtx := effectiveLlamaServerContext(req.opts.NumCtx, f, numParallel)
-	predictedVRAM := predictLlamaServerVRAM(s.vramCalibration, req, f, predictedCtx, gpus, numParallel)
+	predictedVRAM := predictLlamaServerVRAM(s.vramCalibration, vramCalibrationKey(req, gpus, numParallel), req, f, predictedCtx)
 	availableVRAM, _, _ := availableMemoryForPlacement(systemInfo, gpus, launchOpts)
 
 	if reason := disableMmapDefaultReason(runtime.GOOS, req.opts, gpus, f.KV().BlockCount(), predictedVRAM, availableVRAM); reason != "" {
@@ -1248,7 +1270,7 @@ func (s *Scheduler) maybeDisableMmapForHostPressure(req *LlmRequest, launchOpts 
 	modelSize := modelFileSize(req.model.ModelPath)
 	loadedMmapSize := s.loadedMmapModelSizeLocked()
 	predictedCtx := effectiveLlamaServerContext(req.opts.NumCtx, f, numParallel)
-	predictedVRAM := predictLlamaServerVRAM(s.vramCalibration, req, f, predictedCtx, gpus, numParallel)
+	predictedVRAM := predictLlamaServerVRAM(s.vramCalibration, vramCalibrationKey(req, gpus, numParallel), req, f, predictedCtx)
 	availableVRAM, _, _ := availableMemoryForPlacement(systemInfo, gpus, launchOpts)
 	placementGpus := gpusForPlacement(gpus, launchOpts)
 

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -2236,3 +2236,50 @@ func TestSchedulerTracksMultipleLoadedRunners(t *testing.T) {
 	expectedFree := uint64(24*format.GigaByte) - uint64(8*format.GigaByte) - uint64(4*format.GigaByte)
 	require.Equal(t, expectedFree, gpus[0].FreeMemory)
 }
+
+// TestCalibrationKeySurvivesTheAutomaticBatchRewrite pins down the ordering the calibration
+// depends on, because getting it wrong is silent in exactly the way that matters: samples
+// are still recorded, predictions are still made, and the two simply never meet.
+//
+// applyAutomaticGenerationBatch rewrites req.opts.NumBatch, and NumBatch is part of the
+// key. A key built before that call and a key built after it therefore address different
+// buckets for one load, so a load's measurement lands where no later prediction for the
+// same load will look for it -- the calibration never engages, while looking like it does.
+//
+// This guards the property rather than the call site. The call site is held by the
+// compiler: the settled key is a variable the load path must use, so reverting to a key
+// rebuilt from stale inputs fails to build.
+func TestCalibrationKeySurvivesTheAutomaticBatchRewrite(t *testing.T) {
+	req := &LlmRequest{
+		model:        &Model{ModelPath: "/models/test.gguf"},
+		opts:         api.Options{Runner: api.Runner{NumBatch: 512, NumCtx: 262144}},
+		numBatchAuto: true,
+	}
+
+	before := vramCalibrationKey(req, nil, 1)
+
+	// A long-context completion is the case where the automatic batch actually moves.
+	req.applyAutomaticGenerationBatch(true, 262144, 0, 0, ml.FlashAttentionAuto, nil)
+	after := vramCalibrationKey(req, nil, 1)
+
+	if req.opts.NumBatch == 512 {
+		t.Fatal("the automatic batch did not change NumBatch, so this test cannot detect the bug it exists for")
+	}
+	if before == after {
+		t.Fatal("the key did not change across the rewrite; if that is now true by design, this test is obsolete")
+	}
+
+	// A sample recorded under the settled key must be visible to a prediction made with
+	// that same key, and must not be reachable through the pre-rewrite one, which
+	// describes a batch size this load never ran at.
+	cal := llm.NewVRAMCalibration()
+	cal.Record(after, 8192, 20*1024*1024*1024)
+	cal.Record(after, 32768, 24*1024*1024*1024)
+
+	if _, calibrated := cal.Predict(after, 262144, 0, 0); !calibrated {
+		t.Error("a prediction using the settled key could not see the samples recorded under it")
+	}
+	if _, calibrated := cal.Predict(before, 262144, 0, 0); calibrated {
+		t.Error("the pre-rewrite key resolved to samples describing a different batch size")
+	}
+}

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -281,7 +281,14 @@ func (c *Client) HasExited() bool {
 
 // Load checks whether the model fits in GPU memory and starts the subprocess.
 func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo, requireFull bool) ([]ml.DeviceID, error) {
+	// Devices this model ends up resident on, reported back to the scheduler so
+	// /api/ps can attribute it. Empty means the CPU, so leaving it unset made a
+	// GPU-resident MLX model indistinguishable from a CPU one.
+	var placed []ml.DeviceID
+
 	if len(gpus) > 0 {
+		placed = []ml.DeviceID{gpus[0].DeviceID}
+
 		modelSize := c.memory.Load()
 		// We currently only use the first GPU with MLX
 		available := gpus[0].FreeMemory
@@ -401,7 +408,7 @@ func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 		close(c.done)
 	}()
 
-	return nil, nil
+	return placed, nil
 }
 
 // ModelPath implements llm.LlamaServer.

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -280,14 +280,20 @@ func (c *Client) HasExited() bool {
 }
 
 // Load checks whether the model fits in GPU memory and starts the subprocess.
+// placedDevices reports the devices a load will occupy, for the scheduler to
+// record. MLX uses only the first GPU, and an empty result means the CPU, so
+// returning nothing for a GPU-resident model would misreport it as CPU-bound.
+func placedDevices(gpus []ml.DeviceInfo) []ml.DeviceID {
+	if len(gpus) == 0 {
+		return nil
+	}
+	return []ml.DeviceID{gpus[0].DeviceID}
+}
+
 func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo, requireFull bool) ([]ml.DeviceID, error) {
-	// Devices this model ends up resident on, reported back to the scheduler so
-	// /api/ps can attribute it. Empty means the CPU, so leaving it unset made a
-	// GPU-resident MLX model indistinguishable from a CPU one.
-	var placed []ml.DeviceID
+	placed := placedDevices(gpus)
 
 	if len(gpus) > 0 {
-		placed = []ml.DeviceID{gpus[0].DeviceID}
 
 		modelSize := c.memory.Load()
 		// We currently only use the first GPU with MLX

--- a/x/mlxrunner/placement_test.go
+++ b/x/mlxrunner/placement_test.go
@@ -1,0 +1,30 @@
+package mlxrunner
+
+import (
+	"testing"
+
+	"github.com/ollama/ollama/ml"
+)
+
+func TestPlacedDevices(t *testing.T) {
+	metal := ml.DeviceID{ID: "0", Library: "Metal"}
+	second := ml.DeviceID{ID: "1", Library: "Metal"}
+
+	// The scheduler reads an empty list as "on the CPU", so a GPU load must
+	// report its device: this is what /api/ps attributes the model to.
+	got := placedDevices([]ml.DeviceInfo{{DeviceID: metal}})
+	if len(got) != 1 || got[0] != metal {
+		t.Errorf("single GPU: got %+v, want [%+v]", got, metal)
+	}
+
+	// MLX drives only the first device even when more are present, so claiming
+	// both would attribute memory to a card holding none.
+	got = placedDevices([]ml.DeviceInfo{{DeviceID: metal}, {DeviceID: second}})
+	if len(got) != 1 || got[0] != metal {
+		t.Errorf("two GPUs: got %+v, want [%+v] only", got, metal)
+	}
+
+	if got = placedDevices(nil); got != nil {
+		t.Errorf("no GPUs: got %+v, want nil (CPU)", got)
+	}
+}


### PR DESCRIPTION
## Predict single-GPU VRAM from the published head dimensions, and from what earlier loads measured

> **Stacked on #18197.** GitHub cannot base a cross-fork PR on another fork's branch, so this
> branch necessarily contains that one's commits as well. **Only the last four commits are new
> here**, from `fs/ggml: size the KV cache from the published head dimensions` onward. Please
> review and merge #18197 first; this rebases cleanly onto whatever it lands as.

### Context

#18197 establishes that the single-GPU prediction is within ±1.9 GiB at 8k context across 13
models, and states a limitation: the KV term models one cache of the published dimensions, so
architectures that hold more than that are under-predicted by an amount proportional to
context. Qwen3.8-Flash-Next is predicted within +0.06 GiB at 8k and **7.05 GiB low at 256k**,
which is the direction that overcommits a device.

This closes that gap from both ends.

### 1. Read the head dimensions instead of deriving them

The KV term derived the head dimension as `embedding_length / head_count`. That ratio is not
the head dimension for architectures that publish one: Qwen3.8-Flash-Next sets
`attention.key_length` 256 against an implied 2560/24 ≈ 106, so the derived figure is under
half the real width.

Reading `attention.key_length` and `attention.value_length`, and charging each attention block
its own KV head count rather than the minimum across all blocks, makes this exact for the cache
the metadata describes:

```
12 attention blocks x 2 KV heads x (256 + 256) x 2 bytes = 24,576 bytes/token
runtime reports 6144 MiB over 262144 cells       6144 MiB / 262144 = 24,576 bytes/token
```

That alone takes the 256k error from 7.05 GiB to 1.59 GiB.

### 2. Prefer a measurement over a formula

The remainder is not KV at all — it is a second cache this architecture allocates and compute
buffers that grow with context, neither of which the metadata describes. Rather than encode a
guess about either, record what a load actually used and predict the next one from it.

Measured VRAM is close to linear in context length. Fitting a straight line through four loads
each of two architectures:

```
qwen3.8-flash-next   VRAM(ctx) = 76.504 GiB + 39.3486 KiB/token   R² = 0.999971, max residual 29 MiB
qwen3.5:122b         VRAM(ctx) = 73.717 GiB + 24.9295 KiB/token   R² = 0.999928, max residual 15 MiB
```

So two loads at different context lengths predict a third. Measured live across three
successive loads of the same model, with the prediction improving as samples accumulate:

```
ctx   8192   predicted 77.0 GiB   no samples   -> metadata prior
ctx  32768   predicted 77.4 GiB   one sample   -> anchored on the measurement, metadata slope
ctx 262144   predicted 85.8 GiB   two samples  -> fitted line
             actual    86.35 GiB              -> 0.55 GiB error, from 7.05
```

### 3. Account for the multimodal projector

A projector is a separate file the runner loads alongside the weights, and it was absent from
both halves of the accounting. The prediction reads the model's tensors, which do not include
it. `llama-server` reports it on a line of its own rather than through the buffer-size lines
that are scraped, so it was missing from `/api/ps` as well — and therefore from calibration
samples, which is why the fit could not absorb it either:

```
srv    load_model: [mtmd] estimated worst-case memory usage of mmproj is 1135.13 MiB (took 25.13 ms)
clip_ctx: CLIP using CUDA0 backend
```

Both lines are now parsed. The backend line is the one that matters for correctness: ollama
declines to offload the projector under memory pressure, and a projector left on the host must
not be charged to a device. They arrive in either order — the size first, in practice — so each
is recorded as it arrives and attributed once both are known.

Measured on Qwen3.8-Flash-Next at 8k context, a vision build against a text-only build of the
same weights:

| | reported | driver | gap |
|---|---|---|---|
| text-only | 76.84 GiB | 77.54 | 0.69 (CUDA context, present either way) |
| vision, before | 77.09 GiB | 78.62 | **1.53** |
| vision, after | 78.19 GiB | 78.62 | **0.43** |

The prediction counts the projector files, and a second commit adds the projector paths to the
calibration key: ollama stores a projector as its own layer, so a vision build and a text-only
build of the same model share a weights blob and were previously indistinguishable to it.

### What the projector does to the prior, in each of its three states

| State | prior adds | actually in VRAM | prior is |
|---|---|---|---|
| no projector | nothing | nothing | exact |
| projector offloaded | the file size | the runner's worst-case reservation | slightly low |
| projector left on host | the file size | nothing | high by that size |

Counting it is the conservative direction: over-predicting declines a placement, under-predicting
makes one that then does not fit.

**A known imprecision, stated deliberately:** the last two states share a calibration key. The key
describes the inputs to the placement decision, but whether the projector is offloaded is decided
afterwards from live memory, so two loads of the same model can differ by roughly the projector's
size and land in the same bucket. Keying on the outcome instead would produce a key no prediction
could look up, since the prediction is what runs first. What bounds it is that a same-context
record replaces rather than accumulates, so the most recent load's behaviour wins. Reporting has
no such ambiguity — it reads the backend line and attributes accordingly.

### Invalidation

`CalibrationKey` holds everything that moves the curve — model path and size, projector paths, KV
cache type, flash attention, batch, parallel, device count. Samples are looked up by the whole key, so a
change to any of it selects a different bucket and the old samples stop being consulted. There
is no separate expiry policy to get wrong; a sample simply stops being addressable by loads it
no longer describes.

The key is captured at prediction time and stored on the runner, then reused when recording, so
what is written back is addressable by the next prediction made from the same inputs.

### Behaviour when there is nothing to go on

With no samples the metadata estimate is returned unchanged, so a first load behaves exactly as
before this change. With one sample the measurement fixes the intercept and the metadata
supplies the slope. Samples implying that memory shrinks as context grows are rejected in favour
of the prior rather than extrapolated.

### Scope

This affects the single-GPU fit decision only. A model that spills to more than one device is
placed by llama-server's own fitting and never consults this path.

Storage is in-process and bounded at 8 context lengths per key: a server benefits from the
second load of a model onwards, and nothing is written to disk. Persisting across restarts is a
reasonable follow-up and is deliberately not attempted here.

### Testing

`go test ./llm/... ./ml/... ./fs/ggml/... ./server/` passes. The new tests cover the fit,
single-sample anchoring, downward extrapolation and its underflow, each of the seven key fields
invalidating independently, same-context replacement, unusable and nil input, negative-slope
rejection, sample bounding, published-vs-derived head dimensions, per-layer KV head counts, a
projector counted on a device and ignored when left on the host, its two log lines arriving in
either order, a re-reported projector replacing rather than doubling, an unreadable projector file
not aborting a prediction, and one case built from the measured curve above — calibrating on the
8k and 32k loads and asserting the 131k and 262k predictions.

Writing those found a real defect in the single-sample path, where the extrapolation overflowed
`int64` for large inputs and wrapped to a plausible positive number; it now saturates.


---

## Update — a defect in the above, and an independent check of the fitted line

### The calibration was recording samples it would never read back

`applyAutomaticGenerationBatch` rewrites `req.opts.NumBatch` partway through the load path,
and `NumBatch` is part of the key. The prediction built its key before that call and the
record built its key after it, so for any load where the automatic batch moves, the
measurement was filed under a key no later prediction would look up. Samples accumulate,
predictions are made, and the two never meet — the calibration silently never engages, which
is the failure mode least likely to be noticed, because everything downstream still works.

Observed on a two-card host, where one model ends up under two keys for the same context:

```
<blob>  NumBatch=2048  NumGPU=1  num_ctx=[262144]
<blob>  NumBatch=512   NumGPU=2  num_ctx=[262144]
```

Fixed in `server: settle the calibration key before predicting or recording`. The key is
built once, after both placement and batch size are settled, and `predictLlamaServerVRAM`
now takes it rather than deriving it. `NumGPU` also comes from the devices the load was
placed on rather than the devices offered — on a host that declines to spread a model those
differ, and so does the memory used.

### The fitted line, checked against a method that never loads the model

`llama-server`'s `--fit on` pass reports what a load would occupy, per device, before it
reads any tensors — `model + context + compute`, in about half a second regardless of model
size. Killing it as soon as it has answered gives an estimate that shares no code path with
the runtime buffer accounting these samples come from, so it is an independent check on the
claim that VRAM is linear in context.

Probing Qwen3.8-Flash-Next at the same four contexts, with the invocation replayed exactly
and only `-c` varied:

| num_ctx | fitted line above | fit probe | residual | measured load | residual |
|---|---|---|---|---|---|
| 8192 | 76.811 GiB | 76.844 | +33 MiB | 76.84 | +3.8 MiB |
| 32768 | 77.734 | 77.710 | −24 MiB | 77.71 | −0.0 MiB |
| 131072 | 81.423 | 81.414 | −9 MiB | 81.41 | +4.2 MiB |
| 262144 | 86.341 | 86.354 | +13 MiB | 86.35 | +3.6 MiB |

Refitting through the probe points gives **76.506 GiB + 39.3553 KiB/token** against the
**76.504 GiB + 39.3486 KiB/token** stated above — the intercept agrees to 2 MiB and the slope
to 0.02%.

One caveat that fell out of doing this, relevant to the model rather than to the code: the
probe only agrees when the invocation is replayed exactly, and two flags dominate. Measured
at 256k, changing one variable at a time — the model and context terms are byte-identical
across all three, and the entire spread is compute buffers:

| config | model | context | compute | total |
|---|---|---|---|---|
| 1 device, `-b 512` | 78056 | 8560 | 1809 | 86.35 GiB |
| 1 device, `-b 2048` | 78056 | 8560 | 7227 | 91.65 GiB |
| 2 devices, `-b 2048` | 78055 | 8559 | 24304 | 108.32 GiB |

That is the empirical case for `NumBatch` and `NumGPU` being in the key at all, and for the
ordering fix above: neither flag changes the quantity the KV term predicts, but both change
what the load costs by more than the error the calibration exists to remove.

The probe itself is not proposed here — it is a separate mechanism and would be a separate
PR. It appears only as the instrument used to check this one.


---

## Update 2 — measured across 28 architectures

The check above used one model. To find out where the estimate is actually wrong I pulled
models covering every attention mechanism I could find in the library and measured all of
them: 69 loads, 28 architectures, each at three context lengths, every load starting from a
cleared calibration so the predictor is predicting rather than recalling.

Error is `predicted − reported`, in MiB. Negative is under, which is the direction that
overcommits a device. "route" is what answered: `metadata` is the estimate in this PR,
`calibrated` is a fit through measured loads, `probe` is a pre-load measurement of
architectures the metadata cannot describe.

| arch | n | route | mean | worst |
|:---|---:|:---|---:|---:|
| qwen25vl | 3 | calibrated/metadata | -1428 | 2203 |
| muse-glimmer | 3 | calibrated/probe | -1757 | 1932 |
| qwen3vlmoe | 3 | calibrated/metadata | -940 | 1487 |
| qwen3vl | 3 | calibrated/metadata | -869 | 1348 |
| gemma4 | 3 | calibrated/probe | -1140 | 1254 |
| glmocr | 3 | calibrated/metadata | -753 | 1151 |
| nemotron_h_omni | 3 | calibrated/metadata | 543 | 1094 |
| qwen35 | 3 | calibrated/metadata | -470 | 730 |
| stablelm | 1 | metadata | -683 | 683 |
| qwen35moe | 3 | calibrated/metadata | -338 | 591 |
| qwen3 | 2 | metadata | -237 | 487 |
| granite | 3 | calibrated/metadata | -264 | 444 |
| nemotron_h | 3 | calibrated/metadata | -224 | 426 |
| lfm2 | 3 | calibrated/metadata | -250 | 416 |
| lfm2moe | 3 | calibrated/metadata | -239 | 393 |
| nemotron_h_moe | 3 | calibrated/metadata | -133 | 210 |
| llama | 1 | metadata | -136 | 136 |
| olmo2 | 1 | metadata | 128 | 128 |
| starcoder2 | 1 | metadata | -116 | 116 |
| glm4moelite | 3 | calibrated/probe | 21 | 63 |
| internlm2 | 2 | calibrated/metadata | -38 | 45 |
| deepseek2 | 3 | calibrated/probe | 2 | 33 |
| cohere2 | 1 | metadata | 30 | 30 |
| gemma2 | 1 | metadata | -4 | 4 |
| phi3 | 3 | calibrated/probe | -1 | 1 |
| olmo3 | 3 | calibrated/probe | 0 | 1 |
| laguna | 3 | calibrated/probe | 0 | 0 |
| gemma3 | 2 | calibrated/probe | 0 | 0 |

**Overall: mean |error| 438 MiB, worst 2203 MiB.** Before the two corrections below the
worst was 80943 MiB.

### The estimate is wrong in a way `KVCacheModelIsComplete` did not catch

Two mechanisms are described in the metadata and not modelled by the per-token figure, and
in both cases the flag said the estimate was complete:

- **Sliding-window attention.** Most layers hold a fixed window, often at a narrower head
  width, and the estimate charges every attention layer full context at full width.
  `gemma4:12b` at 128k: **89.02 GiB predicted, 9.98 GiB used.** The markers are
  `attention.sliding_window` and `attention.key_length_swa`.
- **Latent attention published as a rank.** Already handled where `key_length_mla` is set,
  but DeepSeek-V2 publishes only `attention.kv_lora_rank` and leaves the head lengths
  describing dimensions the cache does not hold. `deepseek-v2:16b` at 128k: **42.04 GiB
  predicted, 59.67 GiB used** — under, unlike the sliding-window case.

Both now report incomplete. The interpolated predictions become **−1 MiB** and **−26 MiB**.
Neither model existed on the box before this exercise; the architectures a predictor is
wrong about are the ones nobody happened to have downloaded.

### What is still wrong, stated rather than fixed

- **Every vision architecture under-predicts**: qwen25vl −1428, qwen3vlmoe −940, qwen3vl
  −869, glmocr −753 MiB mean. That is the same sign in four independent architectures, so
  it is a term in the projector accounting rather than noise. Not diagnosed.
- **Hybrid attention/SSM stacks with sparse attention.** `full_attention_interval` says most
  layers hold no growing cache; the estimate charges them all. On `qwen3.8:27b` at 128k that
  is 49.01 GiB against 26.35. It is deliberately **not** marked incomplete, because every
  such model here carries an MTP draft head and the measurement it would route to cannot yet
  read a two-model fit output — that would trade a safe over-prediction for an unsafe
  under-prediction.
- **`ssm.*` is not the discriminator.** `granite` is a hybrid whose estimate is fine
  (−264 MiB mean), so keying on the presence of recurrent layers would send well-modelled
  architectures away for no reason.

### Method

Harness and raw rows: contexts 16384/49152/98304, chosen so they never coincide with a
context the probe samples — otherwise the predictor is handed back its own measurement and
reports zero error. Rows where a model clamps two requests onto one effective context are
excluded for the same reason. Embedding models are excluded; they reject `/api/chat`.
