### PR TITLE
mlxrunner: support Qwen static YaRN contexts

### DIFF
--- a/server/routes_options_test.go
+++ b/server/routes_options_test.go
@@ -129,6 +129,37 @@ func TestModelOptionsNumCtxPriority(t *testing.T) {
 	}
 }
 
+func TestUsesAutomaticNumCtxTracksExplicitSources(t *testing.T) {
+	t.Run("vram default is automatic", func(t *testing.T) {
+		t.Setenv("OLLAMA_CONTEXT_LENGTH", "")
+		if !usesAutomaticNumCtx(&Model{}, nil) {
+			t.Fatal("VRAM-derived default must remain a soft automatic context")
+		}
+	})
+
+	t.Run("request option is explicit", func(t *testing.T) {
+		t.Setenv("OLLAMA_CONTEXT_LENGTH", "")
+		if usesAutomaticNumCtx(&Model{}, map[string]any{"num_ctx": float64(65536)}) {
+			t.Fatal("request num_ctx must be treated as a hard context")
+		}
+	})
+
+	t.Run("model option is explicit", func(t *testing.T) {
+		t.Setenv("OLLAMA_CONTEXT_LENGTH", "")
+		m := &Model{Options: map[string]any{"num_ctx": float64(65536)}}
+		if usesAutomaticNumCtx(m, nil) {
+			t.Fatal("model num_ctx must be treated as a hard context")
+		}
+	})
+
+	t.Run("environment option is explicit", func(t *testing.T) {
+		t.Setenv("OLLAMA_CONTEXT_LENGTH", "65536")
+		if usesAutomaticNumCtx(&Model{}, nil) {
+			t.Fatal("OLLAMA_CONTEXT_LENGTH must be treated as a hard context")
+		}
+	})
+}
+
 func TestModelOptionsGenerationDefaultsPriority(t *testing.T) {
 	m := &Model{
 		GenerationDefaults: model.GenerationDefaults{

--- a/server/sched.go
+++ b/server/sched.go
@@ -158,6 +158,13 @@ func modelTrainContext(f *ggml.GGML) int {
 	return int(f.KV().ContextLength())
 }
 
+func mlxContextLengths(numCtx int, automatic bool) (soft, hard int) {
+	if automatic {
+		return numCtx, 0
+	}
+	return numCtx, numCtx
+}
+
 func effectiveContext(numCtx, trainCtx int) int {
 	if trainCtx > 0 && numCtx > trainCtx {
 		return trainCtx
@@ -585,7 +592,8 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 			}
 		} else {
 			modelName := req.model.ShortName
-			llama, err = mlxrunner.NewClient(modelName, req.opts.NumCtx)
+			softContextLength, hardContextLength := mlxContextLengths(req.opts.NumCtx, req.numCtxAuto)
+			llama, err = mlxrunner.NewClient(modelName, softContextLength, hardContextLength)
 		}
 		if err != nil {
 			slog.Info("failed to create server", "model", req.model.ShortName, "error", err)

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -207,6 +207,25 @@ func TestSchedVisionContextFloor(t *testing.T) {
 	})
 }
 
+func TestMLXContextLengthsPreserveAutomaticSoftLimit(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		numCtx    int
+		automatic bool
+		wantSoft  int
+		wantHard  int
+	}{
+		{name: "automatic selection is soft only", numCtx: 32768, automatic: true, wantSoft: 32768},
+		{name: "explicit selection is also hard", numCtx: 65536, wantSoft: 65536, wantHard: 65536},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			soft, hard := mlxContextLengths(tt.numCtx, tt.automatic)
+			require.Equal(t, tt.wantSoft, soft)
+			require.Equal(t, tt.wantHard, hard)
+		})
+	}
+}
+
 type reqBundle struct {
 	ctx     context.Context //nolint:containedctx
 	ctxDone func()

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -31,31 +31,31 @@ import (
 
 // Client wraps an MLX runner subprocess to implement llm.LlamaServer for LLM models.
 type Client struct {
-	port              int
-	modelName         string
-	contextLength     atomic.Int64
-	softContextLength int // recommended limit to avoid poor performance
-	memory            atomic.Uint64
-	done              chan struct{}
-	doneErr           error // valid after done is closed
-	client            *http.Client
-	status            *llm.StatusWriter
-	mu                sync.Mutex
-	cmd               *exec.Cmd
+	port          int
+	modelName     string
+	contextLength atomic.Int64
+	requestedCtx  int
+	memory        atomic.Uint64
+	done          chan struct{}
+	doneErr       error // valid after done is closed
+	client        *http.Client
+	status        *llm.StatusWriter
+	mu            sync.Mutex
+	cmd           *exec.Cmd
 }
 
 // NewClient prepares a new MLX runner client for LLM models.
 // The subprocess is not started until Load() is called.
-func NewClient(modelName string, softContextLength int) (*Client, error) {
+func NewClient(modelName string, contextLength int) (*Client, error) {
 	if err := checkPlatformSupport(); err != nil {
 		return nil, err
 	}
 
 	c := &Client{
-		modelName:         modelName,
-		softContextLength: softContextLength,
-		done:              make(chan struct{}),
-		client:            http.DefaultClient,
+		modelName:    modelName,
+		requestedCtx: contextLength,
+		done:         make(chan struct{}),
+		client:       http.DefaultClient,
 	}
 
 	modelManifest, err := manifest.LoadManifest(modelName)
@@ -263,13 +263,6 @@ func (c *Client) ContextLength() int {
 	return int(c.contextLength.Load())
 }
 
-func (c *Client) reportedContextLength(modelContextLength int) int {
-	if c.softContextLength > 0 && (modelContextLength == 0 || c.softContextLength < modelContextLength) {
-		return c.softContextLength
-	}
-	return modelContextLength
-}
-
 // Detokenize implements llm.LlamaServer.
 func (c *Client) Detokenize(ctx context.Context, tokens []int) (string, error) {
 	return "", errors.New("not supported")
@@ -343,8 +336,7 @@ func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 		exe = eval
 	}
 
-	// Spawn subprocess: ollama runner --mlx-engine --model <name> --port <port>
-	cmd := exec.Command(exe, "runner", "--mlx-engine", "--model", c.modelName, "--port", strconv.Itoa(port))
+	cmd := exec.Command(exe, runnerArgs(c.modelName, port, c.requestedCtx)...)
 	cmd.Env = os.Environ()
 
 	// Set library path environment variable for MLX libraries
@@ -468,10 +460,19 @@ func (c *Client) Ping(ctx context.Context) error {
 		return err
 	}
 
-	c.contextLength.Store(int64(c.reportedContextLength(status.ContextLength)))
+	c.contextLength.Store(int64(status.ContextLength))
 	c.memory.Store(status.Memory)
 
 	return nil
+}
+
+func runnerArgs(modelName string, port, contextLength int) []string {
+	return []string{
+		"runner", "--mlx-engine",
+		"--model", modelName,
+		"--port", strconv.Itoa(port),
+		"--ctx-size", strconv.Itoa(contextLength),
+	}
 }
 
 // Tokenize implements llm.LlamaServer.

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -31,31 +31,33 @@ import (
 
 // Client wraps an MLX runner subprocess to implement llm.LlamaServer for LLM models.
 type Client struct {
-	port          int
-	modelName     string
-	contextLength atomic.Int64
-	requestedCtx  int
-	memory        atomic.Uint64
-	done          chan struct{}
-	doneErr       error // valid after done is closed
-	client        *http.Client
-	status        *llm.StatusWriter
-	mu            sync.Mutex
-	cmd           *exec.Cmd
+	port              int
+	modelName         string
+	contextLength     atomic.Int64
+	softContextLength int // recommended limit to avoid poor performance
+	hardContextLength int // explicit limit enforced by the runner
+	memory            atomic.Uint64
+	done              chan struct{}
+	doneErr           error // valid after done is closed
+	client            *http.Client
+	status            *llm.StatusWriter
+	mu                sync.Mutex
+	cmd               *exec.Cmd
 }
 
 // NewClient prepares a new MLX runner client for LLM models.
 // The subprocess is not started until Load() is called.
-func NewClient(modelName string, contextLength int) (*Client, error) {
+func NewClient(modelName string, softContextLength, hardContextLength int) (*Client, error) {
 	if err := checkPlatformSupport(); err != nil {
 		return nil, err
 	}
 
 	c := &Client{
-		modelName:    modelName,
-		requestedCtx: contextLength,
-		done:         make(chan struct{}),
-		client:       http.DefaultClient,
+		modelName:         modelName,
+		softContextLength: softContextLength,
+		hardContextLength: hardContextLength,
+		done:              make(chan struct{}),
+		client:            http.DefaultClient,
 	}
 
 	modelManifest, err := manifest.LoadManifest(modelName)
@@ -263,6 +265,17 @@ func (c *Client) ContextLength() int {
 	return int(c.contextLength.Load())
 }
 
+func (c *Client) reportedContextLength(modelContextLength int) int {
+	selectedContextLength := c.softContextLength
+	if c.hardContextLength > 0 {
+		selectedContextLength = c.hardContextLength
+	}
+	if selectedContextLength > 0 && (modelContextLength == 0 || selectedContextLength < modelContextLength) {
+		return selectedContextLength
+	}
+	return modelContextLength
+}
+
 // Detokenize implements llm.LlamaServer.
 func (c *Client) Detokenize(ctx context.Context, tokens []int) (string, error) {
 	return "", errors.New("not supported")
@@ -336,7 +349,7 @@ func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 		exe = eval
 	}
 
-	cmd := exec.Command(exe, runnerArgs(c.modelName, port, c.requestedCtx)...)
+	cmd := exec.Command(exe, runnerArgs(c.modelName, port, c.hardContextLength)...)
 	cmd.Env = os.Environ()
 
 	// Set library path environment variable for MLX libraries
@@ -460,19 +473,22 @@ func (c *Client) Ping(ctx context.Context) error {
 		return err
 	}
 
-	c.contextLength.Store(int64(status.ContextLength))
+	c.contextLength.Store(int64(c.reportedContextLength(status.ContextLength)))
 	c.memory.Store(status.Memory)
 
 	return nil
 }
 
-func runnerArgs(modelName string, port, contextLength int) []string {
-	return []string{
+func runnerArgs(modelName string, port, hardContextLength int) []string {
+	args := []string{
 		"runner", "--mlx-engine",
 		"--model", modelName,
 		"--port", strconv.Itoa(port),
-		"--ctx-size", strconv.Itoa(contextLength),
 	}
+	if hardContextLength > 0 {
+		args = append(args, "--ctx-size", strconv.Itoa(hardContextLength))
+	}
+	return args
 }
 
 // Tokenize implements llm.LlamaServer.

--- a/x/mlxrunner/client_test.go
+++ b/x/mlxrunner/client_test.go
@@ -12,6 +12,50 @@ import (
 	"github.com/ollama/ollama/llm"
 )
 
+func TestRunnerArgsIncludeContextLength(t *testing.T) {
+	got := runnerArgs("qwen3.5:27b", 49152, 65536)
+	want := []string{"runner", "--mlx-engine", "--model", "qwen3.5:27b", "--port", "49152", "--ctx-size", "65536"}
+	if len(got) != len(want) {
+		t.Fatalf("runnerArgs = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("runnerArgs[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestPingReportsRunnerContextLength(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/status" {
+			t.Errorf("path = %q, want /v1/status", r.URL.Path)
+		}
+		if err := json.NewEncoder(w).Encode(statusResponse{ContextLength: 65536, Memory: 42}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	_, portString, err := net.SplitHostPort(srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+	client := &Client{port: port, client: srv.Client()}
+	if err := client.Ping(t.Context()); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if got := client.ContextLength(); got != 65536 {
+		t.Fatalf("ContextLength = %d, want 65536", got)
+	}
+	if got := client.memory.Load(); got != 42 {
+		t.Fatalf("memory = %d, want 42", got)
+	}
+}
+
 func testIntPtr(v int) *int {
 	return &v
 }

--- a/x/mlxrunner/client_test.go
+++ b/x/mlxrunner/client_test.go
@@ -12,16 +12,55 @@ import (
 	"github.com/ollama/ollama/llm"
 )
 
-func TestRunnerArgsIncludeContextLength(t *testing.T) {
-	got := runnerArgs("qwen3.5:27b", 49152, 65536)
-	want := []string{"runner", "--mlx-engine", "--model", "qwen3.5:27b", "--port", "49152", "--ctx-size", "65536"}
-	if len(got) != len(want) {
-		t.Fatalf("runnerArgs = %q, want %q", got, want)
+func TestRunnerArgsContextLengthPrecedence(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		hardContext int
+		want        []string
+	}{
+		{
+			name: "automatic soft context leaves runner at model capacity",
+			want: []string{"runner", "--mlx-engine", "--model", "qwen3.5:27b", "--port", "49152"},
+		},
+		{
+			name:        "explicit hard context is enforced",
+			hardContext: 65536,
+			want:        []string{"runner", "--mlx-engine", "--model", "qwen3.5:27b", "--port", "49152", "--ctx-size", "65536"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := runnerArgs("qwen3.5:27b", 49152, tt.hardContext)
+			if len(got) != len(tt.want) {
+				t.Fatalf("runnerArgs = %q, want %q", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("runnerArgs[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
 	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("runnerArgs[%d] = %q, want %q", i, got[i], want[i])
-		}
+}
+
+func TestReportedContextLengthPrecedence(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		softContext  int
+		hardContext  int
+		modelContext int
+		want         int
+	}{
+		{name: "automatic context remains a soft reporting limit", softContext: 32768, modelContext: 262144, want: 32768},
+		{name: "model capacity caps automatic soft context", softContext: 524288, modelContext: 262144, want: 262144},
+		{name: "explicit hard context takes precedence over soft", softContext: 32768, hardContext: 65536, modelContext: 65536, want: 65536},
+		{name: "model capacity caps explicit hard context", softContext: 32768, hardContext: 524288, modelContext: 262144, want: 262144},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{softContextLength: tt.softContext, hardContextLength: tt.hardContext}
+			if got := client.reportedContextLength(tt.modelContext); got != tt.want {
+				t.Fatalf("reportedContextLength(%d) = %d, want %d", tt.modelContext, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -56,7 +56,7 @@ type Runner struct {
 	spec *speculation
 }
 
-func (r *Runner) Load(modelName string) error {
+func (r *Runner) Load(modelName string, contextLength int) error {
 	root, err := model.Open(modelName)
 	if err != nil {
 		return err
@@ -122,7 +122,7 @@ func (r *Runner) Load(modelName string) error {
 
 	r.Model = m
 	r.Tokenizer = m.Tokenizer()
-	r.contextLength = m.MaxContextLength()
+	r.contextLength = effectiveContextLength(contextLength, m.MaxContextLength())
 	caches := m.NewCaches()
 	draftCaches := newDraftCaches(draftModel)
 	r.cache = newPrefixCache(slices.Concat(caches, draftCaches))
@@ -133,6 +133,13 @@ func (r *Runner) Load(modelName string) error {
 	mlx.EnableCompile()
 
 	return nil
+}
+
+func effectiveContextLength(requested, maximum int) int {
+	if requested <= 0 || requested > maximum {
+		return maximum
+	}
+	return requested
 }
 
 func (r *Runner) Close() {

--- a/x/mlxrunner/runner_test.go
+++ b/x/mlxrunner/runner_test.go
@@ -1,0 +1,23 @@
+package mlxrunner
+
+import "testing"
+
+func TestEffectiveContextLength(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		requested int
+		maximum   int
+		want      int
+	}{
+		{name: "unset uses model maximum", maximum: 262144, want: 262144},
+		{name: "smaller request is enforced", requested: 65536, maximum: 262144, want: 65536},
+		{name: "native maximum is accepted", requested: 262144, maximum: 262144, want: 262144},
+		{name: "unsupported extension is capped", requested: 524288, maximum: 262144, want: 262144},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := effectiveContextLength(tt.requested, tt.maximum); got != tt.want {
+				t.Fatalf("effectiveContextLength(%d, %d) = %d, want %d", tt.requested, tt.maximum, got, tt.want)
+			}
+		})
+	}
+}

--- a/x/mlxrunner/server.go
+++ b/x/mlxrunner/server.go
@@ -28,11 +28,13 @@ func Execute(args []string) error {
 	var (
 		modelName string
 		port      int
+		ctxSize   int
 	)
 
 	flagSet := flag.NewFlagSet("mlxrunner", flag.ExitOnError)
 	flagSet.StringVar(&modelName, "model", "", "Model name")
 	flagSet.IntVar(&port, "port", 0, "Port to listen on")
+	flagSet.IntVar(&ctxSize, "ctx-size", 0, "Context length")
 	_ = flagSet.Bool("verbose", false, "Enable debug logging")
 	flagSet.Parse(args)
 
@@ -66,7 +68,7 @@ func Execute(args []string) error {
 	}
 
 	if err := worker.Do(context.Background(), func() error {
-		return runner.Load(modelName)
+		return runner.Load(modelName, ctxSize)
 	}); err != nil {
 		return err
 	}

--- a/x/models/nn/rope.go
+++ b/x/models/nn/rope.go
@@ -17,6 +17,10 @@ type RopeParameters struct {
 	BetaFast                      float32 `json:"beta_fast"`
 	BetaSlow                      float32 `json:"beta_slow"`
 	AttentionFactor               float32 `json:"attention_factor"`
+	MScale                        float32 `json:"mscale"`
+	MScaleAllDim                  float32 `json:"mscale_all_dim"`
+	Truncate                      *bool   `json:"truncate"`
+	MropeSection                  []int32 `json:"mrope_section"`
 }
 
 // TypeName returns rope_type when present, falling back to type.
@@ -32,6 +36,18 @@ func (rp *RopeParameters) TypeName() string {
 
 // BuildYarnRopeFreqs returns YaRN rotary frequencies and the mscale value.
 func BuildYarnRopeFreqs(dim int, base float32, rp *RopeParameters) (*mlx.Array, float32) {
+	freqs, attentionFactor := YarnRopeFreqValues(dim, base, rp)
+	if freqs == nil {
+		return nil, attentionFactor
+	}
+	arr := mlx.FromValues(freqs, len(freqs))
+	mlx.Eval(arr)
+	return arr, attentionFactor
+}
+
+// YarnRopeFreqValues returns YaRN rotary frequencies and the mscale value in
+// CPU memory. The frequencies are wavelengths, matching MLX's custom RoPE API.
+func YarnRopeFreqValues(dim int, base float32, rp *RopeParameters) ([]float32, float32) {
 	if rp == nil || dim <= 0 {
 		return nil, 1
 	}
@@ -40,10 +56,12 @@ func BuildYarnRopeFreqs(dim int, base float32, rp *RopeParameters) (*mlx.Array, 
 		factor = 1
 	}
 	attentionFactor := rp.AttentionFactor
-	if attentionFactor == 0 && factor > 1 {
-		attentionFactor = float32(0.1*math.Log(float64(factor)) + 1.0)
-	} else if attentionFactor == 0 {
-		attentionFactor = 1
+	if attentionFactor == 0 {
+		if rp.MScale != 0 && rp.MScaleAllDim != 0 {
+			attentionFactor = yarnMScale(factor, rp.MScale) / yarnMScale(factor, rp.MScaleAllDim)
+		} else {
+			attentionFactor = yarnMScale(factor, 1)
+		}
 	}
 	if factor <= 1 {
 		return nil, attentionFactor
@@ -62,7 +80,8 @@ func BuildYarnRopeFreqs(dim int, base float32, rp *RopeParameters) (*mlx.Array, 
 		betaSlow = 1
 	}
 	half := dim / 2
-	low, high := yarnCorrectionRange(betaFast, betaSlow, dim, base, originalMax)
+	truncate := rp.Truncate == nil || *rp.Truncate
+	low, high := yarnCorrectionRange(betaFast, betaSlow, dim, base, originalMax, truncate)
 	freqs := make([]float32, half)
 	for i := range half {
 		posFreq := math.Pow(float64(base), float64(2*i)/float64(dim))
@@ -73,17 +92,26 @@ func BuildYarnRopeFreqs(dim int, base float32, rp *RopeParameters) (*mlx.Array, 
 		inv := invInterpolation*(1-mask) + invExtrapolation*mask
 		freqs[i] = float32(1.0 / inv)
 	}
-	arr := mlx.FromValues(freqs, half)
-	mlx.Eval(arr)
-	return arr, attentionFactor
+	return freqs, attentionFactor
 }
 
-func yarnCorrectionRange(betaFast, betaSlow float32, dim int, base float32, maxPosition int32) (float64, float64) {
+func yarnMScale(factor, multiplier float32) float32 {
+	if factor <= 1 {
+		return 1
+	}
+	return float32(0.1*float64(multiplier)*math.Log(float64(factor)) + 1)
+}
+
+func yarnCorrectionRange(betaFast, betaSlow float32, dim int, base float32, maxPosition int32, truncate bool) (float64, float64) {
 	findDim := func(rot float32) float64 {
 		return float64(dim) * math.Log(float64(maxPosition)/(float64(rot)*2*math.Pi)) / (2 * math.Log(float64(base)))
 	}
-	low := math.Floor(findDim(betaFast))
-	high := math.Ceil(findDim(betaSlow))
+	low := findDim(betaFast)
+	high := findDim(betaSlow)
+	if truncate {
+		low = math.Floor(low)
+		high = math.Ceil(high)
+	}
 	low = math.Max(low, 0)
 	high = math.Min(high, float64(dim-1))
 	if low == high {

--- a/x/models/nn/rope_test.go
+++ b/x/models/nn/rope_test.go
@@ -1,0 +1,50 @@
+package nn
+
+import (
+	"math"
+	"testing"
+)
+
+func TestYarnRopeFreqValues(t *testing.T) {
+	freqs, scale := YarnRopeFreqValues(8, 10000, &RopeParameters{
+		Factor:                        2,
+		OriginalMaxPositionEmbeddings: 4096,
+		BetaFast:                      32,
+		BetaSlow:                      1,
+	})
+	want := []float32{1, 10, 133.33333, 2000}
+	if len(freqs) != len(want) {
+		t.Fatalf("len(freqs) = %d, want %d", len(freqs), len(want))
+	}
+	for i := range want {
+		if math.Abs(float64(freqs[i]-want[i])) > 1e-4 {
+			t.Fatalf("freqs[%d] = %v, want %v", i, freqs[i], want[i])
+		}
+	}
+	wantScale := float32(0.1*math.Log(2) + 1)
+	if math.Abs(float64(scale-wantScale)) > 1e-6 {
+		t.Fatalf("scale = %v, want %v", scale, wantScale)
+	}
+}
+
+func TestYarnRopeFreqValuesHonorsMScaleAndTruncate(t *testing.T) {
+	truncate := false
+	freqs, scale := YarnRopeFreqValues(8, 10000, &RopeParameters{
+		Factor:                        2,
+		OriginalMaxPositionEmbeddings: 4096,
+		BetaFast:                      32,
+		BetaSlow:                      1,
+		MScale:                        2,
+		MScaleAllDim:                  1,
+		Truncate:                      &truncate,
+	})
+	want := []float32{1, 10, 129.79179, 2000}
+	for i := range want {
+		if math.Abs(float64(freqs[i]-want[i])) > 1e-4 {
+			t.Fatalf("freqs[%d] = %v, want %v", i, freqs[i], want[i])
+		}
+	}
+	if math.Abs(float64(scale-1.0648216)) > 1e-6 {
+		t.Fatalf("scale = %v, want 1.0648216", scale)
+	}
+}

--- a/x/models/qwen3_5/qwen3_5.go
+++ b/x/models/qwen3_5/qwen3_5.go
@@ -31,15 +31,6 @@ var (
 	_ base.MediaModel = (*Model)(nil)
 )
 
-// RopeParameters carries optional rope metadata embedded under rope_parameters.
-type RopeParameters struct {
-	Type                string  `json:"type"`
-	RopeType            string  `json:"rope_type"`
-	RopeTheta           float32 `json:"rope_theta"`
-	PartialRotaryFactor float32 `json:"partial_rotary_factor"`
-	MropeSection        []int32 `json:"mrope_section"`
-}
-
 // Config holds Qwen 3.5 text config (top-level or nested text_config).
 type Config struct {
 	ModelType             string   `json:"model_type"`
@@ -73,10 +64,10 @@ type Config struct {
 	NormTopKProb                 bool    `json:"norm_topk_prob"`
 	MLPOnlyLayers                []int32 `json:"mlp_only_layers"`
 
-	RopeTheta           float32         `json:"rope_theta"`
-	PartialRotaryFactor float32         `json:"partial_rotary_factor"`
-	RopeScaling         map[string]any  `json:"rope_scaling"`
-	RopeParameters      *RopeParameters `json:"rope_parameters"`
+	RopeTheta           float32            `json:"rope_theta"`
+	PartialRotaryFactor float32            `json:"partial_rotary_factor"`
+	RopeScaling         *nn.RopeParameters `json:"rope_scaling"`
+	RopeParameters      *nn.RopeParameters `json:"rope_parameters"`
 
 	MropeSection []int32 `json:"-"`
 
@@ -87,8 +78,12 @@ type Config struct {
 	TensorQuant    map[string]*model.TensorQuantInfo `json:"-"`
 
 	// Computed fields.
-	Scale   float32 `json:"-"`
-	RopeDim int32   `json:"-"`
+	Scale        float32    `json:"-"`
+	RopeDim      int32      `json:"-"`
+	RopeFreqs    *mlx.Array `json:"-"`
+	RopeFreqVals []float32  `json:"-"`
+	RopeScale    float32    `json:"-"`
+	MaxContext   int        `json:"-"`
 }
 
 // Model is the Qwen 3.5 model.
@@ -260,12 +255,16 @@ func parseConfig(configData []byte) (Config, error) {
 		return Config{}, fmt.Errorf("linear_num_value_heads (%d) must be divisible by linear_num_key_heads (%d)", cfg.LinearNumValueHeads, cfg.LinearNumKeyHeads)
 	}
 
-	if cfg.RopeParameters != nil {
-		if cfg.RopeParameters.RopeTheta > 0 {
-			cfg.RopeTheta = cfg.RopeParameters.RopeTheta
+	ropeParams := cfg.RopeParameters
+	if ropeParams == nil {
+		ropeParams = cfg.RopeScaling
+	}
+	if ropeParams != nil {
+		if ropeParams.RopeTheta > 0 {
+			cfg.RopeTheta = ropeParams.RopeTheta
 		}
-		if cfg.RopeParameters.PartialRotaryFactor > 0 {
-			cfg.PartialRotaryFactor = cfg.RopeParameters.PartialRotaryFactor
+		if ropeParams.PartialRotaryFactor > 0 {
+			cfg.PartialRotaryFactor = ropeParams.PartialRotaryFactor
 		}
 	}
 	if cfg.RopeTheta == 0 {
@@ -286,8 +285,18 @@ func parseConfig(configData []byte) (Config, error) {
 	}
 	cfg.RopeDim = ropeDim
 	cfg.MropeSection = []int32{11, 11, 10}
-	if cfg.RopeParameters != nil && len(cfg.RopeParameters.MropeSection) == 3 {
-		cfg.MropeSection = cfg.RopeParameters.MropeSection
+	if ropeParams != nil && len(ropeParams.MropeSection) == 3 {
+		cfg.MropeSection = ropeParams.MropeSection
+	}
+	cfg.RopeScale = 1
+	cfg.MaxContext = int(cfg.MaxPositionEmbeddings)
+	if ropeParams != nil && strings.EqualFold(ropeParams.TypeName(), "yarn") {
+		cfg.RopeFreqVals, cfg.RopeScale = nn.YarnRopeFreqValues(int(cfg.RopeDim), cfg.RopeTheta, ropeParams)
+		if cfg.RopeFreqVals != nil {
+			cfg.RopeFreqs = mlx.FromValues(cfg.RopeFreqVals, len(cfg.RopeFreqVals))
+			mlx.Eval(cfg.RopeFreqs)
+		}
+		cfg.MaxContext = yarnContextLength(cfg.MaxPositionEmbeddings, ropeParams)
 	}
 
 	if cfg.FullAttentionInterval <= 0 {
@@ -1056,9 +1065,15 @@ func (a *FullAttention) Forward(x *mlx.Array, b *batch.Batch, c cache.Cache, pos
 		q = applyMRoPE(q, mropeCos, mropeSin, cfg.RopeDim)
 		k = applyMRoPE(k, mropeCos, mropeSin, cfg.RopeDim)
 	} else {
-		q = mlx.RoPEWithBase(q, int(cfg.RopeDim), false, cfg.RopeTheta, 1.0, positions)
-		k = mlx.RoPEWithBase(k, int(cfg.RopeDim), false, cfg.RopeTheta, 1.0, positions)
+		q = mlx.RoPEWithFreqs(q, int(cfg.RopeDim), false, cfg.RopeTheta, 1.0, positions, cfg.RopeFreqs)
+		k = mlx.RoPEWithFreqs(k, int(cfg.RopeDim), false, cfg.RopeTheta, 1.0, positions, cfg.RopeFreqs)
 	}
+	ropeScale := cfg.RopeScale
+	if ropeScale == 0 {
+		ropeScale = 1
+	}
+	q = nn.ScaleRotaryPart(q, int(cfg.RopeDim), ropeScale)
+	k = nn.ScaleRotaryPart(k, int(cfg.RopeDim), ropeScale)
 
 	var kv nn.SDPAOption
 	if c != nil {
@@ -1301,7 +1316,21 @@ func (m *Model) NumLayers() int {
 }
 
 func (m *Model) MaxContextLength() int {
-	return int(m.MaxPositionEmbeddings)
+	if m.MaxContext <= 0 {
+		return int(m.MaxPositionEmbeddings)
+	}
+	return m.MaxContext
+}
+
+func yarnContextLength(native int32, rp *nn.RopeParameters) int {
+	if rp == nil || !strings.EqualFold(rp.TypeName(), "yarn") || rp.Factor <= 1 || rp.OriginalMaxPositionEmbeddings <= 0 {
+		return int(native)
+	}
+	extended := float64(rp.OriginalMaxPositionEmbeddings) * float64(rp.Factor)
+	if extended <= float64(native) || extended > float64(math.MaxInt) {
+		return int(native)
+	}
+	return int(extended)
 }
 
 func (m *Model) Tokenizer() *tokenizer.Tokenizer {

--- a/x/models/qwen3_5/qwen3_5_test.go
+++ b/x/models/qwen3_5/qwen3_5_test.go
@@ -1,12 +1,83 @@
 package qwen3_5
 
 import (
+	"math"
 	"testing"
 
 	"github.com/ollama/ollama/x/internal/mlxtest"
 	"github.com/ollama/ollama/x/mlxrunner/cache"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 )
+
+func TestParseConfigYarnContextExtension(t *testing.T) {
+	mlxtest.Run(t, func(t *mlxtest.T) {
+		cfg, err := parseConfig([]byte(`{
+			"hidden_size": 5120,
+			"intermediate_size": 17408,
+			"num_hidden_layers": 1,
+			"num_attention_heads": 24,
+			"num_key_value_heads": 4,
+			"head_dim": 256,
+			"linear_num_value_heads": 48,
+			"linear_num_key_heads": 16,
+			"linear_key_head_dim": 128,
+			"linear_value_head_dim": 128,
+			"max_position_embeddings": 262144,
+			"rope_parameters": {
+				"rope_type": "yarn",
+				"rope_theta": 10000000,
+				"partial_rotary_factor": 0.25,
+				"factor": 4,
+				"original_max_position_embeddings": 262144,
+				"mrope_section": [11, 11, 10]
+			}
+		}`))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := (&Model{Config: &cfg}).MaxContextLength(); got != 1048576 {
+			t.Fatalf("MaxContextLength = %d, want 1048576", got)
+		}
+		if cfg.RopeFreqs == nil {
+			t.Fatal("RopeFreqs should be precomputed for YaRN")
+		}
+		wantScale := float32(0.1*math.Log(4) + 1)
+		if math.Abs(float64(cfg.RopeScale-wantScale)) > 1e-6 {
+			t.Fatalf("RopeScale = %v, want %v", cfg.RopeScale, wantScale)
+		}
+	})
+}
+
+func TestParseConfigDefaultRopeKeepsNativeContext(t *testing.T) {
+	data := []byte(`{
+		"hidden_size": 5120,
+		"intermediate_size": 17408,
+		"num_hidden_layers": 1,
+		"num_attention_heads": 24,
+		"num_key_value_heads": 4,
+		"head_dim": 256,
+		"linear_num_value_heads": 48,
+		"linear_num_key_heads": 16,
+		"linear_key_head_dim": 128,
+		"linear_value_head_dim": 128,
+		"max_position_embeddings": 262144,
+		"rope_parameters": {
+			"rope_type": "default",
+			"factor": 4,
+			"original_max_position_embeddings": 262144
+		}
+	}`)
+	cfg, err := parseConfig(data)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := (&Model{Config: &cfg}).MaxContextLength(); got != 262144 {
+		t.Fatalf("MaxContextLength = %d, want 262144", got)
+	}
+	if cfg.RopeFreqs != nil {
+		t.Fatal("RopeFreqs should remain nil without YaRN")
+	}
+}
 
 func TestSanitizeConvWeight(t *testing.T) {
 	mlxtest.Run(t, func(t *mlxtest.T) {

--- a/x/models/qwen3_5/vision.go
+++ b/x/models/qwen3_5/vision.go
@@ -523,11 +523,8 @@ func ropePositions(b *batch.Batch, L int32) []int32 {
 // half-dims, matching the reference's interleaved M-RoPE. positions is
 // ropePositions' per-row [3][L] blocks.
 func mropeCosSin(cfg *Config, positions []int32, L int32) (cos, sin *mlx.Array) {
-	half := int(cfg.RopeDim) / 2
-	invFreq := make([]float32, half)
-	for i := range invFreq {
-		invFreq[i] = float32(1 / math.Pow(float64(cfg.RopeTheta), float64(2*i)/float64(cfg.RopeDim)))
-	}
+	invFreq := mropeInvFreqs(cfg)
+	half := len(invFreq)
 
 	// Interleave: start from T, then overwrite H at 1,4,7,... and W at
 	// 2,5,8,..., each bounded by its section's 3x length like the reference.
@@ -553,6 +550,19 @@ func mropeCosSin(cfg *Config, positions []int32, L int32) (cos, sin *mlx.Array) 
 	}
 	e := mlx.FromValues(emb, B, 1, int(L), int(cfg.RopeDim))
 	return mlx.Cos(e), mlx.Sin(e)
+}
+
+func mropeInvFreqs(cfg *Config) []float32 {
+	half := int(cfg.RopeDim) / 2
+	invFreq := make([]float32, half)
+	for i := range invFreq {
+		if len(cfg.RopeFreqVals) == half {
+			invFreq[i] = 1 / cfg.RopeFreqVals[i]
+		} else {
+			invFreq[i] = float32(1 / math.Pow(float64(cfg.RopeTheta), float64(2*i)/float64(cfg.RopeDim)))
+		}
+	}
+	return invFreq
 }
 
 // applyMRoPE rotates the leading RopeDim dims with the chunk's tables,

--- a/x/models/qwen3_5/vision_test.go
+++ b/x/models/qwen3_5/vision_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"image"
 	"image/png"
+	"math"
 	"strings"
 	"testing"
 
@@ -11,6 +12,21 @@ import (
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
 	"github.com/ollama/ollama/x/mlxrunner/model/base"
 )
+
+func TestMRoPEUsesConfiguredFrequencies(t *testing.T) {
+	cfg := &Config{
+		RopeDim:      8,
+		RopeTheta:    10000,
+		RopeFreqVals: []float32{1, 10, 133.33333, 2000},
+	}
+	got := mropeInvFreqs(cfg)
+	want := []float32{1, 0.1, 0.0075, 0.0005}
+	for i := range want {
+		if math.Abs(float64(got[i]-want[i])) > 1e-6 {
+			t.Fatalf("mropeInvFreqs[%d] = %v, want %v", i, got[i], want[i])
+		}
+	}
+}
 
 func TestVisionAdapterWeightsAreCollectable(t *testing.T) {
 	mlxtest.Run(t, func(t *mlxtest.T) {


### PR DESCRIPTION
## Summary

- parse Qwen3.5/3.8 static YaRN metadata from the active RoPE configuration
- apply YaRN frequencies and attention scaling to text RoPE and multimodal M-RoPE
- allow the MLX runner to honor requested contexts up to `factor * original_max_position_embeddings`
- preserve native context and default rotary behavior for older/default-RoPE Qwen models

Fixes #18262.

## Dependency

Depends on #18285, which passes and enforces explicit context in the MLX subprocess while preserving automatic soft context. This PR is intentionally stacked on that commit.

## Scope

This supports models whose active `rope_parameters` (or legacy `rope_scaling` when `rope_parameters` is absent) explicitly declares valid static YaRN metadata. `num_ctx` alone does not silently enable YaRN for a stock model; stock/default Qwen configs remain capped at their native maximum.

## Verification

- `go test ./x/models/nn ./x/models/qwen3_5 ./x/mlxrunner ./server -count=1`
- `go test -race ./x/models/nn ./x/models/qwen3_5 ./x/mlxrunner -count=1`
- `go vet ./x/models/nn ./x/models/qwen3_5 ./x/mlxrunner ./server`
- numerical fixtures cover default YaRN frequencies/scale plus `mscale`, `mscale_all_dim`, and `truncate: false`
- live macOS/Metal test with the official `qwen3.5:0.8b-mlx` weights:
  - unchanged default config requested at 300,000 reported the native 262,144 cap
  - a metadata-identical copy with factor-2 YaRN requested at 300,000 loaded, generated successfully, and reported 300,000 from both `/api/ps` and runner `/v1/status`

## Compatibility

Only Qwen models with explicit static YaRN metadata take the new path. Default/older Qwen metadata and every other model architecture retain their existing maximum and rotary implementation.

## Soft and hard context precedence

Automatic VRAM-derived context remains soft: it is reported as scheduler guidance and does not add `--ctx-size`. Explicit context from request `options.num_ctx`, a Modelfile `num_ctx`, or `OLLAMA_CONTEXT_LENGTH` is hard, takes precedence over the soft value, and is passed to the MLX runner for enforcement.
