### PR TITLE
model/renderers: keep replayed deepseek3 assistant history intact

### DIFF
--- a/model/renderers/deepseek3.go
+++ b/model/renderers/deepseek3.go
@@ -131,11 +131,19 @@ func (r *DeepSeek3Renderer) Render(messages []api.Message, tools []api.Tool, thi
 					sb.WriteString(content + "<｜end▁of▁sentence｜>")
 					isTool = false
 				} else {
-					if strings.Contains(content, "</think>") {
-						parts := strings.SplitN(content, "</think>", 2)
-						if len(parts) > 1 {
-							content = parts[1]
-						}
+					// Strip a thinking preamble the model leaked into its own
+					// content so it is not replayed back as text. While the
+					// current assistant turn is still being continued, the
+					// preamble is everything up to the first </think>. In
+					// replayed history only an opening <think> marks one: a
+					// closing tag that opens nothing is ordinary content, and
+					// cutting there dropped the head of earlier assistant
+					// messages. A conversation with no user message has no
+					// history boundary, so every assistant message is a
+					// continuation.
+					if closeAt := strings.Index(content, "</think>"); closeAt >= 0 &&
+						(i > lastUserIndex || strings.HasPrefix(content, "<think>")) {
+						content = content[closeAt+len("</think>"):]
 					}
 					sb.WriteString(content + "<｜end▁of▁sentence｜>")
 				}

--- a/model/renderers/deepseek3_test.go
+++ b/model/renderers/deepseek3_test.go
@@ -1026,6 +1026,45 @@ He found the key, unlocking a door to forgotten memories.<｜end▁of▁sentence
 			thinkValue: &api.ThinkValue{Value: true},
 			expected:   `<｜begin▁of▁sentence｜><｜User｜>Who are you?<｜Assistant｜></think>I am DeepSeek<｜end▁of▁sentence｜><｜User｜>Thanks! Can you tell me a 10 word story?<｜Assistant｜><think>`,
 		},
+		{
+			name: "stray closing think tag in assistant history is not truncated",
+			messages: []api.Message{
+				{Role: "user", Content: "Who are you?"},
+				{Role: "assistant", Content: "ink</think>rath"},
+				{Role: "user", Content: "What did you say?"},
+			},
+			thinkValue: &api.ThinkValue{Value: false},
+			expected:   `<｜begin▁of▁sentence｜><｜User｜>Who are you?<｜Assistant｜></think>ink</think>rath<｜end▁of▁sentence｜><｜User｜>What did you say?<｜Assistant｜></think>`,
+		},
+		{
+			name: "history close-before-open think tags stay verbatim",
+			messages: []api.Message{
+				{Role: "user", Content: "Complex question"},
+				{Role: "assistant", Content: "x</think>y<think>z</think>w"},
+				{Role: "user", Content: "And now?"},
+			},
+			thinkValue: &api.ThinkValue{Value: false},
+			expected:   `<｜begin▁of▁sentence｜><｜User｜>Complex question<｜Assistant｜></think>x</think>y<think>z</think>w<｜end▁of▁sentence｜><｜User｜>And now?<｜Assistant｜></think>`,
+		},
+		{
+			name: "no user message - every assistant is continuation",
+			messages: []api.Message{
+				{Role: "system", Content: "You are a helpful assistant."},
+				{Role: "assistant", Content: "ink</think>rath"},
+			},
+			thinkValue: &api.ThinkValue{Value: false},
+			expected:   `<｜begin▁of▁sentence｜>You are a helpful assistant.rath<｜end▁of▁sentence｜>`,
+		},
+		{
+			name: "history text before a leaked preamble is kept",
+			messages: []api.Message{
+				{Role: "user", Content: "Who are you?"},
+				{Role: "assistant", Content: "Sure.<think>reasoning</think>I am DeepSeek"},
+				{Role: "user", Content: "What did you say?"},
+			},
+			thinkValue: &api.ThinkValue{Value: false},
+			expected:   `<｜begin▁of▁sentence｜><｜User｜>Who are you?<｜Assistant｜></think>Sure.<think>reasoning</think>I am DeepSeek<｜end▁of▁sentence｜><｜User｜>What did you say?<｜Assistant｜></think>`,
+		},
 	}
 
 	renderer := &DeepSeek3Renderer{IsThinking: true, Variant: Deepseek31}


