### PR TITLE
openai: expose tools loaded by client tool search

### DIFF
--- a/middleware/responses_tool_search_test.go
+++ b/middleware/responses_tool_search_test.go
@@ -46,7 +46,7 @@ func TestResponsesMiddlewareToolSearchInput(t *testing.T) {
 	if captured == nil {
 		t.Fatal("request was not converted")
 	}
-	if len(captured.Tools) != 1 || captured.Tools[0].Function.Name != "tool_search" {
+	if len(captured.Tools) != 2 || captured.Tools[0].Function.Name != "tool_search" || captured.Tools[1].Function.Name != "orders.lookup_order" {
 		t.Fatalf("native tools = %#v", captured.Tools)
 	}
 	if len(captured.Messages) != 2 {

--- a/openai/responses.go
+++ b/openai/responses.go
@@ -663,9 +663,10 @@ func FromResponsesRequest(r ResponsesRequest) (*api.ChatRequest, error) {
 
 	// Convert tools from Responses API format to api.Tool format
 	var tools []api.Tool
-	hasWebSearch := HasWebSearchTool(r.Tools)
-	hasToolSearch := HasToolSearchTool(r.Tools)
-	for _, t := range r.Tools {
+	requestTools := responsesRequestTools(r)
+	hasWebSearch := HasWebSearchTool(requestTools)
+	hasToolSearch := HasToolSearchTool(requestTools)
+	for _, t := range requestTools {
 		if isWebSearchTool(t) {
 			tools = append(tools, WebSearchFunctionTool())
 			continue
@@ -695,6 +696,18 @@ func FromResponsesRequest(r ResponsesRequest) (*api.ChatRequest, error) {
 			tools = append(tools, tool)
 		}
 	}
+
+	// Search results can repeat tools already declared or loaded by earlier searches.
+	// Keep the first definition, giving explicit request tools precedence.
+	seen := make(map[string]bool, len(tools))
+	uniqueTools := tools[:0]
+	for _, tool := range tools {
+		if !seen[tool.Function.Name] {
+			seen[tool.Function.Name] = true
+			uniqueTools = append(uniqueTools, tool)
+		}
+	}
+	tools = uniqueTools
 
 	// Handle text format (e.g. json_schema)
 	var format json.RawMessage

--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -608,7 +608,7 @@ func TestFromResponsesRequestRejectsHostedToolSearch(t *testing.T) {
 	}
 }
 
-func TestFromResponsesRequest_ToolSearchOutputBecomesToolContent(t *testing.T) {
+func TestFromResponsesRequest_ToolSearchOutputLoadsToolsAndPreservesContent(t *testing.T) {
 	var request ResponsesRequest
 	if err := json.Unmarshal([]byte(`{
 		"model":"test",
@@ -653,8 +653,8 @@ func TestFromResponsesRequest_ToolSearchOutputBecomesToolContent(t *testing.T) {
 	if len(content) != 1 || content[0]["name"] != "lookup_order" || content[0]["x_client_field"] != "preserved" {
 		t.Fatalf("content = %#v", content)
 	}
-	if len(chat.Tools) != 1 || chat.Tools[0].Function.Name != "tool_search" {
-		t.Fatalf("native tools = %#v; discovered tool must remain content-only", chat.Tools)
+	if len(chat.Tools) != 2 || chat.Tools[0].Function.Name != "tool_search" || chat.Tools[1].Function.Name != "lookup_order" {
+		t.Fatalf("native tools = %#v", chat.Tools)
 	}
 }
 
@@ -742,8 +742,66 @@ func TestFromResponsesRequest_ToolSearchOutputFlattensNamespaceMembers(t *testin
 	if got := string(request.Input.Items[1].(ResponsesToolSearchOutput).Tools[0]); got != string(namespace) {
 		t.Fatalf("Responses tool_search_output was mutated: %s", got)
 	}
-	if len(chat.Tools) != 1 || chat.Tools[0].Function.Name != "tool_search" {
-		t.Fatalf("native tools = %#v; discovered tools must remain content-only", chat.Tools)
+	wantNames := []string{"tool_search", "mcp__openaiDeveloperDocs.search_openai_docs", "mcp__codex_apps__github_search", "plain"}
+	if len(chat.Tools) != len(wantNames) {
+		t.Fatalf("native tools = %#v", chat.Tools)
+	}
+	for i, name := range wantNames {
+		if chat.Tools[i].Function.Name != name {
+			t.Fatalf("tool %d name = %q, want %q", i, chat.Tools[i].Function.Name, name)
+		}
+	}
+	loaded := chat.Tools[1].Function
+	if loaded.Description != "Search docs" || len(loaded.Parameters.Required) != 1 || loaded.Parameters.Required[0] != "query" {
+		t.Fatalf("loaded tool definition = %#v", loaded)
+	}
+}
+
+func TestFromResponsesRequest_ToolSearchOutputDeduplicatesTools(t *testing.T) {
+	var request ResponsesRequest
+	if err := json.Unmarshal([]byte(`{
+		"tools":[{"type":"function","name":"orders.lookup","description":"Explicit definition"}],
+		"input":[
+			{"type":"tool_search_output","call_id":"first","tools":[
+				{"type":"namespace","name":"orders","tools":[
+					{"type":"function","name":"lookup","description":"Discovered definition"},
+					{"type":"function","name":"cancel"}
+				]},
+				{"type":"namespace","name":"customers","tools":[{"type":"function","name":"lookup"}]}
+			]},
+			{"type":"tool_search_output","call_id":"second","tools":[
+				{"type":"function","name":"orders.cancel"}
+			]}
+		]
+	}`), &request); err != nil {
+		t.Fatal(err)
+	}
+	before, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	chat, err := FromResponsesRequest(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantNames := []string{"orders.lookup", "orders.cancel", "customers.lookup"}
+	if len(chat.Tools) != len(wantNames) {
+		t.Fatalf("native tools = %#v", chat.Tools)
+	}
+	for i, name := range wantNames {
+		if chat.Tools[i].Function.Name != name {
+			t.Fatalf("tool %d name = %q, want %q", i, chat.Tools[i].Function.Name, name)
+		}
+	}
+	if chat.Tools[0].Function.Description != "Explicit definition" {
+		t.Fatalf("explicit tool definition was replaced: %#v", chat.Tools[0])
+	}
+	after, err := json.Marshal(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(before) != string(after) {
+		t.Fatal("request was mutated")
 	}
 }
 


### PR DESCRIPTION
A Responses API request following client-side tool search currently includes discovered definitions only in the tool-result text. `FromResponsesRequest` builds the callable tool list from the top-level `tools` array, so the model cannot invoke the discovered tools.

Use the existing `responsesRequestTools` helper when converting the request, and deduplicate converted functions by their qualified names. Explicit request definitions take precedence over repeated search results. The existing built-in handling, namespace conversion, and tool-result content are preserved.

Regression coverage checks flat and namespaced discovered tools, repeated results, explicit-definition precedence, distinct namespaces, and request immutability. The HTTP middleware test verifies that `orders.lookup_order` reaches the native request. These tests failed before the fix and pass afterward.

Validation:
- `go test ./openai ./middleware`
- `go vet ./openai ./middleware`
- `git diff --check`

No live model inference was required or run; the tests exercise the request conversion boundary.

Fixes #18306
