### PR TITLE
docs: fix Large Language casing in macos and windows guides

### DIFF
--- a/docs/macos.mdx
+++ b/docs/macos.mdx
@@ -12,7 +12,7 @@ title: macOS
 
 The preferred method of installation is to mount the `ollama.dmg` and drag-and-drop the Ollama application to the system-wide `Applications` folder.  Upon startup, the Ollama app will verify the `ollama` CLI is present in your PATH, and if not detected, will prompt for permission to create a link in `/usr/local/bin`
 
-Once you've installed Ollama, you'll need additional space for storing the Large Language models, which can be tens to hundreds of GB in size.  If your home directory doesn't have enough space, you can change where the binaries are installed, and where the models are stored.
+Once you've installed Ollama, you'll need additional space for storing the large language models, which can be tens to hundreds of GB in size.  If your home directory doesn't have enough space, you can change where the binaries are installed, and where the models are stored.
 
 ### Changing Install Location
 

--- a/docs/windows.mdx
+++ b/docs/windows.mdx
@@ -26,7 +26,7 @@ Ollama uses unicode characters for progress indication, which may render as unkn
 
 ## Filesystem Requirements
 
-The Ollama install does not require Administrator, and installs in your home directory by default. You'll need at least 4GB of space for the binary install. Once you've installed Ollama, you'll need additional space for storing the Large Language models, which can be tens to hundreds of GB in size. If your home directory doesn't have enough space, you can change where the binaries are installed, and where the models are stored.
+The Ollama install does not require Administrator, and installs in your home directory by default. You'll need at least 4GB of space for the binary install. Once you've installed Ollama, you'll need additional space for storing the large language models, which can be tens to hundreds of GB in size. If your home directory doesn't have enough space, you can change where the binaries are installed, and where the models are stored.
 
 ### Changing Install Location
 


### PR DESCRIPTION
docs: fix Large Language casing in macos and windows guides

Mid-sentence capital Large -> large in both install guides (same shared sentence).
