### PR TITLE
docs: fix .mdx links in faq that 404 on docs site

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -14,11 +14,11 @@ curl -fsSL https://ollama.com/install.sh | sh
 
 ## How can I view the logs?
 
-Review the [Troubleshooting](./troubleshooting.mdx) docs for more about using logs.
+Review the [Troubleshooting](./troubleshooting) docs for more about using logs.
 
 ## Is my GPU compatible with Ollama?
 
-Please refer to the [GPU docs](./gpu.mdx).
+Please refer to the [GPU docs](./gpu).
 
 ## How can I specify the context window size?
 
@@ -248,7 +248,7 @@ Refer to the section [above](#how-do-i-configure-ollama-server) for how to set e
 
 ## How can I use Ollama in Visual Studio Code?
 
-Install the [Ollama extension](https://marketplace.visualstudio.com/items?itemName=Ollama.ollama) to use Ollama models in VS Code Chat. See the [VS Code integration guide](./integrations/vscode.mdx) for setup and troubleshooting.
+Install the [Ollama extension](https://marketplace.visualstudio.com/items?itemName=Ollama.ollama) to use Ollama models in VS Code Chat. See the [VS Code integration guide](./integrations/vscode) for setup and troubleshooting.
 
 ## How do I use Ollama with GPU acceleration in Docker?
 


### PR DESCRIPTION
Fixes #14243.

The FAQ linked ./gpu.mdx, which 404s on the docs site (Mintlify serves pages without the extension). Sibling pages already link extension-less (e.g. [docker](./docker) in troubleshooting.mdx).

Drop the .mdx extension on all three internal .mdx links in docs/faq.mdx (troubleshooting, gpu, vscode integration). Verified these are the only .mdx-suffixed internal links in docs/*.mdx.