### PR TITLE
docs: fix linux uninstall lib removal command

### DIFF
--- a/docs/linux.mdx
+++ b/docs/linux.mdx
@@ -181,7 +181,7 @@ sudo rm /etc/systemd/system/ollama.service
 Remove ollama libraries from your lib directory (either `/usr/local/lib`, `/usr/lib`, or `/lib`):
 
 ```shell
-sudo rm -r $(which ollama | tr 'bin' 'lib')
+sudo rm -rf /usr/local/lib/ollama /usr/lib/ollama /lib/ollama
 ```
 
 Remove the ollama binary from your bin directory (either `/usr/local/bin`, `/usr/bin`, or `/bin`):


### PR DESCRIPTION
docs: fix linux uninstall lib removal command

fixes #14931

tr 'bin' 'lib' translates character-by-character, mangling any path containing b/i/n outside the bin segment (e.g. /snap/bin -> /sbap/lib). Remove the known lib dirs explicitly instead.
