### PR TITLE
server: handle thinking in native generate templates

### DIFF
--- a/server/routes.go
+++ b/server/routes.go
@@ -638,15 +638,10 @@ func (s *Server) GenerateHandler(c *gin.Context) {
 
 	var thinkingState *thinking.Parser
 	if builtinParser == nil {
-		openingTag, closingTag := thinking.InferTags(m.Template.Template)
-		if req.Think != nil && req.Think.Bool() && openingTag != "" && closingTag != "" {
-			thinkingState = &thinking.Parser{
-				OpeningTag: openingTag,
-				ClosingTag: closingTag,
-			}
-			if strings.HasSuffix(strings.TrimSpace(prompt), openingTag) {
-				thinkingState.AddContent(openingTag)
-			}
+		var primeThinking bool
+		thinkingState, primeThinking = thinkingParserForGenerate(m, req.Think)
+		if thinkingState != nil && (primeThinking || strings.HasSuffix(strings.TrimSpace(prompt), thinkingState.OpeningTag)) {
+			thinkingState.AddContent(thinkingState.OpeningTag)
 		}
 	}
 
@@ -2977,6 +2972,31 @@ func prepareNativeChatRequest(ctx context.Context, m *Model, r llm.LlamaServer, 
 	var err error
 	nativeReq.Messages, err = truncateNativeChatMessages(ctx, m, r, optionsForPrompt(opts, r), nativeReq, truncate)
 	return nativeReq, err
+}
+
+func thinkingParserForGenerate(m *Model, think *api.ThinkValue) (*thinking.Parser, bool) {
+	if think == nil || !think.Bool() || m.Template == nil {
+		return nil, false
+	}
+
+	openingTag, closingTag := thinking.InferTags(m.Template.Template)
+	primeThinking := false
+	if openingTag == "" || closingTag == "" {
+		if !m.HasChatTemplate || !slices.Contains(m.Capabilities(), model.CapabilityThinking) {
+			return nil, false
+		}
+
+		// Native Jinja templates are rendered by llama-server and are not
+		// available to InferTags. Their thinking delimiter is nevertheless
+		// known from the model capability detection above.
+		openingTag, closingTag = "<think>", "</think>"
+		primeThinking = true
+	}
+
+	return &thinking.Parser{
+		OpeningTag: openingTag,
+		ClosingTag: closingTag,
+	}, primeThinking
 }
 
 func (s *Server) handleNativeChat(c *gin.Context, req api.ChatRequest, m *Model, r llm.LlamaServer, opts *api.Options, msgs []api.Message, checkpointStart, checkpointLoaded time.Time) {

--- a/server/routes_generate_test.go
+++ b/server/routes_generate_test.go
@@ -670,6 +670,53 @@ func TestGenerateHandlerChatTemplateRoute(t *testing.T) {
 	})
 }
 
+func TestGenerateHandlerNativeChatTemplateThinking(t *testing.T) {
+	t.Setenv("OLLAMA_CONTEXT_LENGTH", "4096")
+	t.Setenv("OLLAMA_GO_TEMPLATE", "")
+	gin.SetMode(gin.TestMode)
+
+	mock := mockRunner{
+		TemplateFn: func(_ context.Context, req llm.ChatRequest) (string, error) {
+			if len(req.Messages) != 1 || req.Messages[0].Content != "is 5 bigger than 6?" {
+				t.Fatalf("chat template messages = %#v", req.Messages)
+			}
+			return "native-thinking-template", nil
+		},
+		CompletionResponse: llm.CompletionResponse{
+			Content:    "The model is checking the comparison. </think> No.",
+			Done:       true,
+			DoneReason: llm.DoneReasonStop,
+		},
+	}
+	s := newServerWithMockRunner(t, &mock)
+	createMinimalGGUFModel(t, s, "native-thinking-generate", ggml.KV{
+		"tokenizer.chat_template": "{% if thinking %}<think>{% endif %}{{ messages[0]['content'] }}{% if thinking %}</think>{% endif %}",
+	}, "", nil)
+
+	stream := false
+	think := true
+	w := createRequest(t, s.GenerateHandler, api.GenerateRequest{
+		Model:  "native-thinking-generate",
+		Prompt: "is 5 bigger than 6?",
+		Think:  &api.ThinkValue{Value: think},
+		Stream: &stream,
+	})
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp api.GenerateResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatal(err)
+	}
+	if resp.Thinking != "The model is checking the comparison. " {
+		t.Errorf("thinking = %q, want %q", resp.Thinking, "The model is checking the comparison. ")
+	}
+	if resp.Response != "No." {
+		t.Errorf("response = %q, want %q", resp.Response, "No.")
+	}
+}
+
 func TestGenerateChatRemote(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
The native `/api/generate` path could return reasoning as visible response text when a thinking-capable Jinja template had no Go-template delimiters. Initialize the existing thinking parser for native templates so reasoning is separated from the visible response.

Fixes #18221