### PR TITLE
fs/gguf: fix integer overflow in TensorInfo.NumValues/NumBytes

### DIFF
--- a/fs/gguf/gguf_internal_test.go
+++ b/fs/gguf/gguf_internal_test.go
@@ -47,6 +47,26 @@ func TestTensorInfoRejectsRowNotMultipleOfBlockSize(t *testing.T) {
 	}
 }
 
+func TestTensorInfoNumBytesOverflow(t *testing.T) {
+	// A shape whose element count overflows int64 must not be reported as a
+	// small, valid tensor.
+	ti := TensorInfo{
+		Name:  "overflow.weight",
+		Shape: []uint64{3, 6148914691236517206},
+		Type:  TensorTypeF32,
+	}
+
+	if n := ti.NumValues(); n != 0 {
+		t.Fatalf("NumValues() = %d, want 0", n)
+	}
+	if n := ti.NumBytes(); n != 0 {
+		t.Fatalf("NumBytes() = %d, want 0", n)
+	}
+	if ti.Valid() {
+		t.Fatal("Valid() unexpectedly true for overflowing shape")
+	}
+}
+
 func TestTensorReaderReturnsLazyParseError(t *testing.T) {
 	var b bytes.Buffer
 	writeInternalRaw(t, &b, []byte("GGUF"))

--- a/fs/gguf/tensor.go
+++ b/fs/gguf/tensor.go
@@ -16,12 +16,14 @@ func (ti TensorInfo) Valid() bool {
 	return ti.Name != "" && ti.NumBytes() > 0
 }
 
+// NumValues returns the number of elements in the tensor, or 0 if the shape
+// overflows int64 (e.g. a maliciously crafted GGUF file).
 func (ti TensorInfo) NumValues() int64 {
-	var numItems int64 = 1
-	for _, dim := range ti.Shape {
-		numItems *= int64(dim)
+	numValues, ok := ti.numValues()
+	if !ok {
+		return 0
 	}
-	return numItems
+	return numValues
 }
 
 func (ti TensorInfo) numValues() (int64, bool) {
@@ -39,9 +41,14 @@ func (ti TensorInfo) numValues() (int64, bool) {
 	return numItems, true
 }
 
-// NumBytes returns the number of bytes in the tensor.
+// NumBytes returns the number of bytes in the tensor, or 0 if the size
+// overflows int64 (e.g. a maliciously crafted GGUF file).
 func (ti TensorInfo) NumBytes() int64 {
-	return int64(float64(ti.NumValues()) * ti.Type.NumBytes())
+	numBytes, ok := ti.numBytes()
+	if !ok {
+		return 0
+	}
+	return numBytes
 }
 
 func (ti TensorInfo) numBytes() (int64, bool) {


### PR DESCRIPTION
## Summary

`TensorInfo.NumValues()` / `NumBytes()` (exported) computed tensor size with
unchecked `int64` multiplication, plus a `float64` round-trip in `NumBytes()`.
This is different from the package's own internal `numValues()` / `numBytes()`,
which already guard against overflow and are what `readTensor`/`TensorReader`
rely on for the file-bounds check.

A crafted tensor shape such as `{3, 6148914691236517206}` (~1.8e19 elements)
silently wraps around in the exported path, so `Valid()` reports `true` and
`NumBytes()` returns `8` for a tensor that in reality declares far more
elements than fit in memory or the file.

I checked and nothing outside this package currently calls these exported
methods, so it isn't reachable via any request path today — this is closing
the gap before something starts relying on the exported API, not a fix for a
live bug. Same overflow class as the GGUF parser issues that have come up in
this repo before, just in the public accessors instead of the internal parse
path.

## Fix

Make `NumValues()`/`NumBytes()` delegate to the already-audited private
`numValues()`/`numBytes()` instead of duplicating the arithmetic, returning
`0` on overflow (consistent with `Valid()`'s existing "empty means invalid"
contract). No API signature changes.

## Test plan

- [x] Added `TestTensorInfoNumBytesOverflow` reproducing the overflow and
      asserting `NumValues()`/`NumBytes()`/`Valid()` all correctly reject it
- [x] `go test ./fs/gguf/... ./fs/ggml/...` passes
- [x] `go vet ./fs/gguf/... ./fs/ggml/... ./server/...` clean
- [x] `go build ./server/... ./api/... ./cmd/...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VZPvqbjK8YUGg2D4aouSuE