### PR TITLE
llm: skip --spec-draft-backend-sampling in tensor split mode

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -804,6 +804,22 @@ const (
 	draftTypeDFlash = "draft-dflash"
 )
 
+// draftBackendSamplingEnabled reports whether backend draft sampling should be
+// requested. llama.cpp rejects backend sampling under SPLIT_MODE_TENSOR (output
+// logits are sharded across GPUs, so the sampling kernel cannot reduce them
+// across devices) and silently falls back to CPU sampling, wasting a doomed
+// sampler offload attempt plus scheduler reserve churn. Skip the flag whenever
+// the server would run in tensor split mode.
+func draftBackendSamplingEnabled(opts api.Options) bool {
+	if opts.MainGPU != nil {
+		// appendMainGPUArgs passes "--split-mode none", which overrides the env var
+		return true
+	}
+	// The runner inherits the parent environment, so an explicitly requested
+	// LLAMA_ARG_SPLIT_MODE=tensor is the one case we can detect from here.
+	return strings.ToLower(strings.TrimSpace(os.Getenv("LLAMA_ARG_SPLIT_MODE"))) != "tensor"
+}
+
 func appendDraftArgs(params []string, draftType, draftModelPath string, opts api.Options) []string {
 	if draftType == "" {
 		return params
@@ -814,7 +830,7 @@ func appendDraftArgs(params []string, draftType, draftModelPath string, opts api
 
 	params = append(params, "--spec-type", draftType)
 	params = append(params, "--spec-draft-n-max", strconv.Itoa(opts.DraftNumPredict))
-	if draftType == draftTypeMTP {
+	if draftType == draftTypeMTP && draftBackendSamplingEnabled(opts) {
 		params = append(params, "--spec-draft-backend-sampling")
 	}
 	if draftModelPath != "" {

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -2545,6 +2545,26 @@ func TestAppendDraftArgs(t *testing.T) {
 	}
 }
 
+func TestAppendDraftArgsTensorSplit(t *testing.T) {
+	// Backend draft sampling is rejected by llama.cpp under SPLIT_MODE_TENSOR,
+	// so the flag must be omitted when the server will run in tensor split mode.
+	t.Setenv("LLAMA_ARG_SPLIT_MODE", "tensor")
+	got := appendDraftArgs([]string{"base"}, draftTypeMTP, "", api.Options{Runner: api.Runner{DraftNumPredict: 4}})
+	want := []string{"base", "--spec-type", "draft-mtp", "--spec-draft-n-max", "4"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("appendDraftArgs with tensor split = %v, want %v", got, want)
+	}
+
+	// An explicit main_gpu forces "--split-mode none", which overrides the env
+	// var, so backend sampling is safe to request again.
+	opts := api.Options{Runner: api.Runner{DraftNumPredict: 4, MainGPU: testIntPtr(0)}}
+	got = appendDraftArgs([]string{"base"}, draftTypeMTP, "", opts)
+	want = []string{"base", "--spec-type", "draft-mtp", "--spec-draft-n-max", "4", "--spec-draft-backend-sampling"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("appendDraftArgs with main_gpu override = %v, want %v", got, want)
+	}
+}
+
 func TestExternalDraftType(t *testing.T) {
 	tests := []struct {
 		architecture string


### PR DESCRIPTION
## Problem

`appendDraftArgs` unconditionally appends `--spec-draft-backend-sampling` for
embedded-MTP drafts. When llama-server runs with `SPLIT_MODE_TENSOR` (e.g. via
the inherited `LLAMA_ARG_SPLIT_MODE=tensor` env var), llama.cpp rejects backend
sampling — the output logits are sharded across GPUs, so the backend sampler
cannot reduce them across devices (`llama-context.cpp` `set_sampler`):

```
set_sampler: backend sampling not supported with SPLIT_MODE_TENSOR; using CPU
spec common_specu: backend offload failed for seq_id=0; using CPU sampler
```

The speculative init then silently falls back to CPU sampling anyway, leaving a
wasted sampler offload attempt and scheduler reserve churn per init. Measured on
a 2×TITAN RTX NVLink (96.8K ctx, MTP n=5) setup: removing the flag raised
end-to-end decode throughput from 27.67 to 35.14 tok/s (+27%).

## Fix

Skip the flag when the runner will run in tensor split mode. The Go layer can
detect this via the inherited `LLAMA_ARG_SPLIT_MODE` environment variable; an
explicit `main_gpu` makes the runner pass `--split-mode none` (which overrides
the env var), so backend sampling stays enabled there.

Single-GPU and layer/row split behavior is unchanged — the flag still applies,
preserving the D2H reduction optimization for the common case.

## Testing

- `go test ./llm/` passes.
- Added `TestAppendDraftArgsTensorSplit` covering the tensor-split omission and
  the `main_gpu` override.
- Runtime-verified with an embedded-MTP model (orcarouter/Qwen3.8-27B-Uncensored:q4_K_M,
  `6fac2f98fdf7`) on a 2×TITAN RTX NVLink setup; other MTP-capable models show the
  same behavior.
- Workload: LongBench-v2 M2 idx 378 (96,804-token English novel "Mouth to Mouth",
  `num_ctx=98304`, `temperature=0.0`, expected answer C) — the answer is correct
  both with and without the flag, confirming the change only affects performance,
  not output correctness.