### PR TITLE
server: retry compaction after context overflow

### DIFF
--- a/openai/responses_compact.go
+++ b/openai/responses_compact.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -21,6 +22,7 @@ const (
 	OllamaCompactionPayloadVersion = 1
 	CreateSummaryToolName          = "create_summary"
 	compactionSummaryToolName      = "ollama_compaction_summary"
+	compactionOmissionNotice       = "Compaction warning: %d older transcript items were omitted before summarization because the model's context limit was exceeded."
 )
 
 // ResponsesCompactionTrigger is the terminal input item sent by current Codex
@@ -80,10 +82,11 @@ type ResponsesCompactionPlan struct {
 	Model  string
 	Stream bool
 
-	items      []CompactionTranscriptItem
-	tools      []compactionToolMetadata
-	groups     []compactionToolGroup
-	forcedRefs map[string]struct{}
+	items        []CompactionTranscriptItem
+	tools        []compactionToolMetadata
+	groups       []compactionToolGroup
+	forcedRefs   map[string]struct{}
+	omittedItems int
 }
 
 // ResponsesCompactionResult is the validated result of a compaction-model call.
@@ -647,6 +650,78 @@ func collectCompactionToolMetadata(tools []ResponsesTool) []compactionToolMetada
 	return metadata
 }
 
