### PR TITLE
x/transfer: finish a .tmp that is already the whole blob

### DIFF
--- a/x/transfer/download.go
+++ b/x/transfer/download.go
@@ -219,6 +219,14 @@ func (d *downloader) downloadOnce(ctx context.Context, blob Blob) (int64, error)
 		d.logger.Debug("downloading blob", "digest", blob.Digest, "size", blob.Size)
 	}
 
+	dest := filepath.Join(d.destDir, digestToPath(blob.Digest))
+	tmp := dest + ".tmp"
+	if blob.Size >= resumeThreshold {
+		if fi, statErr := os.Stat(tmp); statErr == nil && fi.Size() == blob.Size && d.finishTmp(blob, tmp, dest) {
+			return blob.Size, nil
+		}
+	}
+
 	// Hold a body slot for the duration of the GET — released when the body
 	// has been read and the response closed.
 	release, err := d.holdBody(ctx)
@@ -234,18 +242,15 @@ func (d *downloader) downloadOnce(ctx context.Context, blob Blob) (int64, error)
 	}
 
 	// Check for existing partial .tmp file for resume
-	dest := filepath.Join(d.destDir, digestToPath(blob.Digest))
-	tmp := dest + ".tmp"
 	var existingSize int64
 	if blob.Size >= resumeThreshold {
 		if fi, statErr := os.Stat(tmp); statErr == nil {
 			if fi.Size() < blob.Size {
 				existingSize = fi.Size()
-			} else if fi.Size() > blob.Size {
-				// .tmp larger than expected — discard
+			} else {
+				// .tmp at or over the full size and not the blob — discard
 				os.Remove(tmp)
 			}
-			// fi.Size() == blob.Size handled in save (hash check + rename)
 		}
 	}
 
@@ -278,6 +283,28 @@ func (d *downloader) downloadOnce(ctx context.Context, blob Blob) (int64, error)
 	}
 
 	return d.save(ctx, blob, resp.Body, existingSize)
+}
+
+// finishTmp handles a .tmp that already holds the blob's full size: a transfer
+// that completed but was not renamed. It is hashed in place and moved to dest
+// if it is the blob, so nothing is fetched again. Anything else is left for the
+// caller to discard.
+func (d *downloader) finishTmp(blob Blob, tmp, dest string) bool {
+	f, err := os.Open(tmp)
+	if err != nil {
+		return false
+	}
+	h := sha256.New()
+	_, err = io.Copy(h, f)
+	f.Close()
+	if err != nil || fmt.Sprintf("sha256:%x", h.Sum(nil)) != blob.Digest {
+		return false
+	}
+	if err := os.Rename(tmp, dest); err != nil {
+		return false
+	}
+	d.progress.add(blob.Size)
+	return true
 }
 
 func (d *downloader) save(ctx context.Context, blob Blob, r io.Reader, existingSize int64) (int64, error) {

--- a/x/transfer/transfer_test.go
+++ b/x/transfer/transfer_test.go
@@ -12,6 +12,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -2074,13 +2075,26 @@ func TestResumePartialFileExactSize(t *testing.T) {
 	os.MkdirAll(filepath.Dir(dest), 0o755)
 	os.WriteFile(dest+".tmp", data, 0o644)
 
+	var completed int64
 	err := Download(context.Background(), DownloadOptions{
-		Blobs:   []Blob{blob},
-		BaseURL: server.URL,
-		DestDir: clientDir,
+		Blobs:    []Blob{blob},
+		BaseURL:  server.URL,
+		DestDir:  clientDir,
+		Progress: func(c, _ int64) { completed = c },
 	})
 	if err != nil {
 		t.Fatalf("Download failed: %v", err)
+	}
+
+	// The blob was already on disk in full; nothing should have been fetched
+	if n := requestCount.Load(); n != 0 {
+		t.Errorf("Requests = %d, want 0 for a complete .tmp", n)
+	}
+	if completed != int64(blobSize) {
+		t.Errorf("Progress reported %d, want %d", completed, blobSize)
+	}
+	if _, err := os.Stat(dest + ".tmp"); !os.IsNotExist(err) {
+		t.Error("Expected .tmp to be renamed away")
 	}
 
 	// Verify final file is correct
@@ -2090,6 +2104,63 @@ func TestResumePartialFileExactSize(t *testing.T) {
 	}
 	resumeHash := sha256.Sum256(finalData)
 	if fmt.Sprintf("sha256:%x", resumeHash) != digest {
+		t.Error("Final file hash mismatch")
+	}
+}
+
+func TestResumePartialFileExactSizeCorrupt(t *testing.T) {
+	blobSize := resumeThreshold + 1024
+	data := make([]byte, blobSize)
+	for i := range data {
+		data[i] = byte((i * 13) % 256)
+	}
+	h := sha256.Sum256(data)
+	digest := fmt.Sprintf("sha256:%x", h)
+	blob := Blob{Digest: digest, Size: int64(blobSize)}
+
+	var rangeHeader string
+	var mu sync.Mutex
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		rangeHeader = r.Header.Get("Range")
+		mu.Unlock()
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", blobSize))
+		w.WriteHeader(http.StatusOK)
+		w.Write(data)
+	}))
+	defer server.Close()
+
+	clientDir := t.TempDir()
+
+	// A .tmp of the right size whose bytes are not the blob's
+	dest := filepath.Join(clientDir, digestToPath(digest))
+	os.MkdirAll(filepath.Dir(dest), 0o755)
+	wrong := slices.Clone(data)
+	wrong[blobSize/2] ^= 0xff
+	os.WriteFile(dest+".tmp", wrong, 0o644)
+
+	err := Download(context.Background(), DownloadOptions{
+		Blobs:   []Blob{blob},
+		BaseURL: server.URL,
+		DestDir: clientDir,
+	})
+	if err != nil {
+		t.Fatalf("Download failed: %v", err)
+	}
+
+	// Discarded and fetched whole, not resumed from the corrupt bytes
+	mu.Lock()
+	if rangeHeader != "" {
+		t.Errorf("Range header = %q, want none after discarding a corrupt .tmp", rangeHeader)
+	}
+	mu.Unlock()
+
+	finalData, err := os.ReadFile(dest)
+	if err != nil {
+		t.Fatalf("Failed to read final file: %v", err)
+	}
+	if got := sha256.Sum256(finalData); fmt.Sprintf("sha256:%x", got) != digest {
 		t.Error("Final file hash mismatch")
 	}
 }


### PR DESCRIPTION
Your #15320. Resume on the transfer path landed in #14946 four days after you
filed it: blobs of 64 MB and up keep their `.tmp` on failure and continue with
a `Range` request, and the digest and size are checked at the end. The issue
is still open, so this closes it with the one case that was left.

A `.tmp` already at the blob's full size — the transfer finished and the
rename did not, which on Windows is a sharing violation on a file something
else has just opened — was truncated by `os.Create` and fetched again from
zero. It is now hashed in place and renamed if it is the blob, and discarded
if it is not.

`TestResumePartialFileExactSize` already described this case; it now also
asserts that no request reaches the server, that progress reports the full
size, and that the `.tmp` is gone. `TestResumePartialFileExactSizeCorrupt`
covers a full-size `.tmp` with the wrong bytes: discarded, fetched whole, no
`Range` sent.

Closes #15320
