### PR TITLE
README: add Lumi Eggcracker integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ console.log(response.message.content);
 - [Page Assist](https://github.com/n4ze3m/page-assist) - Chrome extension for AI-powered browsing
 - [NativeMind](https://github.com/NativeMindBrowser/NativeMindExtension) - Private, on-device browser AI assistant
 - [Ollama Fortress](https://github.com/ParisNeo/ollama_proxy_server) - Security proxy for Ollama
+- [Lumi Eggcracker](https://github.com/noqt/Lumi-Eggcracker) - External fail-closed process-tree containment for exact qualified native Ollama builds on supported Linux
 - [1Panel](https://github.com/1Panel-dev/1Panel/) - Web-based Linux server management
 - [Writeopia](https://github.com/Writeopia/Writeopia) - Text editor with Ollama integration
 - [QA-Pilot](https://github.com/reid41/QA-Pilot) - GitHub code repository understanding


### PR DESCRIPTION
Adds Lumi Eggcracker to the Community Integrations list alongside Ollama’s existing security tooling.

The current boundary is intentionally narrow: it provides external fail-closed process-tree containment for exact qualified native CPU Ollama launcher and runner identities on supported Linux. Other builds, GPU variants, containers, and remote workloads aren’t claimed.

The public repository includes a read-only compatibility check that requires no root, starts nothing, and installs nothing:
https://github.com/noqt/Lumi-Eggcracker/blob/7e0e181a99076a4191b71c25a94ed10796681ab7/scripts/check_ollama_compatibility.py

Validation:
- `git diff --check`
- confirmed the link and placement against current upstream `main`

If this exact integration doesn’t fit the list, a concrete scope blocker is enough and we’ll close it.