### PR TITLE
server: reload when two tags share a blob but need different runner flags

### DIFF
--- a/server/sched.go
+++ b/server/sched.go
@@ -711,6 +711,7 @@ iGPUScan:
 		useMMapAuto:     req.useMMapAuto,
 		contextShift:    req.contextShift,
 		trainContext:    trainContext,
+		llamaConfig:     llamaServerConfigForModel(req.model),
 	}
 	runner.numParallel = numParallel
 	runner.refMu.Lock() // hold lock until running or aborted
@@ -1360,6 +1361,11 @@ type runnerRef struct {
 	useMMapAuto  bool
 	contextShift bool
 	trainContext int
+	// llamaConfig is the model-derived part of the config this runner was
+	// launched with. Two tags can share one blob -- a Modelfile built FROM
+	// another tag -- so ModelPath alone does not identify the flags the
+	// runner needs.
+	llamaConfig llm.LlamaServerConfig
 	*api.Options
 }
 
@@ -1415,6 +1421,17 @@ func (runner *runnerRef) needsReload(ctx context.Context, req *LlmRequest) bool 
 		contextShift = resolveContextShift(req.shift, req.model)
 	}
 	if runner.contextShift != contextShift {
+		return true
+	}
+
+	// A runner is keyed on ModelPath, and a Modelfile built FROM another tag
+	// shares that path -- but the two tags can still need different
+	// llama-server flags. usesOllamaRenderedChat() decides DisableJinja, so a
+	// tag with a renderer or parser and a bare tag over the same blob disagree
+	// about --jinja: whichever loads first wins, and the second one is handed a
+	// runner it cannot use. Tool calls on the bare tag then fail with
+	// "tools param requires --jinja flag" until the runner happens to expire.
+	if runner.llamaConfig != llamaServerConfigForModel(req.model) {
 		return true
 	}
 

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -2236,3 +2236,40 @@ func TestSchedulerTracksMultipleLoadedRunners(t *testing.T) {
 	expectedFree := uint64(24*format.GigaByte) - uint64(8*format.GigaByte) - uint64(4*format.GigaByte)
 	require.Equal(t, expectedFree, gpus[0].FreeMemory)
 }
+
+func TestSchedNeedsReloadWhenTagsShareABlobButNotTheirFlags(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), 100*time.Millisecond)
+	defer done()
+
+	// Two tags over one blob: a Modelfile built FROM another tag shares its
+	// ModelPath, which is what schedulerModelKey() keys the runner on. The
+	// rendered tag carries a parser, so usesOllamaRenderedChat() sets
+	// DisableJinja and its runner is launched with --no-jinja; the bare tag
+	// needs --jinja to accept tools. Reusing one runner for the other breaks
+	// tool calls with "tools param requires --jinja flag".
+	const sharedBlob = "/models/blobs/sha256-shared"
+
+	rendered := &Model{ModelPath: sharedBlob, Config: model.ConfigV2{Parser: "qwen3.5"}}
+	bare := &Model{ModelPath: sharedBlob}
+
+	require.Equal(t, schedulerModelKey(rendered), schedulerModelKey(bare),
+		"the two tags must share a scheduler key for this test to be meaningful")
+	require.NotEqual(t, llamaServerConfigForModel(rendered), llamaServerConfigForModel(bare),
+		"the two tags must need different llama-server flags")
+
+	opts := api.DefaultOptions()
+	runner := &runnerRef{
+		model:       rendered,
+		Options:     &opts,
+		llama:       &mockLlm{vramByGPU: map[ml.DeviceID]uint64{}},
+		numParallel: 1,
+		// Both tags resolve the same context shift; it is the flags that differ.
+		contextShift: resolveContextShift(nil, rendered),
+		llamaConfig:  llamaServerConfigForModel(rendered),
+	}
+
+	require.False(t, runner.needsReload(ctx, &LlmRequest{model: rendered, opts: api.DefaultOptions()}),
+		"the same tag must not force a reload")
+	require.True(t, runner.needsReload(ctx, &LlmRequest{model: bare, opts: api.DefaultOptions()}),
+		"a tag needing different llama-server flags must force a reload")
+}


### PR DESCRIPTION
`schedulerModelKey()` keys a loaded runner on `ModelPath`. A Modelfile built `FROM` another tag shares that path, so two tags resolve to the same runner — which is usually what you want, since it is the same weights.

But the two tags do not necessarily need the same llama-server flags. `llamaServerConfigForModel()` derives `DisableJinja` from `usesOllamaRenderedChat(m)`, which is true when the tag has a `renderer`, a `parser`, harmony, or a Go template. So a tag with a renderer is launched with `--no-jinja`, while a bare tag over the same blob needs `--jinja` to accept tools.

`needsReload()` compares adapters, projectors, runner options, context shift and a ping. It does not compare that config. Whichever tag loads first fixes the flag for both.

## Reproducing it

Two tags, one blob:

```
FROM ./model.gguf                      # bare
FROM bare-tag                          # + RENDERER/PARSER
```

Send a tool-calling request to the renderer tag, then one to the bare tag while the first runner is still resident:

```json
{"error":{"code":500,"message":"tools param requires --jinja flag","type":"server_error"}}
```

It fails in the request path, so nothing points at the runner. Every retry fails identically until the runner happens to expire, and then it works — which reads as a flaky server. Load the two in the opposite order and nothing looks wrong at all.

I hit this A/B-testing a renderer/parser tag against a bare tag of the same model in an agentic harness. The bare arm died 9 seconds in, on its first tool call, and I lost the run to it. The only thing that decided whether the bug appeared was which arm I scheduled first.

`DraftModelPath` comes from the same per-tag config and has the same exposure — a speculative-decoding draft model configured on one tag and not another over a shared blob.

## The fix

Record the model-derived config on the `runnerRef` and reload when it changes. This follows the existing `contextShift` handling, which is already tracked on the runner and compared in `needsReload` for the same class of reason.

## Test

`TestSchedNeedsReloadWhenTagsShareABlobButNotTheirFlags` asserts up front that the two models share a scheduler key and need different configs — so the test cannot quietly stop testing the thing it is named for — then that the same tag does not reload and the other tag does. On `main`:

```
--- FAIL: TestSchedNeedsReloadWhenTagsShareABlobButNotTheirFlags
    Should be true
    Messages: a tag needing different llama-server flags must force a reload
```

`go test ./server/` passes.
