### PR TITLE
anthropic: output_config.effort without a thinking block should disable thinking

### DIFF
--- a/anthropic/anthropic.go
+++ b/anthropic/anthropic.go
@@ -410,18 +410,33 @@ func FromMessagesRequest(r MessagesRequest) (*api.ChatRequest, error) {
 		}
 	}
 
-	if r.Thinking != nil && r.Thinking.Type == "enabled" {
-		think = &api.ThinkValue{Value: true}
+	effortLevel := ""
+	switch normalizedEffort {
+	case "high", "medium", "low", "max":
+		effortLevel = normalizedEffort
 	}
-	if r.Thinking != nil && r.Thinking.Type == "disabled" {
+
+	switch {
+	case r.Thinking != nil && r.Thinking.Type == "disabled":
+		think = &api.ThinkValue{Value: false}
+	case r.Thinking != nil && (r.Thinking.Type == "enabled" || r.Thinking.Type == "adaptive"):
+		// Extended thinking is on; output_config.effort selects the level for
+		// models that support one, otherwise plain true.
+		if effortLevel != "" {
+			think = &api.ThinkValue{Value: effortLevel}
+		} else {
+			think = &api.ThinkValue{Value: true}
+		}
+	case r.Thinking == nil && r.OutputConfig != nil:
+		// Anthropic semantics: output_config.effort without a thinking block
+		// means NO extended thinking. In practice the only client that sends
+		// this shape is Claude Code with thinking switched off
+		// (alwaysThinkingEnabled=false / MAX_THINKING_TOKENS=0); previously the
+		// effort fell through and re-enabled thinking at that level, so the
+		// user's toggle had no effect against Ollama.
 		think = &api.ThinkValue{Value: false}
 	}
-	if think == nil && r.OutputConfig != nil {
-		switch normalizedEffort {
-		case "high", "medium", "low", "max":
-			think = &api.ThinkValue{Value: normalizedEffort}
-		}
-	}
+	// r.Thinking == nil && r.OutputConfig == nil: leave think nil (model default), unchanged.
 
 	stream := r.Stream
 	convertedRequest := &api.ChatRequest{

--- a/anthropic/anthropic_test.go
+++ b/anthropic/anthropic_test.go
@@ -577,11 +577,11 @@ func TestFromMessagesRequest_WithOutputConfigEffort(t *testing.T) {
 	}
 
 	if result.Think == nil {
-		t.Fatal("expected think to be set from output_config.effort")
+		t.Fatal("expected think to be set")
 	}
 
-	if got := result.Think.String(); got != "high" {
-		t.Fatalf("expected think level 'high', got %q", got)
+	if got, ok := result.Think.Value.(bool); !ok || got {
+		t.Fatalf("expected think=false when output_config.effort is sent without a thinking block (Anthropic semantics), got %v", result.Think.Value)
 	}
 }
 
@@ -606,11 +606,11 @@ func TestFromMessagesRequest_WithOutputConfigEffortXHighMapsToHigh(t *testing.T)
 	}
 
 	if result.Think == nil {
-		t.Fatal("expected think to be set from output_config.effort")
+		t.Fatal("expected think to be set")
 	}
 
-	if got := result.Think.String(); got != "high" {
-		t.Fatalf("expected think level 'high' for xhigh effort, got %q", got)
+	if got, ok := result.Think.Value.(bool); !ok || got {
+		t.Fatalf("expected think=false when output_config.effort is sent without a thinking block (Anthropic semantics), got %v", result.Think.Value)
 	}
 }
 
@@ -2168,5 +2168,53 @@ func TestCitation(t *testing.T) {
 
 	if unmarshaled.CitedText != "Some cited text..." {
 		t.Errorf("cited_text mismatch: expected 'Some cited text...', got %q", unmarshaled.CitedText)
+	}
+}
+
+// Claude Code with thinking switched off (alwaysThinkingEnabled=false or
+// MAX_THINKING_TOKENS=0) sends no thinking block but still sends
+// output_config.effort. That must disable thinking, not select a level.
+func TestFromMessagesRequest_EffortWithoutThinkingDisablesThinking(t *testing.T) {
+	req := MessagesRequest{
+		Model:     "test-model",
+		MaxTokens: 32000,
+		Messages:  []MessageParam{{Role: "user", Content: textContent("Hello")}},
+		OutputConfig: &OutputConfig{
+			Effort: "high",
+		},
+	}
+	result, err := FromMessagesRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	think := result.Think
+	if think == nil {
+		t.Fatal("expected think to be set")
+	}
+	if got, ok := think.Value.(bool); !ok || got {
+		t.Fatalf("expected think=false, got %v", think.Value)
+	}
+}
+
+// Enabled thinking plus an effort still selects the level.
+func TestFromMessagesRequest_EnabledThinkingUsesOutputConfigEffort(t *testing.T) {
+	req := MessagesRequest{
+		Model:     "test-model",
+		MaxTokens: 32000,
+		Messages:  []MessageParam{{Role: "user", Content: textContent("Hello")}},
+		Thinking:  &ThinkingConfig{Type: "enabled", BudgetTokens: 4096},
+		OutputConfig: &OutputConfig{
+			Effort: "low",
+		},
+	}
+	result, err := FromMessagesRequest(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Think == nil {
+		t.Fatal("expected think to be set")
+	}
+	if got, ok := result.Think.Value.(string); !ok || got != "low" {
+		t.Fatalf("expected think level 'low', got %v", result.Think.Value)
 	}
 }


### PR DESCRIPTION
# PR: anthropic: `output_config.effort` without a thinking block should disable thinking

**Branch:** `anthropic-effort-without-thinking` (patch: `0001-anthropic-effort-without-a-thinking-block-disables-t.patch`, based on `83ed7d9`)
**Tests:** `ok  	github.com/ollama/ollama/anthropic	0.237s` (go vet clean)

## Problem

`FromMessagesRequest` currently falls through to `output_config.effort` whenever the request has no
`thinking` block, and turns thinking **on** at that level. Under the Anthropic Messages API, `effort`
without a `thinking` block means *no extended thinking*; `effort` only modulates thinking that the
client has enabled.

In practice the only widely-used client that sends this shape is **Claude Code with thinking switched
off** — `alwaysThinkingEnabled: false` or `MAX_THINKING_TOKENS=0`. Verified with a request-logging proxy
(Claude Code 2.x, Ollama 0.33.3):

| Claude Code state | `thinking` sent | `output_config` sent | Ollama today | Expected |
|---|---|---|---|---|
| default | `{type: adaptive}` | `{effort: high}` | think=`"high"` | think on (level) |
| thinking off (either toggle) | *(absent)* | `{effort: high}` | **think=`"high"`** | **think off** |

So the user's thinking-off toggle has no effect against Ollama. Claude Code never emits
`{type: disabled}`, so there is no client-side workaround short of a rewriting proxy.

Why it matters: on a thinking model this is the difference between a usable and an unusable local agent.
On Laguna S 2.1 (118B-A8B, MLX, M5 Max 128 GB) across 24 paired Claude Code agent tasks, thinking-off
matched thinking-on 24/24 on correctness at **3.1x the median speed** (232s → 76s) and removed the tail
(worst run 1741s — a single 302k-char thinking block — → 708s).

## Change

- `thinking.type` `enabled` / `adaptive` → thinking on; `effort` (if present and valid) selects the
  level, else `true`. (`adaptive` + effort behaves exactly as before.)
- `thinking.type` `disabled` → `false` (unchanged).
- **`thinking` absent + `output_config` present → `false`** (this is the fix).
- `thinking` absent + `output_config` absent → `nil` / model default (unchanged).

## Tests

- `TestFromMessagesRequest_WithOutputConfigEffort` and `...XHighMapsToHigh` updated: effort alone now
  expects `think=false` (they exercised the case this PR changes).
- Added `TestFromMessagesRequest_EffortWithoutThinkingDisablesThinking` (the Claude Code shape) and
  `TestFromMessagesRequest_EnabledThinkingUsesOutputConfigEffort` (level selection still works when
  thinking is enabled).
- `TestFromMessagesRequest_ThinkingAdaptiveUsesOutputConfigEffort` and
  `...ThinkingDisabledOverridesOutputConfigEffort` pass unchanged.

## Compatibility note

Two behaviour changes, one intended and one incidental:
1. **Intended:** `output_config.effort` with no `thinking` block → `think=false` (was: think at that level).
2. **Incidental:** `thinking: {type: enabled}` + `effort` now selects the effort *level* (was: plain `true`),
   which is what `adaptive` + `effort` already did — the two are now consistent. Models without levels
   treat a level as on, so this is only observable on level-aware models.

Anyone relying on "effort alone turns thinking on" changes behaviour. I could not find a client that sends
that shape *intending* thinking on: the Anthropic SDKs and Claude Code send `thinking: {type: adaptive}`
when they want it. If maintainers prefer to keep the old fallthrough, an alternative is to honour
`enabled` with `budget_tokens: 0` as off — but Claude Code does not send that either, so it would not
fix the toggle.
