### PR TITLE
README: add INVAR (receipted Ollama endpoint) to Community Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,6 +328,7 @@ console.log(response.message.content);
 - [Langfuse](https://langfuse.com/docs/integrations/ollama) - Open source LLM observability
 - [HoneyHive](https://docs.honeyhive.ai/integrations/ollama) - AI observability and evaluation for agents
 - [MLflow Tracing](https://mlflow.org/docs/latest/llms/tracing/index.html#automatic-tracing) - Open source LLM observability
+- [INVAR](https://github.com/anomly-labs/invar) - Re-executable receipts for every Ollama answer: OpenAI-compatible endpoint in front of Ollama, hash-chained worldline, `invar verify` re-runs entries against Ollama
 
 ### Database & Embeddings
 


### PR DESCRIPTION
INVAR is an Apache-2.0 wrapper that sits in front of an existing Ollama server: `invar serve --model llama3.2` exposes an OpenAI-compatible endpoint where every answer carries a receipt pinning the `ollama` binary (sha256), the model manifest digest, the GGUF blob digest and the decode options, hash-chained into an append-only log. `invar verify` asks Ollama to run each entry again and compares output digests. Nothing about Ollama changes; it works with any model you have pulled.

Repo: https://github.com/anomly-labs/invar (tests + CI; the Ollama section is in docs/INTEGRATIONS.md).

One line under Observability & Monitoring; happy to move it if another section fits better.
