### PR TITLE
fix: normalize escaped pattern literals in tool/format schemas passed to llama-server

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -1594,7 +1594,7 @@ func (s *llamaServerRunner) Completion(ctx context.Context, req CompletionReques
 			lsReq.Grammar = grammarJSON
 		default:
 			if req.Format[0] == '{' {
-				lsReq.JsonSchema = req.Format
+				lsReq.JsonSchema = normalizeSchemaJSON(req.Format)
 			} else {
 				return fmt.Errorf("invalid format: %q; expected \"json\" or a valid JSON Schema object", req.Format)
 			}
@@ -2178,7 +2178,11 @@ func (s *llamaServerRunner) llamaServerChatRequest(req ChatRequest, stream bool)
 		"seed":              req.Options.Seed,
 	}
 	if len(req.Tools) > 0 {
-		body["tools"] = req.Tools
+		tools, err := normalizeToolsJSON(req.Tools)
+		if err != nil {
+			return nil, err
+		}
+		body["tools"] = tools
 	}
 	if req.Logprobs {
 		body["logprobs"] = true
@@ -2335,6 +2339,8 @@ func llamaServerChatResponseFormat(format json.RawMessage) (map[string]any, erro
 			return nil, fmt.Errorf("invalid format: %q; expected \"json\" or a valid JSON Schema object", format)
 		}
 
+		normalizeSchemaPatterns(schema)
+
 		return map[string]any{
 			"type": "json_schema",
 			"json_schema": map[string]any{
@@ -2343,6 +2349,115 @@ func llamaServerChatResponseFormat(format json.RawMessage) (map[string]any, erro
 			},
 		}, nil
 	}
+}
+
+// normalizeToolsJSON marshals tools for llama-server, normalizing JSON schema
+// string patterns throughout. llama-server compiles tool schemas into the
+// grammar that constrains tool calls, and its regex dialect rejects the
+// identity escapes \/ and \- that ECMAScript permits, failing the whole
+// request. Patterns only survive Ollama's typed schema decoding where they are
+// kept verbatim, such as inside array items, so they must be normalized on the
+// wire regardless of where they are nested.
+func normalizeToolsJSON(tools api.Tools) (json.RawMessage, error) {
+	b, err := json.Marshal(tools)
+	if err != nil {
+		return nil, err
+	}
+	if bytes.IndexByte(b, '\\') < 0 {
+		return b, nil
+	}
+	var decoded any
+	d := json.NewDecoder(bytes.NewReader(b))
+	d.UseNumber()
+	if err := d.Decode(&decoded); err != nil {
+		// The tools marshaled above, so this cannot fail; forward unchanged.
+		return b, nil
+	}
+	normalizeSchemaPatterns(decoded)
+	return marshalWithoutHTMLEscape(decoded)
+}
+
+// normalizeSchemaJSON normalizes JSON schema string patterns in a raw schema.
+// A schema that does not decode is forwarded unchanged for llama-server to reject.
+func normalizeSchemaJSON(raw json.RawMessage) json.RawMessage {
+	if bytes.IndexByte(raw, '\\') < 0 {
+		return raw
+	}
+	var decoded any
+	d := json.NewDecoder(bytes.NewReader(raw))
+	d.UseNumber()
+	if err := d.Decode(&decoded); err != nil {
+		return raw
+	}
+	normalizeSchemaPatterns(decoded)
+	normalized, err := marshalWithoutHTMLEscape(decoded)
+	if err != nil {
+		return raw
+	}
+	return normalized
+}
+
+// normalizeSchemaPatterns rewrites pattern strings in place throughout a
+// decoded JSON schema.
+func normalizeSchemaPatterns(v any) {
+	switch t := v.(type) {
+	case map[string]any:
+		for key, val := range t {
+			if key == "pattern" {
+				if s, ok := val.(string); ok {
+					t[key] = unescapePatternLiterals(s)
+				}
+				continue
+			}
+			normalizeSchemaPatterns(val)
+		}
+	case []any:
+		for _, val := range t {
+			normalizeSchemaPatterns(val)
+		}
+	}
+}
+
+// unescapePatternLiterals replaces the regex identity escapes \/ and \- with
+// the characters they denote. Every regex dialect, including the one behind
+// llama-server's grammar, accepts the unescaped forms.
+func unescapePatternLiterals(s string) string {
+	if !strings.Contains(s, `\/`) && !strings.Contains(s, `\-`) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); {
+		if s[i] == '\\' && i+1 < len(s) {
+			switch s[i+1] {
+			case '/', '-':
+				b.WriteByte(s[i+1])
+				i += 2
+				continue
+			case '\\':
+				// An escaped backslash is consumed as a unit so a following
+				// escape sequence is not hidden behind it.
+				b.WriteString(`\\`)
+				i += 2
+				continue
+			}
+		}
+		b.WriteByte(s[i])
+		i++
+	}
+	return b.String()
+}
+
+// marshalWithoutHTMLEscape marshals v without escaping HTML characters, matching
+// how requests are encoded for llama-server.
+func marshalWithoutHTMLEscape(v any) ([]byte, error) {
+	var buffer bytes.Buffer
+	enc := json.NewEncoder(&buffer)
+	enc.SetEscapeHTML(false)
+	if err := enc.Encode(v); err != nil {
+		return nil, err
+	}
+	return bytes.TrimRight(buffer.Bytes(), "\n"), nil
 }
 
 func (s *llamaServerRunner) Embedding(ctx context.Context, input string) ([]float32, int, error) {

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -1193,6 +1193,7 @@ func TestLlamaServerCompletionRequestFormat(t *testing.T) {
 		format         string
 		wantGrammar    bool
 		wantJsonSchema bool
+		wantContains   string
 		wantErr        bool
 	}{
 		{
@@ -1215,6 +1216,18 @@ func TestLlamaServerCompletionRequestFormat(t *testing.T) {
 			name:           "json schema",
 			format:         `{"type":"object","properties":{"name":{"type":"string"}}}`,
 			wantJsonSchema: true,
+		},
+		{
+			name:           "json schema with escaped pattern in items",
+			format:         `{"type":"object","properties":{"a":{"type":"array","items":{"type":"string","pattern":"^[a\\-b]+$"}}}}`,
+			wantJsonSchema: true,
+			wantContains:   `"pattern":"^[a-b]+$"`,
+		},
+		{
+			name:           "json schema with escaped pattern in top-level property",
+			format:         `{"type":"object","properties":{"a":{"type":"string","pattern":"^x\\/y\\-z$"}}}`,
+			wantJsonSchema: true,
+			wantContains:   `"pattern":"^x/y-z$"`,
 		},
 		{
 			name:    "invalid format",
@@ -1279,6 +1292,9 @@ func TestLlamaServerCompletionRequestFormat(t *testing.T) {
 			if !tt.wantGrammar && !tt.wantJsonSchema && capturedReq.Grammar != "" {
 				t.Errorf("unexpected grammar: %s", capturedReq.Grammar)
 			}
+			if tt.wantContains != "" && !strings.Contains(string(capturedReq.JsonSchema), tt.wantContains) {
+				t.Errorf("json_schema = %s, want it to contain %s", capturedReq.JsonSchema, tt.wantContains)
+			}
 		})
 	}
 }
@@ -1317,6 +1333,153 @@ func TestLlamaServerPreservedTokens(t *testing.T) {
 			got := llamaServerPreservedTokens(tt.parserTokens, tt.toolCallTag)
 			if !slices.Equal(got, tt.want) {
 				t.Fatalf("llamaServerPreservedTokens = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+// firstPattern returns the first "pattern" string in a decoded JSON value, or
+// false when none is present.
+func firstPattern(v any) (string, bool) {
+	switch t := v.(type) {
+	case map[string]any:
+		if s, ok := t["pattern"].(string); ok {
+			return s, true
+		}
+		for _, val := range t {
+			if s, ok := firstPattern(val); ok {
+				return s, true
+			}
+		}
+	case []any:
+		for _, val := range t {
+			if s, ok := firstPattern(val); ok {
+				return s, true
+			}
+		}
+	}
+	return "", false
+}
+
+func TestLlamaServerChatRequestNormalizesToolPatterns(t *testing.T) {
+	tests := []struct {
+		name        string
+		schema      string
+		wantPattern any // string pattern forwarded to llama-server, or nil for none
+	}{
+		{
+			name:        "top-level string pattern is dropped by schema decoding",
+			schema:      `{"type":"object","properties":{"a":{"type":"string","pattern":"^[a\\-b]+$"}}}`,
+			wantPattern: nil,
+		},
+		{
+			name:        "escaped hyphen in array items",
+			schema:      `{"type":"object","properties":{"a":{"type":"array","items":{"type":"string","pattern":"^[a\\-b]+$"}}}}`,
+			wantPattern: `^[a-b]+$`,
+		},
+		{
+			name:        "escaped slash in array items",
+			schema:      `{"type":"object","properties":{"a":{"type":"array","items":{"type":"string","pattern":"^a\\/b$"}}}}`,
+			wantPattern: `^a/b$`,
+		},
+		{
+			name:        "escaped hyphen in object item property",
+			schema:      `{"type":"object","properties":{"a":{"type":"array","items":{"type":"object","properties":{"p":{"type":"string","pattern":"^[a\\-b]+$"}}}}}}`,
+			wantPattern: `^[a-b]+$`,
+		},
+		{
+			name:        "escaped slash and hyphen in path-like pattern",
+			schema:      `{"type":"object","properties":{"writes":{"type":"array","items":{"type":"object","properties":{"path":{"type":"string","pattern":"^(?!\\.\\.?(?:\\/|$))[A-Za-z0-9_\\-.~:@+]{1,200}$"}}}}}}`,
+			wantPattern: `^(?!\.\.?(?:/|$))[A-Za-z0-9_-.~:@+]{1,200}$`,
+		},
+		{
+			name:        "pattern without identity escapes unchanged",
+			schema:      `{"type":"object","properties":{"a":{"type":"array","items":{"type":"string","pattern":"^[a-b]+$"}}}}`,
+			wantPattern: `^[a-b]+$`,
+		},
+		{
+			name:        "escaped backslash keeps the following hyphen literal",
+			schema:      `{"type":"object","properties":{"a":{"type":"array","items":{"type":"string","pattern":"^x\\\\-y\\d+$"}}}}`,
+			wantPattern: `^x\\-y\d+$`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var params api.ToolFunctionParameters
+			if err := json.Unmarshal([]byte(tt.schema), &params); err != nil {
+				t.Fatal(err)
+			}
+
+			body, err := (&llamaServerRunner{}).llamaServerChatRequest(ChatRequest{
+				Messages: []api.Message{{Role: "user", Content: "hi"}},
+				Tools:    api.Tools{{Type: "function", Function: api.ToolFunction{Name: "t", Parameters: params}}},
+			}, true)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			raw, ok := body["tools"].(json.RawMessage)
+			if !ok {
+				t.Fatalf("tools = %T, want json.RawMessage", body["tools"])
+			}
+			var tools any
+			if err := json.Unmarshal(raw, &tools); err != nil {
+				t.Fatal(err)
+			}
+
+			got, found := firstPattern(tools)
+			if tt.wantPattern == nil {
+				if found {
+					t.Fatalf("expected no pattern forwarded to llama-server, got %q", got)
+				}
+				return
+			}
+			if !found {
+				t.Fatal("expected a pattern forwarded to llama-server, found none")
+			}
+			if want := tt.wantPattern.(string); got != want {
+				t.Fatalf("forwarded pattern = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestLlamaServerChatResponseFormatNormalizesPatterns(t *testing.T) {
+	format, err := llamaServerChatResponseFormat(json.RawMessage(`{"type":"object","properties":{"a":{"type":"array","items":{"type":"string","pattern":"^a\\/b$"}}}}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	b, err := json.Marshal(format)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `"pattern":"^a/b$"`) {
+		t.Fatalf("response_format = %s, want pattern %q normalized", b, `^a/b$`)
+	}
+}
+
+func TestUnescapePatternLiterals(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{`^[a-b]+$`, `^[a-b]+$`},
+		{`^a\/b$`, `^a/b$`},
+		{`^[a\-b]+$`, `^[a-b]+$`},
+		{`\\-`, `\\-`}, // escaped backslash: the hyphen is already a literal
+		{`\\/`, `\\/`}, // escaped backslash: the slash is already a literal
+		{`^\d+\.?$`, `^\d+\.?$`},
+		{`^(?!\.\.?(?:\/|$))[a\-z_]+$`, `^(?!\.\.?(?:/|$))[a-z_]+$`},
+		{`a\`, `a\`},
+		{`^ü\-\/ö$`, `^ü-/ö$`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.in, func(t *testing.T) {
+			if got := unescapePatternLiterals(tt.in); got != tt.want {
+				t.Fatalf("unescapePatternLiterals(%q) = %q, want %q", tt.in, got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #18226

## Root cause

The asymmetry is in what Ollama forwards to llama-server. All API surfaces decode tool schemas into typed structs (`api/types.go`): `ToolProperty` has no `pattern` field, so a **top-level** string `pattern` is silently dropped during decoding (never compiled → 200 OK). But `Items` is `any`, so anything nested under `array` → `items` survives **verbatim** — including `pattern` values containing the ECMAScript identity escapes `\/` and `\-`. In native chat mode, llama.cpp compiles tool schemas into the tool-call grammar and its regex dialect rejects those identity escapes → `400 Failed to initialize samplers: failed to parse grammar`. This matches the issue's table exactly, including why Claude Code's `Artifact` tool (`writes[].path` pattern) breaks interactive mode against Ollama.

## Fix

Unescape `\/` → `/` and `\-` → `-` in every schema `pattern` value at the Ollama → llama-server boundary (`llm/llama_server.go`): applied to `body["tools"]`, the chat `response_format` json_schema, and the completion `json_schema` (format schemas are raw at all depths, so escaped patterns failed there too). Semantics-preserving in every regex dialect (identity escapes carry no meaning); `\\` is consumed as a unit so escaped-backslash patterns are untouched; other escapes and lookaheads pass through.

Notes kept out of scope deliberately: the top-level pattern dropping by the typed decode is a pre-existing schema-subset limitation (widening it is a separate decision), and the macOS mlxrunner xgrammar path is noted as a follow-up.

## Tests

`llm/llama_server_test.go`:
- `TestLlamaServerChatRequestNormalizesToolPatterns` — both placements from the issue plus the Claude Code pattern, with plain-pattern and escaped-backslash invariants
- `TestLlamaServerChatResponseFormatNormalizesPatterns`
- `TestUnescapePatternLiterals`
- 2 new cases in the existing `TestLlamaServerCompletionRequestFormat`

`go test ./llm/...` passes, plus `./anthropic/` and `./api/`; `go vet ./llm/` and `gofmt -l` clean.
