### PR TITLE
[WIP] discover: report the memory a device has, alongside the memory it can use

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -510,3 +510,12 @@ func (c *Client) Whoami(ctx context.Context) (*UserResponse, error) {
 	}
 	return &resp, nil
 }
+
+// Info retrieves server information.
+func (c *Client) Info(ctx context.Context) (*InfoResponse, error) {
+	var resp InfoResponse
+	if err := c.do(ctx, http.MethodGet, "/api/info", nil, &resp); err != nil {
+		return nil, err
+	}
+	return &resp, nil
+}

--- a/api/types.go
+++ b/api/types.go
@@ -1395,8 +1395,15 @@ type GPUInfo struct {
 	// Name is the model or other identifying information about the GPU
 	Name string `json:"name"`
 
-	// TotalMemory is the amount of video memory on the GPU
+	// TotalMemory is the amount of video memory on the GPU usable for loading models
 	TotalMemory uint64 `json:"total_memory"`
+
+	// PhysicalMemory is the amount of video memory the device reports having. It is never
+	// smaller than TotalMemory: the driver reserves a portion of the card for itself which
+	// is present but cannot hold model weights. Placement uses TotalMemory; this is the
+	// figure to display as the machine's hardware, since it is what the system's own tools
+	// report. Omitted when no source distinguishes the two.
+	PhysicalMemory uint64 `json:"physical_memory,omitempty"`
 
 	// FreeMemory is the amount of video memory on the GPU available for loading new models
 	FreeMemory uint64 `json:"free_memory"`

--- a/api/types.go
+++ b/api/types.go
@@ -1356,3 +1356,73 @@ func FormatParams(params map[string][]string) (map[string]any, error) {
 
 	return out, nil
 }
+
+type SystemModelInfo struct {
+	// Store is the location where the server stores models in the filesystem.
+	Store string `json:"store"`
+
+	// Count is the number of models currently stored in the filesystem.
+	Count int `json:"count"`
+
+	// FilesystemUsed is the number of bytes used on the filesystem to store models
+	FilesystemUsed uint64 `json:"filesystem_used"`
+
+	// Running is the number of models currently running in the server.
+	Running int `json:"running"`
+
+	// VRAMUsed is the amount of GPU VRAM consumed by the loaded models
+	VRAMUsed uint64 `json:"vram_used"`
+}
+
+type SystemComputeInfo struct {
+	// Cores is the number of detected CPU Cores in the system
+	CPUCores int `json:"cpu_cores"`
+
+	// TotalMemory is the amount of system memory discovered by the server
+	TotalMemory uint64 `json:"total_memory"`
+
+	// FreeMemory is the amount of system memory available for loading new models
+	FreeMemory uint64 `json:"free_memory"`
+
+	// FreeSwap is the amount of swap space available for loading new models
+	FreeSwap uint64 `json:"free_swap"`
+}
+
+type GPUInfo struct {
+	// ID is the unique identifier to use for selection of this specific GPU by device vendor
+	ID string `json:"gpu_id"`
+
+	// Name is the model or other identifying information about the GPU
+	Name string `json:"name"`
+
+	// TotalMemory is the amount of video memory on the GPU
+	TotalMemory uint64 `json:"total_memory"`
+
+	// FreeMemory is the amount of video memory on the GPU available for loading new models
+	FreeMemory uint64 `json:"free_memory"`
+
+	// Compute is the GPU capability version information, specific to each device vendor
+	Compute string `json:"compute,omitempty"`
+
+	// Driver is the device driver detected for this GPU
+	Driver string `json:"driver,omitempty"`
+
+	// Runner is the default runner for this GPU
+	Runner string `json:"runner"`
+}
+
+type ComputeInfo struct {
+	SystemCompute SystemComputeInfo `json:"system_compute"`
+
+	SupportedGPUs []GPUInfo `json:"supported_gpus"`
+}
+
+// InfoResponse is the response returned from [Client.Info].
+type InfoResponse struct {
+	// Version is the current version of the server.
+	Version string `json:"version"`
+
+	Models SystemModelInfo `json:"models"`
+
+	ComputeInfo ComputeInfo `json:"compute"`
+}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2480,6 +2480,12 @@ func NewCLI() *cobra.Command {
 		},
 	}
 	gpuDiscoverCmd.Flags().StringArrayVar(&gpuDiscoverLibDirs, "lib-dir", nil, "Ollama runtime library directory")
+	infoCmd := &cobra.Command{
+		Use:     "info",
+		Short:   "Display system-wide information",
+		PreRunE: checkServerHeartbeat,
+		RunE:    InfoHandler,
+	}
 
 	envVars := envconfig.AsMap()
 
