### PR TITLE
mlxrunner: enforce requested context length

### DIFF
--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -31,31 +31,31 @@ import (
 
 // Client wraps an MLX runner subprocess to implement llm.LlamaServer for LLM models.
 type Client struct {
-	port              int
-	modelName         string
-	contextLength     atomic.Int64
-	softContextLength int // recommended limit to avoid poor performance
-	memory            atomic.Uint64
-	done              chan struct{}
-	doneErr           error // valid after done is closed
-	client            *http.Client
-	status            *llm.StatusWriter
-	mu                sync.Mutex
-	cmd               *exec.Cmd
+	port          int
+	modelName     string
+	contextLength atomic.Int64
+	requestedCtx  int
+	memory        atomic.Uint64
+	done          chan struct{}
+	doneErr       error // valid after done is closed
+	client        *http.Client
+	status        *llm.StatusWriter
+	mu            sync.Mutex
+	cmd           *exec.Cmd
 }
 
 // NewClient prepares a new MLX runner client for LLM models.
 // The subprocess is not started until Load() is called.
-func NewClient(modelName string, softContextLength int) (*Client, error) {
+func NewClient(modelName string, contextLength int) (*Client, error) {
 	if err := checkPlatformSupport(); err != nil {
 		return nil, err
 	}
 
 	c := &Client{
-		modelName:         modelName,
-		softContextLength: softContextLength,
-		done:              make(chan struct{}),
-		client:            http.DefaultClient,
+		modelName:    modelName,
+		requestedCtx: contextLength,
+		done:         make(chan struct{}),
+		client:       http.DefaultClient,
 	}
 
 	modelManifest, err := manifest.LoadManifest(modelName)
@@ -263,13 +263,6 @@ func (c *Client) ContextLength() int {
 	return int(c.contextLength.Load())
 }
 
-func (c *Client) reportedContextLength(modelContextLength int) int {
-	if c.softContextLength > 0 && (modelContextLength == 0 || c.softContextLength < modelContextLength) {
-		return c.softContextLength
-	}
-	return modelContextLength
-}
-
 // Detokenize implements llm.LlamaServer.
 func (c *Client) Detokenize(ctx context.Context, tokens []int) (string, error) {
 	return "", errors.New("not supported")
@@ -343,8 +336,7 @@ func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 		exe = eval
 	}
 
-	// Spawn subprocess: ollama runner --mlx-engine --model <name> --port <port>
-	cmd := exec.Command(exe, "runner", "--mlx-engine", "--model", c.modelName, "--port", strconv.Itoa(port))
+	cmd := exec.Command(exe, runnerArgs(c.modelName, port, c.requestedCtx)...)
 	cmd.Env = os.Environ()
 
 	// Set library path environment variable for MLX libraries
@@ -468,10 +460,19 @@ func (c *Client) Ping(ctx context.Context) error {
 		return err
 	}
 
-	c.contextLength.Store(int64(c.reportedContextLength(status.ContextLength)))
+	c.contextLength.Store(int64(status.ContextLength))
 	c.memory.Store(status.Memory)
 
 	return nil
+}
+
+func runnerArgs(modelName string, port, contextLength int) []string {
+	return []string{
+		"runner", "--mlx-engine",
+		"--model", modelName,
+		"--port", strconv.Itoa(port),
+		"--ctx-size", strconv.Itoa(contextLength),
+	}
 }
 
 // Tokenize implements llm.LlamaServer.

--- a/x/mlxrunner/client_test.go
+++ b/x/mlxrunner/client_test.go
@@ -12,6 +12,50 @@ import (
 	"github.com/ollama/ollama/llm"
 )
 
+func TestRunnerArgsIncludeContextLength(t *testing.T) {
+	got := runnerArgs("qwen3.5:27b", 49152, 65536)
+	want := []string{"runner", "--mlx-engine", "--model", "qwen3.5:27b", "--port", "49152", "--ctx-size", "65536"}
+	if len(got) != len(want) {
+		t.Fatalf("runnerArgs = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("runnerArgs[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestPingReportsRunnerContextLength(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/status" {
+			t.Errorf("path = %q, want /v1/status", r.URL.Path)
+		}
+		if err := json.NewEncoder(w).Encode(statusResponse{ContextLength: 65536, Memory: 42}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	_, portString, err := net.SplitHostPort(srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+	client := &Client{port: port, client: srv.Client()}
+	if err := client.Ping(t.Context()); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if got := client.ContextLength(); got != 65536 {
+		t.Fatalf("ContextLength = %d, want 65536", got)
+	}
+	if got := client.memory.Load(); got != 42 {
+		t.Fatalf("memory = %d, want 42", got)
+	}
+}
+
 func testIntPtr(v int) *int {
 	return &v
 }

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -56,7 +56,7 @@ type Runner struct {
 	spec *speculation
 }
 
-func (r *Runner) Load(modelName string) error {
+func (r *Runner) Load(modelName string, contextLength int) error {
 	root, err := model.Open(modelName)
 	if err != nil {
 		return err
@@ -122,7 +122,7 @@ func (r *Runner) Load(modelName string) error {
 
 	r.Model = m
 	r.Tokenizer = m.Tokenizer()
-	r.contextLength = m.MaxContextLength()
+	r.contextLength = effectiveContextLength(contextLength, m.MaxContextLength())
 	caches := m.NewCaches()
 	draftCaches := newDraftCaches(draftModel)
 	r.cache = newPrefixCache(slices.Concat(caches, draftCaches))
@@ -133,6 +133,13 @@ func (r *Runner) Load(modelName string) error {
 	mlx.EnableCompile()
 
 	return nil
+}
+
+func effectiveContextLength(requested, maximum int) int {
+	if requested <= 0 || requested > maximum {
+		return maximum
+	}
+	return requested
 }
 
 func (r *Runner) Close() {

--- a/x/mlxrunner/runner_test.go
+++ b/x/mlxrunner/runner_test.go
@@ -1,0 +1,23 @@
+package mlxrunner
+
+import "testing"
+
+func TestEffectiveContextLength(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		requested int
+		maximum   int
+		want      int
+	}{
+		{name: "unset uses model maximum", maximum: 262144, want: 262144},
+		{name: "smaller request is enforced", requested: 65536, maximum: 262144, want: 65536},
+		{name: "native maximum is accepted", requested: 262144, maximum: 262144, want: 262144},
+		{name: "unsupported extension is capped", requested: 524288, maximum: 262144, want: 262144},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := effectiveContextLength(tt.requested, tt.maximum); got != tt.want {
+				t.Fatalf("effectiveContextLength(%d, %d) = %d, want %d", tt.requested, tt.maximum, got, tt.want)
+			}
+		})
+	}
+}

--- a/x/mlxrunner/server.go
+++ b/x/mlxrunner/server.go
@@ -28,11 +28,13 @@ func Execute(args []string) error {
 	var (
 		modelName string
 		port      int
+		ctxSize   int
 	)
 
 	flagSet := flag.NewFlagSet("mlxrunner", flag.ExitOnError)
 	flagSet.StringVar(&modelName, "model", "", "Model name")
 	flagSet.IntVar(&port, "port", 0, "Port to listen on")
+	flagSet.IntVar(&ctxSize, "ctx-size", 0, "Context length")
 	_ = flagSet.Bool("verbose", false, "Enable debug logging")
 	flagSet.Parse(args)
 
@@ -66,7 +68,7 @@ func Execute(args []string) error {
 	}
 
 	if err := worker.Do(context.Background(), func() error {
-		return runner.Load(modelName)
+		return runner.Load(modelName, ctxSize)
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- pass the scheduler-selected `num_ctx` into the MLX runner subprocess
- enforce that value as the runner's actual context limit
- report the runner's effective context back to the scheduler and `/api/ps`
- preserve the architecture maximum when the requested value is unset or larger than the model supports

Fixes #18125.

## Root cause

The MLX client kept `num_ctx` only as a reporting-side soft limit. It launched `ollama runner --mlx-engine` without the selected context, while the subprocess always initialized itself with `Model.MaxContextLength()`. The scheduler therefore reported the configured value even though prompt validation used the architecture maximum.

## Verification

- `go test ./x/mlxrunner ./server -count=1`
- `go test -race ./x/mlxrunner -count=1`
- `go vet ./x/mlxrunner ./server`
- live macOS/Metal test with `qwen3.5:0.8b-mlx`:
  - runner command contained `--ctx-size 4096`
  - runner `/v1/status` and `/api/ps` both reported 4096
  - a 6,010-token prompt was rejected with a 4,096-token maximum

## Compatibility

Runner invocations that omit `--ctx-size` still use the model maximum. Requests above an architecture's supported maximum keep the previous effective behavior and are capped to that maximum.

## Soft and hard context precedence

Follow-up commit `d944eba1` restores the existing `softContextLength` behavior. Automatic VRAM-derived context remains reporting guidance and leaves the runner at model capacity. Explicit context from request `options.num_ctx`, a Modelfile `num_ctx`, or `OLLAMA_CONTEXT_LENGTH` is treated as hard, takes precedence over the soft value, and is passed as `--ctx-size`.

Additional verification covers automatic invocation without `--ctx-size`, explicit 4,096 enforcement and prompt rejection, and the unchanged soft context reported through `/api/ps`.