### PR TITLE
model/parsers: preserve Cohere end-of-turn token

### DIFF
--- a/model/parsers/cohere.go
+++ b/model/parsers/cohere.go
@@ -59,6 +59,7 @@ func (p *CohereParser) PreservedTokens() []string {
 		"<|START_THINKING|>", cohereEndThinking,
 		cohereStartText, cohereEndText,
 		cohereStartAction, cohereEndAction,
+		cohereEndOfTurn,
 		cohereStartResponse, cohereEndResponse,
 	}
 }

--- a/model/parsers/cohere_test.go
+++ b/model/parsers/cohere_test.go
@@ -1,6 +1,7 @@
 package parsers
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/ollama/ollama/api"
@@ -134,6 +135,21 @@ func TestCohereParseEndOfTurnWithoutEndText(t *testing.T) {
 	}
 }
 
+func TestCohereParseActionAfterEndOfTurn(t *testing.T) {
+	p := &CohereParser{}
+	p.Init(nil, nil, nil)
+
+	content, thinking, calls := cohereAddAll(t, p, []string{
+		`t<|END_THINKING|><|START_TEXT|>hi<|END_OF_TURN_TOKEN|><|START_ACTION|>[{"tool_call_id":"1","tool_name":"get_weather","parameters":{"city":"SF"}}]<|END_ACTION|><|END_OF_TURN_TOKEN|>`,
+	})
+	if thinking != "t" || content != "hi" {
+		t.Fatalf("thinking = %q, content = %q", thinking, content)
+	}
+	if len(calls) != 1 || calls[0].Function.Name != "get_weather" {
+		t.Fatalf("calls = %v, want get_weather", calls)
+	}
+}
+
 func TestCohereParsePrefillContinuation(t *testing.T) {
 	p := &CohereParser{}
 	last := &api.Message{Role: "assistant", Content: "partial"}
@@ -155,6 +171,9 @@ func TestCohereParserRegistered(t *testing.T) {
 	}
 	if !p.HasToolSupport() || !p.HasThinkingSupport() {
 		t.Error("cohere parser should support tools and thinking")
+	}
+	if !slices.Contains(p.PreservedTokens(), cohereEndOfTurn) {
+		t.Errorf("preserved tokens = %q, want %q", p.PreservedTokens(), cohereEndOfTurn)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #18053.

The Cohere parser treats `<|END_OF_TURN_TOKEN|>` as a content boundary and as a separator before a following action block. llama-server only forwards special tokens returned by `PreservedTokens`, but this boundary was absent from that list. As a result, llama-server could strip the token before the parser saw it and expose an action block as text.

This adds the end-of-turn marker to the preserved-token contract. The tests cover both the contract itself and a text block followed by an action block separated by the marker.

## Validation

- `go test ./model/parsers -count=1`
- `gofmt` on the changed Go files
- `git diff --check`

AI assistance was used for code navigation and test drafting. I reviewed every changed line and ran the parser package tests locally.
