### PR TITLE
Add LibreDB Studio to Community Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,7 @@ console.log(response.message.content);
 - [MindsDB](https://github.com/mindsdb/mindsdb/blob/staging/mindsdb/integrations/handlers/ollama_handler/README.md) - Connect Ollama with 200+ data platforms
 - [chromem-go](https://github.com/philippgille/chromem-go/blob/v0.5.0/embed_ollama.go) - Embeddable vector database for Go ([example](https://github.com/philippgille/chromem-go/tree/v0.5.0/examples/rag-wikipedia-ollama))
 - [Kangaroo](https://github.com/dbkangaroo/kangaroo) - AI-powered SQL client
+- [LibreDB Studio](https://github.com/libredb/libredb-studio) - Self-hosted browser database IDE with a read-only AI agent and natural language to SQL, powered by your local Ollama models
 
 ### Infrastructure & Deployment
 


### PR DESCRIPTION
Adding LibreDB Studio under Community Integrations > Database & Embeddings.

LibreDB Studio is an open-source (MIT), self-hosted, browser-based database IDE. It includes a read-only AI agent and natural language to SQL that can run entirely on your local Ollama models, so data never leaves your network. It connects to 14 database engines from a single interface.

Disclosure: I am part of the LibreDB Studio team.

Repo: https://github.com/libredb/libredb-studio
