### PR TITLE
app: fix Go doc comments that name nonexistent methods

### DIFF
--- a/app/tools/tools.go
+++ b/app/tools/tools.go
@@ -98,7 +98,7 @@ type ToolResult struct {
 	Error      string `json:"error,omitempty"`
 }
 
-// ToolSchemas returns all tools as schema maps suitable for API calls
+// AvailableTools returns all tools as schema maps suitable for API calls
 func (r *Registry) AvailableTools() []map[string]any {
 	schemas := make([]map[string]any, 0, len(r.tools))
 	for _, tool := range r.tools {

--- a/app/types/not/valids.go
+++ b/app/types/not/valids.go
@@ -34,7 +34,7 @@ func (e ValidError) Field() string {
 // Valids is for building a list of validation errors.
 type Valids []ValidError
 
-// Addf adds a validation error to the list with a formatted message using fmt.Sprintf.
+// Add adds a validation error to the list.
 func (b *Valids) Add(name, message string, args ...any) {
 	*b = append(*b, ValidError{name, message, args})
 }


### PR DESCRIPTION
Two Go doc comments were titled for methods that don't exist (copy-paste leftovers):

- `app/types/not/valids.go`: ``// Addf adds a validation error...`` above `func (b *Valids) Add(...)` — no `Addf` exists in the file
- `app/tools/tools.go`: ``// ToolSchemas returns...`` above `func (r *Registry) AvailableTools()` — no `ToolSchemas` symbol exists

Comments renamed to match the declarations. Small doc correction, so no issue per the contributing guidance.