### PR TITLE
examples: use new(false) for GenerateRequest.Stream

### DIFF
--- a/api/examples/generate/main.go
+++ b/api/examples/generate/main.go
@@ -19,7 +19,7 @@ func main() {
 		Prompt: "how many planets are there?",
 
 		// set streaming to false
-		Stream: new(bool),
+		Stream: new(false),
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Since Ollama already uses golang 1.26 in the go module, so we can use `new(false)` directly which is better for reading :)