### PR TITLE
docs: add Harbor to community integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,3 +354,4 @@ console.log(response.message.content);
 - [Gentoo](https://github.com/gentoo/guru/tree/master/app-misc/ollama)
 - [Flox](https://flox.dev/blog/ollama-part-one)
 - [Guix channel](https://codeberg.org/tusharhero/ollama-guix)
+- [Harbor](https://github.com/kauanmezavila/harbor) - Universal package and deployment system for GitHub


### PR DESCRIPTION
Harbor can install and deploy Ollama through its package specification format.

Harbor automatically resolves and downloads the most compatible version for the user's platform.

This PR only adds Harbor to the existing Community Integrations list for now.

More information:
https://github.com/kauanmezavila/harbor
