### PR TITLE
server: deep-clone cached model options

### DIFF
--- a/server/model_inference_cache.go
+++ b/server/model_inference_cache.go
@@ -1,7 +1,6 @@
 package server
 
 import (
-	"maps"
 	"slices"
 	"strconv"
 	"sync"
@@ -106,7 +105,7 @@ func cloneInferenceModel(src *Model) *Model {
 	dst.AdapterPaths = slices.Clone(src.AdapterPaths)
 	dst.ProjectorPaths = slices.Clone(src.ProjectorPaths)
 	dst.License = slices.Clone(src.License)
-	dst.Options = maps.Clone(src.Options)
+	dst.Options = cloneAnyMap(src.Options)
 	dst.Messages = slices.Clone(src.Messages)
 	dst.capabilities = slices.Clone(src.capabilities)
 

--- a/server/model_inference_cache_test.go
+++ b/server/model_inference_cache_test.go
@@ -24,7 +24,14 @@ func TestInferenceModelCache(t *testing.T) {
 	loadCount := 0
 	cache.loadModel = func(name string) (*Model, error) {
 		loadCount++
-		return GetModel(name)
+		m, err := GetModel(name)
+		if err == nil {
+			m.Options = map[string]any{
+				"stop":   []any{"END", "STOP"},
+				"nested": map[string]any{"enabled": true},
+			}
+		}
+		return m, err
 	}
 
 	first, err := cache.Get("inference-cache")
@@ -46,6 +53,8 @@ func TestInferenceModelCache(t *testing.T) {
 	first.Config.Parser = "mutated"
 	first.Config.ModelFamilies[0] = "mutated"
 	first.capabilities[0] = model.CapabilityImage
+	first.Options["stop"].([]any)[0] = "mutated"
+	first.Options["nested"].(map[string]any)["enabled"] = false
 
 	second, err := cache.Get("inference-cache")
 	if err != nil {
@@ -59,6 +68,12 @@ func TestInferenceModelCache(t *testing.T) {
 	}
 	if got := second.Capabilities(); !slices.Contains(got, model.CapabilityCompletion) || slices.Contains(got, model.CapabilityImage) {
 		t.Fatalf("cached capabilities = %v, want completion only", got)
+	}
+	if got := second.Options["stop"].([]any)[0]; got != "END" {
+		t.Fatalf("cached stop option = %v, want END", got)
+	}
+	if got := second.Options["nested"].(map[string]any)["enabled"]; got != true {
+		t.Fatalf("cached nested option = %v, want true", got)
 	}
 
 	// Recreating the manifest changes its digest and invalidates the entry.


### PR DESCRIPTION
## Summary

- recursively clone cached model options before returning a request-local model
- prevent nested option arrays and maps from mutating the shared inference cache
- extend the cache regression test to cover nested option isolation across cache hits

## Testing

- `GOPROXY=https://goproxy.cn,direct go test ./server -run 'TestInferenceModelCache' -count=1`
- `GOPROXY=https://goproxy.cn,direct go test -race ./server -run 'TestInferenceModelCache' -count=1`
