### PR TITLE
docs: fix macOS casing in faq

### DIFF
--- a/docs/faq.mdx
+++ b/docs/faq.mdx
@@ -409,5 +409,5 @@ Ollama for Windows and macOS register as a login item during installation.  You 
 **Windows**
 - In `Task Manager` go to the `Startup apps` tab, search for `ollama` then click `Disable`
 
-**MacOS**
+**macOS**
 - Open `Settings` and search for "Login Items", find the `Ollama` entry under `Allow in the Background`, then click the slider to disable.


### PR DESCRIPTION
docs: fix macOS casing in faq

**MacOS** -> **macOS**, matching the rest of the file (Ollama on macOS, Ollama for Windows and macOS).
