### PR TITLE
launch: align Qwen Code context with Ollama

### DIFF
--- a/cmd/launch/context_window.go
+++ b/cmd/launch/context_window.go
@@ -1,12 +1,132 @@
 package launch
 
 import (
+	"bufio"
 	"context"
+	"errors"
+	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/internal/modelref"
 )
+
+const launchContextLoadTimeout = 5 * time.Minute
+
+type contextWindowSource string
+
+const (
+	contextWindowSourceRuntime   contextWindowSource = "loaded runtime"
+	contextWindowSourceParameter contextWindowSource = "model num_ctx parameter"
+	contextWindowSourceNative    contextWindowSource = "native model metadata"
+	contextWindowSourceInventory contextWindowSource = "model inventory"
+	contextWindowSourceCloud     contextWindowSource = "cloud model metadata"
+)
+
+// contextWindowResolution keeps the runner-verified context separate from
+// metadata fallbacks. Callers can safely continue with ContextLength while
+// still telling users when the server's effective value could not be checked.
+type contextWindowResolution struct {
+	ContextLength   int
+	RuntimeVerified bool
+	Source          contextWindowSource
+	Err             error
+}
+
+func resolveLaunchContextFromEnvironment(model LaunchModel, load bool) contextWindowResolution {
+	if model.Remote || isCloudModelName(model.Name) {
+		return resolveLaunchContext(context.Background(), nil, model.WithCloudLimits(), false)
+	}
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		return contextWindowFallback(model, err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), launchContextLoadTimeout)
+	defer cancel()
+	return resolveLaunchContext(ctx, client, model, load)
+}
+
+// resolveLaunchContext obtains the context the local server actually assigned
+// from /api/ps. Actual launches first issue Ollama's model-only generation
+// request, which loads without changing any model options. Configuration-only
+// calls skip that load and use an already-running process or metadata.
+func resolveLaunchContext(ctx context.Context, client *api.Client, model LaunchModel, load bool) contextWindowResolution {
+	if model.Remote || isCloudModelName(model.Name) {
+		model = model.WithCloudLimits()
+		return contextWindowResolution{ContextLength: launchModelContextLength(model), Source: contextWindowSourceCloud}
+	}
+
+	var failures []error
+	if client != nil {
+		if load {
+			if err := client.Generate(ctx, &api.GenerateRequest{Model: model.Name}, func(api.GenerateResponse) error { return nil }); err != nil {
+				failures = append(failures, fmt.Errorf("load model: %w", err))
+			}
+		}
+
+		if running, err := client.ListRunning(ctx); err == nil {
+			if n := processContextWindow(model.Name, running); n > 0 {
+				return contextWindowResolution{ContextLength: n, RuntimeVerified: true, Source: contextWindowSourceRuntime}
+			}
+			failures = append(failures, errors.New("model was not present in the running process list"))
+		} else {
+			failures = append(failures, fmt.Errorf("read running models: %w", err))
+		}
+
+		if shown, err := client.Show(ctx, &api.ShowRequest{Model: model.Name}); err == nil {
+			native, _ := modelInfoContextLength(shown.ModelInfo)
+			if configured, ok := modelParameterNumCtx(shown.Parameters); ok {
+				if native > 0 && configured > native {
+					configured = native
+				}
+				return contextWindowResolution{ContextLength: configured, Source: contextWindowSourceParameter, Err: errors.Join(failures...)}
+			}
+			if native > 0 {
+				return contextWindowResolution{ContextLength: native, Source: contextWindowSourceNative, Err: errors.Join(failures...)}
+			}
+		} else {
+			failures = append(failures, fmt.Errorf("read model metadata: %w", err))
+		}
+	}
+
+	fallback := contextWindowFallback(model, errors.Join(failures...))
+	return fallback
+}
+
+func contextWindowFallback(model LaunchModel, err error) contextWindowResolution {
+	return contextWindowResolution{
+		ContextLength: launchModelContextLength(model),
+		Source:        contextWindowSourceInventory,
+		Err:           err,
+	}
+}
+
+func launchModelContextLength(model LaunchModel) int {
+	if model.ContextLength > 0 {
+		return model.ContextLength
+	}
+	if model.Details.ContextLength > 0 {
+		return model.Details.ContextLength
+	}
+	return 0
+}
+
+func modelParameterNumCtx(parameters string) (int, bool) {
+	scanner := bufio.NewScanner(strings.NewReader(parameters))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 || fields[0] != "num_ctx" {
+			continue
+		}
+		n, err := strconv.Atoi(fields[1])
+		if err == nil && n > 0 {
+			return n, true
+		}
+	}
+	return 0, false
+}
 
 // LoadedContextWindow reports the context length model is currently running
 // with, per the server's process list — the size the scheduler actually

