### PR TITLE
docs: strip trailing whitespace in xcode guide

### DIFF
--- a/docs/integrations/xcode.mdx
+++ b/docs/integrations/xcode.mdx
@@ -40,6 +40,6 @@ Install [XCode](https://developer.apple.com/xcode/)
 
 
 ## Connecting to ollama.com directly
-1. Create an [API key](https://ollama.com/settings/keys) from ollama.com 
-2. Select **Internet Hosted** and enter URL as `https://ollama.com`  
-3. Enter your **Ollama API Key** and click **Add** 
+1. Create an [API key](https://ollama.com/settings/keys) from ollama.com
+2. Select **Internet Hosted** and enter URL as `https://ollama.com`
+3. Enter your **Ollama API Key** and click **Add**


### PR DESCRIPTION
docs: strip trailing whitespace in xcode guide

Trailing spaces on lines 43-45.