@@ -2497,6 +2503,7 @@ func NewCLI() *cobra.Command {
 		copyCmd,
 		deleteCmd,
 		serveCmd,
+		infoCmd,
 	} {
 		switch cmd {
 		case runCmd:
@@ -2549,6 +2556,7 @@ func NewCLI() *cobra.Command {
 		runnerCmd,
 		gpuDiscoverCmd,
 		launch.LaunchCmd(checkServerHeartbeat, runInteractiveTUI),
+		infoCmd,
 	)
 
 	return rootCmd

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -1,0 +1,189 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/olekukonko/tablewriter"
+	"github.com/spf13/cobra"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/envconfig"
+	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/version"
+)
+
+func InfoHandler(cmd *cobra.Command, args []string) error {
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		return err
+	}
+
+	resp, err := client.Info(cmd.Context())
+	if err != nil {
+		return err
+	}
+	out := os.Stdout
+	prettyPrintClientInfo(out)
+	fmt.Fprint(out, "\n")
+
+	prettyPrintInfoResponse(out, *resp)
+
+	return nil
+}
+
+func prettyPrintClientInfo(out io.Writer) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding(" ")
+	indent := ""
+
+	cfgDir := ""
+	home, err := os.UserHomeDir()
+	if err == nil {
+		cfgDir = filepath.Join(home, ".ollama")
+	}
+
+	data := [][]string{
+		{
+			indent, "Version:", version.Version,
+		},
+		{
+			indent, "Configuration:", cfgDir,
+		},
+		{
+			indent, "Connection:", envconfig.Host().String(),
+		},
+	}
+	fmt.Fprint(out, "Client:\n")
+	table.AppendBulk(data)
+	table.Render()
+}
+
+func prettyPrintInfoResponse(out io.Writer, resp api.InfoResponse) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding(" ")
+	indent := ""
+	data := [][]string{
+		{
+			indent, "Version:", resp.Version,
+		},
+	}
+	fmt.Fprint(out, "Server:\n")
+	table.AppendBulk(data)
+	table.Render()
+	prettyPrintModels(out, " ", resp)
+	prettyPrintCompute(out, " ", resp)
+}
+
+func prettyPrintModels(out io.Writer, indent string, resp api.InfoResponse) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding(" ")
+	data := [][]string{
+		{
+			indent, "Store:", envconfig.Models(),
+		},
+		{
+			indent, "Downloaded:", strconv.Itoa(resp.Models.Count),
+		},
+		{
+			indent, "Filesystem Used:", format.HumanBytes(int64(resp.Models.FilesystemUsed)),
+		},
+		{
+			indent, "Running:", strconv.Itoa(resp.Models.Running),
+		},
+		{
+			indent, "VRAM Used:", format.HumanBytes(int64(resp.Models.VRAMUsed)),
+		},
+	}
+	fmt.Fprintf(out, "%sModels:\n", indent)
+	table.AppendBulk(data)
+	table.Render()
+}
+
+func prettyPrintCompute(out io.Writer, indent string, resp api.InfoResponse) {
+	fmt.Fprintf(out, "%sCompute:\n", indent)
+	indent += " "
+	prettyPrintSystem(out, indent, resp)
+	prettyPrintSupportedGPUs(out, indent, resp)
+}
+
+func prettyPrintSystem(out io.Writer, indent string, resp api.InfoResponse) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding(" ")
+	data := [][]string{
+		{
+			indent, "CPU Cores:", strconv.Itoa(resp.ComputeInfo.SystemCompute.CPUCores),
+		},
+		{
+			indent, "Total Memory:", format.HumanBytes(int64(resp.ComputeInfo.SystemCompute.TotalMemory)),
+		},
+		{
+			indent, "Free Memory:", format.HumanBytes(int64(resp.ComputeInfo.SystemCompute.FreeMemory)),
+		},
+		{
+			indent, "Free Swap:", format.HumanBytes(int64(resp.ComputeInfo.SystemCompute.FreeSwap)),
+		},
+	}
+	fmt.Fprintf(out, "%sSystem:\n", indent)
+	table.AppendBulk(data)
+	table.Render()
+}
+
+func prettyPrintSupportedGPUs(out io.Writer, indent string, resp api.InfoResponse) {
+	fmt.Fprintf(out, "%sSupported GPUs:\n", indent)
+	indent += " "
+	for _, gpu := range resp.ComputeInfo.SupportedGPUs {
+		prettyPrintSupportedGPU(out, indent, gpu)
+	}
+}
+
+func prettyPrintSupportedGPU(out io.Writer, indent string, gpu api.GPUInfo) {
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetHeaderLine(false)
+	table.SetBorder(false)
+	table.SetNoWhiteSpace(true)
+	table.SetTablePadding(" ")
+	data := [][]string{
+		{
+			indent, "Name:", gpu.Name,
+		},
+		{
+			indent, "Total Memory:", format.HumanBytes(int64(gpu.TotalMemory)),
+		},
+		{
+			indent, "Free Memory:", format.HumanBytes(int64(gpu.FreeMemory)),
+		},
+	}
+
+	// Backends that don't report a compute capability or driver version (Metal)
+	// leave these empty; omit the rows rather than showing a blank value.
+	if gpu.Compute != "" {
+		data = append(data, []string{indent, "Compute:", gpu.Compute})
+	}
+	if gpu.Driver != "" {
+		data = append(data, []string{indent, "Driver:", gpu.Driver})
+	}
+	fmt.Fprintf(out, "%s%s %s:\n", indent, gpu.Runner, gpu.ID)
+	table.AppendBulk(data)
+	table.Render()
+}