--- a/cmd/launch/context_window_test.go
+++ b/cmd/launch/context_window_test.go
@@ -1,10 +1,147 @@
 package launch
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
 	"testing"
 
 	"github.com/ollama/ollama/api"
 )
+
+func TestResolveLaunchContextLoadsAndUsesRunningContext(t *testing.T) {
+	var generateCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/generate":
+			generateCalls.Add(1)
+			var request api.GenerateRequest
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatalf("decode generate request: %v", err)
+			}
+			if request.Model != "qwen3.8:27b-mlx" || len(request.Options) != 0 {
+				t.Fatalf("generate request = %#v, want model-only load", request)
+			}
+			_ = json.NewEncoder(w).Encode(api.GenerateResponse{Done: true})
+		case "/api/ps":
+			_ = json.NewEncoder(w).Encode(api.ProcessResponse{Models: []api.ProcessModelResponse{{
+				Name:          "qwen3.8:27b-mlx",
+				ContextLength: 65_536,
+			}}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	base, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := resolveLaunchContext(context.Background(), api.NewClient(base, server.Client()), LaunchModel{
+		Name:          "qwen3.8:27b-mlx",
+		ContextLength: 262_144,
+	}, true)
+	if got.ContextLength != 65_536 || !got.RuntimeVerified {
+		t.Fatalf("resolution = %#v, want verified 65536", got)
+	}
+	if generateCalls.Load() != 1 {
+		t.Fatalf("generate calls = %d, want 1", generateCalls.Load())
+	}
+}
+
+func TestResolveLaunchContextConfigurationOnlyDoesNotLoad(t *testing.T) {
+	var generateCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/generate":
+			generateCalls.Add(1)
+			http.Error(w, "must not load", http.StatusInternalServerError)
+		case "/api/ps":
+			_ = json.NewEncoder(w).Encode(api.ProcessResponse{})
+		case "/api/show":
+			_ = json.NewEncoder(w).Encode(api.ShowResponse{ModelInfo: map[string]any{
+				"qwen3_5.context_length": float64(262_144),
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	base, _ := url.Parse(server.URL)
+	got := resolveLaunchContext(context.Background(), api.NewClient(base, server.Client()), LaunchModel{Name: "qwen3.8:27b-mlx"}, false)
+	if got.ContextLength != 262_144 || got.RuntimeVerified {
+		t.Fatalf("resolution = %#v, want unverified native metadata 262144", got)
+	}
+	if generateCalls.Load() != 0 {
+		t.Fatalf("generate calls = %d, want 0", generateCalls.Load())
+	}
+}
+
+func TestResolveLaunchContextBoundsExplicitNumCtxByNativeCapacity(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/ps":
+			_ = json.NewEncoder(w).Encode(api.ProcessResponse{})
+		case "/api/show":
+			_ = json.NewEncoder(w).Encode(api.ShowResponse{
+				Parameters: "temperature 0.2\nnum_ctx 524288\ntop_p 0.9",
+				ModelInfo:  map[string]any{"qwen3_5.context_length": float64(262_144)},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	base, _ := url.Parse(server.URL)
+	got := resolveLaunchContext(context.Background(), api.NewClient(base, server.Client()), LaunchModel{Name: "qwen3.8:27b-mlx"}, false)
+	if got.ContextLength != 262_144 {
+		t.Fatalf("context = %d, want native-bounded 262144", got.ContextLength)
+	}
+}
+
+func TestResolveLaunchContextFallsBackToInventoryWhenAPIsFail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	base, _ := url.Parse(server.URL)
+	got := resolveLaunchContext(context.Background(), api.NewClient(base, server.Client()), LaunchModel{
+		Name:          "qwen3.8:27b-mlx",
+		ContextLength: 131_072,
+	}, true)
+	if got.ContextLength != 131_072 || got.RuntimeVerified {
+		t.Fatalf("resolution = %#v, want unverified inventory fallback 131072", got)
+	}
+}
+
+func TestResolveLaunchContextCloudDoesNotCallLocalServer(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "unexpected", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	base, _ := url.Parse(server.URL)
+	got := resolveLaunchContext(context.Background(), api.NewClient(base, server.Client()), LaunchModel{
+		Name:          "qwen3.5:cloud",
+		Remote:        true,
+		ContextLength: 262_144,
+	}, true)
+	if got.ContextLength != 262_144 {
+		t.Fatalf("context = %d, want cloud metadata 262144", got.ContextLength)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("local API calls = %d, want 0", calls.Load())
+	}
+}
 
 func TestProcessContextWindowMatchesLatestAlias(t *testing.T) {
 	got := processContextWindow("ornith", &api.ProcessResponse{

--- a/cmd/launch/qwen.go
+++ b/cmd/launch/qwen.go
@@ -18,7 +18,9 @@ const qwenOllamaEnvKey = "OLLAMA_API_KEY"
 
 var qwenGOOS = runtime.GOOS
 
-type Qwen struct{}
+type Qwen struct {
+	resolveContext func(LaunchModel, bool) contextWindowResolution
+}
 
 func (q *Qwen) String() string { return "Qwen Code" }
 
@@ -222,10 +224,21 @@ func qwenInstallerCommand(goos string) (string, []string, error) {
 	}
 }
 
-func (q *Qwen) Run(model string, _ []LaunchModel, args []string) error {
+func (q *Qwen) Run(model string, models []LaunchModel, args []string) error {
 	qwenPath, err := q.findPath()
 	if err != nil {
 		return fmt.Errorf("qwen is not installed: %w", err)
+	}
+
+	model = qwenEffectiveModel(model, args)
+	launchModel, ok := findLaunchModel(models, model)
+	if !ok {
+		launchModel = fallbackLaunchModel(model)
+	}
+	resolution := q.contextWindow(launchModel, true)
+	qwenWarnUnverifiedContext(model, resolution, false)
+	if err := q.writeConfig(model, resolution.ContextLength); err != nil {
+		return fmt.Errorf("refresh qwen context: %w", err)
 	}
 
 	cmd := exec.Command(qwenPath, qwenLaunchArgs(model, args)...)
@@ -248,7 +261,30 @@ func (q *Qwen) Configure(model string) error {
 	if model == "" {
 		return nil
 	}
+	return q.writeConfig(model, 0)
+}
 
+func (q *Qwen) ConfigureWithModels(model string, models []LaunchModel) error {
+	if model == "" {
+		return nil
+	}
+	launchModel, ok := findLaunchModel(models, model)
+	if !ok {
+		launchModel = fallbackLaunchModel(model)
+	}
+	resolution := q.contextWindow(launchModel, false)
+	qwenWarnUnverifiedContext(model, resolution, true)
+	return q.writeConfig(model, resolution.ContextLength)
+}
+
+func (q *Qwen) contextWindow(model LaunchModel, load bool) contextWindowResolution {
+	if q != nil && q.resolveContext != nil {
+		return q.resolveContext(model, load)
+	}
+	return resolveLaunchContextFromEnvironment(model, load)
+}
+
+func (q *Qwen) writeConfig(model string, contextWindow int) error {
 	configPath, err := q.configPath()
 	if err != nil {
 		return err
@@ -262,7 +298,7 @@ func (q *Qwen) Configure(model string) error {
 		return err
 	}
 
-	applyQwenOllamaConfig(cfg, model)
+	applyQwenOllamaConfig(cfg, model, contextWindow)
 
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
@@ -272,13 +308,13 @@ func (q *Qwen) Configure(model string) error {
 	return fileutil.WriteWithBackup(configPath, data, "qwen")
 }
 
-func applyQwenOllamaConfig(cfg map[string]any, model string) {
+func applyQwenOllamaConfig(cfg map[string]any, model string, contextWindow int) {
 	envCfg := qwenMap(cfg["env"])
 	envCfg[qwenOllamaEnvKey] = "ollama"
 	cfg["env"] = envCfg
 
 	modelProviders := qwenMap(cfg["modelProviders"])
-	modelProviders["openai"] = qwenMergeOpenAIProviders(modelProviders["openai"], qwenProvider(model))
+	modelProviders["openai"] = qwenMergeOpenAIProviders(modelProviders["openai"], qwenProvider(model, contextWindow))
 	cfg["modelProviders"] = modelProviders
 
 	security := qwenMap(cfg["security"])
@@ -301,6 +337,33 @@ func qwenMap(value any) map[string]any {
 }
 
 func qwenMergeOpenAIProviders(value any, provider map[string]any) []any {
+	providerID, _ := provider["id"].(string)
+	for _, existing := range qwenProviderList(value) {
+		existingProvider, ok := existing.(map[string]any)
+		if !ok || !qwenIsOllamaProvider(existingProvider) || existingProvider["id"] != providerID {
+			continue
+		}
+		preserved := make(map[string]any, len(existingProvider)+len(provider))
+		for key, item := range existingProvider {
+			preserved[key] = item
+		}
+		for key, item := range provider {
+			preserved[key] = item
+		}
+		generation := qwenMap(existingProvider["generationConfig"])
+		generation = cloneQwenMap(generation)
+		if desired := qwenMap(provider["generationConfig"]); len(desired) > 0 {
+			for key, item := range desired {
+				generation[key] = item
+			}
+		}
+		if len(generation) > 0 {
+			preserved["generationConfig"] = generation
+		}
+		provider = preserved
+		break
+	}
+
 	merged := []any{provider}
 	for _, existing := range qwenProviderList(value) {
 		if qwenIsOllamaProvider(existing) {
@@ -309,6 +372,14 @@ func qwenMergeOpenAIProviders(value any, provider map[string]any) []any {
 		merged = append(merged, existing)
 	}
 	return merged
+}
+
+func cloneQwenMap(value map[string]any) map[string]any {
+	cloned := make(map[string]any, len(value))
+	for key, item := range value {
+		cloned[key] = item
+	}
+	return cloned
 }
 
 func qwenProviderList(value any) []any {
@@ -407,13 +478,53 @@ func qwenBaseURL() string {
 	return strings.TrimRight(envconfig.Host().String(), "/") + "/v1"
 }
 
-func qwenProvider(model string) map[string]any {
-	return map[string]any{
+func qwenProvider(model string, contextWindow int) map[string]any {
+	provider := map[string]any{
 		"id":      model,
 		"name":    fmt.Sprintf("%s (Ollama)", model),
 		"baseUrl": qwenBaseURL(),
 		"envKey":  qwenOllamaEnvKey,
 	}
+	if contextWindow > 0 {
+		provider["generationConfig"] = map[string]any{"contextWindowSize": contextWindow}
+	}
+	return provider
+}
+
+func qwenEffectiveModel(model string, args []string) string {
+	for i := 0; i < len(args); i++ {
+		switch {
+		case args[i] == "--model" || args[i] == "-m":
+			if i+1 < len(args) && strings.TrimSpace(args[i+1]) != "" {
+				model = strings.TrimSpace(args[i+1])
+				i++
+			}
+		case strings.HasPrefix(args[i], "--model="):
+			if value := strings.TrimSpace(strings.TrimPrefix(args[i], "--model=")); value != "" {
+				model = value
+			}
+		case strings.HasPrefix(args[i], "-m="):
+			if value := strings.TrimSpace(strings.TrimPrefix(args[i], "-m=")); value != "" {
+				model = value
+			}
+		}
+	}
+	return model
+}
+
+func qwenWarnUnverifiedContext(model string, resolution contextWindowResolution, refreshOnLaunch bool) {
+	if resolution.RuntimeVerified || isCloudModelName(model) {
+		return
+	}
+	suffix := ""
+	if refreshOnLaunch {
+		suffix = "; it will be runtime-verified when Qwen Code launches"
+	}
+	if resolution.ContextLength > 0 {
+		fmt.Fprintf(os.Stderr, "%s  Warning: %s's loaded context is not yet verified; using %d from %s%s%s\n", ansiYellow, model, resolution.ContextLength, resolution.Source, suffix, ansiReset)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "%s  Warning: could not determine %s's context; Qwen Code will use its fallback%s%s\n", ansiYellow, model, suffix, ansiReset)
 }
 
 func qwenLaunchArgs(model string, args []string) []string {

--- a/cmd/launch/qwen_test.go
+++ b/cmd/launch/qwen_test.go
@@ -79,6 +79,66 @@ func TestQwenConfigure(t *testing.T) {
 	}
 }
 
+func TestQwenConfigureWithModelsWritesProviderContextWindow(t *testing.T) {
+	tmpDir := t.TempDir()
+	setQwenTestHome(t, tmpDir)
+
+	q := &Qwen{resolveContext: func(model LaunchModel, load bool) contextWindowResolution {
+		if load {
+			t.Fatal("ConfigureWithModels must not load the model")
+		}
+		return contextWindowResolution{ContextLength: model.ContextLength, Source: contextWindowSourceInventory}
+	}}
+	if err := q.ConfigureWithModels("qwen3.8:27b-mlx", []LaunchModel{{
+		Name:          "qwen3.8:27b-mlx",
+		ContextLength: 262_144,
+	}}); err != nil {
+		t.Fatalf("ConfigureWithModels() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, ".qwen", "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	provider := cfg["modelProviders"].(map[string]any)["openai"].([]any)[0].(map[string]any)
+	generation := provider["generationConfig"].(map[string]any)
+	if generation["contextWindowSize"] != float64(262_144) {
+		t.Fatalf("contextWindowSize = %v, want 262144", generation["contextWindowSize"])
+	}
+}
+
+func TestQwenProviderPreservesCompatibleSettingsOnlyForSameModel(t *testing.T) {
+	existing := []any{map[string]any{
+		"id":      "qwen3.8:27b-mlx",
+		"name":    "custom name",
+		"baseUrl": qwenBaseURL(),
+		"envKey":  qwenOllamaEnvKey,
+		"generationConfig": map[string]any{
+			"temperature":       0.2,
+			"contextWindowSize": float64(1_000_000),
+		},
+	}}
+
+	same := qwenMergeOpenAIProviders(existing, qwenProvider("qwen3.8:27b-mlx", 262_144))
+	sameGeneration := same[0].(map[string]any)["generationConfig"].(map[string]any)
+	if sameGeneration["temperature"] != 0.2 || sameGeneration["contextWindowSize"] != 262_144 {
+		t.Fatalf("same-model generation config = %#v, want temperature preserved and context refreshed", sameGeneration)
+	}
+
+	switched := qwenMergeOpenAIProviders(existing, qwenProvider("gemma4", 65_536))
+	switchedGeneration := switched[0].(map[string]any)["generationConfig"].(map[string]any)
+	if _, ok := switchedGeneration["temperature"]; ok {
+		t.Fatalf("model-specific temperature transferred across models: %#v", switchedGeneration)
+	}
+	if switchedGeneration["contextWindowSize"] != 65_536 {
+		t.Fatalf("contextWindowSize = %v, want 65536", switchedGeneration["contextWindowSize"])
+	}
+}
+
 func TestQwenConfigureBacksUpUnderIntegrationDirectory(t *testing.T) {
 	tmpDir := t.TempDir()
 	setQwenTestHome(t, tmpDir)
@@ -327,6 +387,10 @@ func TestQwenIntegration(t *testing.T) {
 		var _ ManagedSingleModel = q
 	})
 
+	t.Run("implements ManagedModelListConfigurer", func(t *testing.T) {
+		var _ ManagedModelListConfigurer = q
+	})
+
 	t.Run("implements ManagedInteractiveOnboarding", func(t *testing.T) {
 		var _ ManagedInteractiveOnboarding = q
 	})
@@ -389,6 +453,26 @@ func TestQwenLaunchArgs(t *testing.T) {
 	}
 }
 
+func TestQwenEffectiveModelUsesSupportedOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "long separated", args: []string{"--model", "gemma4"}, want: "gemma4"},
+		{name: "short separated", args: []string{"-m", "qwen3:8b"}, want: "qwen3:8b"},
+		{name: "long equals", args: []string{"--model=phi4-mini"}, want: "phi4-mini"},
+		{name: "last override wins", args: []string{"-m", "gemma4", "--model=qwen3:8b"}, want: "qwen3:8b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := qwenEffectiveModel("llama3.2", tt.args); got != tt.want {
+				t.Fatalf("effective model = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestQwenLaunchEnv(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "")
 	t.Setenv("OPENAI_BASE_URL", "")
@@ -423,7 +507,7 @@ func TestQwenLaunchEnvOverridesExistingOpenAIEnv(t *testing.T) {
 	}
 }
 
-func TestQwenRunDoesNotRewriteConfig(t *testing.T) {
+func TestQwenRunRefreshesContextBeforeExec(t *testing.T) {
 	tmpDir := t.TempDir()
 	setQwenTestHome(t, tmpDir)
 	t.Chdir(tmpDir)
@@ -455,13 +539,19 @@ func TestQwenRunDoesNotRewriteConfig(t *testing.T) {
 		t.Fatalf("failed to create config dir: %v", err)
 	}
 
-	initialConfig := []byte(`{"model":{"name":"qwen3:32b"}}`)
+	initialConfig := []byte(`{"model":{"name":"qwen3:32b"},"modelProviders":{"openai":[{"id":"qwen3:32b","name":"qwen3:32b (Ollama)","envKey":"OLLAMA_API_KEY","baseUrl":"` + qwenBaseURL() + `","generationConfig":{"contextWindowSize":1000000,"temperature":0.2}}]}}`)
 	configPath := filepath.Join(configDir, "settings.json")
 	if err := os.WriteFile(configPath, initialConfig, 0o644); err != nil {
 		t.Fatalf("failed to write initial config: %v", err)
 	}
 
-	if err := (&Qwen{}).Run("qwen3:32b", nil, nil); err != nil {
+	q := &Qwen{resolveContext: func(model LaunchModel, load bool) contextWindowResolution {
+		if !load {
+			t.Fatal("Run must request a loaded runtime context")
+		}
+		return contextWindowResolution{ContextLength: 65_536, RuntimeVerified: true}
+	}}
+	if err := q.Run("qwen3:32b", []LaunchModel{{Name: "qwen3:32b", ContextLength: 262_144}}, nil); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
 
@@ -469,8 +559,17 @@ func TestQwenRunDoesNotRewriteConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read config after run: %v", err)
 	}
-	if string(data) != string(initialConfig) {
-		t.Fatalf("expected run not to rewrite config, got %s", string(data))
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	provider := cfg["modelProviders"].(map[string]any)["openai"].([]any)[0].(map[string]any)
+	generation := provider["generationConfig"].(map[string]any)
+	if generation["contextWindowSize"] != float64(65_536) {
+		t.Fatalf("contextWindowSize = %v, want refreshed 65536", generation["contextWindowSize"])
+	}
+	if generation["temperature"] != 0.2 {
+		t.Fatalf("compatible generation setting lost: %#v", generation)
 	}
 }
 


### PR DESCRIPTION
## Summary

- resolve the effective local context from a model-only load followed by `/api/ps`
- retain explicit `num_ctx`, native model, and inventory fallbacks without treating them as runtime verification
- write Qwen Code's context to the selected Ollama provider's `generationConfig.contextWindowSize`
- refresh on every launch and preserve compatible settings only for the same model and endpoint

Fixes #18256.

## Why

Qwen Code otherwise uses its own 1,000,000-token default even when Ollama's loaded runner has a smaller context. This can delay Qwen Code's normal compaction beyond the capacity Ollama actually serves.

The resolver follows the existing Muse launcher convention: a model-only request bounded to five minutes, then `/api/ps` as the runtime authority. Configuration-only operations never preload a model, and cloud models retain their metadata path.

## Test report

- `go test ./cmd/launch -count=1`
- `go test -race ./cmd/launch -count=1`
- `go vet ./cmd/launch`
- `go build .`
- `git diff --check`
- fork workflow: https://github.com/aeltawela/ollama/actions/runs/33961467079
- real `qwen3.8:27b-mlx` launch: `/api/ps` and the generated Qwen provider both reported 262,144
- isolated HTTP behavior tests cover a 65,536 runtime context, cold and warm loads, configuration-only behavior, aliases, custom endpoints, model switches, repeated launches, cloud models, API failures, incomplete metadata, and warning fallbacks
- configuration behavior tests cover preserving unrelated providers and compatible same-model settings without transferring model-specific settings to another model

Tested revision: `cb09135739d2e2cab26a83be83cfbf3eb58c8dab`

## Validation limitation

The exact separate-server 65,536 test is covered through the launcher's HTTP boundary with a real Ollama API client, but not with a second real model runner: the locally resident test model was unavailable from the on-disk model store. The test did not unload or alter an existing user session, and this degraded path is not counted as runtime verification.

A full live compaction stress run was not completed. The launcher leaves Qwen Code's compaction behavior unchanged; the tests verify the context boundary and generated configuration rather than Qwen Code internals.
