### PR TITLE
log: report the source of the loaded context length

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -189,6 +189,23 @@ func usesAutomaticNumCtx(model *Model, requestOpts map[string]any) bool {
 	return envconfig.ContextLength() == 0
 }
 
+// numCtxSource reports which configuration level supplied the loaded num_ctx,
+// mirroring the resolution order in modelOptionsWithEmbeddingBatchDefault:
+// API request options, then Modelfile options, then OLLAMA_CONTEXT_LENGTH,
+// then the VRAM-based server default.
+func numCtxSource(model *Model, requestOpts map[string]any) string {
+	switch {
+	case hasOption(requestOpts, "num_ctx"):
+		return "request"
+	case model != nil && hasOption(model.Options, "num_ctx"):
+		return "modelfile"
+	case envconfig.ContextLength() > 0:
+		return "env"
+	default:
+		return "default"
+	}
+}
+
 func usesAutomaticNumBatch(model *Model, requestOpts map[string]any) bool {
 	if _, ok := requestOpts["num_batch"]; ok {
 		return false
@@ -217,6 +234,7 @@ func (s *Server) scheduleRunner(ctx context.Context, model *Model, caps []model.
 	}
 
 	numCtxAuto := usesAutomaticNumCtx(model, requestOpts)
+	numCtxSrc := numCtxSource(model, requestOpts)
 	embeddingBatchDefault := shouldApplyEmbeddingBatchDefault(model, requestOpts)
 	numBatchAuto := usesAutomaticNumBatch(model, requestOpts) && !embeddingBatchDefault
 	opts, err := s.modelOptionsWithEmbeddingBatchDefault(model, requestOpts, embeddingBatchDefault)
@@ -224,7 +242,7 @@ func (s *Server) scheduleRunner(ctx context.Context, model *Model, caps []model.
 		return nil, nil, nil, err
 	}
 
-	runnerCh, errCh := s.sched.getRunner(ctx, model, opts, keepAlive, numCtxAuto, numBatchAuto, shift)
+	runnerCh, errCh := s.sched.getRunner(ctx, model, opts, keepAlive, numCtxAuto, numCtxSrc, numBatchAuto, shift)
 	var runner *runnerRef
 	select {
 	case runner = <-runnerCh:

--- a/server/routes_options_test.go
+++ b/server/routes_options_test.go
@@ -129,6 +129,90 @@ func TestModelOptionsNumCtxPriority(t *testing.T) {
 	}
 }
 
+func TestNumCtxSource(t *testing.T) {
+	tests := []struct {
+		name           string
+		envContextLen  string // empty means not set
+		modelNumCtx    int    // 0 means not set in model
+		requestNumCtx  int    // 0 means not set in request
+		expectedSource string
+	}{
+		{
+			name:           "vram default when nothing else set",
+			envContextLen:  "",
+			modelNumCtx:    0,
+			requestNumCtx:  0,
+			expectedSource: "default",
+		},
+		{
+			name:           "env var when only env set",
+			envContextLen:  "8192",
+			modelNumCtx:    0,
+			requestNumCtx:  0,
+			expectedSource: "env",
+		},
+		{
+			name:           "modelfile overrides env var",
+			envContextLen:  "8192",
+			modelNumCtx:    16384,
+			requestNumCtx:  0,
+			expectedSource: "modelfile",
+		},
+		{
+			name:           "request overrides modelfile and env var",
+			envContextLen:  "8192",
+			modelNumCtx:    16384,
+			requestNumCtx:  4096,
+			expectedSource: "request",
+		},
+		{
+			name:           "modelfile when only modelfile set",
+			envContextLen:  "",
+			modelNumCtx:    65536,
+			requestNumCtx:  0,
+			expectedSource: "modelfile",
+		},
+		{
+			name:           "request when only request set",
+			envContextLen:  "",
+			modelNumCtx:    0,
+			requestNumCtx:  16384,
+			expectedSource: "request",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envContextLen != "" {
+				t.Setenv("OLLAMA_CONTEXT_LENGTH", tt.envContextLen)
+			}
+
+			var modelOpts map[string]any
+			if tt.modelNumCtx != 0 {
+				modelOpts = map[string]any{"num_ctx": float64(tt.modelNumCtx)}
+			}
+			m := &Model{
+				Options: modelOpts,
+			}
+
+			var requestOpts map[string]any
+			if tt.requestNumCtx != 0 {
+				requestOpts = map[string]any{"num_ctx": float64(tt.requestNumCtx)}
+			}
+
+			if source := numCtxSource(m, requestOpts); source != tt.expectedSource {
+				t.Errorf("numCtxSource = %q, want %q", source, tt.expectedSource)
+			}
+
+			// numCtxSource must agree with usesAutomaticNumCtx: only the
+			// VRAM-tier default counts as automatic.
+			if auto := usesAutomaticNumCtx(m, requestOpts); auto != (tt.expectedSource == "default") {
+				t.Errorf("usesAutomaticNumCtx = %v, want %v", auto, tt.expectedSource == "default")
+			}
+		})
+	}
+}
+
 func TestModelOptionsGenerationDefaultsPriority(t *testing.T) {
 	m := &Model{
 		GenerationDefaults: model.GenerationDefaults{

--- a/server/sched.go
+++ b/server/sched.go
@@ -43,6 +43,11 @@ type LlmRequest struct {
 	// default rather than explicit request, model, or environment config.
 	numCtxAuto bool
 
+	// numCtxSource records which configuration level supplied NumCtx:
+	// "request", "modelfile", "env", or "default". Logging only; it does not
+	// affect scheduling decisions (numCtxAuto drives those).
+	numCtxSource string
+
 	// numBatchAuto is true when NumBatch came from Ollama's default options
 	// rather than an explicit request or model option.
 	numBatchAuto bool
@@ -166,7 +171,7 @@ func effectiveContext(numCtx, trainCtx int) int {
 	return numCtx
 }
 
-func (s *Scheduler) getRunner(c context.Context, m *Model, opts api.Options, sessionDuration *api.Duration, numCtxAuto bool, numBatchAuto bool, shift *bool) (chan *runnerRef, chan error) {
+func (s *Scheduler) getRunner(c context.Context, m *Model, opts api.Options, sessionDuration *api.Duration, numCtxAuto bool, numCtxSource string, numBatchAuto bool, shift *bool) (chan *runnerRef, chan error) {
 	if opts.NumCtx < 4 {
 		opts.NumCtx = 4
 	}
@@ -189,6 +194,7 @@ func (s *Scheduler) getRunner(c context.Context, m *Model, opts api.Options, ses
 		successCh:       make(chan *runnerRef, 1),
 		errCh:           make(chan error, 1),
 		numCtxAuto:      numCtxAuto,
+		numCtxSource:    numCtxSource,
 		numBatchAuto:    numBatchAuto,
 		contextShift:    contextShift,
 		shift:           shift,
@@ -707,6 +713,7 @@ iGPUScan:
 		loading:         true,
 		pid:             llama.Pid(),
 		numCtxAuto:      req.numCtxAuto,
+		numCtxSource:    req.numCtxSource,
 		numBatchAuto:    req.numBatchAuto,
 		useMMapAuto:     req.useMMapAuto,
 		contextShift:    req.contextShift,
@@ -1356,6 +1363,7 @@ type runnerRef struct {
 	modelKey     string
 	numParallel  int
 	numCtxAuto   bool
+	numCtxSource string
 	numBatchAuto bool
 	useMMapAuto  bool
 	contextShift bool
@@ -1523,7 +1531,10 @@ func (runner *runnerRef) LogValue() slog.Value {
 		slog.String("model", modelID),
 	)
 	if runner.Options != nil {
-		attrs = append(attrs, slog.Int("num_ctx", runner.Options.NumCtx))
+		attrs = append(attrs,
+			slog.Int("num_ctx", runner.Options.NumCtx),
+			slog.String("num_ctx_source", runner.numCtxSource),
+		)
 	}
 	return slog.GroupValue(attrs...)
 }

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -187,7 +187,7 @@ func TestSchedVisionContextFloor(t *testing.T) {
 		opts := api.DefaultOptions()
 		opts.NumCtx = 128
 
-		s.getRunner(ctx, visionModel, opts, nil, true, false, nil)
+		s.getRunner(ctx, visionModel, opts, nil, true, "", false, nil)
 
 		req := <-s.pendingReqCh
 		require.Equal(t, 2048, req.opts.NumCtx)
@@ -199,7 +199,7 @@ func TestSchedVisionContextFloor(t *testing.T) {
 		opts := api.DefaultOptions()
 		opts.NumCtx = 128
 
-		s.getRunner(ctx, visionModel, opts, nil, false, false, nil)
+		s.getRunner(ctx, visionModel, opts, nil, false, "", false, nil)
 
 		req := <-s.pendingReqCh
 		require.Equal(t, 2048, req.opts.NumCtx)
@@ -524,10 +524,10 @@ func TestSchedGetRunner(t *testing.T) {
 	s.getSystemInfoFn = getSystemInfoFn
 	s.newServerFn = a.newServer
 	slog.Info("a")
-	successCh1a, errCh1a := s.getRunner(a.ctx, a.req.model, a.req.opts, a.req.sessionDuration, false, false, nil)
+	successCh1a, errCh1a := s.getRunner(a.ctx, a.req.model, a.req.opts, a.req.sessionDuration, false, "", false, nil)
 	require.Len(t, s.pendingReqCh, 1)
 	slog.Info("b")
-	successCh1b, errCh1b := s.getRunner(b.ctx, b.req.model, b.req.opts, b.req.sessionDuration, false, false, nil)
+	successCh1b, errCh1b := s.getRunner(b.ctx, b.req.model, b.req.opts, b.req.sessionDuration, false, "", false, nil)
 	require.Len(t, s.pendingReqCh, 1)
 	require.Empty(t, successCh1b)
 	require.Len(t, errCh1b, 1)
@@ -551,7 +551,7 @@ func TestSchedGetRunner(t *testing.T) {
 
 	c.req.model.ModelPath = "bad path"
 	slog.Info("c")
-	successCh1c, errCh1c := s.getRunner(c.ctx, c.req.model, c.req.opts, c.req.sessionDuration, false, false, nil)
+	successCh1c, errCh1c := s.getRunner(c.ctx, c.req.model, c.req.opts, c.req.sessionDuration, false, "", false, nil)
 	// Starts in pending channel, then should be quickly processed to return an error
 	time.Sleep(50 * time.Millisecond) // Long enough for the "a" model to expire and unload
 	require.Empty(t, successCh1c)
@@ -586,7 +586,7 @@ func TestSchedGetRunnerUsesDigestKeyWhenModelPathEmpty(t *testing.T) {
 	s.loadedMu.Unlock()
 
 	reqModel := &Model{Name: "safetensors-b", Digest: "sha-b"}
-	successCh, errCh := s.getRunner(ctx, reqModel, opts, nil, false, false, nil)
+	successCh, errCh := s.getRunner(ctx, reqModel, opts, nil, false, "", false, nil)
 
 	require.Empty(t, successCh)
 	require.Empty(t, errCh)
@@ -615,7 +615,7 @@ func TestSchedGetRunnerReusesSameDigestWhenModelPathEmpty(t *testing.T) {
 	s.loadedMu.Unlock()
 
 	reqCtx, cancelReq := context.WithCancel(ctx)
-	successCh, errCh := s.getRunner(reqCtx, &Model{Name: "safetensors-a-copy", Digest: "sha-a"}, opts, nil, false, false, nil)
+	successCh, errCh := s.getRunner(reqCtx, &Model{Name: "safetensors-a-copy", Digest: "sha-a"}, opts, nil, false, "", false, nil)
 	cancelReq()
 
 	select {
@@ -725,7 +725,7 @@ func TestSchedPrematureExpired(t *testing.T) {
 	s.getGpuFn = getGpuFn
 	s.getSystemInfoFn = getSystemInfoFn
 	s.newServerFn = scenario1a.newServer
-	successCh1a, errCh1a := s.getRunner(scenario1a.ctx, scenario1a.req.model, scenario1a.req.opts, scenario1a.req.sessionDuration, false, false, nil)
+	successCh1a, errCh1a := s.getRunner(scenario1a.ctx, scenario1a.req.model, scenario1a.req.opts, scenario1a.req.sessionDuration, false, "", false, nil)
 	require.Len(t, s.pendingReqCh, 1)
 	s.Run(ctx)
 	select {


### PR DESCRIPTION
Fixes #18229

## Summary

When a model is loaded, the runner logs the effective `num_ctx` but not **where it came from**, so a silent deviation from the Modelfile (e.g. a client request overriding it) goes unnoticed. This adds a `num_ctx_source` attr to the existing load/reload/unload log lines, reporting which level of the documented precedence chain supplied the value: `request` → `modelfile` → `env` (`OLLAMA_CONTEXT_LENGTH`) → `default`.

## Implementation

- `numCtxSource(model, requestOpts)` in `server/routes.go` — computed beside the existing `usesAutomaticNumCtx` in `scheduleRunner`, from the raw request/model maps (not the merged value), so a request that merely matches the Modelfile number still reports `request`.
- Threaded `getRunner` → `LlmRequest.numCtxSource` → `runnerRef.numCtxSource` (the same path the existing `numCtxAuto` bool uses) and emitted by `runnerRef.LogValue()` immediately after the existing `num_ctx` attr.
- Logging-only: no behavior change. New log shape for the issue's scenario (Modelfile 65536, request 16384):

```
DBG finished setting up runner=name=mymodel size=4.7GB ... num_ctx=16384 num_ctx_source=request
```

Known limits (deliberate): the auto-tier OOM reduction (only reachable when source is `default`) and the small floors can lower the effective value without changing the attr — both already have their own log signals; `ollama ps` display is out of scope.

## Tests

`server/routes_options_test.go`: `TestNumCtxSource` covers all four sources plus the invariant `usesAutomaticNumCtx == (source == "default")`. `go build`, `go vet`, and the full `go test ./server/ -count=1` pass; `gofmt -l` clean.