+// TrimForContextLimit removes the oldest removable items, targeting 20% of
+// serialized transcript text. This is a fallback estimate, not a token budget.
+// User and instruction messages, prior summaries, the latest item, and active
+// tool state are preserved. Completed tool calls and results are removed together.
+// It returns the number of removed items, or zero when no progress is possible.
+func (p *ResponsesCompactionPlan) TrimForContextLimit() int {
+	if len(p.items) == 0 {
+		return 0
+	}
+
+	sizes := make(map[string]int, len(p.items))
+	var total int
+	for _, item := range p.items {
+		message := item.Message
+		message.Images = nil
+		metadata, err := json.Marshal(compactionTranscriptItemWire{
+			Ref: item.Ref, Type: item.Type, Message: message, ImageCount: len(item.Message.Images),
+		})
+		if err != nil {
+			return 0
+		}
+		sizes[item.Ref] = len(metadata)
+		total += len(metadata)
+	}
+
+	protected := make(map[string]bool, len(p.forcedRefs)+1)
+	for ref := range p.forcedRefs {
+		protected[ref] = true
+	}
+	protected[p.items[len(p.items)-1].Ref] = true
+	peers := make(map[string]string, len(p.groups)*2)
+	for _, group := range p.groups {
+		if group.ResultRef != "" {
+			peers[group.CallRef] = group.ResultRef
+			peers[group.ResultRef] = group.CallRef
+		}
+	}
+
+	removed := make(map[string]bool)
+	var removedBytes int
+	for _, item := range p.items {
+		if removedBytes >= (total+4)/5 {
+			break
+		}
+		if protected[item.Ref] || removed[item.Ref] {
+			continue
+		}
+		peer := peers[item.Ref]
+		if item.Type == "function_call" || item.Type == "function_call_output" {
+			// Prior summary pairs are intentionally absent from p.groups.
+			if peer == "" || protected[peer] {
+				continue
+			}
+		} else if item.Message.Role != "assistant" {
+			continue
+		}
+		removed[item.Ref] = true
+		removedBytes += sizes[item.Ref]
+		if peer != "" {
+			removed[peer] = true
+			removedBytes += sizes[peer]
+		}
+	}
+	if len(removed) == 0 {
+		return 0
+	}
+	p.items = slices.DeleteFunc(p.items, func(item CompactionTranscriptItem) bool { return removed[item.Ref] })
+	p.groups = slices.DeleteFunc(p.groups, func(group compactionToolGroup) bool { return removed[group.CallRef] })
+	p.omittedItems += len(removed)
+	return len(removed)
+}
+
 // SummaryRequest returns an ordinary non-streaming Responses request. A repair
 // request includes the validation error from the first model response.
 func (p *ResponsesCompactionPlan) SummaryRequest(repairError string) ([]byte, error) {
@@ -657,6 +732,9 @@ func (p *ResponsesCompactionPlan) SummaryRequest(repairError string) ([]byte, er
 		return nil, err
 	}
 	prompt := `Summarize the conversation for another coding agent. Preserve the goal, decisions, constraints, repository state, changed files, test results, failures, active work, and next actions. After optional tool metadata, each following user message is one ordered transcript item: its JSON input_text describes the source item, and its input_image blocks belong to that item. Use retain_item_ids for exact source items, including images, that cannot safely be paraphrased. Tool calls and results are execution state; do not invent or edit them. Call create_summary exactly once.`
+	if p.omittedItems > 0 {
+		prompt += " " + fmt.Sprintf(compactionOmissionNotice, p.omittedItems)
+	}
 	if repairError != "" {
 		prompt += " Your previous create_summary call was invalid: " + repairError + ". Return one corrected create_summary call."
 	}
@@ -789,6 +867,9 @@ func (p *ResponsesCompactionPlan) Complete(body []byte) (ResponsesCompactionResu
 	}
 	payload := OllamaCompactionPayload{
 		Type: OllamaCompactionPayloadType, Version: OllamaCompactionPayloadVersion, Summary: selection.Summary, Retained: retained,
+	}
+	if p.omittedItems > 0 {
+		payload.Summary = fmt.Sprintf(compactionOmissionNotice, p.omittedItems) + "\n\n" + payload.Summary
 	}
 	payloadJSON, err := json.Marshal(payload)
 	if err != nil {

--- a/openai/responses_compact_test.go
+++ b/openai/responses_compact_test.go
@@ -3,11 +3,133 @@ package openai
 import (
 	"bytes"
 	"encoding/json"
+	"slices"
 	"strings"
 	"testing"
 
 	"github.com/ollama/ollama/api"
 )
+
+func TestCompactionTrimPreservesProtectedState(t *testing.T) {
+	body := []byte(`{"model":"test","input":[
+		{"type":"message","role":"system","content":"system instructions"},
+		{"type":"message","role":"developer","content":"developer instructions"},
+		{"type":"message","role":"user","content":"original goal"},
+		{"type":"tool_search_call","call_id":"old","arguments":{"query":"find a tool"}},
+		{"type":"tool_search_output","call_id":"old","tools":[{"type":"namespace","name":"example","tools":[{"type":"function","name":"shell","description":"` + strings.Repeat("old output ", 1000) + `","parameters":{"type":"object"}}]}]},
+		{"type":"message","role":"assistant","content":"old result processed"},
+		{"type":"message","role":"user","content":"latest request"},
+		{"type":"function_call","call_id":"pending","name":"shell","arguments":"{}"},
+		{"type":"function_call","call_id":"latest","name":"read_image","arguments":"{}"},
+		{"type":"function_call_output","call_id":"latest","output":[{"type":"input_image","image_url":"` + compactionTestPNG + `"}]}
+	]}`)
+	plan, err := PrepareStandaloneCompaction(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed := plan.TrimForContextLimit(); removed != 2 {
+		t.Fatalf("removed %d items, want the old call/result pair", removed)
+	}
+	var refs []string
+	for _, item := range plan.items {
+		refs = append(refs, item.Ref)
+	}
+	want := []string{"item_000001", "item_000002", "item_000003", "item_000006", "item_000007", "item_000008", "item_000009", "item_000010"}
+	if !slices.Equal(refs, want) {
+		t.Fatalf("remaining references = %v, want %v", refs, want)
+	}
+	request, err := plan.SummaryRequest("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, marker := range []string{"system instructions", "developer instructions", "original goal", "latest request", compactionTestPNG, "2 older transcript items were omitted"} {
+		if !bytes.Contains(request, []byte(marker)) {
+			t.Errorf("retry prompt missing %q", marker)
+		}
+	}
+	if bytes.Contains(request, []byte("old output")) {
+		t.Fatal("old tool output remains in retry prompt")
+	}
+	result, err := plan.Complete(compactionResponseBody(t, map[string]any{
+		"summary": "Continue the task.", "retain_item_ids": []string{},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	payload := decodeResultPayload(t, result)
+	if !strings.Contains(payload.Summary, "2 older transcript items were omitted") {
+		t.Fatal("summary does not disclose omitted history")
+	}
+	if len(payload.Retained) != 3 || payload.Retained[0].ToolCalls[0].ID != "pending" || payload.Retained[1].ToolCalls[0].ID != "latest" || len(payload.Retained[2].Images) != 1 {
+		t.Fatalf("active tool state changed: %+v", payload.Retained)
+	}
+	if _, err := plan.Complete(compactionResponseBody(t, map[string]any{
+		"summary": "invalid selection", "retain_item_ids": []string{"item_000004"},
+	})); err == nil {
+		t.Fatal("accepted a reference removed before summarization")
+	}
+}
+
+func TestCompactionTrimPreservesPriorSummaryAndLatestItem(t *testing.T) {
+	old, err := json.Marshal(OllamaCompactionPayload{
+		Type: OllamaCompactionPayloadType, Version: OllamaCompactionPayloadVersion, Summary: "prior summary",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	body, err := json.Marshal(map[string]any{
+		"model": "test", "input": []any{
+			ResponsesCompactionItem{Type: "compaction", EncryptedContent: string(old)},
+			map[string]any{"type": "message", "role": "user", "content": "user request"},
+			map[string]any{"type": "message", "role": "assistant", "content": strings.Repeat("older assistant text ", 500)},
+			map[string]any{"type": "message", "role": "assistant", "content": "latest assistant text"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	plan, err := PrepareStandaloneCompaction(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed := plan.TrimForContextLimit(); removed != 1 {
+		t.Fatalf("removed=%d, want 1", removed)
+	}
+	request, err := plan.SummaryRequest("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, marker := range []string{"prior summary", "user request", "latest assistant text"} {
+		if !bytes.Contains(request, []byte(marker)) {
+			t.Errorf("retry prompt missing %q", marker)
+		}
+	}
+	if removed := plan.TrimForContextLimit(); removed != 0 {
+		t.Fatalf("removed %d protected items", removed)
+	}
+}
+
+func TestCompactionTrimKeepsToolPairsAcrossInterleavedResults(t *testing.T) {
+	plan, err := PrepareStandaloneCompaction([]byte(`{"model":"test","input":[
+		{"type":"function_call","call_id":"a","name":"shell","arguments":"{}"},
+		{"type":"function_call","call_id":"b","name":"shell","arguments":"{}"},
+		{"type":"function_call_output","call_id":"b","output":"b output"},
+		{"type":"function_call_output","call_id":"a","output":"` + strings.Repeat("a output ", 1000) + `"},
+		{"type":"message","role":"assistant","content":"processed both results"}
+	]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed := plan.TrimForContextLimit(); removed != 2 {
+		t.Fatalf("removed=%d, want 2", removed)
+	}
+	if len(plan.items) != 3 || plan.items[0].Message.ToolCalls[0].ID != "b" || plan.items[1].Message.ToolCallID != "b" {
+		t.Fatal("did not preserve the other complete tool pair")
+	}
+	if _, _, err := analyzeCompactionToolState(plan.items); err != nil {
+		t.Fatalf("trim left invalid tool state: %v", err)
+	}
+}
 
 func compactionResponseBody(t *testing.T, selection map[string]any) []byte {
 	t.Helper()

--- a/server/responses_compact.go
+++ b/server/responses_compact.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -98,7 +100,8 @@ func resetResponsesRequestBody(r *http.Request, body []byte) {
 
 func (s *Server) handleResponsesCompaction(c *gin.Context, plan *openai.ResponsesCompactionPlan, stream bool) {
 	var validationErr error
-	for range 2 {
+	overflowRetried := false
+	for {
 		repair := ""
 		if validationErr != nil {
 			repair = validationErr.Error()
@@ -111,12 +114,22 @@ func (s *Server) handleResponsesCompaction(c *gin.Context, plan *openai.Response
 
 		response := s.runResponsesCompactionInference(c, request)
 		if response.status < http.StatusOK || response.status >= http.StatusMultipleChoices {
+			if !overflowRetried && c.Request.Context().Err() == nil && isCompactionContextLimit(response) {
+				if removed := plan.TrimForContextLimit(); removed > 0 {
+					overflowRetried = true
+					slog.WarnContext(c.Request.Context(), "retrying compaction after context overflow", "model", plan.Model, "omitted_items", removed)
+					continue
+				}
+			}
 			copyResponsesCompactionResponse(c, response)
 			return
 		}
 
 		result, err := plan.Complete(response.body.Bytes())
 		if err != nil {
+			if validationErr != nil {
+				break
+			}
 			validationErr = err
 			continue
 		}
@@ -131,6 +144,22 @@ func (s *Server) handleResponsesCompaction(c *gin.Context, plan *openai.Response
 	}
 
 	writeResponsesCompactionError(c, http.StatusInternalServerError, "compaction_failed", "compaction failed; the selected model did not return a valid summary and the original conversation is unchanged")
+}
+
+var compactionContextLimitPattern = regexp.MustCompile(`^The prompt is too long: [0-9]+, model maximum context length: [0-9]+(?: \(ref: [^()]+\))?$`)
+
+func isCompactionContextLimit(response *responsesInferenceRecorder) bool {
+	if response.status != http.StatusBadRequest && response.status != http.StatusRequestEntityTooLarge {
+		return false
+	}
+	var body openai.ErrorResponse
+	if json.Unmarshal(response.body.Bytes(), &body) != nil {
+		return false
+	}
+	if body.Error.Code != nil && *body.Error.Code == "context_length_exceeded" {
+		return true
+	}
+	return compactionContextLimitPattern.MatchString(body.Error.Message)
 }
 
 // runResponsesCompactionInference uses the normal Responses stack without the

--- a/server/responses_compact_test.go
+++ b/server/responses_compact_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,129 @@ import (
 
 	"github.com/ollama/ollama/openai"
 )
+
+func TestIsCompactionContextLimit(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		status int
+		body   string
+		want   bool
+	}{
+		{"reported cloud error", 400, `{"error":{"message":"The prompt is too long: 1068408, model maximum context length: 1048576 (ref: 00000000-0000-4000-8000-000000000001)","code":null}}`, true},
+		{"without reference", 400, `{"error":{"message":"The prompt is too long: 100, model maximum context length: 90"}}`, true},
+		{"structured code", 400, `{"error":{"message":"input too large","code":"context_length_exceeded"}}`, true},
+		{"structured 413", 413, `{"error":{"code":"context_length_exceeded"}}`, true},
+		{"wrong status", 500, `{"error":{"code":"context_length_exceeded"}}`, false},
+		{"rate limit", 429, `{"error":{"code":"context_length_exceeded"}}`, false},
+		{"other 413", 413, `{"error":{"message":"request body too large"}}`, false},
+		{"other invalid request", 400, `{"error":{"message":"invalid tool schema","code":"invalid_request_error"}}`, false},
+		{"untrusted embedded phrase", 400, `{"error":{"message":"Invalid input contains: The prompt is too long: 100, model maximum context length: 90"}}`, false},
+		{"missing counts", 400, `{"error":{"message":"The prompt is too long: unknown, model maximum context length: unknown"}}`, false},
+		{"invalid JSON", 400, `upstream failed`, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			response := &responsesInferenceRecorder{status: tt.status, body: *bytes.NewBufferString(tt.body)}
+			if got := isCompactionContextLimit(response); got != tt.want {
+				t.Fatalf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResponsesCompactionOverflowRecovery(t *testing.T) {
+	const overflow = `{"error":{"message":"The prompt is too long: 1068408, model maximum context length: 1048576 (ref: fixture)","type":"invalid_request_error","code":null}}`
+	const invalid = `{"id":"bad","object":"response","output":[]}`
+	for _, tt := range []struct {
+		name        string
+		path        string
+		responses   []string
+		statuses    []int
+		wantStatus  int
+		wantTrimmed bool
+	}{
+		{"standalone", "/v1/responses/compact", []string{overflow, ""}, []int{400, 200}, 200, true},
+		{"trigger", "/v1/responses", []string{overflow, ""}, []int{400, 200}, 200, true},
+		{"overflow then repair", "/v1/responses/compact", []string{overflow, invalid, ""}, []int{400, 200, 200}, 200, true},
+		{"repair then overflow", "/v1/responses/compact", []string{invalid, overflow, ""}, []int{200, 400, 200}, 200, true},
+		{"overflow retry exhausted", "/v1/responses/compact", []string{overflow, overflow}, []int{400, 400}, 400, true},
+		{"both retries exhausted", "/v1/responses/compact", []string{overflow, invalid, invalid}, []int{400, 200, 200}, 500, true},
+		{"unrelated error", "/v1/responses/compact", []string{`{"error":{"message":"invalid tool schema"}}`}, []int{400}, 400, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			local, capture := newCompactionTestServer(t, func(attempt int, w http.ResponseWriter, _ *http.Request, _ []byte) {
+				w.Header().Set("Content-Type", "application/json")
+				if attempt > len(tt.responses) {
+					t.Errorf("unexpected attempt %d", attempt)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				w.WriteHeader(tt.statuses[attempt-1])
+				if body := tt.responses[attempt-1]; body != "" {
+					_, _ = io.WriteString(w, body)
+				} else {
+					_, _ = w.Write(summaryResponse(t, "Continue from the latest result.", nil))
+				}
+			})
+			input := `[
+				{"type":"message","role":"user","content":"original goal"},
+				{"type":"function_call","call_id":"old","name":"shell","arguments":"{}"},
+				{"type":"function_call_output","call_id":"old","output":"` + strings.Repeat("old output ", 1000) + `"},
+				{"type":"message","role":"assistant","content":"old result processed"},
+				{"type":"message","role":"user","content":"latest request"},
+				{"type":"function_call","call_id":"latest","name":"shell","arguments":"{}"},
+				{"type":"function_call_output","call_id":"latest","output":"latest result"}
+			]`
+			stream := tt.path == "/v1/responses"
+			if stream {
+				input = strings.TrimSuffix(input, "]") + `,{"type":"compaction_trigger"}]`
+			}
+			request := fmt.Sprintf(`{"model":"fixture:cloud","stream":%t,"input":%s}`, stream, input)
+			status, _, body := postCompactionRequest(t, local, tt.path, request)
+			if status != tt.wantStatus {
+				t.Fatalf("status=%d, want %d: %s", status, tt.wantStatus, body)
+			}
+			_, requests := capture.snapshot()
+			if len(requests) != len(tt.responses) {
+				t.Fatalf("made %d attempts, want %d", len(requests), len(tt.responses))
+			}
+			if tt.wantTrimmed {
+				last := requests[len(requests)-1]
+				if len(last) >= len(requests[0]) || bytes.Contains(last, []byte("old output")) {
+					t.Fatal("overflow retry did not shrink the old transcript")
+				}
+				for _, marker := range []string{"original goal", "latest request", "latest result", "2 older transcript items were omitted"} {
+					if !bytes.Contains(last, []byte(marker)) {
+						t.Errorf("retry prompt missing %q", marker)
+					}
+				}
+			}
+			if status == http.StatusOK {
+				if !bytes.Contains(body, []byte("2 older transcript items were omitted")) || !bytes.Contains(body, []byte("latest result")) {
+					t.Fatalf("compaction output lost omission notice or active result: %s", body)
+				}
+			} else if status == http.StatusBadRequest && string(body) != tt.responses[len(tt.responses)-1] {
+				t.Fatalf("did not preserve upstream error: %s", body)
+			}
+		})
+	}
+}
+
+func TestResponsesCompactionOverflowWithoutRemovableHistory(t *testing.T) {
+	const overflow = `{"error":{"code":"context_length_exceeded","message":"too many tokens"}}`
+	local, capture := newCompactionTestServer(t, func(_ int, w http.ResponseWriter, _ *http.Request, _ []byte) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, overflow)
+	})
+	status, _, body := postCompactionRequest(t, local, "/v1/responses/compact", `{"model":"fixture:cloud","input":"oversized user message"}`)
+	if status != http.StatusBadRequest || string(body) != overflow {
+		t.Fatalf("status=%d body=%s", status, body)
+	}
+	_, requests := capture.snapshot()
+	if len(requests) != 1 {
+		t.Fatalf("made %d requests without removable history", len(requests))
+	}
+}
 
 func summaryResponse(t *testing.T, summary string, retained []string) []byte {
 	t.Helper()


### PR DESCRIPTION
Compaction can exceed the model’s context limit after Ollama expands the conversation into a summarization prompt, leaving the client retrying the same oversized history.

Retry compaction once on context-overflow errors after removing roughly 20% of the oldest removable transcript text. Preserve user and instruction messages, prior summaries, the latest item, and active tool state. Remove completed tool calls and results together, and record omissions in the returned summary.

Keep the existing malformed-summary repair retry, with at most three inference attempts total. If recovery fails, return the error without replacing the original conversation.
