### PR TITLE
gemma4: a tool call can open before the thinking channel is closed

### DIFF
--- a/model/parsers/gemma4.go
+++ b/model/parsers/gemma4.go
@@ -252,7 +252,36 @@ func (p *Gemma4Parser) eat(done bool) ([]gemma4Event, bool) {
 			}
 		}
 
-		if strings.Contains(bufStr, gemma4ThinkingCloseTag) {
+		// A tool call can open before the thinking channel is closed. The model
+		// is supposed to emit <channel|> first, and usually does -- but when it
+		// does not, this state used to scan for the close tag alone and the
+		// whole call was collected as reasoning. Captured verbatim at the end
+		// of a 17,325-character thinking block:
+		//
+		//   Let's go.<|tool_call>call:editor{end_line:91,...}<tool_call|><|tool_response>
+		//
+		// Complete, well-formed, and invisible: the caller saw a turn with no
+		// tool calls, so the run ended and the edit was never made. Content
+		// state has always checked for both tags; this makes thinking state
+		// symmetric with it. Whichever tag comes first wins, so a close tag
+		// followed by a call still takes the ordinary path below.
+		closeIdx := strings.Index(bufStr, gemma4ThinkingCloseTag)
+		toolIdx := strings.Index(bufStr, gemma4ToolCallOpenTag)
+		if toolIdx != -1 && (closeIdx == -1 || toolIdx < closeIdx) {
+			thinking := strings.TrimRightFunc(bufStr[:toolIdx], unicode.IsSpace)
+			remaining := bufStr[toolIdx+len(gemma4ToolCallOpenTag):]
+
+			p.buffer.Reset()
+			p.buffer.WriteString(remaining)
+			p.state = Gemma4CollectingToolCall
+
+			if len(thinking) > 0 {
+				events = append(events, gemma4EventThinkingContent{content: thinking})
+			}
+			return events, true
+		}
+
+		if closeIdx != -1 {
 			split := strings.SplitN(bufStr, gemma4ThinkingCloseTag, 2)
 			thinking := strings.TrimRightFunc(split[0], unicode.IsSpace)
 			remaining := strings.TrimLeftFunc(split[1], unicode.IsSpace)
@@ -267,9 +296,11 @@ func (p *Gemma4Parser) eat(done bool) ([]gemma4Event, bool) {
 			return events, true
 		}
 
-		// Check for partial close tag
+		// Check for a partial close tag -- or a partial tool-call open tag,
+		// which streams in across chunks exactly the same way and would
+		// otherwise have its prefix emitted as reasoning before it completed.
 		if !done {
-			if overlapLen := overlap(bufStr, gemma4ThinkingCloseTag); overlapLen > 0 {
+			if overlapLen := longestOverlap(bufStr, gemma4ThinkingCloseTag, gemma4ToolCallOpenTag); overlapLen > 0 {
 				beforePartialTag := bufStr[:len(bufStr)-overlapLen]
 				trailingLen := trailingWhitespaceLen(beforePartialTag)
 				ambiguousStart := len(beforePartialTag) - trailingLen

--- a/model/parsers/gemma4_test.go
+++ b/model/parsers/gemma4_test.go
@@ -784,6 +784,90 @@ func TestGemma4Parser_StreamingSplitThinkingTag(t *testing.T) {
 	}
 }
 
+// A tool call opened while the thinking channel is still open.
+//
+// The model is supposed to close the channel first, and usually does. When it
+// does not, this state used to scan for `<channel|>` alone and the entire call
+// was collected as reasoning -- the caller saw a turn with no tool calls, ended
+// the run, and the edit was never made. Captured live on a local Gemma 4:
+//
+//	Let's go.<|tool_call>call:editor{...}<tool_call|><|tool_response>
+//
+// Content state has always checked for both tags; thinking state now matches.
+func TestGemma4Parser_ToolCallInsideThinking(t *testing.T) {
+	tests := []struct {
+		name             string
+		chunks           []string
+		expectedThinking string
+		expectedName     string
+		expectedArgs     map[string]any
+	}{
+		{
+			name: "no_close_tag_before_the_call",
+			chunks: []string{
+				"<|channel>thought\nLet's go.<|tool_call>call:get_weather{location:<|\"|>Paris<|\"|>}<tool_call|>",
+			},
+			expectedThinking: "Let's go.",
+			expectedName:     "get_weather",
+			expectedArgs:     map[string]any{"location": "Paris"},
+		},
+		{
+			name: "open_tag_split_across_chunks",
+			chunks: []string{
+				"<|channel>thought\nLet's go.<|tool",
+				`_call>call:get_weather{location:<|"|>Paris<|"|>}<tool_call|>`,
+			},
+			expectedThinking: "Let's go.",
+			expectedName:     "get_weather",
+			expectedArgs:     map[string]any{"location": "Paris"},
+		},
+		{
+			// The ordinary path must be untouched: a close tag before the call
+			// still ends thinking and the call is read from content.
+			name: "close_tag_first_still_wins",
+			chunks: []string{
+				"<|channel>thought\nthinking<channel|><|tool_call>call:get_weather{location:<|\"|>Paris<|\"|>}<tool_call|>",
+			},
+			expectedThinking: "thinking",
+			expectedName:     "get_weather",
+			expectedArgs:     map[string]any{"location": "Paris"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parser := &Gemma4Parser{hasThinkingSupport: true}
+			parser.Init(nil, nil, &api.ThinkValue{Value: true})
+
+			var finalContent, finalThinking strings.Builder
+			var finalToolCalls []api.ToolCall
+			for i, chunk := range tt.chunks {
+				done := i == len(tt.chunks)-1
+				content, thinking, toolCalls, err := parser.Add(chunk, done)
+				if err != nil {
+					t.Fatalf("Add() error on chunk %d: %v", i, err)
+				}
+				finalContent.WriteString(content)
+				finalThinking.WriteString(thinking)
+				finalToolCalls = append(finalToolCalls, toolCalls...)
+			}
+
+			if finalThinking.String() != tt.expectedThinking {
+				t.Errorf("expected thinking %q, got %q", tt.expectedThinking, finalThinking.String())
+			}
+			if finalContent.String() != "" {
+				t.Errorf("expected no content, got %q", finalContent.String())
+			}
+			expected := []api.ToolCall{
+				{Function: api.ToolCallFunction{Name: tt.expectedName, Arguments: testArgs(tt.expectedArgs)}},
+			}
+			if diff := cmp.Diff(expected, finalToolCalls, argsComparer); diff != "" {
+				t.Errorf("tool calls mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
 func TestGemma4ArgsToJSON(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
### The problem

`Gemma4CollectingThinking` scans for exactly one tag, `<channel|>`. `Gemma4CollectingContent` scans for two — the thinking open tag and the tool-call open tag. Thinking state is the asymmetric one.

So when a model opens a tool call *without* closing the thinking channel first, the entire call is collected as reasoning and the caller sees a turn with no tool calls. Captured verbatim at the end of a 17,325-character thinking block from a local Gemma 4:

```
Let's go.<|tool_call>call:editor{end_line:91,new_text:<|"|>…<|"|>,path:<|"|>manic_miner.html<|"|>,start_line:91}<tool_call|><|tool_response>
```

The call is complete and well-formed. It is simply invisible: the agent framework ended the run because nothing had been called, and the edit the model had spent the whole turn deriving was never made. From the outside it looks like the model stopped mid-task for no reason.

### The change

Thinking state now takes whichever of the two tags appears first. A close tag followed by a call still goes down the existing path, so nothing about the well-formed case changes.

The partial-tag check becomes `longestOverlap` over both tags, for the same reason content state already does this: the open tag arrives split across chunks in streaming, and holding back only a partial `<channel|>` would emit `<|tool` as reasoning before the rest arrived.

### Tests

Three cases in `TestGemma4Parser_ToolCallInsideThinking`:

- a call with no close tag before it
- the same with the open tag split across two chunks
- a close tag first, pinning the precedence so the ordinary path is covered

Without the parser change the first two report no tool calls at all — `[]api.ToolCall(nil)` where a call is expected. `go test ./model/...` passes with it.
