### PR TITLE
docs: show actual JSON array output for embeddings example

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -76,6 +76,12 @@ ollama run embeddinggemma "Hello world"
 Output is a JSON array:
 
 ```
+[0.010071029,-0.0017594862,0.05007221,-0.03259638,...]
+```
+
+Text can also be piped in via stdin:
+
+```
 echo "Hello world" | ollama run nomic-embed-text
 ```
 


### PR DESCRIPTION
The "Generate embeddings" section in `docs/cli.mdx` says "Output is a JSON array:" and then shows a second, unrelated `ollama run` command (piping via stdin) instead of example output. `generateEmbedding` in `cmd/cmd.go` (`json.Marshal(resp.Embeddings[0])`) confirms the actual output is a flat JSON array of floats.

Verified against the code path for `ollama run <embedding-model>` (`cmd/cmd.go`, `generateEmbedding`), which marshals and prints the embedding vector as a JSON array.

This PR was prepared with AI assistance (Claude).