--- a/cmd/info.go
+++ b/cmd/info.go
@@ -36,7 +36,7 @@ func InfoHandler(cmd *cobra.Command, args []string) error {
 }
 
 func prettyPrintClientInfo(out io.Writer) {
-	table := tablewriter.NewWriter(os.Stdout)
+	table := tablewriter.NewWriter(out)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetHeaderLine(false)
 	table.SetBorder(false)
@@ -67,7 +67,7 @@ func prettyPrintClientInfo(out io.Writer) {
 }
 
 func prettyPrintInfoResponse(out io.Writer, resp api.InfoResponse) {
-	table := tablewriter.NewWriter(os.Stdout)
+	table := tablewriter.NewWriter(out)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetHeaderLine(false)
 	table.SetBorder(false)
@@ -87,7 +87,7 @@ func prettyPrintInfoResponse(out io.Writer, resp api.InfoResponse) {
 }
 
 func prettyPrintModels(out io.Writer, indent string, resp api.InfoResponse) {
-	table := tablewriter.NewWriter(os.Stdout)
+	table := tablewriter.NewWriter(out)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetHeaderLine(false)
 	table.SetBorder(false)
@@ -123,7 +123,7 @@ func prettyPrintCompute(out io.Writer, indent string, resp api.InfoResponse) {
 }
 
 func prettyPrintSystem(out io.Writer, indent string, resp api.InfoResponse) {
-	table := tablewriter.NewWriter(os.Stdout)
+	table := tablewriter.NewWriter(out)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetHeaderLine(false)
 	table.SetBorder(false)
@@ -151,13 +151,23 @@ func prettyPrintSystem(out io.Writer, indent string, resp api.InfoResponse) {
 func prettyPrintSupportedGPUs(out io.Writer, indent string, resp api.InfoResponse) {
 	fmt.Fprintf(out, "%sSupported GPUs:\n", indent)
 	indent += " "
+
+	// Say so explicitly rather than leaving the heading bare: "did it find my GPU?"
+	// is the question this command exists to answer, and an empty section reads as
+	// a rendering fault rather than an answer. The system block above already states
+	// the CPU budget, so there is nothing to add here.
+	if len(resp.ComputeInfo.SupportedGPUs) == 0 {
+		fmt.Fprintf(out, "%sNone detected\n", indent)
+		return
+	}
+
 	for _, gpu := range resp.ComputeInfo.SupportedGPUs {
 		prettyPrintSupportedGPU(out, indent, gpu)
 	}
 }
 
 func prettyPrintSupportedGPU(out io.Writer, indent string, gpu api.GPUInfo) {
-	table := tablewriter.NewWriter(os.Stdout)
+	table := tablewriter.NewWriter(out)
 	table.SetAlignment(tablewriter.ALIGN_LEFT)
 	table.SetHeaderLine(false)
 	table.SetBorder(false)

--- a/cmd/info_test.go
+++ b/cmd/info_test.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/api"
+)
+
+func TestPrettyPrintSupportedGPUsNoneDetected(t *testing.T) {
+	var buf bytes.Buffer
+	prettyPrintSupportedGPUs(&buf, " ", api.InfoResponse{})
+
+	out := buf.String()
+	if !strings.Contains(out, "Supported GPUs:") {
+		t.Errorf("missing heading, got %q", out)
+	}
+	// "did it find my GPU?" must be answered, not left to an empty section
+	if !strings.Contains(out, "None detected") {
+		t.Errorf("a server with no GPUs should say so, got %q", out)
+	}
+}
+
+func TestPrettyPrintSupportedGPUs(t *testing.T) {
+	var buf bytes.Buffer
+	prettyPrintSupportedGPUs(&buf, " ", api.InfoResponse{
+		ComputeInfo: api.ComputeInfo{
+			SupportedGPUs: []api.GPUInfo{{
+				ID:          "0",
+				Name:        "NVIDIA GeForce RTX 4080 Laptop GPU",
+				TotalMemory: 12878610432,
+				FreeMemory:  12878610432,
+				Compute:     "8.9",
+				Driver:      "13.2",
+				Runner:      "CUDA",
+			}},
+		},
+	})
+
+	out := buf.String()
+	for _, want := range []string{"CUDA 0:", "RTX 4080", "Compute:", "8.9", "Driver:", "13.2"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output, got:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "None detected") {
+		t.Errorf("a populated list should not report none detected, got:\n%s", out)
+	}
+}
+
+// A backend that reports no compute capability or driver version (Metal) leaves
+// those fields empty; the rows are dropped rather than printed blank.
+func TestPrettyPrintSupportedGPUsOmitsEmptyRows(t *testing.T) {
+	var buf bytes.Buffer
+	prettyPrintSupportedGPUs(&buf, " ", api.InfoResponse{
+		ComputeInfo: api.ComputeInfo{
+			SupportedGPUs: []api.GPUInfo{{
+				ID:          "0",
+				Name:        "MTL0",
+				TotalMemory: 12712935424,
+				FreeMemory:  12711886848,
+				Runner:      "Metal",
+			}},
+		},
+	})
+
+	out := buf.String()
+	if !strings.Contains(out, "MTL0") {
+		t.Fatalf("expected the device, got:\n%s", out)
+	}
+	if strings.Contains(out, "Compute:") {
+		t.Errorf("compute row should be omitted when unknown, got:\n%s", out)
+	}
+	if strings.Contains(out, "Driver:") {
+		t.Errorf("driver row should be omitted when unknown, got:\n%s", out)
+	}
+}

--- a/discover/llama_server.go
+++ b/discover/llama_server.go
@@ -336,6 +336,11 @@ func parseLlamaServerDevicesWithNative(output, nativeOutput string, libDirs []st
 			if nativeDevice.DeviceID != "" {
 				dev.PCIID = nativeDevice.DeviceID
 			}
+			// Only the native probe can tell these apart: llama-server reports the memory
+			// it can use, which is already dev.TotalMemory.
+			if nativeDevice.PhysicalMemory > dev.TotalMemory {
+				dev.PhysicalMemory = nativeDevice.PhysicalMemory
+			}
 			if nativeDevice.IntegratedKnown {
 				dev.Integrated = nativeDevice.Integrated
 			} else {

--- a/discover/native_probe.go
+++ b/discover/native_probe.go
@@ -34,6 +34,7 @@ type nativeProbeDevice struct {
 	Integrated          bool   `json:"integrated,omitempty"`
 	IntegratedKnown     bool   `json:"integrated_known"`
 	TotalMemory         uint64 `json:"total_memory,omitempty"`
+	PhysicalMemory      uint64 `json:"physical_memory,omitempty"`
 	FreeMemory          uint64 `json:"free_memory,omitempty"`
 	ComputeMajor        int    `json:"compute_major,omitempty"`
 	ComputeMinor        int    `json:"compute_minor,omitempty"`
@@ -186,6 +187,9 @@ func mergeNativeProbeDevice(dst *nativeProbeDevice, src nativeProbeDevice) {
 	}
 	if dst.TotalMemory == 0 {
 		dst.TotalMemory = src.TotalMemory
+	}
+	if dst.PhysicalMemory == 0 {
+		dst.PhysicalMemory = src.PhysicalMemory
 	}
 	if dst.FreeMemory == 0 {
 		dst.FreeMemory = src.FreeMemory

--- a/discover/native_probe_linux.go
+++ b/discover/native_probe_linux.go
@@ -110,10 +110,35 @@ static int ollama_call_nvml_system_get_driver_version(void * fn, char * version,
 	return ((ollama_nvml_system_get_driver_version_fn) fn)(version, len);
 }
 
+// nvmlMemory_t as of NVML 8. Only the leading three fields are read, and NVML has only
+// ever appended to this structure, so a newer library filling more of it is harmless.
+typedef struct {
+	unsigned long long total;
+	unsigned long long free;
+	unsigned long long used;
+} ollama_nvml_memory_t;
+
+typedef int (*ollama_nvml_device_get_handle_by_pci_bus_id_fn)(const char *, void **);
+typedef int (*ollama_nvml_device_get_memory_info_fn)(void *, ollama_nvml_memory_t *);
+
+static int ollama_call_nvml_device_get_handle_by_pci_bus_id(void * fn, const char * pci, void ** device) {
+	return ((ollama_nvml_device_get_handle_by_pci_bus_id_fn) fn)(pci, device);
+}
+
+static int ollama_call_nvml_device_get_memory_info(void * fn, void * device, unsigned long long * total) {
+	ollama_nvml_memory_t memory = {0};
+	int ret = ((ollama_nvml_device_get_memory_info_fn) fn)(device, &memory);
+	if (ret == 0) {
+		*total = memory.total;
+	}
+	return ret;
+}
+
 */
 import "C"
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -347,6 +372,20 @@ func probeCUDADriverLinux() ([]nativeProbeDevice, error) {
 		})
 	}
 
+	// CUDA reports what a context can address; NVML reports what the card holds. Fill the
+	// latter in where it is available, and leave it zero where it is not.
+	pciIDs := make([]string, 0, len(devices))
+	for _, d := range devices {
+		pciIDs = append(pciIDs, d.DeviceID)
+	}
+	if physical := nvmlPhysicalMemoryByPCI(pciIDs); len(physical) > 0 {
+		for i := range devices {
+			if total, ok := physical[devices[i].DeviceID]; ok && total >= devices[i].TotalMemory {
+				devices[i].PhysicalMemory = total
+			}
+		}
+	}
+
 	return devices, nil
 }
 
@@ -415,6 +454,68 @@ func probeNVIDIADriverMajorLinux() (int, error) {
 		return 0, fmt.Errorf("nvmlSystemGetDriverVersion failed: %d", int(ret))
 	}
 	return parseNVIDIADriverMajor(C.GoString(&version[0]))
+}
+
+// nvmlPhysicalMemoryByPCI reports the memory each device holds according to NVML, keyed by
+// PCI bus ID.
+//
+// This is a different quantity from the one CUDA reports, and larger. cuDeviceTotalMem
+// returns what a CUDA context can address, which excludes memory the driver has reserved
+// for itself; NVML reports the device's framebuffer. On an RTX PRO 6000 the two are
+// 94.97 GiB and 95.59 GiB — a 638 MiB gap that is not usable for models but is present on
+// the card, and that a user reading nvidia-smi will expect to see accounted for.
+//
+// A failure here is not an error: NVML may be absent, too old, or refuse a device. Callers
+// fall back to the CUDA figure, which is the one every decision is made from anyway.
+func nvmlPhysicalMemoryByPCI(pciIDs []string) map[string]uint64 {
+	if len(pciIDs) == 0 {
+		return nil
+	}
+
+	nvml, err := dlopenFirst([]string{"libnvidia-ml.so.1", "libnvidia-ml.so"}, false)
+	if err != nil {
+		slog.Debug("NVML unavailable, reporting CUDA's device memory total", "error", err)
+		return nil
+	}
+
+	initFn, initErr := dlsym(nvml, "nvmlInit_v2")
+	shutdownFn, shutdownErr := dlsym(nvml, "nvmlShutdown")
+	handleFn, handleErr := dlsym(nvml, "nvmlDeviceGetHandleByPciBusId_v2")
+	memoryFn, memoryErr := dlsym(nvml, "nvmlDeviceGetMemoryInfo")
+	if err := cmp.Or(initErr, shutdownErr, handleErr, memoryErr); err != nil {
+		slog.Debug("NVML missing a required symbol", "error", err)
+		return nil
+	}
+
+	if ret := C.ollama_call_nvml_init(initFn); ret != 0 {
+		slog.Debug("nvmlInit_v2 failed", "status", int(ret))
+		return nil
+	}
+	defer C.ollama_call_nvml_shutdown(shutdownFn)
+
+	out := make(map[string]uint64, len(pciIDs))
+	for _, pci := range pciIDs {
+		if pci == "" {
+			continue
+		}
+
+		cpci := C.CString(pci)
+		var handle unsafe.Pointer
+		ret := C.ollama_call_nvml_device_get_handle_by_pci_bus_id(handleFn, cpci, &handle)
+		C.free(unsafe.Pointer(cpci))
+		if ret != 0 {
+			slog.Debug("NVML did not recognize device", "pci_id", pci, "status", int(ret))
+			continue
+		}
+
+		var total C.ulonglong
+		if ret := C.ollama_call_nvml_device_get_memory_info(memoryFn, handle, &total); ret != 0 {
+			slog.Debug("nvmlDeviceGetMemoryInfo failed", "pci_id", pci, "status", int(ret))
+			continue
+		}
+		out[pci] = uint64(total)
+	}
+	return out
 }
 
 func cudaDeviceAttribute(fn unsafe.Pointer, attr int, device C.int) int {

--- a/discover/native_probe_test.go
+++ b/discover/native_probe_test.go
@@ -201,3 +201,34 @@ func TestMergeNativeProbeDevicesAvoidsUnreliableIndexMatch(t *testing.T) {
 		})
 	}
 }
+
+func TestMergeNativeProbeDevicesCarriesPhysicalMemory(t *testing.T) {
+	// Only the CUDA probe can tell the two totals apart, and it merges against a ggml
+	// device that reports just the usable figure. The distinction has to survive that.
+	ggml := []nativeProbeDevice{{
+		Library:             "CUDA",
+		Index:               0,
+		IndexMatchesBackend: true,
+		Description:         "NVIDIA RTX PRO 6000",
+		TotalMemory:         101972967424,
+	}}
+	cuda := []nativeProbeDevice{{
+		Library:             "CUDA",
+		Index:               0,
+		IndexMatchesBackend: true,
+		Description:         "NVIDIA RTX PRO 6000",
+		TotalMemory:         101972967424,
+		PhysicalMemory:      102641958912,
+	}}
+
+	merged := mergeNativeProbeDevices(ggml, cuda)
+	if len(merged) != 1 {
+		t.Fatalf("expected the devices to merge into one, got %d", len(merged))
+	}
+	if got, want := merged[0].PhysicalMemory, uint64(102641958912); got != want {
+		t.Errorf("PhysicalMemory: got %d, want %d", got, want)
+	}
+	if got, want := merged[0].TotalMemory, uint64(101972967424); got != want {
+		t.Errorf("TotalMemory should be untouched: got %d, want %d", got, want)
+	}
+}

--- a/ml/device.go
+++ b/ml/device.go
@@ -50,6 +50,20 @@ type DeviceInfo struct {
 	// TotalMemory is the total amount of memory the device can use for loading models
 	TotalMemory uint64 `json:"total_memory"`
 
+	// PhysicalMemory is the memory the device reports having, which is not the same
+	// quantity as TotalMemory and is never smaller. TotalMemory is what a runner can
+	// address; the driver reserves a further amount for itself that is present on the card
+	// but unusable for models — 638 MiB of an RTX PRO 6000's 95.59 GiB.
+	//
+	// Every placement decision uses TotalMemory. PhysicalMemory exists so that a tool
+	// displaying a machine's hardware can show the figure the rest of the system shows: it
+	// is what nvidia-smi reports, and a UI that quietly omits it looks like it has lost
+	// memory the user can see elsewhere.
+	//
+	// It is zero where no source distinguishes the two, in which case TotalMemory is the
+	// only figure available and should be displayed instead.
+	PhysicalMemory uint64 `json:"physical_memory,omitempty"`
+
 	// FreeMemory is the amount of memory currently available on the device for loading models
 	FreeMemory uint64 `json:"free_memory,omitempty"`
 

--- a/server/routes.go
+++ b/server/routes.go
@@ -20,6 +20,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"runtime"
 	"slices"
 	"strings"
 	"sync/atomic"
@@ -1909,6 +1910,7 @@ func (s *Server) GenerateRoutes() (http.Handler, error) {
 	r.POST("/api/chat", s.withInferenceRequestLogging("/api/chat", s.ChatHandler)...)
 	r.POST("/api/embed", s.EmbedHandler)
 	r.POST("/api/embeddings", s.EmbeddingsHandler)
+	r.GET("/api/info", s.InfoHandler)
 
 	// Inference (OpenAI compatibility)
 	// TODO(cloud-stage-a): apply Modelfile overlay deltas for local models with cloud
@@ -2435,6 +2437,74 @@ func writeChatResponse(c *gin.Context, req api.ChatRequest, ch chan any) {
 	}
 
 	streamResponse(c, ch)
+}
+
+func (s *Server) InfoHandler(c *gin.Context) {
+	// Read discovery through the scheduler's hooks rather than calling discover
+	// directly, so the reported devices are the same ones the scheduler places
+	// models on (and so this handler is testable with injected devices).
+	devices := s.sched.getGpuFn(c.Request.Context(), nil)
+
+	gpus := make([]api.GPUInfo, len(devices))
+	for i, dev := range devices {
+		gpus[i] = api.GPUInfo{
+			ID:          dev.ID,
+			Name:        dev.Name,
+			TotalMemory: dev.TotalMemory,
+			FreeMemory:  dev.FreeMemory,
+			Runner:      dev.Library,
+		}
+
+		// Compute capability and driver version are CUDA/ROCm concepts; a backend
+		// that doesn't report them (Metal) leaves the versions at zero, which would
+		// otherwise surface as a meaningless "0.0". Report them only when known.
+		if dev.ComputeMajor > 0 || dev.ComputeMinor > 0 {
+			gpus[i].Compute = dev.Compute()
+		}
+		if dev.DriverMajor > 0 || dev.DriverMinor > 0 {
+			gpus[i].Driver = dev.Driver()
+		}
+	}
+
+	ms, _ := manifest.Manifests(true)
+	var fsUsed uint64
+	counted := map[string]struct{}{}
+	for _, m := range ms {
+		for _, l := range m.Layers {
+			// a layer shared by several models occupies the store once
+			if _, dup := counted[l.Digest]; !dup {
+				counted[l.Digest] = struct{}{}
+				fsUsed += uint64(l.Size)
+			}
+		}
+	}
+
+	loaded := s.sched.loadedModels()
+	var vramUsed uint64
+	for _, r := range loaded {
+		vramUsed += uint64(r.sizeVRAM)
+	}
+
+	sysInfo := s.sched.getSystemInfoFn()
+	c.JSON(http.StatusOK, api.InfoResponse{
+		Version: version.Version,
+		Models: api.SystemModelInfo{
+			Store:          envconfig.Models(),
+			Count:          len(ms),
+			FilesystemUsed: fsUsed,
+			Running:        len(loaded),
+			VRAMUsed:       vramUsed,
+		},
+		ComputeInfo: api.ComputeInfo{
+			SystemCompute: api.SystemComputeInfo{
+				CPUCores:    runtime.NumCPU(),
+				TotalMemory: sysInfo.TotalMemory,
+				FreeMemory:  sysInfo.FreeMemory,
+				FreeSwap:    sysInfo.FreeSwap,
+			},
+			SupportedGPUs: gpus,
+		},
+	})
 }
 
 func (s *Server) ChatHandler(c *gin.Context) {

--- a/server/routes.go
+++ b/server/routes.go
@@ -2448,11 +2448,12 @@ func (s *Server) InfoHandler(c *gin.Context) {
 	gpus := make([]api.GPUInfo, len(devices))
 	for i, dev := range devices {
 		gpus[i] = api.GPUInfo{
-			ID:          dev.ID,
-			Name:        dev.Name,
-			TotalMemory: dev.TotalMemory,
-			FreeMemory:  dev.FreeMemory,
-			Runner:      dev.Library,
+			ID:             dev.ID,
+			Name:           dev.Name,
+			TotalMemory:    dev.TotalMemory,
+			PhysicalMemory: dev.PhysicalMemory,
+			FreeMemory:     dev.FreeMemory,
+			Runner:         dev.Library,
 		}
 
 		// Compute capability and driver version are CUDA/ROCm concepts; a backend

--- a/server/routes_info_test.go
+++ b/server/routes_info_test.go
@@ -205,3 +205,27 @@ func TestInfoHandlerReportsKnownComputeAndDriver(t *testing.T) {
 		t.Errorf("runner: got %q, want %q", gpu.Runner, "CUDA")
 	}
 }
+
+// A CPU-only server reports an empty device list rather than failing. The system
+// memory block is the whole compute budget in that case, so it must still be there.
+func TestInfoHandlerNoDevices(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	s := &Server{
+		sched: &Scheduler{
+			getSystemInfoFn: getSystemInfoFn,
+			getGpuFn: func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo {
+				return nil
+			},
+		},
+	}
+
+	got := infoResponse(t, s)
+
+	if len(got.ComputeInfo.SupportedGPUs) != 0 {
+		t.Errorf("expected no GPUs, got %d", len(got.ComputeInfo.SupportedGPUs))
+	}
+	if got.ComputeInfo.SystemCompute.TotalMemory != 32*format.GigaByte {
+		t.Errorf("system memory should still be reported: got %d", got.ComputeInfo.SystemCompute.TotalMemory)
+	}
+}

--- a/server/routes_info_test.go
+++ b/server/routes_info_test.go
@@ -1,0 +1,207 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"runtime"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/format"
+	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/types/model"
+	"github.com/ollama/ollama/version"
+)
+
+// infoTestServer builds a server whose discovery is the fake pair from sched_test.go
+// (one 24GB Metal device, 32GB of system memory), so the reported values are
+// deterministic and the test does not depend on the machine it runs on.
+func infoTestServer(t *testing.T) *Server {
+	t.Helper()
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	return &Server{
+		sched: &Scheduler{
+			getGpuFn:        getGpuFn,
+			getSystemInfoFn: getSystemInfoFn,
+		},
+	}
+}
+
+func infoResponse(t *testing.T, s *Server) api.InfoResponse {
+	t.Helper()
+
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodGet, "/api/info", nil)
+
+	s.InfoHandler(c)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var got api.InfoResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decoding response: %v (body %q)", err, w.Body.String())
+	}
+	return got
+}
+
+// createInfoTestModel writes a model into OLLAMA_MODELS. It mirrors the model
+// creation inside TestRoutes, which lives in a closure and cannot be reused here.
+func createInfoTestModel(t *testing.T, name, digest string) {
+	t.Helper()
+
+	fn := func(resp api.ProgressResponse) { t.Logf("Status: %s", resp.Status) }
+
+	baseLayers, err := ggufLayers(digest, "test.gguf", fn)
+	if err != nil {
+		t.Fatalf("failed to build layers: %v", err)
+	}
+
+	config := &model.ConfigV2{
+		OS:           "linux",
+		Architecture: "amd64",
+	}
+
+	r := api.CreateRequest{Name: name, Files: map[string]string{"test.gguf": digest}}
+	if err := createModel(r, model.ParseName(name), baseLayers, config, fn); err != nil {
+		t.Fatalf("failed to create model %s: %v", name, err)
+	}
+}
+
+func TestInfoHandlerReportsDiscoveredDevices(t *testing.T) {
+	got := infoResponse(t, infoTestServer(t))
+
+	if len(got.ComputeInfo.SupportedGPUs) != 1 {
+		t.Fatalf("expected 1 GPU, got %d", len(got.ComputeInfo.SupportedGPUs))
+	}
+
+	gpu := got.ComputeInfo.SupportedGPUs[0]
+	if gpu.TotalMemory != 24*format.GigaByte {
+		t.Errorf("total memory: got %d, want %d", gpu.TotalMemory, 24*format.GigaByte)
+	}
+	if gpu.FreeMemory != 12*format.GigaByte {
+		t.Errorf("free memory: got %d, want %d", gpu.FreeMemory, 12*format.GigaByte)
+	}
+	if gpu.Runner != "Metal" {
+		t.Errorf("runner: got %q, want %q", gpu.Runner, "Metal")
+	}
+}
+
+func TestInfoHandlerReportsSystemCompute(t *testing.T) {
+	got := infoResponse(t, infoTestServer(t))
+
+	sys := got.ComputeInfo.SystemCompute
+	if sys.TotalMemory != 32*format.GigaByte {
+		t.Errorf("system total memory: got %d, want %d", sys.TotalMemory, 32*format.GigaByte)
+	}
+	if sys.FreeMemory != 26*format.GigaByte {
+		t.Errorf("system free memory: got %d, want %d", sys.FreeMemory, 26*format.GigaByte)
+	}
+	if sys.CPUCores != runtime.NumCPU() {
+		t.Errorf("cpu cores: got %d, want %d", sys.CPUCores, runtime.NumCPU())
+	}
+	if got.Version != version.Version {
+		t.Errorf("version: got %q, want %q", got.Version, version.Version)
+	}
+}
+
+// With nothing loaded the memory counters are zero rather than absent, so a client
+// can render "0 B in use" without special-casing an idle server.
+func TestInfoHandlerIdleServerReportsZeroUsage(t *testing.T) {
+	got := infoResponse(t, infoTestServer(t))
+
+	if got.Models.Running != 0 {
+		t.Errorf("running: got %d, want 0", got.Models.Running)
+	}
+	if got.Models.VRAMUsed != 0 {
+		t.Errorf("vram used: got %d, want 0", got.Models.VRAMUsed)
+	}
+	if got.Models.Count != 0 {
+		t.Errorf("model count: got %d, want 0 for an empty store", got.Models.Count)
+	}
+}
+
+// A layer shared by several models occupies the store once, so filesystem usage
+// counts each digest a single time: adding a second model built from the same
+// file must not grow the reported total.
+func TestInfoHandlerCountsSharedLayersOnce(t *testing.T) {
+	s := infoTestServer(t)
+	_, digest := createTestFile(t, "ollama-model")
+
+	createInfoTestModel(t, "shared-a", digest)
+	first := infoResponse(t, s)
+	if first.Models.Count != 1 {
+		t.Fatalf("model count: got %d, want 1", first.Models.Count)
+	}
+	if first.Models.FilesystemUsed == 0 {
+		t.Fatal("filesystem used should be non-zero once a model exists")
+	}
+
+	// same source file → same layer digests, already counted
+	createInfoTestModel(t, "shared-b", digest)
+	second := infoResponse(t, s)
+
+	if second.Models.Count != 2 {
+		t.Fatalf("model count: got %d, want 2", second.Models.Count)
+	}
+	if second.Models.FilesystemUsed != first.Models.FilesystemUsed {
+		t.Errorf("shared layers counted twice: got %d, want %d (unchanged)",
+			second.Models.FilesystemUsed, first.Models.FilesystemUsed)
+	}
+}
+
+// Metal reports no compute capability or driver version, so those fields are
+// omitted rather than sent as a meaningless "0.0".
+func TestInfoHandlerOmitsUnknownComputeAndDriver(t *testing.T) {
+	got := infoResponse(t, infoTestServer(t))
+
+	gpu := got.ComputeInfo.SupportedGPUs[0]
+	if gpu.Compute != "" {
+		t.Errorf("compute: got %q, want empty for a backend that doesn't report it", gpu.Compute)
+	}
+	if gpu.Driver != "" {
+		t.Errorf("driver: got %q, want empty for a backend that doesn't report it", gpu.Driver)
+	}
+}
+
+// ...but a backend that does report them (CUDA) still gets them through.
+func TestInfoHandlerReportsKnownComputeAndDriver(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	s := &Server{
+		sched: &Scheduler{
+			getSystemInfoFn: getSystemInfoFn,
+			getGpuFn: func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo {
+				return []ml.DeviceInfo{{
+					DeviceID:     ml.DeviceID{ID: "0", Library: "CUDA"},
+					Name:         "NVIDIA GeForce RTX 3090",
+					TotalMemory:  24 * format.GigaByte,
+					FreeMemory:   20 * format.GigaByte,
+					ComputeMajor: 8,
+					ComputeMinor: 6,
+					DriverMajor:  12,
+					DriverMinor:  4,
+				}}
+			},
+		},
+	}
+
+	gpu := infoResponse(t, s).ComputeInfo.SupportedGPUs[0]
+	if gpu.Compute != "8.6" {
+		t.Errorf("compute: got %q, want %q", gpu.Compute, "8.6")
+	}
+	if gpu.Driver != "12.4" {
+		t.Errorf("driver: got %q, want %q", gpu.Driver, "12.4")
+	}
+	if gpu.Runner != "CUDA" {
+		t.Errorf("runner: got %q, want %q", gpu.Runner, "CUDA")
+	}
+}

--- a/server/routes_info_test.go
+++ b/server/routes_info_test.go
@@ -229,3 +229,45 @@ func TestInfoHandlerNoDevices(t *testing.T) {
 		t.Errorf("system memory should still be reported: got %d", got.ComputeInfo.SystemCompute.TotalMemory)
 	}
 }
+
+// A device whose driver reserves memory for itself reports both figures: the usable one
+// that placement is decided from, and the physical one a tool should display as the
+// machine's hardware.
+func TestInfoHandlerReportsPhysicalMemoryWhenItDiffers(t *testing.T) {
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+
+	const usable, physical = 94*format.GibiByte, 95*format.GibiByte
+	s := &Server{
+		sched: &Scheduler{
+			getSystemInfoFn: getSystemInfoFn,
+			getGpuFn: func(ctx context.Context, runners []ml.FilteredRunnerDiscovery) []ml.DeviceInfo {
+				return []ml.DeviceInfo{{
+					DeviceID:       ml.DeviceID{ID: "0", Library: "CUDA"},
+					Name:           "CUDA0",
+					TotalMemory:    usable,
+					PhysicalMemory: physical,
+					FreeMemory:     usable,
+				}}
+			},
+			loaded: map[string]*runnerRef{},
+		},
+	}
+
+	gpu := infoResponse(t, s).ComputeInfo.SupportedGPUs[0]
+	if gpu.TotalMemory != usable {
+		t.Errorf("total_memory: got %d, want %d", gpu.TotalMemory, usable)
+	}
+	if gpu.PhysicalMemory != physical {
+		t.Errorf("physical_memory: got %d, want %d", gpu.PhysicalMemory, physical)
+	}
+}
+
+// Where nothing distinguishes the two there is no second figure to report, and the field
+// must be absent rather than duplicating or zeroing the total.
+func TestInfoHandlerOmitsPhysicalMemoryWhenUnknown(t *testing.T) {
+	got := infoResponse(t, infoTestServer(t))
+
+	if gpu := got.ComputeInfo.SupportedGPUs[0]; gpu.PhysicalMemory != 0 {
+		t.Errorf("physical_memory: got %d, want 0 for a backend that doesn't distinguish it", gpu.PhysicalMemory)
+	}
+}


### PR DESCRIPTION
## Report the memory a device has, alongside the memory it can use

> **Stacked on #18142**, which adds the `/api/info` endpoint this field is exposed through.
> GitHub cannot base a cross-fork PR on another fork's branch, so this branch contains that
> one's commits as well — **only the last commit is new here**. Review and merge #18142
> first.

### The problem

`TotalMemory` is what a runner can address, and every placement decision is correctly made
from it. It is not the amount of memory on the card. `cuDeviceTotalMem` excludes memory the
driver reserves for itself, so the two differ:

```
96.00 GiB   nominal, from the spec sheet    no API reports this
95.59 GiB   what the device reports         nvidia-smi / NVML
94.97 GiB   what a CUDA context can use     cuDeviceTotalMem, today's TotalMemory
```

The 638 MiB between the last two is real, present on the card, and unusable for models. It
must stay out of placement. But a tool that displays a machine's hardware currently has no
way to show anything except the smaller figure, so it appears to lose most of a gigabyte
that `nvidia-smi` says is there — and the natural conclusion for a user is that ollama has
miscounted.

This is a display problem, not a scheduling one, which is why the fix adds a field rather
than changing an existing one.

### The change

`PhysicalMemory` on `ml.DeviceInfo`, surfaced as `physical_memory` on `/api/info`, read
from NVML. NVML ships wherever CUDA does and is already dlopened on this path for the
driver version, so this adds two symbols rather than a dependency.

```
CUDA0: total_memory=94.97 GiB  physical_memory=95.59 GiB  (+638 MiB)
CUDA1: total_memory=94.97 GiB  physical_memory=95.59 GiB  (+638 MiB)
nvidia-smi:                    97887 MiB = 95.59 GiB
```

### Two deliberate choices

**Omitted rather than mirrored when unknown.** A backend that does not distinguish the two
leaves the field unset instead of copying `TotalMemory` into it. A consumer can then tell
"these are the same" from "nobody knows", and choose its own fallback rather than being
handed a figure that looks authoritative and is not. This is the same reasoning #18142
already applies to compute capability and driver version.

**A failure to read it is not an error.** NVML may be absent, too old, or refuse a device.
Each case leaves the field unset and logs at debug; the CUDA figure stands, and that is the
one everything except a display already uses. Nothing regresses if NVML is unavailable.

The nominal 96 GiB is not reachable from any API and this does not attempt to synthesise
it. The 417 MiB between it and the device's own report is board firmware reservation that
nothing addresses.

### Testing

`go test ./server/ ./discover/... ./api/... ./ml/...` passes. New cases cover the field
surviving the native-probe merge — only the CUDA probe can distinguish the two totals, and
it merges against a ggml device that reports just the usable figure — and the API reporting
both figures when they differ while omitting the field when they do not.

Verified on a two-card host: `physical_memory` matches `nvidia-smi --query-gpu=memory.total`
exactly on both devices.
