### PR TITLE
readme: add deel to Code Editors & Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ console.log(response.message.content);
 - [orbiton](https://github.com/xyproto/orbiton) - Config-free text editor with Ollama tab completion
 - [AI ST Completion](https://github.com/yaroslavyaroslav/OpenAI-sublime-text) - Sublime Text 4 AI assistant
 - [VT Code](https://github.com/vinhnx/vtcode) - Rust-based terminal coding agent with Tree-sitter
+- [deel](https://github.com/jysvai/deel-local-cli) - Zero-dependency terminal coding agent with editor (ACP) support
 - [QodeAssist](https://github.com/Palm1r/QodeAssist) - AI coding assistant for Qt Creator
 - [AI Toolkit for VS Code](https://aka.ms/ai-tooklit/ollama-docs) - Microsoft-official VS Code extension
 - [Open Interpreter](https://docs.openinterpreter.com/language-model-setup/local-models/ollama) - Natural language interface for computers


### PR DESCRIPTION
Adds one line to the Community Integrations list.

**[deel](https://github.com/jysvai/deel-local-cli)** — a terminal coding agent built for local models. Ollama is a first-class target: `deel setup` detects a running Ollama, lists the pulled models, and picks one; there is no cloud fallback and no telemetry.

A few things that may be relevant to this list specifically:

- **Zero runtime dependencies.** Node 20+ and nothing else — no install scripts, no postinstall, no bundled binaries. `npx -y deel-local-cli` is the whole install.
- **One network destination.** It talks to the endpoint you configured and nowhere else. There is a test that fails the build if a second host appears.
- **Also an ACP agent.** `deel acp` runs it inside Zed, JetBrains, Neovim and Emacs, so the same Ollama setup works in the terminal and in the editor.

npm: https://www.npmjs.com/package/deel-local-cli · MIT · published with SLSA provenance.

Happy to move the entry to **Terminal & CLI** instead if that fits better — it sits between the two.