### PR TITLE
model/parsers: preserve multiline functiongemma tool arguments

### DIFF
--- a/model/parsers/functiongemma.go
+++ b/model/parsers/functiongemma.go
@@ -158,7 +158,7 @@ func (p *FunctionGemmaParser) eat() ([]functionGemmaEvent, bool) {
 }
 
 // Matches call:function_name{args}
-var functionGemmaCallRegex = regexp.MustCompile(`call:([^{]+)\{(.*)\}`)
+var functionGemmaCallRegex = regexp.MustCompile(`(?s)call:([^{]+)\{(.*)\}`)
 
 func (p *FunctionGemmaParser) parseToolCall(content string) (api.ToolCall, error) {
 	toolCall := api.ToolCall{}

--- a/model/parsers/functiongemma_test.go
+++ b/model/parsers/functiongemma_test.go
@@ -55,6 +55,31 @@ func TestFunctionGemmaParser(t *testing.T) {
 			expectedText: "",
 		},
 		{
+			name: "multiline_string_argument",
+			chunks: []string{
+				"<start_function_call>call:write_file{content:<escape>first line\nsecond line<escape>}<end_function_call>",
+			},
+			expectedCalls: []api.ToolCall{
+				{Function: api.ToolCallFunction{
+					Name:      "write_file",
+					Arguments: testArgs(map[string]any{"content": "first line\nsecond line"}),
+				}},
+			},
+		},
+		{
+			name: "chunked_multiline_string_argument",
+			chunks: []string{
+				"<start_function_call>call:write_file{content:<escape>first line\r",
+				"\nsecond line<escape>}<end_function_call>",
+			},
+			expectedCalls: []api.ToolCall{
+				{Function: api.ToolCallFunction{
+					Name:      "write_file",
+					Arguments: testArgs(map[string]any{"content": "first line\r\nsecond line"}),
+				}},
+			},
+		},
+		{
 			name: "content_before_tool_call",
 			chunks: []string{
 				"L", "et", " ", "me", " ", "check", ".",


### PR DESCRIPTION
# Description

FunctionGemma tool calls containing a newline in a string argument currently produce a call with an empty function name and no arguments. For example, `write_file` with two lines of content is lost because the call-matching regular expression does not match newlines. This is valid input: the FunctionGemma renderer writes string values verbatim between `<escape>` delimiters.

Allow the argument capture to span newlines. Add regressions for a complete LF-containing call and a streamed call split between CR and LF, asserting the original function name and exact argument content.

Validation: both regressions fail before the fix. `go test ./model/parsers ./model/renderers -count=1` passes after the fix.
