### PR TITLE
api: use value receivers for tool String methods

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -282,8 +282,8 @@ func (t *ToolCallFunctionArguments) ToMap() map[string]any {
 	return t.om.ToMap()
 }
 
-func (t *ToolCallFunctionArguments) String() string {
-	if t == nil || t.om == nil {
+func (t ToolCallFunctionArguments) String() string {
+	if t.om == nil {
 		return "{}"
 	}
 	bts, _ := json.Marshal(t.om)
@@ -478,7 +478,7 @@ type ToolFunctionParameters struct {
 	Properties *ToolPropertiesMap `json:"properties"`
 }
 
-func (t *ToolFunctionParameters) String() string {
+func (t ToolFunctionParameters) String() string {
 	bts, _ := json.Marshal(t)
 	return string(bts)
 }
@@ -489,7 +489,7 @@ type ToolFunction struct {
 	Parameters  ToolFunctionParameters `json:"parameters"`
 }
 
-func (t *ToolFunction) String() string {
+func (t ToolFunction) String() string {
 	bts, _ := json.Marshal(t)
 	return string(bts)
 }

--- a/api/types_test.go
+++ b/api/types_test.go
@@ -1,12 +1,14 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"math"
 	"reflect"
 	"strings"
 	"testing"
+	"text/template"
 	"time"
 
 	"github.com/ollama/ollama/types/model"
@@ -750,6 +752,83 @@ func TestToolFunctionParameters_String(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			result := test.params.String()
 			assert.Equal(t, test.expected, result)
+		})
+	}
+}
+
+// Model templates render tool schemas by printing values directly, e.g.
+// `{"type": "function", "function": {{ .Function }}}`. text/template only uses
+// String() if the value satisfies fmt.Stringer; a field reached through a
+// non-addressable value does not satisfy it when String() is declared on a
+// pointer receiver, and text/template falls back to printing the raw struct.
+func TestToolTemplateRendering(t *testing.T) {
+	tool := Tool{
+		Type: "function",
+		Function: ToolFunction{
+			Name:        "get_weather",
+			Description: "Get the current weather",
+			Parameters: ToolFunctionParameters{
+				Type:     "object",
+				Required: []string{"location"},
+				Properties: testPropsMap(map[string]ToolProperty{
+					"location": {
+						Type:        PropertyType{"string"},
+						Description: "The city",
+					},
+				}),
+			},
+		},
+	}
+
+	args := NewToolCallFunctionArguments()
+	args.Set("location", "London")
+	toolCall := ToolCall{
+		Function: ToolCallFunction{
+			Name:      "get_weather",
+			Arguments: args,
+		},
+	}
+
+	tests := []struct {
+		name     string
+		tmpl     string
+		data     any
+		expected string
+	}{
+		{
+			name:     "tool",
+			tmpl:     `{{ . }}`,
+			data:     tool,
+			expected: `{"type":"function","function":{"name":"get_weather","description":"Get the current weather","parameters":{"type":"object","required":["location"],"properties":{"location":{"type":"string","description":"The city"}}}}}`,
+		},
+		{
+			name:     "tool function",
+			tmpl:     `{{ .Function }}`,
+			data:     tool,
+			expected: `{"name":"get_weather","description":"Get the current weather","parameters":{"type":"object","required":["location"],"properties":{"location":{"type":"string","description":"The city"}}}}`,
+		},
+		{
+			name:     "tool function parameters",
+			tmpl:     `{{ .Function.Parameters }}`,
+			data:     tool,
+			expected: `{"type":"object","required":["location"],"properties":{"location":{"type":"string","description":"The city"}}}`,
+		},
+		{
+			name:     "tool call arguments",
+			tmpl:     `{{ .Function.Arguments }}`,
+			data:     toolCall,
+			expected: `{"location":"London"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tmpl, err := template.New("test").Parse(test.tmpl)
+			require.NoError(t, err)
+
+			var b bytes.Buffer
+			require.NoError(t, tmpl.Execute(&b, test.data))
+			assert.Equal(t, test.expected, b.String())
 		})
 	}
 }


### PR DESCRIPTION
Fixes the malformed tool schemas reported in #14601.

## Problem

Model templates render tool schemas by printing values directly. qwen3's template contains:

```
{{- range .Tools }}
{"type": "function", "function": {{ .Function }}}
{{- end }}
```

`text/template` only calls `String()` when the value satisfies `fmt.Stringer`. `Tool.String()` has a value receiver, but `ToolFunction.String()` had a pointer receiver, and the `ToolFunction` reached through `{{ .Function }}` is not addressable, so it does not satisfy `fmt.Stringer`. `text/template` fell back to printing the raw struct:

```
{"type": "function", "function": {get_weather Get the current weather {object <nil> <nil> [location] 0xc000123456}}}
```

The model never sees a schema. It guesses a plausible function name, the tool call parser finds no match, and the entire response is discarded: `content` is `""` and `tool_calls` is absent, while `eval_count` shows the tokens were generated. The failure is silent and total rather than degraded.

Templates that print the whole tool with `{{ . }}`, such as llama3.2, were unaffected, because `Tool.String()` already had a value receiver.

`ToolFunctionParameters` and `ToolCallFunctionArguments` had the same pointer receiver and are reachable the same way. `command-r.gotmpl` renders `{{ .Function.Arguments }}` on line 58, which printed `{0xc000123456}`.

## Fix

Value receivers on the three `String()` methods for types that are stored as value fields:

| type | stored as | reached by |
| --- | --- | --- |
| `ToolFunction` | `Tool.Function` | `{{ .Function }}` |
| `ToolFunctionParameters` | `ToolFunction.Parameters` | `{{ .Function.Parameters }}` |
| `ToolCallFunctionArguments` | `ToolCallFunction.Arguments` | `{{ .Function.Arguments }}` |

`ThinkValue` also has a pointer receiver `String()` but is only ever held as `*ThinkValue`, so it renders correctly and is left alone.

The receiver nil check in `ToolCallFunctionArguments.String` is no longer applicable; the `om` field is still checked, and the method is only ever called on a value.

## Before / after

`{{ .Function }}` against the same `api.Tool`:

```
before: {get_weather Get the current weather {object <nil> <nil> [location] 0xc000123456}}
after:  {"name":"get_weather","description":"Get the current weather","parameters":{"type":"object","required":["location"],"properties":{"location":{"type":"string","description":"The city"}}}}
```

End to end, `qwen3:1.7b` via `/api/chat` with `"think": false`, n=20, one tool supplied:

| | tool calls returned |
| --- | --- |
| before | 0/20, all with empty `content` |
| after | 20/20 |

Reproduced on 0.31.2, 0.32.0, 0.32.15, 0.33.2, 0.33.3 and 0.34.0-rc1, so this is not a recent regression.

## Notes

The `json` template function is an effective per-template workaround (`{{ .Function | json }}`), but the affected templates ship inside model blobs on the registry, so that only helps users who rewrite the template themselves. Since `Tool.String()` already returns JSON, the asymmetry looks unintentional.

## Testing

Added `TestToolTemplateRendering` in `api/types_test.go`, covering the four template forms above. It fails on three of the four subtests without this change and passes with it.

`go build ./...` succeeds. `go test` passes for all packages except `cmd/launch`, where `TestCodexAppCountsOnlyOllamaRequestsInRegularProfile` fails identically on an unmodified tree at the same commit and is unrelated to this change. Integration tests were not run as they need a running server.
