### PR TITLE
app: configure allowed browser origins in settings

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -5,6 +5,18 @@
 - [macOS](https://github.com/ollama/app/releases/download/latest/Ollama.dmg)
 - [Windows](https://github.com/ollama/app/releases/download/latest/OllamaSetup.exe)
 
+## Browser access
+
+In Settings, enter website origins in **Allowed browser origins**, for example
+`https://app.example.com`. Separate multiple origins with commas. Press Enter or
+leave the field to save; Ollama restarts to apply the change and remembers it on
+subsequent launches. Enable **Expose Ollama to the network** as well when
+connecting from another device.
+
+A nonempty list overrides `OLLAMA_ORIGINS` for the app-managed server. Clearing
+the field restores the existing environment and browser-access defaults. This
+setting controls CORS; it does not enable HTTPS.
+
 ## Development
 
 ### Desktop App

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -250,7 +250,9 @@ func (s *Server) cmd(ctx context.Context) (*exec.Cmd, error) {
 	if settings.Expose {
 		env["OLLAMA_HOST"] = "0.0.0.0"
 	}
-	if settings.Browser {
+	if settings.AllowedOrigins != "" {
+		env["OLLAMA_ORIGINS"] = settings.AllowedOrigins
+	} else if settings.Browser {
 		env["OLLAMA_ORIGINS"] = "*"
 	}
 	if settings.Models != "" {

--- a/app/server/server_test.go
+++ b/app/server/server_test.go
@@ -66,6 +66,18 @@ func TestServerCmd(t *testing.T) {
 			dont:     []string{"OLLAMA_HOST="},
 		},
 		{
+			name:     "allowed origins",
+			settings: store.Settings{AllowedOrigins: "https://app.example.com,https://other.example.com"},
+			want:     []string{"OLLAMA_ORIGINS=https://app.example.com,https://other.example.com"},
+			dont:     []string{"OLLAMA_HOST="},
+		},
+		{
+			name:     "allowed origins override browser wildcard",
+			settings: store.Settings{Browser: true, AllowedOrigins: "https://app.example.com"},
+			want:     []string{"OLLAMA_ORIGINS=https://app.example.com"},
+			dont:     []string{"OLLAMA_ORIGINS=*"},
+		},
+		{
 			name:     "models",
 			settings: store.Settings{Models: tmpModels},
 			want:     []string{"OLLAMA_MODELS=" + tmpModels},
@@ -396,5 +408,39 @@ func TestGetInferenceInfoTimeout(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "timeout") {
 		t.Fatalf("unexpected error: %s", err)
+	}
+}
+
+func TestServerCmdAllowedOriginsEnvironment(t *testing.T) {
+	t.Setenv("OLLAMA_ORIGINS", "https://environment.example.com")
+	for _, origins := range []string{"", "https://app.example.com"} {
+		t.Run(origins, func(t *testing.T) {
+			st := &store.Store{DBPath: filepath.Join(t.TempDir(), "db.sqlite")}
+			defer st.Close()
+			if err := st.SetSettings(store.Settings{AllowedOrigins: origins}); err != nil {
+				t.Fatal(err)
+			}
+			s := &Server{store: st}
+			cmd, err := s.cmd(t.Context())
+			if err != nil {
+				t.Fatal(err)
+			}
+			want := origins
+			if want == "" {
+				want = "https://environment.example.com"
+			}
+			count := 0
+			for _, env := range cmd.Env {
+				if strings.HasPrefix(env, "OLLAMA_ORIGINS=") {
+					count++
+					if env != "OLLAMA_ORIGINS="+want {
+						t.Errorf("got %q, want origins %q", env, want)
+					}
+				}
+			}
+			if count != 1 {
+				t.Errorf("got %d OLLAMA_ORIGINS entries, want 1", count)
+			}
+		})
 	}
 }

--- a/app/store/database.go
+++ b/app/store/database.go
@@ -14,7 +14,7 @@ import (
 
 // currentSchemaVersion defines the current database schema version.
 // Increment this when making schema changes that require migrations.
-const currentSchemaVersion = 18
+const currentSchemaVersion = 19
 
 // database wraps the SQLite connection.
 // SQLite handles its own locking for concurrent access:
@@ -69,6 +69,7 @@ func (db *database) init() error {
 		expose BOOLEAN NOT NULL DEFAULT 0,
 		survey BOOLEAN NOT NULL DEFAULT TRUE,
 		browser BOOLEAN NOT NULL DEFAULT 0,
+		allowed_origins TEXT NOT NULL DEFAULT '',
 		models TEXT NOT NULL DEFAULT '',
 		agent BOOLEAN NOT NULL DEFAULT 0,
 		tools BOOLEAN NOT NULL DEFAULT 0,
@@ -285,6 +286,11 @@ func (db *database) migrate() error {
 				return fmt.Errorf("migrate v17 to v18: %w", err)
 			}
 			version = 18
+		case 18:
+			if err := db.migrateV18ToV19(); err != nil {
+				return fmt.Errorf("migrate v18 to v19: %w", err)
+			}
+			version = 19
 		default:
 			// If we have a version we don't recognize, just set it to current
 			// This might happen during development
@@ -583,6 +589,19 @@ func (db *database) migrateV17ToV18() error {
 		return fmt.Errorf("update schema version: %w", err)
 	}
 
+	return nil
+}
+
+// migrateV18ToV19 adds configurable browser origins.
+func (db *database) migrateV18ToV19() error {
+	_, err := db.conn.Exec(`ALTER TABLE settings ADD COLUMN allowed_origins TEXT NOT NULL DEFAULT ''`)
+	if err != nil && !duplicateColumnError(err) {
+		return fmt.Errorf("add allowed_origins column: %w", err)
+	}
+	_, err = db.conn.Exec(`UPDATE settings SET schema_version = 19`)
+	if err != nil {
+		return fmt.Errorf("update schema version: %w", err)
+	}
 	return nil
 }
 
@@ -1234,9 +1253,9 @@ func (db *database) getSettings() (Settings, error) {
 	var s Settings
 
 	err := db.conn.QueryRow(`
-		SELECT expose, survey, browser, models, agent, tools, working_dir, context_length, turbo_enabled, websearch_enabled, selected_model, sidebar_open, last_home_view, onboarding_version, think_enabled, think_level, auto_update_enabled, claude_desktop_used
+		SELECT expose, survey, browser, allowed_origins, models, agent, tools, working_dir, context_length, turbo_enabled, websearch_enabled, selected_model, sidebar_open, last_home_view, onboarding_version, think_enabled, think_level, auto_update_enabled, claude_desktop_used
 		FROM settings
-	`).Scan(&s.Expose, &s.Survey, &s.Browser, &s.Models, &s.Agent, &s.Tools, &s.WorkingDir, &s.ContextLength, &s.TurboEnabled, &s.WebSearchEnabled, &s.SelectedModel, &s.SidebarOpen, &s.LastHomeView, &s.OnboardingVersion, &s.ThinkEnabled, &s.ThinkLevel, &s.AutoUpdateEnabled, &s.ClaudeDesktopUsed)
+	`).Scan(&s.Expose, &s.Survey, &s.Browser, &s.AllowedOrigins, &s.Models, &s.Agent, &s.Tools, &s.WorkingDir, &s.ContextLength, &s.TurboEnabled, &s.WebSearchEnabled, &s.SelectedModel, &s.SidebarOpen, &s.LastHomeView, &s.OnboardingVersion, &s.ThinkEnabled, &s.ThinkLevel, &s.AutoUpdateEnabled, &s.ClaudeDesktopUsed)
 	if err != nil {
 		return Settings{}, fmt.Errorf("get settings: %w", err)
 	}
@@ -1252,8 +1271,8 @@ func (db *database) setSettings(s Settings) error {
 
 	_, err := db.conn.Exec(`
 		UPDATE settings
-		SET expose = ?, survey = ?, browser = ?, models = ?, agent = ?, tools = ?, working_dir = ?, context_length = ?, turbo_enabled = ?, websearch_enabled = ?, selected_model = ?, sidebar_open = ?, last_home_view = ?, onboarding_version = ?, think_enabled = ?, think_level = ?, auto_update_enabled = ?, claude_desktop_used = ?
-	`, s.Expose, s.Survey, s.Browser, s.Models, s.Agent, s.Tools, s.WorkingDir, s.ContextLength, s.TurboEnabled, s.WebSearchEnabled, s.SelectedModel, s.SidebarOpen, lastHomeView, s.OnboardingVersion, s.ThinkEnabled, s.ThinkLevel, s.AutoUpdateEnabled, s.ClaudeDesktopUsed)
+		SET expose = ?, survey = ?, browser = ?, allowed_origins = ?, models = ?, agent = ?, tools = ?, working_dir = ?, context_length = ?, turbo_enabled = ?, websearch_enabled = ?, selected_model = ?, sidebar_open = ?, last_home_view = ?, onboarding_version = ?, think_enabled = ?, think_level = ?, auto_update_enabled = ?, claude_desktop_used = ?
+	`, s.Expose, s.Survey, s.Browser, s.AllowedOrigins, s.Models, s.Agent, s.Tools, s.WorkingDir, s.ContextLength, s.TurboEnabled, s.WebSearchEnabled, s.SelectedModel, s.SidebarOpen, lastHomeView, s.OnboardingVersion, s.ThinkEnabled, s.ThinkLevel, s.AutoUpdateEnabled, s.ClaudeDesktopUsed)
 	if err != nil {
 		return fmt.Errorf("set settings: %w", err)
 	}

--- a/app/store/database_test.go
+++ b/app/store/database_test.go
@@ -563,3 +563,61 @@ func loadV2Schema(t *testing.T, dbPath string) *database {
 
 	return &database{conn: conn}
 }
+
+func TestAllowedOriginsMigrationAndPersistence(t *testing.T) {
+	dbPath := filepath.Join(t.TempDir(), "origins.db")
+	db, err := newDatabase(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { db.Close() }()
+	settings, err := db.getSettings()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if settings.AllowedOrigins != "" {
+		t.Fatalf("unexpected default origins %q", settings.AllowedOrigins)
+	}
+	if _, err := db.conn.Exec(`ALTER TABLE settings DROP COLUMN allowed_origins; UPDATE settings SET schema_version = 18, expose = 1, browser = 1;`); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.migrate(); err != nil {
+		t.Fatal(err)
+	}
+	settings, err = db.getSettings()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if settings.AllowedOrigins != "" || !settings.Expose || !settings.Browser {
+		t.Fatalf("migration changed existing behavior: %+v", settings)
+	}
+	settings.AllowedOrigins = "https://app.example.com,https://other.example.com"
+	if err := db.setSettings(settings); err != nil {
+		t.Fatal(err)
+	}
+	if err := db.Close(); err != nil {
+		t.Fatal(err)
+	}
+	db, err = newDatabase(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	loaded, err := db.getSettings()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.AllowedOrigins != settings.AllowedOrigins {
+		t.Fatalf("origins not persisted: %q", loaded.AllowedOrigins)
+	}
+	loaded.AllowedOrigins = ""
+	if err := db.setSettings(loaded); err != nil {
+		t.Fatal(err)
+	}
+	loaded, err = db.getSettings()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if loaded.AllowedOrigins != "" {
+		t.Fatalf("origins not cleared: %q", loaded.AllowedOrigins)
+	}
+}

--- a/app/store/store.go
+++ b/app/store/store.go
@@ -129,6 +129,9 @@ type Settings struct {
 	// be exposed to browser windows (e.g. CORS set to allow all origins)
 	Browser bool
 
+	// AllowedOrigins is a comma-separated list of additional browser origins.
+	AllowedOrigins string
+
 	// Survey is a boolean that indicates if the user allows anonymous
 	// inference information to be shared with Ollama
 	Survey bool

--- a/app/ui/app/codegen/gotypes.gen.ts
+++ b/app/ui/app/codegen/gotypes.gen.ts
@@ -402,6 +402,7 @@ export class ErrorEvent {
 export class Settings {
     Expose: boolean;
     Browser: boolean;
+    AllowedOrigins: string;
     Survey: boolean;
     Models: string;
     Agent: boolean;
@@ -423,6 +424,7 @@ export class Settings {
         if ('string' === typeof source) source = JSON.parse(source);
         this.Expose = source["Expose"];
         this.Browser = source["Browser"];
+        this.AllowedOrigins = source["AllowedOrigins"];
         this.Survey = source["Survey"];
         this.Models = source["Models"];
         this.Agent = source["Agent"];

--- a/app/ui/app/src/components/Settings.interaction.test.tsx
+++ b/app/ui/app/src/components/Settings.interaction.test.tsx
@@ -186,6 +186,43 @@ describe("Settings reset interactions", () => {
     vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
   });
 
+  it.each([
+    [
+      " https://app.example.com, https://other.example.com ",
+      "https://app.example.com,https://other.example.com",
+    ],
+    ["", ""],
+  ])("saves browser origins on blur: %s", async (value, expected) => {
+    mocks.settings = new SettingsType({
+      ContextLength: 65_536,
+      AllowedOrigins: "https://old.example.com",
+    });
+    let renderer;
+    try {
+      await act(async () => {
+        renderer = create(<Settings />);
+      });
+      const input = renderer!.root
+        .findAllByType("input")
+        .find((node) => node.props.placeholder === "https://app.example.com");
+      expect(input?.props.defaultValue).toBe("https://old.example.com");
+      expect(mocks.updateSettings).not.toHaveBeenCalled();
+      await act(async () => {
+        input!.props.onBlur({ target: { value } });
+      });
+      expect(mocks.updateSettings).toHaveBeenCalledWith(
+        expect.objectContaining({
+          AllowedOrigins: expected,
+          ContextLength: 65_536,
+        }),
+      );
+    } finally {
+      await act(async () => {
+        renderer?.unmount();
+      });
+    }
+  });
+
   it("locks every control and shows Saved after reset succeeds", async () => {
     const pendingClaudeReset = deferred<boolean>();
     mocks.resetClaudeMappings.mockImplementation(

--- a/app/ui/app/src/components/Settings.test.ts
+++ b/app/ui/app/src/components/Settings.test.ts
@@ -39,6 +39,7 @@ describe("Settings defaults", () => {
       resetClaudeMappings,
       currentSettings: currentSettings({
         Expose: true,
+        AllowedOrigins: "https://app.example.com",
         Models: "/custom/models",
       }),
       currentShowAppsInMenu: false,
@@ -55,6 +56,7 @@ describe("Settings defaults", () => {
 
     expect(updateSettings.mock.calls[0][0]).toMatchObject({
       Expose: false,
+      AllowedOrigins: "",
       Models: "",
       ContextLength: 65_536,
       AutoUpdateEnabled: true,

--- a/app/ui/app/src/components/Settings.tsx
+++ b/app/ui/app/src/components/Settings.tsx
@@ -99,6 +99,7 @@ export async function applySettingsDefaults({
       new SettingsType({
         Expose: false,
         Browser: false,
+        AllowedOrigins: "",
         Models: "",
         Agent: false,
         Tools: false,
@@ -699,6 +700,35 @@ export default function Settings() {
                     />
                   </div>
                 </div>
+              </Field>
+
+              <Field>
+                <Label>Allowed browser origins</Label>
+                <Description>
+                  Allow websites to connect to Ollama. Separate origins with
+                  commas, for example https://app.example.com. Leave blank to
+                  use defaults. Changes restart Ollama.
+                </Description>
+                <Input
+                  className="mt-2"
+                  key={settings.AllowedOrigins || ""}
+                  defaultValue={settings.AllowedOrigins || ""}
+                  placeholder="https://app.example.com"
+                  onBlur={(e) => {
+                    const origins = e.target.value
+                      .split(",")
+                      .map((origin) => origin.trim())
+                      .filter(Boolean)
+                      .join(",");
+                    e.target.value = origins;
+                    if (origins !== (settings.AllowedOrigins || "")) {
+                      handleChange("AllowedOrigins", origins);
+                    }
+                  }}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") e.currentTarget.blur();
+                  }}
+                />
               </Field>
 
               {/* Model Directory */}

--- a/app/ui/ui.go
+++ b/app/ui/ui.go
@@ -1541,12 +1541,17 @@ func (s *Server) settings(w http.ResponseWriter, r *http.Request) error {
 		store.Settings
 		OnboardingVersion *int
 		ClaudeDesktopUsed *bool
+		AllowedOrigins    *string
 	}
 	if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
 		return fmt.Errorf("invalid request body: %w", err)
 	}
 
 	settings := request.Settings
+	settings.AllowedOrigins = old.AllowedOrigins
+	if request.AllowedOrigins != nil {
+		settings.AllowedOrigins = *request.AllowedOrigins
+	}
 	if request.OnboardingVersion == nil {
 		settings.OnboardingVersion = old.OnboardingVersion
 	} else {
@@ -1582,7 +1587,8 @@ func (s *Server) settings(w http.ResponseWriter, r *http.Request) error {
 
 	if old.ContextLength != settings.ContextLength ||
 		old.Models != settings.Models ||
-		old.Expose != settings.Expose {
+		old.Expose != settings.Expose ||
+		old.AllowedOrigins != settings.AllowedOrigins {
 		s.Restart()
 	}
 

--- a/app/ui/ui_test.go
+++ b/app/ui/ui_test.go
@@ -1061,3 +1061,42 @@ func TestSettingsToggleAutoUpdateOn_NoPendingUpdate_DoesNotNotify(t *testing.T) 
 		t.Fatal("UpdateAvailableFunc should not be called when there is no pending update")
 	}
 }
+
+func TestSettingsAllowedOrigins(t *testing.T) {
+	for _, tt := range []struct {
+		name, body, want string
+		restart          bool
+	}{
+		{"change", `{"Models":"/test/models","AllowedOrigins":"https://new.example.com"}`, "https://new.example.com", true},
+		{"clear", `{"Models":"/test/models","AllowedOrigins":""}`, "", true},
+		{"unchanged", `{"Models":"/test/models","AllowedOrigins":"https://app.example.com"}`, "https://app.example.com", false},
+		{"omitted", `{"Models":"/test/models"}`, "https://app.example.com", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			st := &store.Store{DBPath: filepath.Join(t.TempDir(), "db.sqlite")}
+			defer st.Close()
+			if err := st.SetSettings(store.Settings{Models: "/test/models", AllowedOrigins: "https://app.example.com"}); err != nil {
+				t.Fatal(err)
+			}
+			restarts := 0
+			s := &Server{Store: st, Restart: func() { restarts++ }}
+			if err := s.settings(httptest.NewRecorder(), httptest.NewRequest("POST", "/api/v1/settings", strings.NewReader(tt.body))); err != nil {
+				t.Fatal(err)
+			}
+			settings, err := st.Settings()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if settings.AllowedOrigins != tt.want {
+				t.Fatalf("got origins %q, want %q", settings.AllowedOrigins, tt.want)
+			}
+			wantRestarts := 0
+			if tt.restart {
+				wantRestarts = 1
+			}
+			if restarts != wantRestarts {
+				t.Fatalf("got %d restarts, want %d", restarts, wantRestarts)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Title: app: configure allowed browser origins in settings

Desktop users connecting a hosted website to Ollama currently have to configure `OLLAMA_ORIGINS` outside the app. Add an **Allowed browser origins** field below the network-exposure setting. For example, entering `https://app.phygineer.com` and pressing Enter saves the origin and restarts the managed server; subsequent launches reuse it.

Persist the comma-separated list with a v18-to-v19 SQLite migration. A nonempty list overrides the inherited origin environment and legacy browser wildcard. Clearing it restores existing defaults. Preserve the value when older settings requests omit the new field, and clear it when resetting settings to defaults. This changes CORS configuration only; HTTPS still requires separate configuration.

Fixes #11295.

Validation:

- All 145 UI tests pass, including saving/clearing origins and resetting defaults.
- Production UI build passes.
- Changed TypeScript files pass ESLint with no errors (one existing Fast Refresh warning).
- Generated TypeScript matches tscriptify output.
- Store and server tests pass on Linux using a temporary Go overlay that changes desktop build constraints only. Includes schema migration, reopen persistence, clearing, environment precedence, and no duplicate environment entries.
- Chromium check against the built UI with a mocked API verifies the accessible field, save on Enter, and restoration after reload. Screenshot: settings.png.
- Added native settings-handler tests for changes, clearing, unchanged values, and omitted fields. These were not run in this Linux workspace; macOS/Windows CI and a native desktop smoke test remain required.

Native smoke test: enter an origin in Settings, confirm the server restarts and accepts that website's origin, relaunch the desktop app and confirm the value remains, then clear it and confirm default behavior is restored.

No new dependencies.

<img width="1100" height="1000" alt="settings" src="https://github.com/user-attachments/assets/7ab13f35-0587-4f0d-8ef9-d89fad190073" />
