### PR TITLE
docs: add non-root Linux manual install instructions

### DIFF
--- a/docs/linux.mdx
+++ b/docs/linux.mdx
@@ -24,6 +24,26 @@ curl -fsSL https://ollama.com/download/ollama-linux-amd64.tar.zst \
     | sudo tar x -C /usr
 ```
 
+### Non-root install
+
+If you don't have root or sudo access (e.g. on shared or managed machines),
+you can install into user space instead. Substitute any directory you have
+write access to for `~/.local`:
+
+```shell
+mkdir -p ~/.local
+curl -fsSL https://ollama.com/download/ollama-linux-amd64.tar.zst \
+    | tar x -C ~/.local
+```
+
+Add the binary and libraries to your environment (persist this in your
+`~/.bashrc`):
+
+```shell
+export PATH=$HOME/.local/bin:$PATH
+export LD_LIBRARY_PATH=$HOME/.local/lib/ollama:$LD_LIBRARY_PATH
+```
+
 Start Ollama:
 
 ```shell


### PR DESCRIPTION
Fixes #7421.

The Linux manual install required sudo, which is unavailable on shared or managed machines. This adds a Non-root install subsection that extracts the tarball into ~/.local and exports PATH / LD_LIBRARY_PATH, adapted from the proposal in the issue to the current .tar.zst layout (in/ + lib/ollama/, matching scripts/install.sh).