### PR TITLE
openai: accept agent_message input items

### DIFF
--- a/openai/responses.go
+++ b/openai/responses.go
@@ -264,6 +264,35 @@ type ResponsesReasoningInput struct {
 
 func (ResponsesReasoningInput) responsesInputItem() {}
 
+func unmarshalResponsesAgentMessage(data []byte) (ResponsesInputMessage, error) {
+	var message struct {
+		Content []struct {
+			Type             string `json:"type"`
+			Text             string `json:"text"`
+			EncryptedContent string `json:"encrypted_content"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(data, &message); err != nil {
+		return ResponsesInputMessage{}, err
+	}
+
+	content := make([]ResponsesContent, 0, len(message.Content))
+	for i, part := range message.Content {
+		var text string
+		switch part.Type {
+		case "input_text":
+			text = part.Text
+		case "encrypted_content":
+			text = part.EncryptedContent
+		default:
+			return ResponsesInputMessage{}, fmt.Errorf("content[%d]: unknown content type: %s", i, part.Type)
+		}
+		content = append(content, ResponsesTextContent{Type: "input_text", Text: text})
+	}
+
+	return ResponsesInputMessage{Type: "message", Role: "user", Content: content}, nil
+}
+
 // unmarshalResponsesInputItem unmarshals a single input item from JSON.
 func unmarshalResponsesInputItem(data []byte) (ResponsesInputItem, error) {
 	var typeField struct {
@@ -288,6 +317,8 @@ func unmarshalResponsesInputItem(data []byte) (ResponsesInputItem, error) {
 			return nil, err
 		}
 		return msg, nil
+	case "agent_message":
+		return unmarshalResponsesAgentMessage(data)
 	case "function_call":
 		var fc ResponsesFunctionCall
 		if err := json.Unmarshal(data, &fc); err != nil {

--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -300,6 +300,16 @@ func TestUnmarshalResponsesInputItem(t *testing.T) {
 		}
 	})
 
+	t.Run("agent message with unknown content type", func(t *testing.T) {
+		_, err := unmarshalResponsesInputItem([]byte(`{"type":"agent_message","content":[{"type":"input_audio"}]}`))
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if err.Error() != "content[0]: unknown content type: input_audio" {
+			t.Errorf("unexpected error message: %v", err)
+		}
+	})
+
 	t.Run("unknown item type", func(t *testing.T) {
 		_, err := unmarshalResponsesInputItem([]byte(`{"type": "unknown_type"}`))
 		if err == nil {
@@ -329,6 +339,55 @@ func TestUnmarshalResponsesInputItem(t *testing.T) {
 			t.Errorf("unexpected error message: %v", err)
 		}
 	})
+}
+
+func TestFromResponsesRequest_AgentMessage(t *testing.T) {
+	var req ResponsesRequest
+	err := json.Unmarshal([]byte(`{
+		"model": "test",
+		"input": [
+			{
+				"type": "message",
+				"role": "user",
+				"content": [{"type": "input_text", "text": "Relay the task below."}]
+			},
+			{
+				"type": "agent_message",
+				"id": "amsg_0000",
+				"author": "/root",
+				"recipient": "/root/child",
+				"content": [
+					{
+						"type": "input_text",
+						"text": "Message Type: NEW_TASK\nTask name: /root/child\nSender: /root\nPayload:\n"
+					},
+					{
+						"type": "encrypted_content",
+						"encrypted_content": "Reply with the single word: ALPHA"
+					}
+				]
+			}
+		]
+	}`), &req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	chat, err := FromResponsesRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(chat.Messages) != 2 {
+		t.Fatalf("len(Messages) = %d, want 2", len(chat.Messages))
+	}
+
+	message := chat.Messages[1]
+	if message.Role != "user" {
+		t.Errorf("Role = %q, want %q", message.Role, "user")
+	}
+	if message.Content != "Message Type: NEW_TASK\nTask name: /root/child\nSender: /root\nPayload:\nReply with the single word: ALPHA" {
+		t.Errorf("Content = %q", message.Content)
+	}
 }
 
 func TestFromResponsesRequestIgnoresReplayedWebSearchCall(t *testing.T) {


### PR DESCRIPTION
## Summary

Codex sends spawned-agent tasks as `agent_message` items, which `/v1/responses` currently rejects with `unknown input item type: "agent_message"`. This change converts the captured item format into a user message.

- recognize Responses API `agent_message` input items used to deliver spawned-agent tasks
- preserve the order of `input_text` and plaintext `encrypted_content` parts while normalizing the item to an ordinary user message
- keep strict validation for unknown input items and unsupported agent-message content types

Fixes #18286.

## Testing

- `go test ./openai -count=1`
- `go test -race ./openai -count=1`
- `go vet ./openai`
- `go test -count=1 -bench=. -benchtime=1x ./openai`
- `go mod tidy --diff`
- `go generate ./...`
- `go build ./...`
- `golangci-lint run`
- `go test ./...` after `npm ci && npm run build` in `app/ui/app`
- `go test -count=1 -bench=. -benchtime=1x ./...`
- `go test -race -count=1 ./...`
- `CI=true npm test -- --run` in `app/ui/app`

## Scope and limitations

The conversion is deliberately limited to the wire shape documented in #18286. In that captured payload, `encrypted_content` contains plaintext; this change does not implement decryption or claim support for unspecified future agent-message formats. A live model-backed Codex multi-agent round trip was not run locally.

The local checks ran on macOS arm64. The Go suite passed with `TestThreadedMLXOperations` skipped because the MLX dynamic library was unavailable; native MLX execution and Linux/Windows CI coverage were not verified locally.

## AI assistance

This contribution was prepared with Codex assistance and independently reviewed by another Codex agent. Regression coverage and completed local checks are listed above. No human line-by-line review is being claimed.
