### PR TITLE
docs: sync launch integrations list with CLI

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -18,11 +18,24 @@ Configure and launch external applications to use Ollama models. This provides a
 
 #### Supported integrations
 
-- **OpenCode** - Open-source coding assistant
-- **Claude Code** - Anthropic's agentic coding tool
-- **Codex** - OpenAI's coding assistant
-- **VS Code** - Microsoft's IDE with built-in AI chat
-- **Droid** - Factory's AI coding agent
+- **Claude Code** - Anthropic's coding tool with subagents
+- **ChatGPT** - Use Ollama models in ChatGPT
+- **Hermes Agent** - Self-improving AI agent built by Nous Research
+- **OpenClaw** - Personal AI with 100+ skills
+- **OpenCode** - Anomaly's open-source coding agent
+- **Codex** - OpenAI's open-source coding agent
+- **Hermes Desktop** - Desktop app for Hermes Agent by Nous Research
+- **Copilot CLI** - GitHub's AI coding agent for the terminal
+- **OMP** - AI coding agent with IDE integration
+- **Droid** - Factory's coding agent across terminal and IDEs
+- **DeepSeek Harness** - DeepSeek's open-source agent harness
+- **Kimi Code CLI** - Moonshot's coding agent for terminal and IDEs
+- **Muse Code** - Meta's agentic coding CLI
+- **Pi** - Minimal AI agent toolkit with plugin support
+- **Pool** - Poolside's software agent for enterprise development
+- **Cline** - Autonomous coding agent with parallel execution
+- **Qwen Code** - Qwen's AI coding agent with tool use
+- **VS Code** - Microsoft's open-source AI code editor
 
 #### Examples
 


### PR DESCRIPTION
docs: sync launch integrations list with CLI

docs/cli.mdx listed only 5 integrations, but ollama launch ships 18 (see Supported integrations in cmd/launch/launch.go and descriptions in cmd/launch/registry.go). Sync the docs list with the CLI help output so users can discover all integrations.
