### PR TITLE
app: align ChatGPT connection status copy with Claude

### DIFF
--- a/app/ui/app/src/components/CodexDesktopRow.test.tsx
+++ b/app/ui/app/src/components/CodexDesktopRow.test.tsx
@@ -42,7 +42,7 @@ describe("CodexDesktopRow", () => {
     expect(html).toContain('aria-checked="false"');
   });
 
-  it("shows only the Ollama request count when connected", () => {
+  it("matches Claude's connected copy before the first request", () => {
     const html = renderToStaticMarkup(
       <CodexDesktopRow
         integration={integration}
@@ -54,27 +54,36 @@ describe("CodexDesktopRow", () => {
       />,
     );
 
-    expect(html).toContain("0 Ollama requests this session");
+    expect(html).toContain("Connected to Ollama · 0 requests this session");
     expect(html).not.toContain("Codex + Ollama");
     expect(html).not.toContain("3 Ollama models");
     expect(html).toContain('aria-label="Remove Ollama models from ChatGPT"');
     expect(html).toContain('aria-checked="true"');
   });
 
-  it("shows the Ollama request count with singular copy", () => {
-    const html = renderToStaticMarkup(
-      <CodexDesktopRow
-        integration={integration}
-        initialStatus={status({
-          connected: true,
-          model: "qwen3:8b",
-          requests: 1,
-        })}
-      />,
-    );
+  it.each([
+    { requests: 1, expected: "Connected to Ollama · 1 request this session" },
+    {
+      requests: 12,
+      expected: "Connected to Ollama · 12 requests this session",
+    },
+  ])(
+    "matches Claude's connected copy for $requests requests",
+    ({ requests, expected }) => {
+      const html = renderToStaticMarkup(
+        <CodexDesktopRow
+          integration={integration}
+          initialStatus={status({
+            connected: true,
+            model: "qwen3:8b",
+            requests,
+          })}
+        />,
+      );
 
-    expect(html).toContain("1 Ollama request this session");
-  });
+      expect(html).toContain(expected);
+    },
+  );
 
   it("offers installation when ChatGPT is not installed", () => {
     const html = renderToStaticMarkup(

--- a/app/ui/app/src/components/CodexDesktopRow.tsx
+++ b/app/ui/app/src/components/CodexDesktopRow.tsx
@@ -54,7 +54,7 @@ function codexDesktopDescription(
 ): string {
   if (!status?.connected) return defaultDescription;
   const requestCount = status.requests ?? 0;
-  return `${requestCount} Ollama ${requestCount === 1 ? "request" : "requests"} this session`;
+  return `Connected to Ollama · ${requestCount} ${requestCount === 1 ? "request" : "requests"} this session`;
 }
 
 export function CodexDesktopRow({


### PR DESCRIPTION
## Summary

Match the connected ChatGPT status to Claude: `Connected to Ollama · 12 requests this session`.

The request count remains dynamic, with correct singular/plural wording. This only changes ChatGPT copy and adds coverage for zero, one, and multiple requests; Claude and connection behavior are unchanged.

## Testing

- All 144 UI tests passed (`npm test -- --run`).
- TypeScript checks passed (`tsc -b`).
- ESLint passed for both changed files.