### PR DESCRIPTION
## Problem

`deepseek3.go` trimmed assistant content at the first literal `</think>` in every message it rendered:

```go
if strings.Contains(content, "</think>") {
    parts := strings.SplitN(content, "</think>", 2)
    if len(parts) > 1 {
        content = parts[1]
    }
}
```

`SplitN` discards `parts[0]` whether or not a `<think>` ever opened it. Two shapes lose data:

- a closing-only tag leaked by degenerate output — `ink</think>rath` is replayed as `rath`, so a prior assistant turn silently loses its head;
- ordinary content in front of a real pair — `Sure.<think>reasoning</think>I am DeepSeek` is replayed as `I am DeepSeek`.

## Scope: this does not fix the cloud loop in #17617

#17617 reports this shape on `deepseek-v4-flash:cloud`. Cloud models are proxied upstream in `server/routes.go` (`req.Model = m.Config.RemoteModel`) and never reach this renderer, so @rick-github is right that the local render has nothing to do with that issue. #17248 seeing the same corruption in *user* messages across several model families points the same way.

The truncation is still real on the local path, where deepseek models are rendered by this code, and that is all this PR claims to fix. #17617 stays open.

Reading of the renderer that this builds on: @Saad-Mallebhari's [comment](https://github.com/ollama/ollama/issues/17617#issuecomment-5225861955).

## Relation to the reference template

For completeness, since this changes ported behaviour rather than a local mistake: the trim is a faithful port of DeepSeek-V3.1's official `chat_template`, which does

```jinja
{%- if '</think>' in content %}{%- set content = content.split('</think>', 1)[1] -%}{%- endif %}
```

for every assistant message. So this PR is a deliberate divergence from that template, on three grounds:

- `deepseek-ai/DeepSeek-V4-Flash-0731` ships no `chat_template` at all. Its reference encoder (`encoding/encoding_dsv4.py`) carries reasoning in a separate `reasoning_content` field, writes `content` verbatim, and drops earlier-turn reasoning outright rather than trimming a string. Nothing in the V4 format asks for this split.
- `rendererNameForIdentifier` routes every identifier containing `deepseek` to this family, so both generations are rendered by the V3.1-derived renderer.
- Inside Ollama the trim is largely redundant anyway: `model/parsers/deepseek3.go` already separates thinking into `message.Thinking`, so a `</think>` still present in `Content` is text the parser classified as content.

If you would rather track the V3.1 template exactly and treat the truncation as upstream behaviour, say so and I will close this.

## Fix

Strip a leaked thinking preamble only where one exists:

- **current assistant turn being continued** — unchanged: strip at the first `</think>`, the prefill case the strip was written for;
- **replayed history** — strip only when an opening `<think>` actually starts the content.

A closing tag that opens nothing, and content that precedes a preamble, stay verbatim.

## Tests

Three new table cases, each failing against the pre-change file and passing here (checked by rendering both):

- `ink</think>rath` in history stays whole;
- `x</think>y<think>z</think>w` stays whole;
- `Sure.<think>reasoning</think>I am DeepSeek` keeps `Sure.`.

One further case pins existing behaviour rather than new: with no user message there is no history boundary, so every assistant message is still treated as a continuation and the strip applies.

The existing cases — current-turn tag removal, multiple tags, and history with a proper `<think>...</think>` pair — are unchanged. `go test ./model/...` is green, `gofmt` and `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AtKq5cPToV9TMQ3riikCot
