### PR TITLE
docs: fix resent typo in windows guide

### DIFF
--- a/docs/windows.mdx
+++ b/docs/windows.mdx
@@ -64,7 +64,7 @@ Ollama on Windows stores files in a few different locations. You can view them i
 the explorer window by hitting `<Ctrl>+R` and type in:
 
 - `explorer %LOCALAPPDATA%\Ollama` contains logs, and downloaded updates
-  - _app.log_ contains most resent logs from the GUI application
+  - _app.log_ contains most recent logs from the GUI application
   - _server.log_ contains the most recent server logs
   - _upgrade.log_ contains log output for upgrades
 - `explorer %LOCALAPPDATA%\Programs\Ollama` contains the binaries (The installer adds this to your user PATH)


### PR DESCRIPTION
docs: fix resent typo in windows guide

most resent -> most recent, matching the adjacent server.log line and docs/macos.mdx.
