### PR TITLE
llm: send renderer message delimiters to llama-server for user-turn checkpoints

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -47,6 +47,7 @@ import (
 	"github.com/ollama/ollama/envconfig"
 	"github.com/ollama/ollama/fs/ggml"
 	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/model/renderers"
 )
 
 var grammarJSON = `
@@ -1413,6 +1414,10 @@ type llamaServerCompletionRequest struct {
 	NProbs          int             `json:"n_probs,omitempty"`
 	PreservedTokens []string        `json:"preserved_tokens,omitempty"`
 	TimingsPerToken bool            `json:"timings_per_token,omitempty"`
+
+	// MessageDelimiters tells llama-server where each message starts so it
+	// can place context checkpoints at message boundaries.
+	MessageDelimiters []renderers.MessageDelimiter `json:"message_delimiters,omitempty"`
 }
 
 func llamaServerPreservedTokens(parserTokens []string, toolCallTag string) []string {
@@ -1561,24 +1566,25 @@ func (s *llamaServerRunner) Completion(ctx context.Context, req CompletionReques
 
 	// Build the llama-server request
 	lsReq := llamaServerCompletionRequest{
-		Prompt:          prompt,
-		Stream:          true,
-		CachePrompt:     true,
-		NPredict:        req.Options.NumPredict,
-		NKeep:           req.Options.NumKeep,
-		Temperature:     req.Options.Temperature,
-		TopK:            req.Options.TopK,
-		TopP:            req.Options.TopP,
-		MinP:            req.Options.MinP,
-		Stop:            req.Options.Stop,
-		RepeatPenalty:   req.Options.RepeatPenalty,
-		RepeatLastN:     req.Options.RepeatLastN,
-		FreqPenalty:     req.Options.FrequencyPenalty,
-		PresPenalty:     req.Options.PresencePenalty,
-		TypicalP:        req.Options.TypicalP,
-		Seed:            req.Options.Seed,
-		PreservedTokens: llamaServerPreservedTokens(req.PreservedTokens, req.ToolCallTag),
-		TimingsPerToken: req.IncludeIntermediateMetrics,
+		Prompt:            prompt,
+		Stream:            true,
+		CachePrompt:       true,
+		NPredict:          req.Options.NumPredict,
+		NKeep:             req.Options.NumKeep,
+		Temperature:       req.Options.Temperature,
+		TopK:              req.Options.TopK,
+		TopP:              req.Options.TopP,
+		MinP:              req.Options.MinP,
+		Stop:              req.Options.Stop,
+		RepeatPenalty:     req.Options.RepeatPenalty,
+		RepeatLastN:       req.Options.RepeatLastN,
+		FreqPenalty:       req.Options.FrequencyPenalty,
+		PresPenalty:       req.Options.PresencePenalty,
+		TypicalP:          req.Options.TypicalP,
+		Seed:              req.Options.Seed,
+		PreservedTokens:   llamaServerPreservedTokens(req.PreservedTokens, req.ToolCallTag),
+		TimingsPerToken:   req.IncludeIntermediateMetrics,
+		MessageDelimiters: req.MessageDelimiters,
 	}
 
 	if req.Logprobs {

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/ollama/ollama/fs/ggml"
 	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/model/renderers"
 
 	"github.com/ollama/ollama/api"
 	"golang.org/x/sync/semaphore"
@@ -148,6 +149,41 @@ func TestContextShiftPromptLimit(t *testing.T) {
 				t.Fatalf("contextShiftPromptLimit(%d, %d) = %d, want %d", tt.numCtx, tt.numKeep, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestLlamaServerCompletionRequestMessageDelimitersMarshal(t *testing.T) {
+	withDelimiters := llamaServerCompletionRequest{
+		Prompt: "test prompt",
+		MessageDelimiters: []renderers.MessageDelimiter{
+			{Role: "system", Delimiter: "<|im_start|>system\n"},
+			{Role: "user", Delimiter: "<|im_start|>user\n"},
+			{Role: "assistant", Delimiter: "<|im_start|>assistant\n"},
+		},
+	}
+
+	b, err := json.Marshal(withDelimiters)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(string(b), `"message_delimiters":[`) {
+		t.Fatalf("expected message_delimiters in marshaled request, got %s", b)
+	}
+	var roundTripped llamaServerCompletionRequest
+	if err := json.Unmarshal(b, &roundTripped); err != nil {
+		t.Fatalf("unexpected error unmarshaling: %v", err)
+	}
+	if !reflect.DeepEqual(roundTripped.MessageDelimiters, withDelimiters.MessageDelimiters) {
+		t.Fatalf("message_delimiters round-trip = %#v, want %#v", roundTripped.MessageDelimiters, withDelimiters.MessageDelimiters)
+	}
+
+	withoutDelimiters := llamaServerCompletionRequest{Prompt: "test prompt"}
+	b, err = json.Marshal(withoutDelimiters)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(string(b), "message_delimiters") {
+		t.Fatalf("expected message_delimiters to be omitted when nil, got %s", b)
 	}
 }
 

--- a/llm/server.go
+++ b/llm/server.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ollama/ollama/format"
 	"github.com/ollama/ollama/fs/ggml"
 	"github.com/ollama/ollama/ml"
+	"github.com/ollama/ollama/model/renderers"
 )
 
 var ErrLoadRequiredFull = errors.New("unable to load full model on GPU")
@@ -216,6 +217,10 @@ type CompletionRequest struct {
 	LeadingBOS      string   // textual BOS emitted by Go rendering, if any
 	// IncludeIntermediateMetrics adds cumulative metrics to non-final responses; final responses always include metrics.
 	IncludeIntermediateMetrics bool
+
+	// MessageDelimiters marks where each message starts in Prompt, keyed by
+	// role; ignored by runners other than llama-server.
+	MessageDelimiters []renderers.MessageDelimiter
 
 	// Logprobs specifies whether to include log probabilities in the response
 	Logprobs bool

--- a/model/renderers/qwen35.go
+++ b/model/renderers/qwen35.go
@@ -72,6 +72,10 @@ func (r *Qwen35Renderer) LeadingBOS() string {
 	return ""
 }
 
+func (r *Qwen35Renderer) MessageDelimiters() []MessageDelimiter {
+	return chatMLMessageDelimiters()
+}
+
 func (r *Qwen35Renderer) renderContent(content api.Message, imageOffset int) (string, int) {
 	if r.useImgTags {
 		return renderContentWithImageTags(content.Content, len(content.Images), imageOffset)

--- a/model/renderers/qwen3vl.go
+++ b/model/renderers/qwen3vl.go
@@ -17,6 +17,10 @@ func (r *Qwen3VLRenderer) LeadingBOS() string {
 	return ""
 }
 
+func (r *Qwen3VLRenderer) MessageDelimiters() []MessageDelimiter {
+	return chatMLMessageDelimiters()
+}
+
 func (r *Qwen3VLRenderer) renderContent(content api.Message, imageOffset int) (string, int) {
 	if r.useImgTags {
 		return renderContentWithImageTags(content.Content, len(content.Images), imageOffset)

--- a/model/renderers/renderer.go
+++ b/model/renderers/renderer.go
@@ -11,6 +11,22 @@ type Renderer interface {
 	LeadingBOS() string
 }
 
+// MessageDelimiter marks where a message of the given role starts in the
+// rendered prompt; llama-server uses these to place context checkpoints at
+// message boundaries.
+type MessageDelimiter struct {
+	Role      string `json:"role"`
+	Delimiter string `json:"delimiter"`
+}
+
+// MessageDelimiterProvider is an optional interface implemented by renderers
+// that use fixed, role-keyed markers to open each message. Renderers whose
+// message boundaries can't be expressed as a static per-role marker should
+// not implement it.
+type MessageDelimiterProvider interface {
+	MessageDelimiters() []MessageDelimiter
+}
+
 type (
 	RendererConstructor func() Renderer
 	RendererRegistry    struct {
@@ -50,6 +66,33 @@ func LeadingBOSForRenderer(name string) string {
 	}
 
 	return renderer.LeadingBOS()
+}
+
+// MessageDelimitersForRenderer returns the message delimiters for the named
+// renderer, or nil if the renderer is unknown or doesn't have fixed,
+// role-keyed message markers.
+func MessageDelimitersForRenderer(name string) []MessageDelimiter {
+	renderer := rendererForName(name)
+	if renderer == nil {
+		return nil
+	}
+
+	provider, ok := renderer.(MessageDelimiterProvider)
+	if !ok {
+		return nil
+	}
+
+	return provider.MessageDelimiters()
+}
+
+// chatMLMessageDelimiters returns the message delimiters shared by renderers
+// that use ChatML-style "<|im_start|>role\n" markers to open messages.
+func chatMLMessageDelimiters() []MessageDelimiter {
+	return []MessageDelimiter{
+		{Role: "system", Delimiter: imStartTag + "system\n"},
+		{Role: "user", Delimiter: imStartTag + "user\n"},
+		{Role: "assistant", Delimiter: imStartTag + "assistant\n"},
+	}
 }
 
 func rendererForName(name string) Renderer {

--- a/model/renderers/renderer_test.go
+++ b/model/renderers/renderer_test.go
@@ -1,6 +1,7 @@
 package renderers
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/ollama/ollama/api"
@@ -83,6 +84,34 @@ func TestLeadingBOSForRenderer(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := LeadingBOSForRenderer(tt.name); got != tt.want {
 				t.Fatalf("LeadingBOSForRenderer(%q) = %q, want %q", tt.name, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMessageDelimitersForRenderer(t *testing.T) {
+	wantChatML := []MessageDelimiter{
+		{Role: "system", Delimiter: "<|im_start|>system\n"},
+		{Role: "user", Delimiter: "<|im_start|>user\n"},
+		{Role: "assistant", Delimiter: "<|im_start|>assistant\n"},
+	}
+
+	tests := []struct {
+		name string
+		want []MessageDelimiter
+	}{
+		{name: "qwen3.5", want: wantChatML},
+		{name: "qwen3-vl-instruct", want: wantChatML},
+		{name: "qwen3-vl-thinking", want: wantChatML},
+		{name: "qwen3-coder", want: nil},
+		{name: "unknown", want: nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MessageDelimitersForRenderer(tt.name)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("MessageDelimitersForRenderer(%q) = %#v, want %#v", tt.name, got, tt.want)
 			}
 		})
 	}

--- a/server/routes.go
+++ b/server/routes.go
@@ -661,16 +661,17 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 		var parserErr error
 
 		if err := r.Completion(ctx, llm.CompletionRequest{
-			Prompt:          prompt,
-			Media:           media,
-			Format:          req.Format,
-			Options:         opts,
-			Shift:           req.Shift == nil || *req.Shift,
-			Truncate:        req.Truncate == nil || *req.Truncate,
-			Logprobs:        req.Logprobs,
-			TopLogprobs:     req.TopLogprobs,
-			PreservedTokens: preservedTokensForCompletion(builtinParser),
-			LeadingBOS:      leadingBOS,
+			Prompt:            prompt,
+			Media:             media,
+			Format:            req.Format,
+			Options:           opts,
+			Shift:             req.Shift == nil || *req.Shift,
+			Truncate:          req.Truncate == nil || *req.Truncate,
+			Logprobs:          req.Logprobs,
+			TopLogprobs:       req.TopLogprobs,
+			PreservedTokens:   preservedTokensForCompletion(builtinParser),
+			LeadingBOS:        leadingBOS,
+			MessageDelimiters: messageDelimitersForModel(m),
 		}, func(cr llm.CompletionResponse) {
 			res := api.GenerateResponse{
 				Model:     req.Model,
@@ -2347,6 +2348,14 @@ func leadingBOSForModel(m *Model) string {
 	return renderers.LeadingBOSForRenderer(resolveRendererName(m))
 }
 
+func messageDelimitersForModel(m *Model) []renderers.MessageDelimiter {
+	if m == nil || m.Config.Renderer == "" {
+		return nil
+	}
+
+	return renderers.MessageDelimitersForRenderer(resolveRendererName(m))
+}
+
 func optionsForPrompt(opts *api.Options, runner llm.LlamaServer) *api.Options {
 	if opts == nil || runner == nil {
 		return opts
@@ -2800,6 +2809,7 @@ func (s *Server) ChatHandler(c *gin.Context) {
 				ToolCallTag:                toolCallTagForCompletion(toolParser),
 				LeadingBOS:                 leadingBOSForModel(m),
 				IncludeIntermediateMetrics: includeIntermediateMetrics,
+				MessageDelimiters:          messageDelimitersForModel(m),
 			}, func(r llm.CompletionResponse) {
 				metrics := api.Metrics{
 					PromptEvalCount:       r.PromptEvalCount,


### PR DESCRIPTION
## Problem

llama-server places context checkpoints only at points it can identify in
the prompt it is given. When Ollama renders a prompt with a Go renderer and
sends it to llama-server's raw `/completion` endpoint, llama-server never
sees a `message_delimiters` field, so it can't create a checkpoint at the
start of the user turn.

For architectures that are hybrid or recurrent (for example, the qwen3.5
family), a cached prompt can only be branched at a checkpoint. Without a
checkpoint at the user turn, two requests that share the same system prompt
but differ later on (e.g. the same instructions/rubric with a different
attached image) can't reuse the cached prefix at all — llama-server
re-prefills the entire prompt from the beginning instead of resuming from
just after the system prompt.

This affects every model whose Go renderer builds the full prompt itself,
currently the qwen3.5 and qwen3-vl (instruct and thinking) renderers.

## Change

- `model/renderers/renderer.go`: add a `MessageDelimiter` type, an optional
  `MessageDelimiterProvider` interface for renderers with fixed, role-keyed
  message markers, `MessageDelimitersForRenderer`, and a shared
  `chatMLMessageDelimiters` helper for ChatML-style renderers.
- `model/renderers/qwen35.go`, `model/renderers/qwen3vl.go`: implement
  `MessageDelimiters()` via the ChatML helper.
- `llm/server.go`: add `MessageDelimiters []renderers.MessageDelimiter` to
  `CompletionRequest`.
- `llm/llama_server.go`: add `MessageDelimiters` to
  `llamaServerCompletionRequest` (`json:"message_delimiters,omitempty"`) and
  forward it from `CompletionRequest` in `Completion()`.
- `server/routes.go`: add `messageDelimitersForModel`, mirroring the
  existing `leadingBOSForModel` helper, and pass its result through on both
  the generate and chat completion paths.

## How this was tested

- Unit tests: `TestMessageDelimitersForRenderer` (renderer lookup, including
  renderers that don't implement the provider) and
  `TestLlamaServerCompletionRequestMessageDelimitersMarshal` (the field is
  present and round-trips when set, and omitted entirely when nil).
- `go vet` and `gofmt` over the changed packages; `go build`.
- A production-style workload: sent a request, then a follow-up request
  reusing the same system prompt but with a different attached image. With
  `message_delimiters` present, the follow-up request reused the cached
  system-prompt prefix and only prefilled 674 tokens in 1.0s, versus 3980
  tokens in 3.9s without it — and produced identical output tokens at
  temperature 0 in both cases, confirming the checkpoint restore doesn't
  change generation.

## Compatibility

Renderers that don't implement `MessageDelimiterProvider` are unaffected —
`MessageDelimitersForRenderer` returns `nil` for them, so the JSON field is
omitted entirely (`omitempty`) and llama-server's existing behavior is
unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WS3L5mCDfX1VhaQBMuzbyE
