### PR TITLE
docs: drop mdx extension on openai-compatibility link

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -11,4 +11,4 @@ Ollama JavaScript examples at [ollama-js/examples](https://github.com/ollama/oll
 
 
 ## OpenAI compatibility examples
-Ollama OpenAI compatibility examples at [ollama/examples/openai](./api/openai-compatibility.mdx)
+Ollama OpenAI compatibility examples at [ollama/examples/openai](./api/openai-compatibility)


### PR DESCRIPTION
docs: drop mdx extension on openai-compatibility link

.mdx-suffixed internal links 404 on the docs site (same pattern as #14243); link without extension.
