### PR TITLE
llm: bound the llama-server prompt cache with OLLAMA_CACHE_RAM

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -368,6 +368,10 @@ How much the cache quantization impacts the model's response quality will depend
 
 You may need to experiment with different quantization types to find the best balance between memory usage and quality.
 
+## How much system memory does a loaded model use?
+
+Besides the weights and the K/V cache, the runner keeps a prompt cache in system memory. When a request replaces the prompt in a slot, the previous prompt's K/V state is saved on the host so a later request that shares a prefix can restore it instead of processing it again. This cache is limited to 8 GiB per loaded model by default, and it fills up over time on workloads that alternate between many different prompts, even when the model itself is fully offloaded to the GPU. Set `OLLAMA_CACHE_RAM` to a limit in MiB to bound it, or `OLLAMA_CACHE_RAM=0` to disable it.
+
 ## Where can I find my Ollama Public Key?
 
 Your **Ollama Public Key** is the public part of the key pair that lets your local Ollama instance talk to [ollama.com](https://ollama.com).

--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -302,6 +302,25 @@ func Uint64(key string, defaultValue uint64) func() uint64 {
 // Set aside VRAM per GPU
 var GpuOverhead = Uint64("OLLAMA_GPU_OVERHEAD", 0)
 
+// CacheRAM returns the limit, in MiB, for the prompt cache llama-server keeps
+// in system memory, and whether OLLAMA_CACHE_RAM was set. llama-server saves
+// the KV state of prompts evicted from a slot so a later request that shares
+// a prefix can skip re-processing it; its own default budget is 8192 MiB per
+// runner, which is not part of Ollama's memory estimates. 0 disables the
+// cache. When unset, llama-server's default applies.
+func CacheRAM() (uint, bool) {
+	s := Var("OLLAMA_CACHE_RAM")
+	if s == "" {
+		return 0, false
+	}
+	n, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		slog.Warn("invalid environment variable, ignoring", "key", "OLLAMA_CACHE_RAM", "value", s)
+		return 0, false
+	}
+	return uint(n), true
+}
+
 type EnvVar struct {
 	Name        string
 	Value       any
@@ -316,6 +335,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_FLASH_ATTENTION":      {"OLLAMA_FLASH_ATTENTION", FlashAttention(false), "Enabled flash attention"},
 		"OLLAMA_KV_CACHE_TYPE":        {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
 		"OLLAMA_GPU_OVERHEAD":         {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},
+		"OLLAMA_CACHE_RAM":            {"OLLAMA_CACHE_RAM", String("OLLAMA_CACHE_RAM")(), "Limit for the llama-server prompt cache in system memory (MiB, 0 disables; default 8192)"},
 		"OLLAMA_IGPU_ENABLE":          {"OLLAMA_IGPU_ENABLE", String("OLLAMA_IGPU_ENABLE")(), "Enable integrated GPUs"},
 		"LLAMA_ARG_FIT":               {"LLAMA_ARG_FIT", String("LLAMA_ARG_FIT")(), "Enable llama.cpp automatic fit of unset memory options (default \"on\")"},
 		"LLAMA_ARG_FIT_TARGET":        {"LLAMA_ARG_FIT_TARGET", String("LLAMA_ARG_FIT_TARGET")(), "Target free VRAM margin per device for llama.cpp fit (MiB)"},

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -226,6 +226,29 @@ func TestUint(t *testing.T) {
 	}
 }
 
+func TestCacheRAM(t *testing.T) {
+	cases := map[string]struct {
+		mib uint
+		ok  bool
+	}{
+		"":     {0, false},
+		"0":    {0, true},
+		"1024": {1024, true},
+		"-1":   {0, false},
+		"8g":   {0, false},
+	}
+
+	for k, v := range cases {
+		t.Run(k, func(t *testing.T) {
+			t.Setenv("OLLAMA_CACHE_RAM", k)
+			mib, ok := CacheRAM()
+			if mib != v.mib || ok != v.ok {
+				t.Errorf("%s: expected (%d, %t), got (%d, %t)", k, v.mib, v.ok, mib, ok)
+			}
+		})
+	}
+}
+
 func TestKeepAlive(t *testing.T) {
 	cases := map[string]time.Duration{
 		"":       5 * time.Minute,

--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -389,6 +389,7 @@ func startLlamaServer(launch llamaServerLaunchConfig, out io.Writer) (cmd *exec.
 	}
 
 	params = appendLoadModeArgs(params, launch.opts, launch.gpus)
+	params = appendPromptCacheArgs(params)
 
 	// KV cache type
 	if launch.kvCacheType != "" {
@@ -633,6 +634,22 @@ func appendLoadModeArgs(params []string, opts api.Options, gpus []ml.DeviceInfo)
 
 	if opts.UseMMap != nil && !*opts.UseMMap {
 		return append(params, "--load-mode", "none")
+	}
+
+	return params
+}
+
+// appendPromptCacheArgs bounds the prompt cache llama-server keeps in system
+// memory. When a slot is reused for a different prompt, llama-server saves the
+// evicted KV state on the host so a later request sharing a prefix can restore
+// it instead of re-processing the prompt; the upstream default allows 8 GiB of
+// these states per runner, allocated on top of the weights and KV cache and
+// invisible to Ollama's scheduler. OLLAMA_CACHE_RAM sets an explicit limit in
+// MiB (0 disables the cache). When it is unset no flag is passed, so an
+// inherited LLAMA_ARG_CACHE_RAM or llama-server's own default still applies.
+func appendPromptCacheArgs(params []string) []string {
+	if mib, ok := envconfig.CacheRAM(); ok {
+		return append(params, "--cache-ram", strconv.FormatUint(uint64(mib), 10))
 	}
 
 	return params

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -3768,3 +3768,26 @@ func fakeRunningCmd() *exec.Cmd {
 	// SIGKILL children when the test process exits.
 	return cmd
 }
+
+func TestAppendPromptCacheArgs(t *testing.T) {
+	tests := []struct {
+		name string
+		env  string
+		want []string
+	}{
+		{name: "unset leaves llama-server default", env: "", want: []string{"base"}},
+		{name: "zero disables the cache", env: "0", want: []string{"base", "--cache-ram", "0"}},
+		{name: "explicit limit in MiB", env: "1024", want: []string{"base", "--cache-ram", "1024"}},
+		{name: "invalid value is ignored", env: "lots", want: []string{"base"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OLLAMA_CACHE_RAM", tt.env)
+			got := appendPromptCacheArgs([]string{"base"})
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("appendPromptCacheArgs = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #18264.

## Problem

llama-server keeps a prompt cache in system memory: when a slot is reused for a different prompt, the evicted prompt's KV state is saved on the host so a later request that shares a prefix can restore it instead of re-processing the prompt. The llama.cpp default budget is **8192 MiB per runner**, allocated on top of the weights and KV cache. Ollama passes no flag, offers no way to change it, and `MemorySize()` reports a fully offloaded model as VRAM-only, so the memory is invisible to the scheduler and to `ollama ps`.

On a runner shared by several agents (`OLLAMA_NUM_PARALLEL=1`, prompts alternating), a 100 %-GPU gemma4:12b reached 9.4 GB of host RSS (8.3 GB anonymous) with the cache reporting `27 prompts, 7377.676 MiB (limits: 8192.000 MiB …)`. With the cache bounded to 1024 MiB the same runner sits at 1.6 GB. Numbers and log excerpts are in the issue.

## Change

- `envconfig`: `CacheRAM()` reads `OLLAMA_CACHE_RAM` (MiB, `0` disables the cache) and reports whether it was set; listed in `ollama serve --help`.
- `llm`: `appendPromptCacheArgs` passes `--cache-ram <n>` only when the variable is set. Unset keeps today's behaviour exactly: llama-server's own default applies, and an inherited `LLAMA_ARG_CACHE_RAM` still works (llama-server would otherwise warn that the flag overrides it).
- FAQ entry explaining where the memory goes and how to bound it.

The default is deliberately left at llama.cpp's 8 GiB. Whether Ollama should pick a smaller or system-memory-relative default now that it controls the flag is raised in the issue for maintainers; this PR only adds the control.

## Tests

- `envconfig`: `TestCacheRAM` — unset, `0`, a value, and rejected inputs (`-1`, `8g`).
- `llm`: `TestAppendPromptCacheArgs` — no flag when unset or invalid, `--cache-ram 0` and `--cache-ram 1024` when set.
- `gofmt -l` clean; `go test ./envconfig ./llm` passes.
- Live: `LLAMA_ARG_CACHE_RAM=1024` through the same llama-server path on the machine above — runner log shows `prompt cache is enabled, size limit: 1024 MiB`, `ollama ps` unchanged at `100% GPU`, RSS 9.4 GB → 1.6 GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019RW22cVmbE3YFFpfqByYty