### PR TITLE
x/mlxrunner/mlx: report missing symbols lazily instead of printing to stderr

### DIFF
--- a/x/mlxrunner/mlx/dynamic.c
+++ b/x/mlxrunner/mlx/dynamic.c
@@ -1,6 +1,20 @@
 #include "dynamic.h"
 
 #include <stdio.h>
+#include <string.h>
+
+// Holds the name of the first symbol that failed to resolve during
+// mlx_dynamic_load_symbols, for the Go side to report lazily.
+static char mlx_load_error_symbol[128];
+
+void mlx_dynamic_record_load_error(const char* symbol) {
+    strncpy(mlx_load_error_symbol, symbol, sizeof(mlx_load_error_symbol) - 1);
+    mlx_load_error_symbol[sizeof(mlx_load_error_symbol) - 1] = '\0';
+}
+
+const char* mlx_dynamic_load_error(void) {
+    return mlx_load_error_symbol;
+}
 
 #ifdef _WIN32
 #include <windows.h>

--- a/x/mlxrunner/mlx/dynamic.go
+++ b/x/mlxrunner/mlx/dynamic.go
@@ -69,7 +69,7 @@ func tryLoadFromDir(dir string) bool {
 			continue
 		}
 		if C.mlx_dynamic_load_symbols(handle) != 0 {
-			initLoadError = fmt.Sprintf("failed to load MLX dynamic library symbols: path=%s", path)
+			initLoadError = fmt.Sprintf("failed to load MLX dynamic library symbols: path=%s missing_symbol=%s", path, C.GoString(C.mlx_dynamic_load_error()))
 			C.mlx_dynamic_unload(&handle)
 			continue
 		}

--- a/x/mlxrunner/mlx/dynamic.h
+++ b/x/mlxrunner/mlx/dynamic.h
@@ -23,13 +23,13 @@ typedef uint16_t float16_t;
 typedef uint16_t bfloat16_t;
 #endif
 
-// Undef ERROR to avoid conflict with wingdi.h on Windows
-#ifdef ERROR
-#undef ERROR
-#endif
-#define MLX_ERROR(fmt, ...) fprintf(stderr, "%s %s - ERROR - %s:%d - " fmt "\n", __DATE__, __TIME__, __FILE__, __LINE__, ##__VA_ARGS__); return 1
-#define CHECK(x) if (!(x)) { MLX_ERROR("CHECK failed: " #x); }
-#define CHECK_LOAD(handle, x) *(void**)(&x##_) = DLSYM(handle, #x); CHECK(x##_)
+// Symbol load failures must not print to stderr here: this loader runs at
+// startup in every process (including machines where MLX is not applicable),
+// so a missing symbol is recorded and surfaced through the Go side (see
+// CheckInit in dynamic.go) only when MLX is actually requested.
+void mlx_dynamic_record_load_error(const char* symbol);
+const char* mlx_dynamic_load_error(void);
+#define CHECK_LOAD(handle, x) *(void**)(&x##_) = DLSYM(handle, #x); if (!(x##_)) { mlx_dynamic_record_load_error(#x); return 1; }
 // OPTIONAL_LOAD: load symbol if available, leave function pointer NULL otherwise
 #define OPTIONAL_LOAD(handle, x) *(void**)(&x##_) = DLSYM(handle, #x)
 


### PR DESCRIPTION
Fixes #18283

On Windows machines with no CUDA and no Apple Silicon, every `ollama` command printed a line like this before its output:

```
Sep 3 2026 16:31:11 - ERROR - generated.c:2650 - CHECK failed: mlx_compile_cache_new_
```

**Root cause**

- The MLX dynamic loader (`x/mlxrunner/mlx/dynamic.go`) runs at package `init()` in every ollama process, client commands included, since the CLI links the server which imports `x/mlxrunner`.
- When it finds an `mlxc` library whose exports don't match the generated bindings (e.g. a bundled `mlx_cuda_*` variant on a machine without CUDA, or a version-skewed dll), `mlx_dynamic_load_symbols` fails at the first missing symbol and the `CHECK` macro in `dynamic.h` printed straight to stderr.
- The "stale timestamp" reported in the issue is not a cached error being replayed: the `MLX_ERROR` macro formatted `__DATE__ __TIME__`, i.e. the build timestamp baked into the binary, which is why it was identical across invocations at different real times.

**Fix**

The Go side already treats a failed MLX load as a deferred condition: it records `initLoadError` and only surfaces it via `CheckInit()` at the points where MLX is actually required (safetensors pull, MLX runner startup, quantize). The stray `fprintf` in the C shim bypassed that design.

- `dynamic.h`: `CHECK_LOAD` now records the missing symbol name via `mlx_dynamic_record_load_error()` and returns, instead of printing to stderr. The unused `MLX_ERROR`/`CHECK` macros (and the `#undef ERROR` that existed only for them) are removed.
- `dynamic.c`: implements the small record/read helpers with a static buffer.
- `dynamic.go`: includes the missing symbol in `initLoadError`, so when MLX is genuinely needed the log now says which symbol failed to resolve (`failed to load MLX dynamic library symbols: path=... missing_symbol=...`) — strictly more diagnostic than before.

`generated.c` and the generator template are unchanged; they keep emitting `CHECK_LOAD`/`OPTIONAL_LOAD` calls.

**Testing**

On Windows (amd64, go1.26.0, mingw-w64 gcc 14.2.0):

- `go build ./x/mlxrunner/... ./discover/... ./server/...` — clean
- `go vet ./x/mlxrunner/mlx/` — clean
- `go test ./x/mlxrunner/mlx/` — ok
- `go test ./discover/` — ok

Behavior change: startup is silent when MLX can't load; the failure (now with the missing symbol name) is logged only when something actually requests MLX.