### PR TITLE
docs: fix bare faq link in gpu guide

### DIFF
--- a/docs/gpu.mdx
+++ b/docs/gpu.mdx
@@ -166,7 +166,7 @@ sudo setcap cap_perfmon+ep /usr/local/bin/ollama
 
 To select specific Vulkan GPU(s), you can set the environment variable
 `GGML_VK_VISIBLE_DEVICES` to one or more numeric IDs on the Ollama server as
-described in the [FAQ](faq#how-do-i-configure-ollama-server). If you
+described in the [FAQ](./faq#how-do-i-configure-ollama-server). If you
 encounter any problems with Vulkan based GPUs, you can disable all Vulkan GPUs
 by setting `OLLAMA_VULKAN=0` or `GGML_VK_VISIBLE_DEVICES=-1`.
 


### PR DESCRIPTION
docs: fix bare faq link in gpu guide

faq#... without ./ prefix breaks on the docs site; every other internal link uses ./ prefix.
