### PR TITLE
docs: drop mdx extension on anthropic-compatibility link

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,7 +14,7 @@
 * [API Reference](https://docs.ollama.com/api)
 * [Modelfile Reference](https://docs.ollama.com/modelfile)
 * [OpenAI Compatibility](https://docs.ollama.com/api/openai-compatibility)
-* [Anthropic Compatibility](./api/anthropic-compatibility.mdx)
+* [Anthropic Compatibility](./api/anthropic-compatibility)
 
 ### Resources
 


### PR DESCRIPTION
docs: drop mdx extension on anthropic-compatibility link

.mdx-suffixed internal links 404 on the docs site (same pattern as #14243); link without extension.
