### PR TITLE
mlxrunner: honor explicit context without overriding soft sizing

### DIFF
--- a/server/routes_options_test.go
+++ b/server/routes_options_test.go
@@ -129,6 +129,37 @@ func TestModelOptionsNumCtxPriority(t *testing.T) {
 	}
 }
 
+func TestUsesAutomaticNumCtxTracksExplicitSources(t *testing.T) {
+	t.Run("vram default is automatic", func(t *testing.T) {
+		t.Setenv("OLLAMA_CONTEXT_LENGTH", "")
+		if !usesAutomaticNumCtx(&Model{}, nil) {
+			t.Fatal("VRAM-derived default must remain a soft automatic context")
+		}
+	})
+
+	t.Run("request option is explicit", func(t *testing.T) {
+		t.Setenv("OLLAMA_CONTEXT_LENGTH", "")
+		if usesAutomaticNumCtx(&Model{}, map[string]any{"num_ctx": float64(65536)}) {
+			t.Fatal("request num_ctx must be treated as a hard context")
+		}
+	})
+
+	t.Run("model option is explicit", func(t *testing.T) {
+		t.Setenv("OLLAMA_CONTEXT_LENGTH", "")
+		m := &Model{Options: map[string]any{"num_ctx": float64(65536)}}
+		if usesAutomaticNumCtx(m, nil) {
+			t.Fatal("model num_ctx must be treated as a hard context")
+		}
+	})
+
+	t.Run("environment option is explicit", func(t *testing.T) {
+		t.Setenv("OLLAMA_CONTEXT_LENGTH", "65536")
+		if usesAutomaticNumCtx(&Model{}, nil) {
+			t.Fatal("OLLAMA_CONTEXT_LENGTH must be treated as a hard context")
+		}
+	})
+}
+
 func TestModelOptionsGenerationDefaultsPriority(t *testing.T) {
 	m := &Model{
 		GenerationDefaults: model.GenerationDefaults{

--- a/server/sched.go
+++ b/server/sched.go
@@ -158,6 +158,13 @@ func modelTrainContext(f *ggml.GGML) int {
 	return int(f.KV().ContextLength())
 }
 
+func mlxContextLengths(numCtx int, automatic bool) (soft, hard int) {
+	if automatic {
+		return numCtx, 0
+	}
+	return numCtx, numCtx
+}
+
 func effectiveContext(numCtx, trainCtx int) int {
 	if trainCtx > 0 && numCtx > trainCtx {
 		return trainCtx
@@ -585,7 +592,8 @@ func (s *Scheduler) load(req *LlmRequest, systemInfo ml.SystemInfo, gpus []ml.De
 			}
 		} else {
 			modelName := req.model.ShortName
-			llama, err = mlxrunner.NewClient(modelName, req.opts.NumCtx)
+			softContextLength, hardContextLength := mlxContextLengths(req.opts.NumCtx, req.numCtxAuto)
+			llama, err = mlxrunner.NewClient(modelName, softContextLength, hardContextLength)
 		}
 		if err != nil {
 			slog.Info("failed to create server", "model", req.model.ShortName, "error", err)

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -207,6 +207,25 @@ func TestSchedVisionContextFloor(t *testing.T) {
 	})
 }
 
+func TestMLXContextLengthsPreserveAutomaticSoftLimit(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		numCtx    int
+		automatic bool
+		wantSoft  int
+		wantHard  int
+	}{
+		{name: "automatic selection is soft only", numCtx: 32768, automatic: true, wantSoft: 32768},
+		{name: "explicit selection is also hard", numCtx: 65536, wantSoft: 65536, wantHard: 65536},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			soft, hard := mlxContextLengths(tt.numCtx, tt.automatic)
+			require.Equal(t, tt.wantSoft, soft)
+			require.Equal(t, tt.wantHard, hard)
+		})
+	}
+}
+
 type reqBundle struct {
 	ctx     context.Context //nolint:containedctx
 	ctxDone func()

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -31,31 +31,31 @@ import (
 
 // Client wraps an MLX runner subprocess to implement llm.LlamaServer for LLM models.
 type Client struct {
-	port              int
-	modelName         string
-	contextLength     atomic.Int64
-	softContextLength int // recommended limit to avoid poor performance
-	memory            atomic.Uint64
-	done              chan struct{}
-	doneErr           error // valid after done is closed
-	client            *http.Client
-	status            *llm.StatusWriter
-	mu                sync.Mutex
-	cmd               *exec.Cmd
+	port          int
+	modelName     string
+	contextLength atomic.Int64
+	requestedCtx  int
+	memory        atomic.Uint64
+	done          chan struct{}
+	doneErr       error // valid after done is closed
+	client        *http.Client
+	status        *llm.StatusWriter
+	mu            sync.Mutex
+	cmd           *exec.Cmd
 }
 
 // NewClient prepares a new MLX runner client for LLM models.
 // The subprocess is not started until Load() is called.
-func NewClient(modelName string, softContextLength int) (*Client, error) {
+func NewClient(modelName string, contextLength int) (*Client, error) {
 	if err := checkPlatformSupport(); err != nil {
 		return nil, err
 	}
 
 	c := &Client{
-		modelName:         modelName,
-		softContextLength: softContextLength,
-		done:              make(chan struct{}),
-		client:            http.DefaultClient,
+		modelName:    modelName,
+		requestedCtx: contextLength,
+		done:         make(chan struct{}),
+		client:       http.DefaultClient,
 	}
 
 	modelManifest, err := manifest.LoadManifest(modelName)
@@ -263,13 +263,6 @@ func (c *Client) ContextLength() int {
 	return int(c.contextLength.Load())
 }
 
-func (c *Client) reportedContextLength(modelContextLength int) int {
-	if c.softContextLength > 0 && (modelContextLength == 0 || c.softContextLength < modelContextLength) {
-		return c.softContextLength
-	}
-	return modelContextLength
-}
-
 // Detokenize implements llm.LlamaServer.
 func (c *Client) Detokenize(ctx context.Context, tokens []int) (string, error) {
 	return "", errors.New("not supported")
@@ -343,8 +336,7 @@ func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 		exe = eval
 	}
 
-	// Spawn subprocess: ollama runner --mlx-engine --model <name> --port <port>
-	cmd := exec.Command(exe, "runner", "--mlx-engine", "--model", c.modelName, "--port", strconv.Itoa(port))
+	cmd := exec.Command(exe, runnerArgs(c.modelName, port, c.requestedCtx)...)
 	cmd.Env = os.Environ()
 
 	// Set library path environment variable for MLX libraries
@@ -468,10 +460,19 @@ func (c *Client) Ping(ctx context.Context) error {
 		return err
 	}
 
-	c.contextLength.Store(int64(c.reportedContextLength(status.ContextLength)))
+	c.contextLength.Store(int64(status.ContextLength))
 	c.memory.Store(status.Memory)
 
 	return nil
+}
+
+func runnerArgs(modelName string, port, contextLength int) []string {
+	return []string{
+		"runner", "--mlx-engine",
+		"--model", modelName,
+		"--port", strconv.Itoa(port),
+		"--ctx-size", strconv.Itoa(contextLength),
+	}
 }
 
 // Tokenize implements llm.LlamaServer.

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -31,31 +31,33 @@ import (
 
 // Client wraps an MLX runner subprocess to implement llm.LlamaServer for LLM models.
 type Client struct {
-	port          int
-	modelName     string
-	contextLength atomic.Int64
-	requestedCtx  int
-	memory        atomic.Uint64
-	done          chan struct{}
-	doneErr       error // valid after done is closed
-	client        *http.Client
-	status        *llm.StatusWriter
-	mu            sync.Mutex
-	cmd           *exec.Cmd
+	port              int
+	modelName         string
+	contextLength     atomic.Int64
+	softContextLength int // recommended limit to avoid poor performance
+	hardContextLength int // explicit limit enforced by the runner
+	memory            atomic.Uint64
+	done              chan struct{}
+	doneErr           error // valid after done is closed
+	client            *http.Client
+	status            *llm.StatusWriter
+	mu                sync.Mutex
+	cmd               *exec.Cmd
 }
 
 // NewClient prepares a new MLX runner client for LLM models.
 // The subprocess is not started until Load() is called.
-func NewClient(modelName string, contextLength int) (*Client, error) {
+func NewClient(modelName string, softContextLength, hardContextLength int) (*Client, error) {
 	if err := checkPlatformSupport(); err != nil {
 		return nil, err
 	}
 
 	c := &Client{
-		modelName:    modelName,
-		requestedCtx: contextLength,
-		done:         make(chan struct{}),
-		client:       http.DefaultClient,
+		modelName:         modelName,
+		softContextLength: softContextLength,
+		hardContextLength: hardContextLength,
+		done:              make(chan struct{}),
+		client:            http.DefaultClient,
 	}
 
 	modelManifest, err := manifest.LoadManifest(modelName)
@@ -263,6 +265,17 @@ func (c *Client) ContextLength() int {
 	return int(c.contextLength.Load())
 }
 
+func (c *Client) reportedContextLength(modelContextLength int) int {
+	selectedContextLength := c.softContextLength
+	if c.hardContextLength > 0 {
+		selectedContextLength = c.hardContextLength
+	}
+	if selectedContextLength > 0 && (modelContextLength == 0 || selectedContextLength < modelContextLength) {
+		return selectedContextLength
+	}
+	return modelContextLength
+}
+
 // Detokenize implements llm.LlamaServer.
 func (c *Client) Detokenize(ctx context.Context, tokens []int) (string, error) {
 	return "", errors.New("not supported")
@@ -336,7 +349,7 @@ func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo
 		exe = eval
 	}
 
-	cmd := exec.Command(exe, runnerArgs(c.modelName, port, c.requestedCtx)...)
+	cmd := exec.Command(exe, runnerArgs(c.modelName, port, c.hardContextLength)...)
 	cmd.Env = os.Environ()
 
 	// Set library path environment variable for MLX libraries
@@ -460,19 +473,22 @@ func (c *Client) Ping(ctx context.Context) error {
 		return err
 	}
 
-	c.contextLength.Store(int64(status.ContextLength))
+	c.contextLength.Store(int64(c.reportedContextLength(status.ContextLength)))
 	c.memory.Store(status.Memory)
 
 	return nil
 }
 
-func runnerArgs(modelName string, port, contextLength int) []string {
-	return []string{
+func runnerArgs(modelName string, port, hardContextLength int) []string {
+	args := []string{
 		"runner", "--mlx-engine",
 		"--model", modelName,
 		"--port", strconv.Itoa(port),
-		"--ctx-size", strconv.Itoa(contextLength),
 	}
+	if hardContextLength > 0 {
+		args = append(args, "--ctx-size", strconv.Itoa(hardContextLength))
+	}
+	return args
 }
 
 // Tokenize implements llm.LlamaServer.

--- a/x/mlxrunner/client_test.go
+++ b/x/mlxrunner/client_test.go
@@ -12,6 +12,50 @@ import (
 	"github.com/ollama/ollama/llm"
 )
 
+func TestRunnerArgsIncludeContextLength(t *testing.T) {
+	got := runnerArgs("qwen3.5:27b", 49152, 65536)
+	want := []string{"runner", "--mlx-engine", "--model", "qwen3.5:27b", "--port", "49152", "--ctx-size", "65536"}
+	if len(got) != len(want) {
+		t.Fatalf("runnerArgs = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("runnerArgs[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestPingReportsRunnerContextLength(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/status" {
+			t.Errorf("path = %q, want /v1/status", r.URL.Path)
+		}
+		if err := json.NewEncoder(w).Encode(statusResponse{ContextLength: 65536, Memory: 42}); err != nil {
+			t.Errorf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	_, portString, err := net.SplitHostPort(srv.Listener.Addr().String())
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+	port, err := strconv.Atoi(portString)
+	if err != nil {
+		t.Fatalf("parse server port: %v", err)
+	}
+	client := &Client{port: port, client: srv.Client()}
+	if err := client.Ping(t.Context()); err != nil {
+		t.Fatalf("Ping: %v", err)
+	}
+	if got := client.ContextLength(); got != 65536 {
+		t.Fatalf("ContextLength = %d, want 65536", got)
+	}
+	if got := client.memory.Load(); got != 42 {
+		t.Fatalf("memory = %d, want 42", got)
+	}
+}
+
 func testIntPtr(v int) *int {
 	return &v
 }

--- a/x/mlxrunner/client_test.go
+++ b/x/mlxrunner/client_test.go
@@ -12,16 +12,55 @@ import (
 	"github.com/ollama/ollama/llm"
 )
 
-func TestRunnerArgsIncludeContextLength(t *testing.T) {
-	got := runnerArgs("qwen3.5:27b", 49152, 65536)
-	want := []string{"runner", "--mlx-engine", "--model", "qwen3.5:27b", "--port", "49152", "--ctx-size", "65536"}
-	if len(got) != len(want) {
-		t.Fatalf("runnerArgs = %q, want %q", got, want)
+func TestRunnerArgsContextLengthPrecedence(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		hardContext int
+		want        []string
+	}{
+		{
+			name: "automatic soft context leaves runner at model capacity",
+			want: []string{"runner", "--mlx-engine", "--model", "qwen3.5:27b", "--port", "49152"},
+		},
+		{
+			name:        "explicit hard context is enforced",
+			hardContext: 65536,
+			want:        []string{"runner", "--mlx-engine", "--model", "qwen3.5:27b", "--port", "49152", "--ctx-size", "65536"},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := runnerArgs("qwen3.5:27b", 49152, tt.hardContext)
+			if len(got) != len(tt.want) {
+				t.Fatalf("runnerArgs = %q, want %q", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("runnerArgs[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
 	}
-	for i := range want {
-		if got[i] != want[i] {
-			t.Fatalf("runnerArgs[%d] = %q, want %q", i, got[i], want[i])
-		}
+}
+
+func TestReportedContextLengthPrecedence(t *testing.T) {
+	for _, tt := range []struct {
+		name         string
+		softContext  int
+		hardContext  int
+		modelContext int
+		want         int
+	}{
+		{name: "automatic context remains a soft reporting limit", softContext: 32768, modelContext: 262144, want: 32768},
+		{name: "model capacity caps automatic soft context", softContext: 524288, modelContext: 262144, want: 262144},
+		{name: "explicit hard context takes precedence over soft", softContext: 32768, hardContext: 65536, modelContext: 65536, want: 65536},
+		{name: "model capacity caps explicit hard context", softContext: 32768, hardContext: 524288, modelContext: 262144, want: 262144},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{softContextLength: tt.softContext, hardContextLength: tt.hardContext}
+			if got := client.reportedContextLength(tt.modelContext); got != tt.want {
+				t.Fatalf("reportedContextLength(%d) = %d, want %d", tt.modelContext, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/x/mlxrunner/runner.go
+++ b/x/mlxrunner/runner.go
@@ -56,7 +56,7 @@ type Runner struct {
 	spec *speculation
 }
 
-func (r *Runner) Load(modelName string) error {
+func (r *Runner) Load(modelName string, contextLength int) error {
 	root, err := model.Open(modelName)
 	if err != nil {
 		return err
@@ -122,7 +122,7 @@ func (r *Runner) Load(modelName string) error {
 
 	r.Model = m
 	r.Tokenizer = m.Tokenizer()
-	r.contextLength = m.MaxContextLength()
+	r.contextLength = effectiveContextLength(contextLength, m.MaxContextLength())
 	caches := m.NewCaches()
 	draftCaches := newDraftCaches(draftModel)
 	r.cache = newPrefixCache(slices.Concat(caches, draftCaches))
@@ -133,6 +133,13 @@ func (r *Runner) Load(modelName string) error {
 	mlx.EnableCompile()
 
 	return nil
+}
+
+func effectiveContextLength(requested, maximum int) int {
+	if requested <= 0 || requested > maximum {
+		return maximum
+	}
+	return requested
 }
 
 func (r *Runner) Close() {

--- a/x/mlxrunner/runner_test.go
+++ b/x/mlxrunner/runner_test.go
@@ -1,0 +1,23 @@
+package mlxrunner
+
+import "testing"
+
+func TestEffectiveContextLength(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		requested int
+		maximum   int
+		want      int
+	}{
+		{name: "unset uses model maximum", maximum: 262144, want: 262144},
+		{name: "smaller request is enforced", requested: 65536, maximum: 262144, want: 65536},
+		{name: "native maximum is accepted", requested: 262144, maximum: 262144, want: 262144},
+		{name: "unsupported extension is capped", requested: 524288, maximum: 262144, want: 262144},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := effectiveContextLength(tt.requested, tt.maximum); got != tt.want {
+				t.Fatalf("effectiveContextLength(%d, %d) = %d, want %d", tt.requested, tt.maximum, got, tt.want)
+			}
+		})
+	}
+}

--- a/x/mlxrunner/server.go
+++ b/x/mlxrunner/server.go
@@ -28,11 +28,13 @@ func Execute(args []string) error {
 	var (
 		modelName string
 		port      int
+		ctxSize   int
 	)
 
 	flagSet := flag.NewFlagSet("mlxrunner", flag.ExitOnError)
 	flagSet.StringVar(&modelName, "model", "", "Model name")
 	flagSet.IntVar(&port, "port", 0, "Port to listen on")
+	flagSet.IntVar(&ctxSize, "ctx-size", 0, "Context length")
 	_ = flagSet.Bool("verbose", false, "Enable debug logging")
 	flagSet.Parse(args)
 
@@ -66,7 +68,7 @@ func Execute(args []string) error {
 	}
 
 	if err := worker.Do(context.Background(), func() error {
-		return runner.Load(modelName)
+		return runner.Load(modelName, ctxSize)
 	}); err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

- preserve the existing automatic `softContextLength` behavior used for VRAM sizing
- distinguish automatic soft context from explicit hard context
- pass `--ctx-size` to the MLX subprocess only when context was explicitly set through request `options.num_ctx`, a Modelfile `num_ctx`, or `OLLAMA_CONTEXT_LENGTH`
- make an explicit hard value take precedence over the automatic soft value and report the effective value consistently through runner status and `/api/ps`

Fixes #18125.
Supersedes #18261 with the follow-up compatibility correction included.

## Why explicit context still matters

Using only a model's native/trained context does not cover every officially supported long-context configuration. For example, the official Qwen3.5-27B model card declares a native context of 262,144 tokens and extension up to 1,010,000 tokens. Its documented extension path uses YaRN metadata; the complementary Qwen/YaRN implementation is in #18263.

Longer context is an important use case for capable models handling large documents, repositories, and long-running agent workflows. Explicitly smaller context is also valid: it gives users predictable memory use and latency, can avoid OOM failures, and provides a deliberate safety bound. The model card itself recommends reducing context when OOM occurs.

This PR therefore keeps automatic sizing advisory while honoring explicit user/model/environment configuration as a hard choice.

Qwen source: https://huggingface.co/Qwen/Qwen3.5-27B

## Root cause

The MLX client retained `num_ctx` only as a reporting-side soft limit. It launched `ollama runner --mlx-engine` without the selected explicit context, while the subprocess initialized itself with `Model.MaxContextLength()`. The scheduler could therefore report a configured value that prompt admission did not actually enforce.

## Compatibility

- automatic VRAM-derived context remains soft and does not add `--ctx-size`
- explicit request, Modelfile, and environment context becomes hard and takes precedence
- runner invocations without a hard context retain the existing model-capacity behavior
- requested values above the model's supported maximum remain capped by the architecture/model maximum

## Verification

- `go test ./x/mlxrunner ./server -count=1`
- `go test -race ./x/mlxrunner -count=1`
- `go vet ./x/mlxrunner ./server`
- `git diff --check`
- tests cover automatic invocation without `--ctx-size`
- tests cover explicit 4,096 enforcement and prompt rejection above that limit
- tests cover request/Modelfile/environment hard-context detection and hard-over-soft precedence
- prior live macOS/Metal verification with `qwen3.5:0.8b-mlx`:
  - automatic mode omitted `--ctx-size` and `/api/ps` reported the soft 262,144 context
  - explicit 4,096 mode passed `--ctx-size 4096`; runner status and `/api/ps` reported 4,096; a 6,010-token prompt was rejected
  - explicit YaRN 300,000 mode generated successfully and runner status plus `/api/ps` reported 300,000

Latest revision: `d944eba1e830eee4295164efbd9f4f53429e648f`
