### PR TITLE
docs: fix broken download links in app README

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -2,8 +2,8 @@
 
 ## Download
 
-- [macOS](https://github.com/ollama/app/releases/download/latest/Ollama.dmg)
-- [Windows](https://github.com/ollama/app/releases/download/latest/OllamaSetup.exe)
+- [macOS](https://ollama.com/download/Ollama.dmg)
+- [Windows](https://ollama.com/download/OllamaSetup.exe)
 
 ## Development
 


### PR DESCRIPTION
## Summary

The Download section of `app/README.md` pointed at:

- `https://github.com/ollama/app/releases/download/latest/Ollama.dmg`
- `https://github.com/ollama/app/releases/download/latest/OllamaSetup.exe`

Both return **404** — there is no public `ollama/app` repository, so these links have never resolved for readers.

This PR points them at the official download URLs that the top-level `README.md` already uses for the same installers:

- `https://ollama.com/download/Ollama.dmg`
- `https://ollama.com/download/OllamaSetup.exe`

## Verification

- `curl -sL` on the old links → 404 (confirmed for both)
- `curl -sL` on the replacement links → 200 (confirmed for both; same URLs as the top-level README's "download manually" links)
- `grep` confirms no remaining `ollama/app/releases` references in the repo docs
- `git diff --check` → clean
- Documentation-only change: 1 file, 2 lines changed, no code touched