### PR TITLE
openai: use tsc_ prefix for tool search call IDs

### DIFF
--- a/internal/proxy/codex_desktop_test.go
+++ b/internal/proxy/codex_desktop_test.go
@@ -1036,7 +1036,7 @@ func TestCodexDesktopPreservesToolSearchAndOllamaCompactionForOllama(t *testing.
 		"input":[
 			{"type":"compaction","encrypted_content":"native-opaque-state"},
 			{"type":"compaction","encrypted_content":"{\"type\":\"ollama_compaction\",\"version\":1,\"summary\":\"summary\",\"retained\":[]}"},
-			{"type":"tool_search_call","id":"ts_1","call_id":"call_search","execution":"client","status":"completed","arguments":{"query":"notion"}},
+			{"type":"tool_search_call","id":"tsc_1","call_id":"call_search","execution":"client","status":"completed","arguments":{"query":"notion"}},
 			{"type":"tool_search_output","id":"tso_1","call_id":"call_search","execution":"client","status":"completed","tools":[{"type":"function","name":"notion.search"}]},
 			{"type":"message","role":"user","content":"continue"},
 			{"type":"compaction_trigger"}

--- a/middleware/responses_tool_search_test.go
+++ b/middleware/responses_tool_search_test.go
@@ -27,7 +27,7 @@ func TestResponsesMiddlewareToolSearchInput(t *testing.T) {
 			"parameters":{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}
 		}],
 		"input":[
-			{"type":"tool_search_call","id":"ts_1","call_id":"call_search","execution":"client","status":"completed","arguments":{"query":"orders"}},
+			{"type":"tool_search_call","id":"tsc_1","call_id":"call_search","execution":"client","status":"completed","arguments":{"query":"orders"}},
 			{"type":"tool_search_output","id":"tso_1","call_id":"call_search","execution":"client","status":"completed","tools":[
 				{"type":"namespace","name":"orders","tools":[
 					{"type":"function","name":"lookup_order","description":"Look up an order","parameters":{"type":"object"}}

--- a/openai/responses.go
+++ b/openai/responses.go
@@ -1148,7 +1148,7 @@ func ToResponse(model, responseID, itemID string, chatResponse api.ChatResponse,
 		for i, tc := range toolCalls {
 			if HasToolSearchTool(request.Tools) && tc.Function.Name == "tool_search" {
 				output = append(output, ResponsesOutputItem{
-					ID:        fmt.Sprintf("ts_%s_%d", responseID, i),
+					ID:        fmt.Sprintf("tsc_%s_%d", responseID, i),
 					Type:      "tool_search_call",
 					Status:    "completed",
 					CallID:    tc.ID,
@@ -1559,7 +1559,7 @@ func (c *ResponsesStreamConverter) emitFunctionCallEvents(toolCalls []api.ToolCa
 	for i, tc := range converted {
 		outputIndex := c.outputIndex + i
 		if HasToolSearchTool(c.request.Tools) && tc.Function.Name == "tool_search" {
-			itemID := fmt.Sprintf("ts_%d_%d", rand.Intn(999999), i)
+			itemID := fmt.Sprintf("tsc_%d_%d", rand.Intn(999999), i)
 			arguments := toolSearchArguments(tc.Function.Arguments)
 			item := map[string]any{
 				"id":        itemID,

--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -250,7 +250,7 @@ func TestUnmarshalResponsesInputItem(t *testing.T) {
 	})
 
 	t.Run("tool_search_call item", func(t *testing.T) {
-		got, err := unmarshalResponsesInputItem([]byte(`{"type":"tool_search_call","id":"ts_1","call_id":"call_search","execution":"client","status":"completed","arguments":{"query":"order lookup","limit":5}}`))
+		got, err := unmarshalResponsesInputItem([]byte(`{"type":"tool_search_call","id":"tsc_1","call_id":"call_search","execution":"client","status":"completed","arguments":{"query":"order lookup","limit":5}}`))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -619,7 +619,7 @@ func TestFromResponsesRequest_ToolSearchOutputBecomesToolContent(t *testing.T) {
 			"parameters":{"type":"object","properties":{"query":{"type":"string"}},"required":["query"]}
 		}],
 		"input":[
-			{"type":"tool_search_call","id":"ts_1","call_id":"call_search","execution":"client","status":"completed","arguments":{"query":"orders","limit":5}},
+			{"type":"tool_search_call","id":"tsc_1","call_id":"call_search","execution":"client","status":"completed","arguments":{"query":"orders","limit":5}},
 			{"type":"tool_search_output","id":"tso_1","call_id":"call_search","execution":"client","status":"completed","tools":[
 				{"type":"function","name":"lookup_order","description":"Look up an order","defer_loading":true,"x_client_field":"preserved","parameters":{"type":"object"}}
 			]}
@@ -1014,7 +1014,8 @@ func TestToResponseEmitsClientToolSearchCall(t *testing.T) {
 		t.Fatalf("output = %#v", response.Output)
 	}
 	item := response.Output[0]
-	if item.Type != "tool_search_call" || item.CallID != "call_search" || item.Execution != "client" || item.Status != "completed" {
+	if item.Type != "tool_search_call" || item.CallID != "call_search" || item.Execution != "client" || item.Status != "completed" ||
+		!strings.HasPrefix(item.ID, "tsc_") {
 		t.Fatalf("item = %#v", item)
 	}
 	encoded, err := json.Marshal(item)
@@ -1946,7 +1947,8 @@ func TestResponsesStreamConverter_ToolSearchCall(t *testing.T) {
 		t.Fatalf("events = %#v", events)
 	}
 	item := events[3].Data.(map[string]any)["item"].(map[string]any)
-	if item["type"] != "tool_search_call" || item["call_id"] != "call_search" || item["execution"] != "client" || item["status"] != "completed" {
+	if item["type"] != "tool_search_call" || item["call_id"] != "call_search" || item["execution"] != "client" || item["status"] != "completed" ||
+		!strings.HasPrefix(item["id"].(string), "tsc_") {
 		t.Fatalf("item = %#v", item)
 	}
 	encoded, err := json.Marshal(item)


### PR DESCRIPTION
Ollama’s `ts_` tool-search IDs cause validation errors when switching a Codex conversation to an OpenAI model. Use the required `tsc_` prefix in both streaming and non-streaming responses.