### PR TITLE
cmd: add shell tab completion

### DIFF
--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -2092,6 +2092,44 @@ func checkServerHeartbeat(cmd *cobra.Command, _ []string) error {
 	return nil
 }
 
+func completeModelNames(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	list, err := client.List(cmd.Context())
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	var names []string
+	seen := make(map[string]struct{})
+	for _, m := range list.Models {
+		name := strings.TrimSpace(m.Name)
+		if name == "" {
+			name = strings.TrimSpace(m.Model)
+		}
+		if name == "" {
+			continue
+		}
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		seen[name] = struct{}{}
+		if toComplete == "" || strings.HasPrefix(strings.ToLower(name), strings.ToLower(toComplete)) {
+			names = append(names, name)
+		}
+	}
+
+	sort.Strings(names)
+	return names, cobra.ShellCompDirectiveNoFileComp
+}
+
 func versionHandler(cmd *cobra.Command, _ []string) {
 	client, err := api.ClientFromEnvironment()
 	if err != nil {
@@ -2289,9 +2327,6 @@ func NewCLI() *cobra.Command {
 		Short:         "Large language model runner",
 		SilenceUsage:  true,
 		SilenceErrors: true,
-		CompletionOptions: cobra.CompletionOptions{
-			DisableDefaultCmd: true,
-		},
 		Run: func(cmd *cobra.Command, args []string) {
 			if version, _ := cmd.Flags().GetBool("version"); version {
 				versionHandler(cmd, args)
@@ -2341,11 +2376,12 @@ func NewCLI() *cobra.Command {
 	showCmd.Flags().BoolP("verbose", "v", false, "Show detailed model information")
 
 	runCmd := &cobra.Command{
-		Use:     "run MODEL [PROMPT]",
-		Short:   "Run a model",
-		Args:    cobra.MinimumNArgs(1),
-		PreRunE: checkServerHeartbeat,
-		RunE:    RunHandler,
+		Use:               "run MODEL [PROMPT]",
+		Short:             "Run a model",
+		Args:              cobra.MinimumNArgs(1),
+		PreRunE:           checkServerHeartbeat,
+		RunE:              RunHandler,
+		ValidArgsFunction: completeModelNames,
 	}
 
 	runCmd.Flags().String("keepalive", "", "Duration to keep a model loaded (e.g. 5m)")

--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -143,3 +143,39 @@ ollama serve
 ```
 
 To view a list of environment variables that can be set run `ollama serve --help`
+
+### Enable shell tab completion
+
+Ollama can provide tab completion for model names on the command line (for example, completing `ollama run` model arguments). Generate the completion script for your shell and load it from your shell config file.
+
+**Bash** — add to `~/.bashrc`:
+
+```sh
+source <(ollama completion bash)
+```
+
+**Zsh** — add to `~/.zshrc`:
+
+```sh
+source <(ollama completion zsh)
+```
+
+**Fish** — add to `~/.config/fish/config.fish`:
+
+```fish
+ollama completion fish | source
+```
+
+**PowerShell** — add to your PowerShell profile (run `$PROFILE` to find it):
+
+```powershell
+ollama completion powershell | Out-String | Invoke-Expression
+```
+
+After adding the line above, open a new terminal (or source your config file) and tab-complete a model name:
+
+```
+ollama run qwen<tab>
+```
+
+Completion lists models available on your local Ollama server.


### PR DESCRIPTION
# Summary
Enables shell tab-completion for Ollama's CLI, fixing the long-standing gap where `ollama run <model>` (and the hidden `__complete` machinery) could not autocomplete model names. Tab-completing a model name in `ollama run qwen<tab>` now works.
# What changed
- `cmd/cmd.go`: Removed `CompletionOptions.DisableDefaultCmd: true`, re-enabling cobra's built-in `ollama completion bash|zsh|fish|powershell` subcommand (previously disabled since the very first Go CLI scaffolding, added in `76cb60d` - no documented rationale).
- `cmd/cmd.go`: Added a `ValidArgsFunction` (`completeModelNames`) to `runCmd` that queries the local server's `/api/tags` and completes model names, deduplicated, prefix-filtered, and sorted.
# Comparison to prior attempts
Model-name completion for the CLI has been requested several times (#1653, #7239, #11844, #4444) and attempted in PRs that ultimately did not land (#980, #4690).
This change is intentionally minimal and narrowly scoped to address that gap cleanly:
- Enables cobra's built-in completion subcommand directly - the mechanism suggested in #4690.
- Adds model-name completion only to ollama run. Per maintainer guidance in those threads, pull is deliberately excluded, since it fetches from the remote library rather than local models.
Keeping the change to a single ValidArgsFunction avoids the earlier PRs' pitfalls (large surface area, unmaintained autocomplete wiring) and keeps it easy to review and extend later (e.g. to show, cp, rm, stop).
# Usage
`source <(ollama completion bash)   # bash`
`source <(ollama completion zsh)    # zsh`
`ollama completion fish | source    # fish`
Then:
`ollama run qwen<tab>`
Completion lists models available on the local Ollama server.
# Testing
Verified live against a running server:
$ ollama __complete run "ornith-1"
ornith-1.5:35b
ornith-1.5:9b
:4
Completion ended with directive: ShellCompDirectiveNoFileComp
- `go build ./...` - successful
- `go vet ./cmd/...` - successful
- `sudo cp /tmp/opencode/ollama /usr/local/bin/ollama` + `source <(ollama completion bash) ` + manual testing of the auto-complete behavior
# Documentation
Added an "Enable shell tab completion" section to `docs/cli.mdx` covering bash/zsh/fish/powershell.
# Notes / open questions
- Completion currently lists local models only. Cloud-sourced model recommendations (`/api/experimental/model-recommendations`) could be merged in as a follow-up using the existing logic in agentModelOptions (`cmd/agent_tui.go:439`).
- Auto-installing completion scripts in install.sh was deliberately left out - appending to users' dotfiles from an installer seemed invasive; perhaps adding an optional  `--install-completions sh|zsh|bash|powershell` parameter to the installer in the future might be an interesting idea as well.
# Attribution
The code changes in this commit were authored by Big Pickle (Opencode) and reviewed, validated, and tested by me. I take responsibility for the content.