### PR TITLE
launch: align Codex CLI context with Ollama

### DIFF
--- a/cmd/launch/codex.go
+++ b/cmd/launch/codex.go
@@ -125,7 +125,7 @@ func codexWarnUnverifiedContext(model string, resolution contextWindowResolution
 }
 
 func codexConfiguredContextWindow() (int, error) {
-	configPath, err := codexConfigPath()
+	configPath, err := codexCLIConfigPath()
 	if err != nil {
 		return 0, err
 	}
@@ -221,7 +221,7 @@ func codexContextWindowAssignment(assignment string) (int, bool, error) {
 }
 
 func (c *Codex) Restore() error {
-	configPath, err := codexConfigPath()
+	configPath, err := codexCLIConfigPath()
 	if err != nil {
 		return err
 	}
@@ -349,7 +349,7 @@ func codexConfigOverrideConflicts(value string) bool {
 // ensureCodexConfig writes a Codex profile file and model catalog so Codex uses
 // the local Ollama server without changing app-visible root config.
 func ensureCodexConfig(modelName string, models []LaunchModel) error {
-	configPath, err := codexConfigPath()
+	configPath, err := codexCLIConfigPath()
 	if err != nil {
 		return err
 	}
@@ -379,8 +379,15 @@ func codexConfigPath() (string, error) {
 	return filepath.Join(home, ".codex", "config.toml"), nil
 }
 
+func codexCLIConfigPath() (string, error) {
+	if codexHome := os.Getenv("CODEX_HOME"); codexHome != "" {
+		return filepath.Join(codexHome, "config.toml"), nil
+	}
+	return codexConfigPath()
+}
+
 func codexModelCatalogPath() (string, error) {
-	configPath, err := codexConfigPath()
+	configPath, err := codexCLIConfigPath()
 	if err != nil {
 		return "", err
 	}
@@ -392,7 +399,7 @@ func codexModelCatalogPathForConfig(configPath string) string {
 }
 
 func codexProfileConfigPath() (string, error) {
-	configPath, err := codexConfigPath()
+	configPath, err := codexCLIConfigPath()
 	if err != nil {
 		return "", err
 	}

--- a/cmd/launch/codex.go
+++ b/cmd/launch/codex.go
@@ -1,6 +1,7 @@
 package launch
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -9,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/cmd/internal/fileutil"
 	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/types/model"
@@ -18,7 +20,8 @@ import (
 
 // Codex implements Runner for Codex integration
 type Codex struct {
-	resolveContext func(LaunchModel, bool) contextWindowResolution
+	resolveContext       func(LaunchModel, bool) contextWindowResolution
+	resolveModelMetadata func(LaunchModel) LaunchModel
 }
 
 func (c *Codex) String() string { return "Codex CLI" }
@@ -69,6 +72,7 @@ func (c *Codex) Run(model string, models []LaunchModel, args []string) error {
 	if resolution.ContextLength > 0 {
 		launchModel.ContextLength = resolution.ContextLength
 	}
+	launchModel = c.modelMetadata(launchModel)
 
 	inheritedContext, err := codexConfiguredContextWindow()
 	if err != nil {
@@ -111,6 +115,53 @@ func (c *Codex) contextWindow(model LaunchModel) contextWindowResolution {
 		return c.resolveContext(model, true)
 	}
 	return resolveLaunchContextFromEnvironment(model, true)
+}
+
+func (c *Codex) modelMetadata(model LaunchModel) LaunchModel {
+	if c != nil && c.resolveModelMetadata != nil {
+		return c.resolveModelMetadata(model)
+	}
+	return resolveCodexModelMetadataFromEnvironment(model)
+}
+
+func resolveCodexModelMetadataFromEnvironment(launchModel LaunchModel) LaunchModel {
+	if launchModel.Remote || isCloudModelName(launchModel.Name) {
+		return launchModel
+	}
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		return launchModel
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), launchContextLoadTimeout)
+	defer cancel()
+	shown, err := client.Show(ctx, &api.ShowRequest{Model: launchModel.Name})
+	if err != nil {
+		return launchModel
+	}
+	if len(shown.Capabilities) > 0 {
+		launchModel.Capabilities = append([]model.Capability(nil), shown.Capabilities...)
+	}
+	if thinking, ok := codexThinkingRecommendationFromShow(shown); ok {
+		launchModel.Thinking = thinking
+	}
+	return launchModel
+}
+
+func codexThinkingRecommendationFromShow(shown *api.ShowResponse) (*api.ModelRecommendationThinking, bool) {
+	if shown == nil {
+		return nil, false
+	}
+	renderer := shown.Renderer
+	if renderer == "" {
+		for line := range strings.SplitSeq(shown.Modelfile, "\n") {
+			fields := strings.Fields(line)
+			if len(fields) == 2 && strings.EqualFold(fields[0], "RENDERER") {
+				renderer = fields[1]
+				break
+			}
+		}
+	}
+	return codexThinkingRecommendationForRenderer(renderer)
 }
 
 func codexWarnUnverifiedContext(model string, resolution contextWindowResolution) {
@@ -883,6 +934,23 @@ func buildCodexModelEntry(launchModel LaunchModel) map[string]any {
 		truncationMode = "tokens"
 	}
 
+	var defaultReasoningLevel any
+	var supportedReasoningLevels []any
+	if thinking, ok := codexAppThinkingContractFromRecommendation(launchModel.Thinking); ok {
+		if thinking.defaultLevel != "" {
+			defaultReasoningLevel = thinking.defaultLevel
+		}
+		for _, level := range thinking.levels {
+			supportedReasoningLevels = append(supportedReasoningLevels, map[string]any{
+				"effort":      level,
+				"description": codexAppThinkingLevelDescription(level),
+			})
+		}
+	}
+	if supportedReasoningLevels == nil {
+		supportedReasoningLevels = []any{}
+	}
+
 	return map[string]any{
 		"slug":                         modelName,
 		"display_name":                 modelName,
@@ -898,8 +966,21 @@ func buildCodexModelEntry(launchModel LaunchModel) map[string]any {
 		"default_verbosity":            "low",
 		"supports_parallel_tool_calls": false,
 		"supports_reasoning_summaries": false,
-		"supported_reasoning_levels":   []any{},
+		"default_reasoning_level":      defaultReasoningLevel,
+		"supported_reasoning_levels":   supportedReasoningLevels,
 		"experimental_supported_tools": []any{},
+	}
+}
+
+func codexThinkingRecommendationForRenderer(renderer string) (*api.ModelRecommendationThinking, bool) {
+	switch strings.ToLower(strings.TrimSpace(renderer)) {
+	case "qwen3.8":
+		return &api.ModelRecommendationThinking{
+			Values:  []any{false, "low", "medium", "high"},
+			Default: "high",
+		}, true
+	default:
+		return nil, false
 	}
 }
 

--- a/cmd/launch/codex.go
+++ b/cmd/launch/codex.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/ollama/ollama/cmd/internal/fileutil"
@@ -16,7 +17,9 @@ import (
 )
 
 // Codex implements Runner for Codex integration
-type Codex struct{}
+type Codex struct {
+	resolveContext func(LaunchModel, bool) contextWindowResolution
+}
 
 func (c *Codex) String() string { return "Codex CLI" }
 
@@ -33,7 +36,7 @@ const (
 	codexRootOpenAIBaseURLKey    = "openai_base_url"
 )
 
-func (c *Codex) args(model, modelCatalogPath string, extra []string) ([]string, error) {
+func (c *Codex) args(model, modelCatalogPath string, contextWindow int, extra []string) ([]string, error) {
 	if err := codexValidateExtraArgs(extra); err != nil {
 		return nil, err
 	}
@@ -41,6 +44,9 @@ func (c *Codex) args(model, modelCatalogPath string, extra []string) ([]string, 
 	args := []string{"--profile", codexProfileName}
 	for _, override := range codexManagedConfigOverrides(modelCatalogPath) {
 		args = append(args, "-c", override)
+	}
+	if contextWindow > 0 {
+		args = append(args, "-c", fmt.Sprintf("model_context_window=%d", contextWindow))
 	}
 	if model != "" {
 		args = append(args, "-m", model)
@@ -50,11 +56,33 @@ func (c *Codex) args(model, modelCatalogPath string, extra []string) ([]string, 
 }
 
 func (c *Codex) Run(model string, models []LaunchModel, args []string) error {
+	if err := codexValidateExtraArgs(args); err != nil {
+		return fmt.Errorf("failed to configure codex: %w", err)
+	}
 	if err := checkCodexVersion(); err != nil {
 		return err
 	}
 
-	if err := ensureCodexConfig(model, models); err != nil {
+	launchModel := codexCatalogModel(model, models)
+	resolution := c.contextWindow(launchModel)
+	codexWarnUnverifiedContext(model, resolution)
+	if resolution.ContextLength > 0 {
+		launchModel.ContextLength = resolution.ContextLength
+	}
+
+	inheritedContext, err := codexConfiguredContextWindow()
+	if err != nil {
+		return fmt.Errorf("failed to configure codex: %w", err)
+	}
+	effectiveContext, cleanArgs, corrected, err := codexReconcileContextWindow(resolution.ContextLength, inheritedContext, args)
+	if err != nil {
+		return fmt.Errorf("failed to configure codex: %w", err)
+	}
+	if corrected {
+		fmt.Fprintf(os.Stderr, "%s  Warning: configured model_context_window exceeds Ollama's %d-token context; using %d%s\n", ansiYellow, resolution.ContextLength, effectiveContext, ansiReset)
+	}
+
+	if err := ensureCodexConfig(model, []LaunchModel{launchModel}); err != nil {
 		return fmt.Errorf("failed to configure codex: %w", err)
 	}
 
@@ -63,7 +91,7 @@ func (c *Codex) Run(model string, models []LaunchModel, args []string) error {
 		return fmt.Errorf("failed to configure codex: %w", err)
 	}
 
-	codexArgs, err := c.args(model, catalogPath, args)
+	codexArgs, err := c.args(model, catalogPath, effectiveContext, cleanArgs)
 	if err != nil {
 		return fmt.Errorf("failed to configure codex: %w", err)
 	}
@@ -76,6 +104,120 @@ func (c *Codex) Run(model string, models []LaunchModel, args []string) error {
 		"OPENAI_API_KEY=ollama",
 	)
 	return cmd.Run()
+}
+
+func (c *Codex) contextWindow(model LaunchModel) contextWindowResolution {
+	if c != nil && c.resolveContext != nil {
+		return c.resolveContext(model, true)
+	}
+	return resolveLaunchContextFromEnvironment(model, true)
+}
+
+func codexWarnUnverifiedContext(model string, resolution contextWindowResolution) {
+	if resolution.RuntimeVerified || isCloudModelName(model) {
+		return
+	}
+	if resolution.ContextLength > 0 {
+		fmt.Fprintf(os.Stderr, "%s  Warning: could not verify %s's loaded context; using %d from %s%s\n", ansiYellow, model, resolution.ContextLength, resolution.Source, ansiReset)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "%s  Warning: could not determine %s's context; Codex will use its existing fallback%s\n", ansiYellow, model, ansiReset)
+}
+
+func codexConfiguredContextWindow() (int, error) {
+	configPath, err := codexConfigPath()
+	if err != nil {
+		return 0, err
+	}
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, nil
+		}
+		return 0, err
+	}
+	config, err := codexParseConfig(string(data))
+	if err != nil {
+		return 0, err
+	}
+	value, _ := config.Int("model_context_window")
+	return value, nil
+}
+
+func codexReconcileContextWindow(available, inherited int, extra []string) (int, []string, bool, error) {
+	if available <= 0 {
+		return 0, append([]string(nil), extra...), false, nil
+	}
+
+	requested, found, cleaned, err := codexExtractContextWindowOverride(extra)
+	if err != nil {
+		return 0, nil, false, err
+	}
+	if !found {
+		requested = inherited
+	}
+	if requested <= 0 {
+		requested = available
+	}
+	corrected := requested > available
+	if corrected {
+		requested = available
+	}
+	return requested, cleaned, corrected, nil
+}
+
+func codexExtractContextWindowOverride(args []string) (int, bool, []string, error) {
+	cleaned := make([]string, 0, len(args))
+	var requested int
+	var found bool
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if (arg == "-c" || arg == "--config") && i+1 < len(args) {
+			if value, ok, err := codexContextWindowAssignment(args[i+1]); ok || err != nil {
+				if err != nil {
+					return 0, false, nil, err
+				}
+				requested, found = value, true
+				i++
+				continue
+			}
+			cleaned = append(cleaned, arg, args[i+1])
+			i++
+			continue
+		}
+
+		assignment := ""
+		switch {
+		case strings.HasPrefix(arg, "--config="):
+			assignment = strings.TrimPrefix(arg, "--config=")
+		case strings.HasPrefix(arg, "-c") && len(arg) > len("-c"):
+			assignment = strings.TrimPrefix(strings.TrimPrefix(arg, "-c"), "=")
+		}
+		if assignment != "" {
+			if value, ok, err := codexContextWindowAssignment(assignment); ok || err != nil {
+				if err != nil {
+					return 0, false, nil, err
+				}
+				requested, found = value, true
+				continue
+			}
+		}
+		cleaned = append(cleaned, arg)
+	}
+	return requested, found, cleaned, nil
+}
+
+func codexContextWindowAssignment(assignment string) (int, bool, error) {
+	key, value, ok := strings.Cut(strings.TrimSpace(assignment), "=")
+	if !ok || strings.Trim(strings.TrimSpace(key), `"'`) != "model_context_window" {
+		return 0, false, nil
+	}
+	value = strings.ReplaceAll(strings.TrimSpace(value), "_", "")
+	n, err := strconv.Atoi(value)
+	if err != nil || n <= 0 {
+		return 0, true, fmt.Errorf("invalid model_context_window override %q", assignment)
+	}
+	return n, true, nil
 }
 
 func (c *Codex) Restore() error {
@@ -406,6 +548,31 @@ type codexParsedConfig struct {
 	values map[string]any
 }
 
+func (c codexParsedConfig) Int(path ...string) (int, bool) {
+	if len(path) == 0 {
+		return 0, false
+	}
+	var current any = c.values
+	for _, part := range path {
+		table, ok := current.(map[string]any)
+		if !ok {
+			return 0, false
+		}
+		current, ok = table[part]
+		if !ok {
+			return 0, false
+		}
+	}
+	switch value := current.(type) {
+	case int64:
+		return int(value), value > 0
+	case int:
+		return value, value > 0
+	default:
+		return 0, false
+	}
+}
+
 func (c codexParsedConfig) String(path ...string) (string, bool) {
 	if len(path) == 0 {
 		return "", false
@@ -697,12 +864,6 @@ func buildCodexModelEntry(launchModel LaunchModel) map[string]any {
 	}
 	if l, ok := lookupCloudModelLimit(modelName); ok {
 		contextWindow = l.Context
-	}
-
-	if !isCloudModelName(modelName) && launchModel.Details.Format != "safetensors" {
-		if ctxLen := envconfig.ContextLength(); ctxLen > 0 {
-			contextWindow = int(ctxLen)
-		}
 	}
 
 	modalities := []string{"text"}

--- a/cmd/launch/codex_test.go
+++ b/cmd/launch/codex_test.go
@@ -38,6 +38,7 @@ func TestCodexArgs(t *testing.T) {
 		"-c", fmt.Sprintf("model_providers.%s.base_url=%q", codexProfileName, codexBaseURL()),
 		"-c", fmt.Sprintf("model_providers.%s.wire_api=%q", codexProfileName, "responses"),
 		"-c", fmt.Sprintf("%s=%q", codexRootModelCatalogJSONKey, catalogPath),
+		"-c", "model_context_window=65536",
 	}
 
 	tests := []struct {
@@ -53,7 +54,7 @@ func TestCodexArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := c.args(tt.model, catalogPath, tt.args)
+			got, err := c.args(tt.model, catalogPath, 65_536, tt.args)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -73,7 +74,7 @@ func TestCodexArgsRejectManagedProfile(t *testing.T) {
 		{"--profile=myprofile"},
 	} {
 		t.Run(strings.Join(extra, " "), func(t *testing.T) {
-			_, err := c.args("llama3.2", "", extra)
+			_, err := c.args("llama3.2", "", 65_536, extra)
 			if err == nil || !strings.Contains(err.Error(), "manages --profile") {
 				t.Fatalf("args error = %v, want profile conflict", err)
 			}
@@ -93,11 +94,114 @@ func TestCodexArgsRejectManagedOverrides(t *testing.T) {
 		{"--config=model_providers.ollama-launch.base_url=\"http://other.invalid/v1/\""},
 	} {
 		t.Run(strings.Join(extra, " "), func(t *testing.T) {
-			_, err := c.args("llama3.2", "", extra)
+			_, err := c.args("llama3.2", "", 65_536, extra)
 			if err == nil {
 				t.Fatalf("args error = nil, want managed config conflict")
 			}
 		})
+	}
+}
+
+func TestCodexContextOverridePreservesSmallerAndClampsLarger(t *testing.T) {
+	tests := []struct {
+		name          string
+		available     int
+		inherited     int
+		extra         []string
+		wantEffective int
+		wantCorrected bool
+	}{
+		{name: "runtime default", available: 65_536, wantEffective: 65_536},
+		{name: "smaller inherited budget", available: 65_536, inherited: 32_768, wantEffective: 32_768},
+		{name: "larger inherited budget", available: 65_536, inherited: 1_000_000, wantEffective: 65_536, wantCorrected: true},
+		{name: "smaller CLI budget", available: 65_536, inherited: 48_000, extra: []string{"-c", "model_context_window=16384"}, wantEffective: 16_384},
+		{name: "larger CLI budget", available: 65_536, extra: []string{"--config=model_context_window=1000000"}, wantEffective: 65_536, wantCorrected: true},
+		{name: "compact short CLI budget", available: 65_536, extra: []string{"-c=model_context_window=32768"}, wantEffective: 32_768},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, cleaned, corrected, err := codexReconcileContextWindow(tt.available, tt.inherited, tt.extra)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.wantEffective || corrected != tt.wantCorrected {
+				t.Fatalf("effective = %d, corrected = %v; want %d, %v", got, corrected, tt.wantEffective, tt.wantCorrected)
+			}
+			for _, arg := range cleaned {
+				if strings.Contains(arg, "model_context_window") {
+					t.Fatalf("cleaned args retained managed override: %v", cleaned)
+				}
+			}
+		})
+	}
+}
+
+func TestCodexRunWritesRuntimeContextAndOverridesConflictingRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	argsLog := filepath.Join(tmpDir, "codex-args.json")
+	script := fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "--version" ]; then
+  echo "codex-cli 0.153.2"
+  exit 0
+fi
+printf '%%s\n' "$@" > %q
+`, argsLog)
+	if err := os.WriteFile(filepath.Join(binDir, "codex"), []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	configDir := filepath.Join(tmpDir, ".codex")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rootConfig := "model_context_window = 1000000\nmodel_auto_compact_token_limit = 60000\n"
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), []byte(rootConfig), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &Codex{resolveContext: func(model LaunchModel, load bool) contextWindowResolution {
+		if !load {
+			t.Fatal("Codex Run must load before resolving context")
+		}
+		return contextWindowResolution{ContextLength: 65_536, RuntimeVerified: true, Source: contextWindowSourceRuntime}
+	}}
+	if err := c.Run("qwen3.8:27b-mlx", []LaunchModel{{Name: "qwen3.8:27b-mlx", ContextLength: 262_144}}, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	catalogData, err := os.ReadFile(filepath.Join(configDir, "model.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var catalog struct {
+		Models []map[string]any `json:"models"`
+	}
+	if err := json.Unmarshal(catalogData, &catalog); err != nil {
+		t.Fatal(err)
+	}
+	if got := catalog.Models[0]["context_window"]; got != float64(65_536) {
+		t.Fatalf("catalog context_window = %v, want 65536", got)
+	}
+	argsData, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(argsData), "model_context_window=65536") {
+		t.Fatalf("managed runtime override missing from args:\n%s", argsData)
+	}
+	rootData, err := os.ReadFile(filepath.Join(configDir, "config.toml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(rootData), "model_auto_compact_token_limit = 60000") {
+		t.Fatalf("compatible compaction setting was not preserved:\n%s", rootData)
 	}
 }
 
@@ -615,14 +719,14 @@ func TestBuildCodexModelEntryContextWindow(t *testing.T) {
 			wantContext: 131072,
 		},
 		{
-			name: "OLLAMA_CONTEXT_LENGTH overrides local gguf inventory context",
+			name: "launcher environment does not override resolved model context",
 			model: LaunchModel{
 				Name:          "llama3.2",
 				ContextLength: 131072,
 				Details:       api.ModelDetails{Format: "gguf"},
 			},
 			envContextLen: "64000",
-			wantContext:   64000,
+			wantContext:   131072,
 		},
 		{
 			name: "safetensors uses inventory context only",

--- a/cmd/launch/codex_test.go
+++ b/cmd/launch/codex_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"slices"
@@ -186,12 +188,18 @@ printf '%%s\n' "$@" > %q
 		t.Fatal(err)
 	}
 
-	c := &Codex{resolveContext: func(model LaunchModel, load bool) contextWindowResolution {
-		if !load {
-			t.Fatal("Codex Run must load before resolving context")
-		}
-		return contextWindowResolution{ContextLength: 65_536, RuntimeVerified: true, Source: contextWindowSourceRuntime}
-	}}
+	c := &Codex{
+		resolveContext: func(model LaunchModel, load bool) contextWindowResolution {
+			if !load {
+				t.Fatal("Codex Run must load before resolving context")
+			}
+			return contextWindowResolution{ContextLength: 65_536, RuntimeVerified: true, Source: contextWindowSourceRuntime}
+		},
+		resolveModelMetadata: func(model LaunchModel) LaunchModel {
+			model.Thinking, _ = codexThinkingRecommendationForRenderer("qwen3.8")
+			return model
+		},
+	}
 	if err := c.Run("qwen3.8:27b-mlx", []LaunchModel{{Name: "qwen3.8:27b-mlx", ContextLength: 262_144}}, nil); err != nil {
 		t.Fatal(err)
 	}
@@ -208,6 +216,10 @@ printf '%%s\n' "$@" > %q
 	}
 	if got := catalog.Models[0]["context_window"]; got != float64(65_536) {
 		t.Fatalf("catalog context_window = %v, want 65536", got)
+	}
+	levels, _ := catalog.Models[0]["supported_reasoning_levels"].([]any)
+	if len(levels) != 4 {
+		t.Fatalf("catalog supported_reasoning_levels length = %d, want 4", len(levels))
 	}
 	argsData, err := os.ReadFile(argsLog)
 	if err != nil {
@@ -844,4 +856,162 @@ func TestBuildCodexModelEntryContextWindow(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildCodexModelEntryReasoningLevels(t *testing.T) {
+	entry := buildCodexModelEntry(LaunchModel{
+		Name:         "qwen3.8:27b-mlx",
+		Capabilities: []modelpkg.Capability{modelpkg.CapabilityThinking},
+		Thinking: &api.ModelRecommendationThinking{
+			Values:  []any{false, "low", "medium", "high"},
+			Default: "high",
+		},
+	})
+
+	if got := entry["default_reasoning_level"]; got != "high" {
+		t.Fatalf("default_reasoning_level = %v, want high", got)
+	}
+
+	levels, ok := entry["supported_reasoning_levels"].([]any)
+	if !ok {
+		t.Fatalf("supported_reasoning_levels = %T, want []any", entry["supported_reasoning_levels"])
+	}
+	want := []string{"none", "low", "medium", "high"}
+	if len(levels) != len(want) {
+		t.Fatalf("supported_reasoning_levels length = %d, want %d", len(levels), len(want))
+	}
+	for i, level := range levels {
+		item, ok := level.(map[string]any)
+		if !ok {
+			t.Fatalf("reasoning level %d = %T, want object", i, level)
+		}
+		if got := item["effort"]; got != want[i] {
+			t.Errorf("reasoning level %d effort = %v, want %s", i, got, want[i])
+		}
+		if description, _ := item["description"].(string); description == "" {
+			t.Errorf("reasoning level %q has no description", want[i])
+		}
+	}
+}
+
+func TestCodexThinkingRecommendationForRenderer(t *testing.T) {
+	tests := []struct {
+		name         string
+		renderer     string
+		wantDefault  any
+		wantValues   []any
+		wantResolved bool
+	}{
+		{
+			name:         "Qwen 3.8 exposes graded effort",
+			renderer:     "qwen3.8",
+			wantDefault:  "high",
+			wantValues:   []any{false, "low", "medium", "high"},
+			wantResolved: true,
+		},
+		{
+			name:     "unknown renderer is left unchanged",
+			renderer: "qwen3.5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := codexThinkingRecommendationForRenderer(tt.renderer)
+			if ok != tt.wantResolved {
+				t.Fatalf("resolved = %v, want %v", ok, tt.wantResolved)
+			}
+			if !ok {
+				return
+			}
+			if got.Default != tt.wantDefault {
+				t.Errorf("default = %#v, want %#v", got.Default, tt.wantDefault)
+			}
+			if !slices.Equal(got.Values, tt.wantValues) {
+				t.Errorf("values = %#v, want %#v", got.Values, tt.wantValues)
+			}
+		})
+	}
+}
+
+func TestCodexThinkingRecommendationFromShowUsesModelfileRenderer(t *testing.T) {
+	shown := &api.ShowResponse{
+		Modelfile: "FROM qwen3.8:27b-mlx\nTEMPLATE {{ .Prompt }}\nRENDERER qwen3.8\nPARSER qwen3.5\n",
+	}
+
+	got, ok := codexThinkingRecommendationFromShow(shown)
+	if !ok {
+		t.Fatal("expected Qwen 3.8 thinking recommendation")
+	}
+	if got.Default != "high" || !slices.Equal(got.Values, []any{false, "low", "medium", "high"}) {
+		t.Fatalf("thinking recommendation = %#v, want Qwen 3.8 levels", got)
+	}
+}
+
+func TestResolveCodexModelMetadataFromEnvironment(t *testing.T) {
+	t.Run("selected alias uses show metadata", func(t *testing.T) {
+		var requestedModel string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.URL.Path != "/api/show" {
+				t.Fatalf("path = %q, want /api/show", r.URL.Path)
+			}
+			var request api.ShowRequest
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatal(err)
+			}
+			requestedModel = request.Model
+			if err := json.NewEncoder(w).Encode(api.ShowResponse{
+				Modelfile:    "FROM qwen3.8:27b-mlx\nRENDERER qwen3.8\nPARSER qwen3.5\n",
+				Capabilities: []modelpkg.Capability{modelpkg.CapabilityCompletion, modelpkg.CapabilityThinking},
+			}); err != nil {
+				t.Fatal(err)
+			}
+		}))
+		defer server.Close()
+		t.Setenv("OLLAMA_HOST", server.URL)
+
+		got := resolveCodexModelMetadataFromEnvironment(LaunchModel{Name: "qwen-coding-alias"})
+		if requestedModel != "qwen-coding-alias" {
+			t.Fatalf("show model = %q, want selected alias", requestedModel)
+		}
+		if got.Thinking == nil || got.Thinking.Default != "high" {
+			t.Fatalf("thinking = %#v, want Qwen 3.8 recommendation", got.Thinking)
+		}
+		if !slices.Contains(got.Capabilities, modelpkg.CapabilityThinking) {
+			t.Fatalf("capabilities = %v, want thinking", got.Capabilities)
+		}
+	})
+
+	t.Run("show failure preserves inventory metadata", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			http.Error(w, "unavailable", http.StatusServiceUnavailable)
+		}))
+		defer server.Close()
+		t.Setenv("OLLAMA_HOST", server.URL)
+		thinking := &api.ModelRecommendationThinking{Values: []any{false, true}, Default: true}
+		model := LaunchModel{Name: "thinking-alias", Thinking: thinking}
+
+		got := resolveCodexModelMetadataFromEnvironment(model)
+		if got.Thinking != thinking {
+			t.Fatalf("thinking = %#v, want preserved inventory metadata", got.Thinking)
+		}
+	})
+
+	t.Run("cloud model does not call local show", func(t *testing.T) {
+		called := false
+		server := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			called = true
+		}))
+		defer server.Close()
+		t.Setenv("OLLAMA_HOST", server.URL)
+
+		model := LaunchModel{Name: "qwen3.8:cloud", Remote: true}
+		got := resolveCodexModelMetadataFromEnvironment(model)
+		if called {
+			t.Fatal("cloud model unexpectedly called local /api/show")
+		}
+		if got.Name != model.Name || !got.Remote {
+			t.Fatalf("model = %#v, want cloud metadata unchanged", got)
+		}
+	})
 }

--- a/cmd/launch/codex_test.go
+++ b/cmd/launch/codex_test.go
@@ -28,6 +28,26 @@ func TestCodexIntegration(t *testing.T) {
 	})
 }
 
+func TestEnsureCodexConfigUsesCodexHome(t *testing.T) {
+	osHome := filepath.Join(t.TempDir(), "home")
+	codexHome := filepath.Join(t.TempDir(), "codex-home")
+	setTestHome(t, osHome)
+	t.Setenv("CODEX_HOME", codexHome)
+
+	if err := ensureCodexConfig("llama3.2", []LaunchModel{{Name: "llama3.2"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, name := range []string{"model.json", codexProfileName + ".config.toml"} {
+		if _, err := os.Stat(filepath.Join(codexHome, name)); err != nil {
+			t.Fatalf("expected %s in CODEX_HOME: %v", name, err)
+		}
+	}
+	if _, err := os.Stat(filepath.Join(osHome, ".codex", "model.json")); !os.IsNotExist(err) {
+		t.Fatalf("launcher wrote outside CODEX_HOME: %v", err)
+	}
+}
+
 func TestCodexArgs(t *testing.T) {
 	c := &Codex{}
 	catalogPath := filepath.Join("tmp", "model.json")

--- a/cmd/launch/context_window.go
+++ b/cmd/launch/context_window.go
@@ -1,12 +1,132 @@
 package launch
 
 import (
+	"bufio"
 	"context"
+	"errors"
+	"fmt"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/ollama/ollama/api"
 	"github.com/ollama/ollama/internal/modelref"
 )
+
+const launchContextLoadTimeout = 5 * time.Minute
+
+type contextWindowSource string
+
+const (
+	contextWindowSourceRuntime   contextWindowSource = "loaded runtime"
+	contextWindowSourceParameter contextWindowSource = "model num_ctx parameter"
+	contextWindowSourceNative    contextWindowSource = "native model metadata"
+	contextWindowSourceInventory contextWindowSource = "model inventory"
+	contextWindowSourceCloud     contextWindowSource = "cloud model metadata"
+)
+
+// contextWindowResolution keeps the runner-verified context separate from
+// metadata fallbacks. Callers can safely continue with ContextLength while
+// still telling users when the server's effective value could not be checked.
+type contextWindowResolution struct {
+	ContextLength   int
+	RuntimeVerified bool
+	Source          contextWindowSource
+	Err             error
+}
+
+func resolveLaunchContextFromEnvironment(model LaunchModel, load bool) contextWindowResolution {
+	if model.Remote || isCloudModelName(model.Name) {
+		return resolveLaunchContext(context.Background(), nil, model.WithCloudLimits(), false)
+	}
+	client, err := api.ClientFromEnvironment()
+	if err != nil {
+		return contextWindowFallback(model, err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), launchContextLoadTimeout)
+	defer cancel()
+	return resolveLaunchContext(ctx, client, model, load)
+}
+
+// resolveLaunchContext obtains the context the local server actually assigned
+// from /api/ps. Actual launches first issue Ollama's model-only generation
+// request, which loads without changing any model options. Configuration-only
+// calls skip that load and use an already-running process or metadata.
+func resolveLaunchContext(ctx context.Context, client *api.Client, model LaunchModel, load bool) contextWindowResolution {
+	if model.Remote || isCloudModelName(model.Name) {
+		model = model.WithCloudLimits()
+		return contextWindowResolution{ContextLength: launchModelContextLength(model), Source: contextWindowSourceCloud}
+	}
+
+	var failures []error
+	if client != nil {
+		if load {
+			if err := client.Generate(ctx, &api.GenerateRequest{Model: model.Name}, func(api.GenerateResponse) error { return nil }); err != nil {
+				failures = append(failures, fmt.Errorf("load model: %w", err))
+			}
+		}
+
+		if running, err := client.ListRunning(ctx); err == nil {
+			if n := processContextWindow(model.Name, running); n > 0 {
+				return contextWindowResolution{ContextLength: n, RuntimeVerified: true, Source: contextWindowSourceRuntime}
+			}
+			failures = append(failures, errors.New("model was not present in the running process list"))
+		} else {
+			failures = append(failures, fmt.Errorf("read running models: %w", err))
+		}
+
+		if shown, err := client.Show(ctx, &api.ShowRequest{Model: model.Name}); err == nil {
+			native, _ := modelInfoContextLength(shown.ModelInfo)
+			if configured, ok := modelParameterNumCtx(shown.Parameters); ok {
+				if native > 0 && configured > native {
+					configured = native
+				}
+				return contextWindowResolution{ContextLength: configured, Source: contextWindowSourceParameter, Err: errors.Join(failures...)}
+			}
+			if native > 0 {
+				return contextWindowResolution{ContextLength: native, Source: contextWindowSourceNative, Err: errors.Join(failures...)}
+			}
+		} else {
+			failures = append(failures, fmt.Errorf("read model metadata: %w", err))
+		}
+	}
+
+	fallback := contextWindowFallback(model, errors.Join(failures...))
+	return fallback
+}
+
+func contextWindowFallback(model LaunchModel, err error) contextWindowResolution {
+	return contextWindowResolution{
+		ContextLength: launchModelContextLength(model),
+		Source:        contextWindowSourceInventory,
+		Err:           err,
+	}
+}
+
+func launchModelContextLength(model LaunchModel) int {
+	if model.ContextLength > 0 {
+		return model.ContextLength
+	}
+	if model.Details.ContextLength > 0 {
+		return model.Details.ContextLength
+	}
+	return 0
+}
+
+func modelParameterNumCtx(parameters string) (int, bool) {
+	scanner := bufio.NewScanner(strings.NewReader(parameters))
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 2 || fields[0] != "num_ctx" {
+			continue
+		}
+		n, err := strconv.Atoi(fields[1])
+		if err == nil && n > 0 {
+			return n, true
+		}
+	}
+	return 0, false
+}
 
 // LoadedContextWindow reports the context length model is currently running
 // with, per the server's process list — the size the scheduler actually

--- a/cmd/launch/context_window_test.go
+++ b/cmd/launch/context_window_test.go
@@ -1,10 +1,147 @@
 package launch
 
 import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
 	"testing"
 
 	"github.com/ollama/ollama/api"
 )
+
+func TestResolveLaunchContextLoadsAndUsesRunningContext(t *testing.T) {
+	var generateCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/generate":
+			generateCalls.Add(1)
+			var request api.GenerateRequest
+			if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+				t.Fatalf("decode generate request: %v", err)
+			}
+			if request.Model != "qwen3.8:27b-mlx" || len(request.Options) != 0 {
+				t.Fatalf("generate request = %#v, want model-only load", request)
+			}
+			_ = json.NewEncoder(w).Encode(api.GenerateResponse{Done: true})
+		case "/api/ps":
+			_ = json.NewEncoder(w).Encode(api.ProcessResponse{Models: []api.ProcessModelResponse{{
+				Name:          "qwen3.8:27b-mlx",
+				ContextLength: 65_536,
+			}}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	base, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := resolveLaunchContext(context.Background(), api.NewClient(base, server.Client()), LaunchModel{
+		Name:          "qwen3.8:27b-mlx",
+		ContextLength: 262_144,
+	}, true)
+	if got.ContextLength != 65_536 || !got.RuntimeVerified {
+		t.Fatalf("resolution = %#v, want verified 65536", got)
+	}
+	if generateCalls.Load() != 1 {
+		t.Fatalf("generate calls = %d, want 1", generateCalls.Load())
+	}
+}
+
+func TestResolveLaunchContextConfigurationOnlyDoesNotLoad(t *testing.T) {
+	var generateCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/generate":
+			generateCalls.Add(1)
+			http.Error(w, "must not load", http.StatusInternalServerError)
+		case "/api/ps":
+			_ = json.NewEncoder(w).Encode(api.ProcessResponse{})
+		case "/api/show":
+			_ = json.NewEncoder(w).Encode(api.ShowResponse{ModelInfo: map[string]any{
+				"qwen3_5.context_length": float64(262_144),
+			}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	base, _ := url.Parse(server.URL)
+	got := resolveLaunchContext(context.Background(), api.NewClient(base, server.Client()), LaunchModel{Name: "qwen3.8:27b-mlx"}, false)
+	if got.ContextLength != 262_144 || got.RuntimeVerified {
+		t.Fatalf("resolution = %#v, want unverified native metadata 262144", got)
+	}
+	if generateCalls.Load() != 0 {
+		t.Fatalf("generate calls = %d, want 0", generateCalls.Load())
+	}
+}
+
+func TestResolveLaunchContextBoundsExplicitNumCtxByNativeCapacity(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/ps":
+			_ = json.NewEncoder(w).Encode(api.ProcessResponse{})
+		case "/api/show":
+			_ = json.NewEncoder(w).Encode(api.ShowResponse{
+				Parameters: "temperature 0.2\nnum_ctx 524288\ntop_p 0.9",
+				ModelInfo:  map[string]any{"qwen3_5.context_length": float64(262_144)},
+			})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	base, _ := url.Parse(server.URL)
+	got := resolveLaunchContext(context.Background(), api.NewClient(base, server.Client()), LaunchModel{Name: "qwen3.8:27b-mlx"}, false)
+	if got.ContextLength != 262_144 {
+		t.Fatalf("context = %d, want native-bounded 262144", got.ContextLength)
+	}
+}
+
+func TestResolveLaunchContextFallsBackToInventoryWhenAPIsFail(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "unavailable", http.StatusServiceUnavailable)
+	}))
+	t.Cleanup(server.Close)
+
+	base, _ := url.Parse(server.URL)
+	got := resolveLaunchContext(context.Background(), api.NewClient(base, server.Client()), LaunchModel{
+		Name:          "qwen3.8:27b-mlx",
+		ContextLength: 131_072,
+	}, true)
+	if got.ContextLength != 131_072 || got.RuntimeVerified {
+		t.Fatalf("resolution = %#v, want unverified inventory fallback 131072", got)
+	}
+}
+
+func TestResolveLaunchContextCloudDoesNotCallLocalServer(t *testing.T) {
+	var calls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls.Add(1)
+		http.Error(w, "unexpected", http.StatusInternalServerError)
+	}))
+	t.Cleanup(server.Close)
+
+	base, _ := url.Parse(server.URL)
+	got := resolveLaunchContext(context.Background(), api.NewClient(base, server.Client()), LaunchModel{
+		Name:          "qwen3.5:cloud",
+		Remote:        true,
+		ContextLength: 262_144,
+	}, true)
+	if got.ContextLength != 262_144 {
+		t.Fatalf("context = %d, want cloud metadata 262144", got.ContextLength)
+	}
+	if calls.Load() != 0 {
+		t.Fatalf("local API calls = %d, want 0", calls.Load())
+	}
+}
 
 func TestProcessContextWindowMatchesLatestAlias(t *testing.T) {
 	got := processContextWindow("ornith", &api.ProcessResponse{

--- a/cmd/launch/qwen.go
+++ b/cmd/launch/qwen.go
@@ -18,7 +18,9 @@ const qwenOllamaEnvKey = "OLLAMA_API_KEY"
 
 var qwenGOOS = runtime.GOOS
 
-type Qwen struct{}
+type Qwen struct {
+	resolveContext func(LaunchModel, bool) contextWindowResolution
+}
 
 func (q *Qwen) String() string { return "Qwen Code" }
 
@@ -222,10 +224,21 @@ func qwenInstallerCommand(goos string) (string, []string, error) {
 	}
 }
 
-func (q *Qwen) Run(model string, _ []LaunchModel, args []string) error {
+func (q *Qwen) Run(model string, models []LaunchModel, args []string) error {
 	qwenPath, err := q.findPath()
 	if err != nil {
 		return fmt.Errorf("qwen is not installed: %w", err)
+	}
+
+	model = qwenEffectiveModel(model, args)
+	launchModel, ok := findLaunchModel(models, model)
+	if !ok {
+		launchModel = fallbackLaunchModel(model)
+	}
+	resolution := q.contextWindow(launchModel, true)
+	qwenWarnUnverifiedContext(model, resolution, false)
+	if err := q.writeConfig(model, resolution.ContextLength); err != nil {
+		return fmt.Errorf("refresh qwen context: %w", err)
 	}
 
 	cmd := exec.Command(qwenPath, qwenLaunchArgs(model, args)...)
@@ -248,7 +261,30 @@ func (q *Qwen) Configure(model string) error {
 	if model == "" {
 		return nil
 	}
+	return q.writeConfig(model, 0)
+}
 
+func (q *Qwen) ConfigureWithModels(model string, models []LaunchModel) error {
+	if model == "" {
+		return nil
+	}
+	launchModel, ok := findLaunchModel(models, model)
+	if !ok {
+		launchModel = fallbackLaunchModel(model)
+	}
+	resolution := q.contextWindow(launchModel, false)
+	qwenWarnUnverifiedContext(model, resolution, true)
+	return q.writeConfig(model, resolution.ContextLength)
+}
+
+func (q *Qwen) contextWindow(model LaunchModel, load bool) contextWindowResolution {
+	if q != nil && q.resolveContext != nil {
+		return q.resolveContext(model, load)
+	}
+	return resolveLaunchContextFromEnvironment(model, load)
+}
+
+func (q *Qwen) writeConfig(model string, contextWindow int) error {
 	configPath, err := q.configPath()
 	if err != nil {
 		return err
@@ -262,7 +298,7 @@ func (q *Qwen) Configure(model string) error {
 		return err
 	}
 
-	applyQwenOllamaConfig(cfg, model)
+	applyQwenOllamaConfig(cfg, model, contextWindow)
 
 	data, err := json.MarshalIndent(cfg, "", "  ")
 	if err != nil {
@@ -272,13 +308,13 @@ func (q *Qwen) Configure(model string) error {
 	return fileutil.WriteWithBackup(configPath, data, "qwen")
 }
 
-func applyQwenOllamaConfig(cfg map[string]any, model string) {
+func applyQwenOllamaConfig(cfg map[string]any, model string, contextWindow int) {
 	envCfg := qwenMap(cfg["env"])
 	envCfg[qwenOllamaEnvKey] = "ollama"
 	cfg["env"] = envCfg
 
 	modelProviders := qwenMap(cfg["modelProviders"])
-	modelProviders["openai"] = qwenMergeOpenAIProviders(modelProviders["openai"], qwenProvider(model))
+	modelProviders["openai"] = qwenMergeOpenAIProviders(modelProviders["openai"], qwenProvider(model, contextWindow))
 	cfg["modelProviders"] = modelProviders
 
 	security := qwenMap(cfg["security"])
@@ -301,6 +337,33 @@ func qwenMap(value any) map[string]any {
 }
 
 func qwenMergeOpenAIProviders(value any, provider map[string]any) []any {
+	providerID, _ := provider["id"].(string)
+	for _, existing := range qwenProviderList(value) {
+		existingProvider, ok := existing.(map[string]any)
+		if !ok || !qwenIsOllamaProvider(existingProvider) || existingProvider["id"] != providerID {
+			continue
+		}
+		preserved := make(map[string]any, len(existingProvider)+len(provider))
+		for key, item := range existingProvider {
+			preserved[key] = item
+		}
+		for key, item := range provider {
+			preserved[key] = item
+		}
+		generation := qwenMap(existingProvider["generationConfig"])
+		generation = cloneQwenMap(generation)
+		if desired := qwenMap(provider["generationConfig"]); len(desired) > 0 {
+			for key, item := range desired {
+				generation[key] = item
+			}
+		}
+		if len(generation) > 0 {
+			preserved["generationConfig"] = generation
+		}
+		provider = preserved
+		break
+	}
+
 	merged := []any{provider}
 	for _, existing := range qwenProviderList(value) {
 		if qwenIsOllamaProvider(existing) {
@@ -309,6 +372,14 @@ func qwenMergeOpenAIProviders(value any, provider map[string]any) []any {
 		merged = append(merged, existing)
 	}
 	return merged
+}
+
+func cloneQwenMap(value map[string]any) map[string]any {
+	cloned := make(map[string]any, len(value))
+	for key, item := range value {
+		cloned[key] = item
+	}
+	return cloned
 }
 
 func qwenProviderList(value any) []any {
@@ -407,13 +478,53 @@ func qwenBaseURL() string {
 	return strings.TrimRight(envconfig.Host().String(), "/") + "/v1"
 }
 
-func qwenProvider(model string) map[string]any {
-	return map[string]any{
+func qwenProvider(model string, contextWindow int) map[string]any {
+	provider := map[string]any{
 		"id":      model,
 		"name":    fmt.Sprintf("%s (Ollama)", model),
 		"baseUrl": qwenBaseURL(),
 		"envKey":  qwenOllamaEnvKey,
 	}
+	if contextWindow > 0 {
+		provider["generationConfig"] = map[string]any{"contextWindowSize": contextWindow}
+	}
+	return provider
+}
+
+func qwenEffectiveModel(model string, args []string) string {
+	for i := 0; i < len(args); i++ {
+		switch {
+		case args[i] == "--model" || args[i] == "-m":
+			if i+1 < len(args) && strings.TrimSpace(args[i+1]) != "" {
+				model = strings.TrimSpace(args[i+1])
+				i++
+			}
+		case strings.HasPrefix(args[i], "--model="):
+			if value := strings.TrimSpace(strings.TrimPrefix(args[i], "--model=")); value != "" {
+				model = value
+			}
+		case strings.HasPrefix(args[i], "-m="):
+			if value := strings.TrimSpace(strings.TrimPrefix(args[i], "-m=")); value != "" {
+				model = value
+			}
+		}
+	}
+	return model
+}
+
+func qwenWarnUnverifiedContext(model string, resolution contextWindowResolution, refreshOnLaunch bool) {
+	if resolution.RuntimeVerified || isCloudModelName(model) {
+		return
+	}
+	suffix := ""
+	if refreshOnLaunch {
+		suffix = "; it will be runtime-verified when Qwen Code launches"
+	}
+	if resolution.ContextLength > 0 {
+		fmt.Fprintf(os.Stderr, "%s  Warning: %s's loaded context is not yet verified; using %d from %s%s%s\n", ansiYellow, model, resolution.ContextLength, resolution.Source, suffix, ansiReset)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "%s  Warning: could not determine %s's context; Qwen Code will use its fallback%s%s\n", ansiYellow, model, suffix, ansiReset)
 }
 
 func qwenLaunchArgs(model string, args []string) []string {

--- a/cmd/launch/qwen_test.go
+++ b/cmd/launch/qwen_test.go
@@ -79,6 +79,66 @@ func TestQwenConfigure(t *testing.T) {
 	}
 }
 
+func TestQwenConfigureWithModelsWritesProviderContextWindow(t *testing.T) {
+	tmpDir := t.TempDir()
+	setQwenTestHome(t, tmpDir)
+
+	q := &Qwen{resolveContext: func(model LaunchModel, load bool) contextWindowResolution {
+		if load {
+			t.Fatal("ConfigureWithModels must not load the model")
+		}
+		return contextWindowResolution{ContextLength: model.ContextLength, Source: contextWindowSourceInventory}
+	}}
+	if err := q.ConfigureWithModels("qwen3.8:27b-mlx", []LaunchModel{{
+		Name:          "qwen3.8:27b-mlx",
+		ContextLength: 262_144,
+	}}); err != nil {
+		t.Fatalf("ConfigureWithModels() error = %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(tmpDir, ".qwen", "settings.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	provider := cfg["modelProviders"].(map[string]any)["openai"].([]any)[0].(map[string]any)
+	generation := provider["generationConfig"].(map[string]any)
+	if generation["contextWindowSize"] != float64(262_144) {
+		t.Fatalf("contextWindowSize = %v, want 262144", generation["contextWindowSize"])
+	}
+}
+
+func TestQwenProviderPreservesCompatibleSettingsOnlyForSameModel(t *testing.T) {
+	existing := []any{map[string]any{
+		"id":      "qwen3.8:27b-mlx",
+		"name":    "custom name",
+		"baseUrl": qwenBaseURL(),
+		"envKey":  qwenOllamaEnvKey,
+		"generationConfig": map[string]any{
+			"temperature":       0.2,
+			"contextWindowSize": float64(1_000_000),
+		},
+	}}
+
+	same := qwenMergeOpenAIProviders(existing, qwenProvider("qwen3.8:27b-mlx", 262_144))
+	sameGeneration := same[0].(map[string]any)["generationConfig"].(map[string]any)
+	if sameGeneration["temperature"] != 0.2 || sameGeneration["contextWindowSize"] != 262_144 {
+		t.Fatalf("same-model generation config = %#v, want temperature preserved and context refreshed", sameGeneration)
+	}
+
+	switched := qwenMergeOpenAIProviders(existing, qwenProvider("gemma4", 65_536))
+	switchedGeneration := switched[0].(map[string]any)["generationConfig"].(map[string]any)
+	if _, ok := switchedGeneration["temperature"]; ok {
+		t.Fatalf("model-specific temperature transferred across models: %#v", switchedGeneration)
+	}
+	if switchedGeneration["contextWindowSize"] != 65_536 {
+		t.Fatalf("contextWindowSize = %v, want 65536", switchedGeneration["contextWindowSize"])
+	}
+}
+
 func TestQwenConfigureBacksUpUnderIntegrationDirectory(t *testing.T) {
 	tmpDir := t.TempDir()
 	setQwenTestHome(t, tmpDir)
@@ -327,6 +387,10 @@ func TestQwenIntegration(t *testing.T) {
 		var _ ManagedSingleModel = q
 	})
 
+	t.Run("implements ManagedModelListConfigurer", func(t *testing.T) {
+		var _ ManagedModelListConfigurer = q
+	})
+
 	t.Run("implements ManagedInteractiveOnboarding", func(t *testing.T) {
 		var _ ManagedInteractiveOnboarding = q
 	})
@@ -389,6 +453,26 @@ func TestQwenLaunchArgs(t *testing.T) {
 	}
 }
 
+func TestQwenEffectiveModelUsesSupportedOverride(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "long separated", args: []string{"--model", "gemma4"}, want: "gemma4"},
+		{name: "short separated", args: []string{"-m", "qwen3:8b"}, want: "qwen3:8b"},
+		{name: "long equals", args: []string{"--model=phi4-mini"}, want: "phi4-mini"},
+		{name: "last override wins", args: []string{"-m", "gemma4", "--model=qwen3:8b"}, want: "qwen3:8b"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := qwenEffectiveModel("llama3.2", tt.args); got != tt.want {
+				t.Fatalf("effective model = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestQwenLaunchEnv(t *testing.T) {
 	t.Setenv("OPENAI_API_KEY", "")
 	t.Setenv("OPENAI_BASE_URL", "")
@@ -423,7 +507,7 @@ func TestQwenLaunchEnvOverridesExistingOpenAIEnv(t *testing.T) {
 	}
 }
 
-func TestQwenRunDoesNotRewriteConfig(t *testing.T) {
+func TestQwenRunRefreshesContextBeforeExec(t *testing.T) {
 	tmpDir := t.TempDir()
 	setQwenTestHome(t, tmpDir)
 	t.Chdir(tmpDir)
@@ -455,13 +539,19 @@ func TestQwenRunDoesNotRewriteConfig(t *testing.T) {
 		t.Fatalf("failed to create config dir: %v", err)
 	}
 
-	initialConfig := []byte(`{"model":{"name":"qwen3:32b"}}`)
+	initialConfig := []byte(`{"model":{"name":"qwen3:32b"},"modelProviders":{"openai":[{"id":"qwen3:32b","name":"qwen3:32b (Ollama)","envKey":"OLLAMA_API_KEY","baseUrl":"` + qwenBaseURL() + `","generationConfig":{"contextWindowSize":1000000,"temperature":0.2}}]}}`)
 	configPath := filepath.Join(configDir, "settings.json")
 	if err := os.WriteFile(configPath, initialConfig, 0o644); err != nil {
 		t.Fatalf("failed to write initial config: %v", err)
 	}
 
-	if err := (&Qwen{}).Run("qwen3:32b", nil, nil); err != nil {
+	q := &Qwen{resolveContext: func(model LaunchModel, load bool) contextWindowResolution {
+		if !load {
+			t.Fatal("Run must request a loaded runtime context")
+		}
+		return contextWindowResolution{ContextLength: 65_536, RuntimeVerified: true}
+	}}
+	if err := q.Run("qwen3:32b", []LaunchModel{{Name: "qwen3:32b", ContextLength: 262_144}}, nil); err != nil {
 		t.Fatalf("Run() error = %v", err)
 	}
 
@@ -469,8 +559,17 @@ func TestQwenRunDoesNotRewriteConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to read config after run: %v", err)
 	}
-	if string(data) != string(initialConfig) {
-		t.Fatalf("expected run not to rewrite config, got %s", string(data))
+	var cfg map[string]any
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		t.Fatal(err)
+	}
+	provider := cfg["modelProviders"].(map[string]any)["openai"].([]any)[0].(map[string]any)
+	generation := provider["generationConfig"].(map[string]any)
+	if generation["contextWindowSize"] != float64(65_536) {
+		t.Fatalf("contextWindowSize = %v, want refreshed 65536", generation["contextWindowSize"])
+	}
+	if generation["temperature"] != 0.2 {
+		t.Fatalf("compatible generation setting lost: %#v", generation)
 	}
 }
 


### PR DESCRIPTION
## Summary

- resolve the local runner context before generating Codex's model catalog
- make verified server context take precedence over the 128K fallback and launcher-process environment
- cap inherited and CLI `model_context_window` overrides while preserving deliberately smaller values
- preserve Codex's compatible compaction settings and normal reserve calculations
- write CLI configuration to `CODEX_HOME` when set, matching the location Codex actually reads
- expose Qwen 3.8's supported reasoning levels (`none`, `low`, `medium`, and `high`) in Codex's model catalog, with `high` matching Ollama's default renderer behavior
- refresh renderer and capability metadata from `/api/show` for the exact selected model and configured Ollama host, while preserving existing metadata if that lookup fails

Fixes #18257.

## Dependency

Depends on #18258.

This draft is stacked on #18258, which supplies the internal context resolver. Until that PR merges, this PR includes both commits when compared with upstream `main`; the Codex-only diff is https://github.com/aeltawela/ollama/compare/fix/qwen-launch-context...fix/codex-launch-context. After the dependency merges, this branch will be rebased onto upstream `main`, validation rerun, and the PR marked ready.

## Test report

- `go test ./cmd/launch -count=1`
- `go test -race ./cmd/launch -count=1`
- `go vet ./cmd/launch`
- `go test ./... -count=1`
- `go build .`
- `git diff --check`
- prior fork workflow baseline (before this additive effort commit): https://github.com/aeltawela/ollama/actions/runs/33965994418
- current-launcher reproduction: generated catalog advertised 128,000 for `qwen3.8:27b-mlx`
- patched real-model launch: `/api/ps` and the generated Codex catalog reported 262,144
- patched isolated Codex run: a real `qwen3.8:27b-mlx` request at `low` effort completed successfully, returned the requested `OK`, and exited cleanly
- captured `/v1/responses` request: `reasoning.effort` was `low`, confirming the Codex selection reached Ollama
- isolated configuration: the launcher wrote the profile and catalog only to `CODEX_HOME`; the catalog reported 262,144 and Codex derived its normal 249,036-token usable budget
- reasoning catalog: Qwen 3.8 advertises `none`, `low`, `medium`, and `high`, with `high` selected by default; unknown renderers retain the existing empty-level fallback
- HTTP behavior tests cover the exact selected alias, configured host, `/api/show` failure preservation, and avoiding local probes for cloud models
- regression test: failed before the path fix because configuration was written outside `CODEX_HOME`, then passed with the fix
- isolated behavior tests cover a 65,536 runtime context, conflicting and smaller inherited/CLI overrides, and preservation of compatible compaction configuration

Tested Codex branch revision: `76df5f41c196cd85007c4ee17e95ade77501f5dd`

Fork integration revision: `0a293cf1ee5cb4b59e3c34d3db83e9d1cd082732`

## Reasoning-level UI

Current Codex CLI exposes reasoning effort through `/model`: select the model, then select its reasoning level. It does not currently implement a separate `/effort` slash command.

![Codex reasoning-level picker for qwen3.8:27b-mlx](https://raw.githubusercontent.com/aeltawela/ollama/ecde40ef9982396f9f39a0be3829f3cbdb7bef01/.github/pr-assets/codex-model-effort-picker.png)

## Validation limitation

The exact separate-server 65,536 test is covered through the launcher's HTTP boundary with a real Ollama API client, but not with a second real model runner: the locally resident test model was unavailable from the on-disk model store. The test did not unload or alter an existing user session, and this degraded path is not counted as runtime verification.

A deterministic multi-turn compaction stress run remains outside the completed live verification; behavior tests cover the effective context and preservation of Codex's compaction setting.