### PR TITLE
docs: add CORS and HTTP 403 troubleshooting section

### DIFF
--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -142,3 +142,12 @@ If you experience gibberish responses when models load across multiple AMD GPUs 
 ## Windows Terminal Errors
 
 Older versions of Windows 10 (e.g., 21H1) are known to have a bug where the standard terminal program does not display control characters correctly. This can result in a long string of strings like `←[?25h←[?25l` being displayed, sometimes erroring with `The parameter is incorrect` To resolve this problem, please update to Win 10 22H1 or newer.
+
+## CORS and HTTP 403 Forbidden
+
+Requests from browser extensions or web applications hosted on non-localhost domains (or local network IPs) will fail with an HTTP 403 Forbidden error because Ollama only permits requests from localhost, 127.0.0.1, and 0.0.0.0 by default.
+
+To resolve this, set `OLLAMA_ORIGINS` to include your origin. For browser extensions, use:
+
+```shell
+OLLAMA_ORIGINS="chrome-extension://*,moz-extension://*,safari-web-extension://*"


### PR DESCRIPTION
Add a troubleshooting section for HTTP 403 and CORS errors when accessing Ollama from browser extensions (Chrome, Firefox, Safari) and non-localhost origins.