### PR TITLE
parsers: drop an unmatched thinking close tag instead of leaking it

### DIFF
--- a/model/parsers/gemma4.go
+++ b/model/parsers/gemma4.go
@@ -193,6 +193,26 @@ func (p *Gemma4Parser) eat(done bool) ([]gemma4Event, bool) {
 			return events, true
 		}
 
+		// A thinking close tag with no matching open tag is a control token that
+		// escaped its block: the model emitted one spuriously, or it closed a
+		// block the prompt primed but this parser was not initialized to track.
+		// It is in PreservedTokens, so it is never legitimate assistant text --
+		// emitting it verbatim leaks the tag, and the reasoning that preceded
+		// it, into content. Drop it and keep collecting content, the same way
+		// Gemma4IgnoringPostToolCallNoise drops a stray <tool_call|>.
+		if idx := strings.Index(bufStr, gemma4ThinkingCloseTag); idx != -1 {
+			contentBefore := bufStr[:idx]
+			remaining := bufStr[idx+len(gemma4ThinkingCloseTag):]
+
+			p.buffer.Reset()
+			p.buffer.WriteString(remaining)
+
+			if contentBefore = strings.TrimRightFunc(contentBefore, unicode.IsSpace); len(contentBefore) > 0 {
+				events = append(events, gemma4EventContent{content: contentBefore})
+			}
+			return events, true
+		}
+
 		// Check for tool call open tag
 		if idx := strings.Index(bufStr, gemma4ToolCallOpenTag); idx != -1 {
 			contentBefore := bufStr[:idx]
@@ -210,7 +230,7 @@ func (p *Gemma4Parser) eat(done bool) ([]gemma4Event, bool) {
 
 		// Check for partial tag overlap
 		if !done {
-			if overlapLen := longestOverlap(bufStr, gemma4ThinkingOpenTag, gemma4ToolCallOpenTag); overlapLen > 0 {
+			if overlapLen := longestOverlap(bufStr, gemma4ThinkingOpenTag, gemma4ToolCallOpenTag, gemma4ThinkingCloseTag); overlapLen > 0 {
 				beforePartialTag := bufStr[:len(bufStr)-overlapLen]
 				trailingLen := trailingWhitespaceLen(beforePartialTag)
 				ambiguousStart := len(beforePartialTag) - trailingLen

--- a/model/parsers/gemma4_test.go
+++ b/model/parsers/gemma4_test.go
@@ -1501,3 +1501,77 @@ func TestParseGemma4ToolCall_RawQuotedStructuralString(t *testing.T) {
 		t.Fatalf("tool call mismatch (-want +got):\n%s", diff)
 	}
 }
+
+func TestGemma4ParserDropsUnmatchedThinkingCloseTag(t *testing.T) {
+	// A thinking close tag can reach the content state with no open tag before
+	// it: the model emits one spuriously, or it closes a block the rendered
+	// prompt primed. <channel|> is a PreservedTokens control token, so it is
+	// never assistant text -- it must not be shown to the user.
+	t.Run("whole", func(t *testing.T) {
+		p := &Gemma4Parser{hasThinkingSupport: true}
+		p.Init(nil, nil, &api.ThinkValue{Value: true})
+
+		content, thinking, calls, err := p.Add("I have analyzed the syntax error.\n\n<channel|>", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if strings.Contains(content, gemma4ThinkingCloseTag) {
+			t.Errorf("content leaked the close tag: %q", content)
+		}
+		if content != "I have analyzed the syntax error." {
+			t.Errorf("content = %q, want the visible text with the tag removed", content)
+		}
+		if thinking != "" {
+			t.Errorf("thinking = %q, want empty", thinking)
+		}
+		if len(calls) != 0 {
+			t.Errorf("calls = %v, want none", calls)
+		}
+	})
+
+	// The tokenizer can split the tag across streamed chunks. The content state
+	// has to hold back a partial close tag the same way it holds back a partial
+	// open tag, or the halves are emitted before they can be matched.
+	t.Run("split across chunks", func(t *testing.T) {
+		p := &Gemma4Parser{hasThinkingSupport: true}
+		p.Init(nil, nil, &api.ThinkValue{Value: true})
+
+		var got strings.Builder
+		for _, chunk := range []string{"done.", "<chan", "nel", "|>"} {
+			content, _, _, err := p.Add(chunk, false)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got.WriteString(content)
+		}
+		content, _, _, err := p.Add("", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got.WriteString(content)
+
+		if strings.Contains(got.String(), gemma4ThinkingCloseTag) {
+			t.Errorf("content leaked the close tag: %q", got.String())
+		}
+		if got.String() != "done." {
+			t.Errorf("content = %q, want %q", got.String(), "done.")
+		}
+	})
+
+	// A properly opened block must still be collected as thinking.
+	t.Run("matched block still parses", func(t *testing.T) {
+		p := &Gemma4Parser{hasThinkingSupport: true}
+		p.Init(nil, nil, &api.ThinkValue{Value: true})
+
+		content, thinking, _, err := p.Add("<|channel>thought\nweighing it\n<channel|>the answer", true)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if thinking != "weighing it" {
+			t.Errorf("thinking = %q, want %q", thinking, "weighing it")
+		}
+		if content != "the answer" {
+			t.Errorf("content = %q, want %q", content, "the answer")
+		}
+	})
+}


### PR DESCRIPTION
`Gemma4CollectingContent` matches the thinking **open** tag and the tool-call open tag, but there is no case for the thinking **close** tag. A `<channel|>` that arrives in the content state with no open tag before it falls through to the final "no tags found, emit all content" branch and is sent to the client verbatim.

`<channel|>` is listed in `PreservedTokens`. It is a control token — it is never legitimate assistant text.

## What it looks like

I hit this running an agentic coding task through Cline against a Gemma-4-family model with `renderer`/`parser` set to `gemma4`. One turn out of a 82,232-event run came back as a 521-character `content` block that ended in a bare `<channel|>`, with **no thinking block at all** for that turn:

```
…
1.  WHERE - `manic_miner.html`, line 90
    WHAT - Replace line 90 with a corrected version that removes the redundant `}` …
    WHY - To fix the `SyntaxError: missing ) after argument list` …

<channel|>
```

Two things are wrong for the user there. The raw control token is rendered in the reply, and the text in front of it — planning, in the model's private format — is classified as `content` instead of `thinking`, so an agent's internal deliberation is shown as its answer. In a tool-calling loop it also goes back into the transcript as content on the next turn.

## The fix

Drop an unmatched close tag and keep collecting content. `Gemma4IgnoringPostToolCallNoise` already does exactly this for a stray `<tool_call|>`:

> We've observed Gemma 4 occasionally emitting extra `<tool_call|>` tags after a valid tool call. We suppress those leading control tags […] so they do not leak into assistant content.

The same reasoning applies to the thinking closer, and the same tradeoff is accepted: a model that deliberately begins a content span with the literal string loses it. For a token in `PreservedTokens` that is the right side to err on.

The content state's partial-tag guard needs the close tag too. `longestOverlap` was called with only the two open tags, so a tokenizer that splits `<channel|>` across streamed chunks emits the halves before they can be matched — the fix has to cover the streaming path or it only works when the tag lands whole in one chunk.

## Tests

`TestGemma4ParserDropsUnmatchedThinkingCloseTag`, three subtests. Both leak cases fail on `main`:

```
--- FAIL: TestGemma4ParserDropsUnmatchedThinkingCloseTag/whole
    content leaked the close tag: "I have analyzed the syntax error.\n\n<channel|>"
--- FAIL: TestGemma4ParserDropsUnmatchedThinkingCloseTag/split_across_chunks
    content leaked the close tag: "done.<channel|>"
```

The third subtest is a regression guard: a properly opened `<|channel>thought\n…<channel|>` block still parses as thinking, with the following text as content.

`go test ./model/parsers/` passes.

## A related gap I am not fixing here

While tracking this down I found that the renderer and the parser disagree about when a thinking block is open. `Gemma4Renderer` primes `<|channel>thought\n` only when `prevMessageType == "tool_response"` (`model/renderers/gemma4.go:144`), which is set inside `if len(message.ToolCalls) > 0`. `Gemma4Parser.Init` opens in thinking on `lastMessage.Role == "tool"` alone. So for a tool result whose preceding assistant message carries no `ToolCalls`, the prompt is not primed but the parser is in thinking:

```
assistant-toolcall-then-tool              primed=true   -> thinking="plan: replace line 90"
tool-result-no-toolcalls-on-assistant     primed=false  -> thinking="plan: replace line 90"   ← mismatch
assistant-content-and-toolcall-then-tool  primed=true   -> thinking="plan: replace line 90"
```

That shape has a deeper problem than the state mismatch — the renderer `continue`s over tool messages and only emits them inside the `ToolCalls` branch, so those tool results are dropped from the prompt entirely. Fixing it properly means either changing the `Parser.Init` signature (it only receives the last message, so it cannot see whether the previous assistant had tool calls) or changing how the renderer emits orphaned tool results. Both are larger than this bug and I did not want to bundle a speculative change with a fix I can demonstrate. Happy to open it separately if you'd like it tracked.
