### PR TITLE
docs: fix broken links and punctuation in README and import docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The official [Ollama Docker image](https://hub.docker.com/r/ollama/ollama) `olla
 ollama
 ```
 
-You'll be prompted to run a model or connect Ollama to your existing agents or applications such as `Claude Code`, `OpenClaw`, `OpenCode` , `Codex`, `Copilot`,  and more.
+You'll be prompted to run a model or connect Ollama to your existing agents or applications such as `Claude Code`, `OpenClaw`, `OpenCode`, `Codex`, `Copilot`, and more.
 
 ### Coding
 

--- a/docs/import.mdx
+++ b/docs/import.mdx
@@ -7,7 +7,7 @@ title: Importing a Model
 - [Importing a Safetensors adapter](#importing-a-fine-tuned-adapter-from-safetensors-weights)
 - [Importing a Safetensors model](#importing-a-model-from-safetensors-weights)
 - [Importing a GGUF file](#importing-a-gguf-based-model-or-adapter)
-- [Sharing models on ollama.com](#sharing-your-model-on-ollama-com)
+- [Sharing models on ollama.com](#sharing-your-model-on-ollamacom)
 
 ## Importing a fine tuned adapter from Safetensors weights
 

--- a/x/mlxrunner/mlx/include/mlx/c/README.md
+++ b/x/mlxrunner/mlx/include/mlx/c/README.md
@@ -9,4 +9,4 @@ Headers are automatically refreshed when you run a CMake build:
 cmake --preset 'MLX CUDA 13'
 ```
 
-See the [MLX Engine](../../../../../../../docs/development.md#mlx-engine-optional) section of the development docs for full build instructions.
+See the [MLX Engine](../../../../../../docs/development.md#mlx-engine-optional) section of the development docs for full build instructions.


### PR DESCRIPTION
Three small docs fixes:

1. `x/mlxrunner/mlx/include/mlx/c/README.md` — the development-docs link used seven `../` from a directory six levels below the root, resolving outside the repo; dropped one.
2. `docs/import.mdx` — the TOC anchor `#sharing-your-model-on-ollama-com` matches nothing; slugifiers strip the dot without inserting a hyphen, so the heading's fragment is `#sharing-your-model-on-ollamacom`.
3. `README.md` — stray space before the comma after `OpenCode` and a doubled space after `Copilot` in the integrations line.