### PR TITLE
llm: send assistant thinking to the chat template

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -2216,6 +2216,16 @@ func llamaServerChatMessage(msg Message) (map[string]any, error) {
 	converted := map[string]any{
 		"role": msg.Role,
 	}
+	// Thinking has to reach the chat template, not just the client. A template
+	// that replays an assistant think block reads `reasoning_content`, and the
+	// Qwen-family templates gate that replay on the message being newer than
+	// the last real user query -- which, in an agentic tool loop, is every
+	// assistant turn since the task was set. Dropping the field here leaves
+	// those blocks empty, so a model re-derives each turn what it already
+	// worked out, and describes its own earlier turns as someone else's.
+	if msg.Thinking != "" {
+		converted["reasoning_content"] = msg.Thinking
+	}
 	if msg.ToolCallID != "" {
 		converted["tool_call_id"] = msg.ToolCallID
 	}

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -3768,3 +3768,30 @@ func fakeRunningCmd() *exec.Cmd {
 	// SIGKILL children when the test process exits.
 	return cmd
 }
+
+func TestLlamaServerChatMessageCarriesThinking(t *testing.T) {
+	msg, err := llamaServerChatMessage(Message{
+		Role:     "assistant",
+		Content:  "OK",
+		Thinking: "the secret number is 7413",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := msg["reasoning_content"]; got != "the secret number is 7413" {
+		t.Fatalf("reasoning_content = %#v, want the thinking to reach the template", got)
+	}
+	if got := msg["content"]; got != "OK" {
+		t.Fatalf("content = %#v, want the visible reply untouched", got)
+	}
+
+	// A message that never carried thinking must not gain an empty field: a
+	// template that only checks for presence would render a blank think block.
+	plain, err := llamaServerChatMessage(Message{Role: "assistant", Content: "OK"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := plain["reasoning_content"]; ok {
+		t.Fatalf("reasoning_content present on a message with no thinking: %#v", plain)
+	}
+}


### PR DESCRIPTION
`llamaServerChatMessage` builds the outbound message from an explicit field list — `role`, `tool_call_id`, `name`, `tool_calls`, `content`, media. `Thinking` is not on it. The field is parsed from the API (`api.Message.Thinking`, `json:"thinking"`), survives `MessageFromAPI` into `llm.Message`, and is then dropped at the wire. llama-server never sees it, so a chat template that replays an assistant think block has nothing to replay.

The rendered path never had this gap — renderers read `message.Thinking` directly (`model/renderers/qwen35.go`). This brings the native path level with it.

### Why this is mostly invisible

Three things have to line up before anything looks wrong, which is why the native path has been fine for most users:

1. **Single-turn chat can't show it** — there is no prior thinking to replay.
2. **Most clients never send thinking back.** `thinking` on an assistant message is optional and rarely populated.
3. **The Qwen-family templates only replay thinking inside a tool loop.** The gate is `(preserve_thinking is defined and preserve_thinking is true) or (loop.index0 > ns.last_query_index)`, and the backward scan that sets `last_query_index` deliberately skips messages wrapped in `<tool_response>`. So thinking is replayed for every assistant turn since the last *real* user query, and dropped once a new user turn arrives.

### Where it does show: agentic clients

Cline hits all three. Its Ollama provider accumulates reasoning deltas and attaches them to the assistant message it sends back (`ollama-ai-provider-v2`, `thinking += part.text`), and an agentic task is one user message followed by a long alternation of assistant turns and `role: "tool"` results — exactly the shape the template preserves thinking through. Cline is careful about this on its side; there is a comment in its Ollama vendor explaining that it refuses to relocate tool images into a synthetic user message because doing so "costs the model its entire reasoning history, because a chat template replays thinking only from the last user turn onward". It protects the history, and it is discarded one layer below.

### Reproducer

With `_debug_render_only`, an agentic-shaped conversation on a model running its own GGUF chat template (`ornith-1.5:35b`, no renderer or parser set):

```json
{"model":"ornith-1.5:35b","think":"low","_debug_render_only":true,
 "messages":[
  {"role":"user","content":"TASK-TEXT"},
  {"role":"assistant","content":"VISIBLE-REPLY","thinking":"SECRET-THINKING-7413",
   "tool_calls":[{"function":{"name":"list_files","arguments":{"path":"."}}}]},
  {"role":"tool","content":"TOOL-RESULT-PAYLOAD","tool_name":"list_files"}
]}
```

Before:

```
<|im_start|>assistant
<think>

</think>

VISIBLE-REPLY
```

After:

```
<|im_start|>assistant
<think>
SECRET-THINKING-7413
</think>

VISIBLE-REPLY
```

The empty block is the failure mode, and it is worse than a plain omission: the model is shown a think block attached to its own previous turn with nothing in it. In a long agentic run this reads back as a model that re-derives every turn what it already worked out, and refers to its own earlier turns in the third person. One run we captured spent a 45k-character reasoning block re-counting braces it had already counted, and wrote "I cannot fabricate thinking content that I didn't actually produce" about its own prior analysis.

### Test

`TestLlamaServerChatMessageCarriesThinking` asserts the thinking reaches `reasoning_content` and that the visible content is untouched. It also asserts the negative — a message that carried no thinking must not gain an empty `reasoning_content`, since a template that only checks for presence would then render a blank think block for every turn.

llama-server already accepts the field on input (`common/chat.cpp` reads `reasoning_content` into `msg.reasoning_content`, and aliases it to `thinking` for templates that use that name), so nothing is needed on the other side.
