### PR TITLE
model/parsers: preserve quoted qwen3 tool delimiters

### DIFF
--- a/model/parsers/qwen3.go
+++ b/model/parsers/qwen3.go
@@ -105,7 +105,7 @@ func (qwen3EventThinkingContent) isQwen3Event() {}
 
 func (p *Qwen3Parser) Add(s string, done bool) (content string, thinking string, calls []api.ToolCall, err error) {
 	p.buffer.WriteString(s)
-	events := p.parseEvents()
+	events := p.parseEvents(done)
 
 	var contentSb strings.Builder
 	var thinkingSb strings.Builder
@@ -130,13 +130,13 @@ func (p *Qwen3Parser) Add(s string, done bool) (content string, thinking string,
 	return contentSb.String(), thinkingSb.String(), calls, nil
 }
 
-func (p *Qwen3Parser) parseEvents() []qwen3Event {
+func (p *Qwen3Parser) parseEvents(done bool) []qwen3Event {
 	var all []qwen3Event
 
 	keepLooping := true
 	for keepLooping {
 		var events []qwen3Event
-		events, keepLooping = p.eat()
+		events, keepLooping = p.eat(done)
 		if len(events) > 0 {
 			all = append(all, events...)
 		}
@@ -164,7 +164,7 @@ func (p *Qwen3Parser) splitAtTag(tag string, trimAfter bool) (string, string) {
 	return splitAtTag(&p.buffer, tag, trimAfter)
 }
 
-func (p *Qwen3Parser) eat() ([]qwen3Event, bool) {
+func (p *Qwen3Parser) eat(done bool) ([]qwen3Event, bool) {
 	var events []qwen3Event
 
 	switch p.state {
@@ -320,7 +320,34 @@ func (p *Qwen3Parser) eat() ([]qwen3Event, bool) {
 	case qwen3ParserStateCollectingToolContent:
 		acc := p.buffer.String()
 		if strings.Contains(acc, qwen3ToolCloseTag) {
-			toolContent, _ := p.splitAtTag(qwen3ToolCloseTag, true)
+			// A closing tag inside a JSON string is part of the argument.
+			closeIdx := -1
+			inString, escaped := false, false
+			for i := range len(acc) {
+				switch c := acc[i]; {
+				case escaped:
+					escaped = false
+				case c == '\\' && inString:
+					escaped = true
+				case c == '"':
+					inString = !inString
+				case !inString && strings.HasPrefix(acc[i:], qwen3ToolCloseTag):
+					closeIdx = i
+				}
+				if closeIdx >= 0 {
+					break
+				}
+			}
+			if closeIdx < 0 {
+				if !done {
+					return events, false
+				}
+				// Preserve the JSON error for an unterminated string at EOF.
+				closeIdx = strings.Index(acc, qwen3ToolCloseTag)
+			}
+			toolContent := strings.TrimRightFunc(acc[:closeIdx], unicode.IsSpace)
+			p.buffer.Reset()
+			p.buffer.WriteString(strings.TrimLeftFunc(acc[closeIdx+len(qwen3ToolCloseTag):], unicode.IsSpace))
 			if len(toolContent) == 0 {
 				slog.Warn("qwen3 tool call closing tag found but no content before it")
 			}

--- a/model/parsers/qwen3_test.go
+++ b/model/parsers/qwen3_test.go
@@ -1,6 +1,8 @@
 package parsers
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/ollama/ollama/api"
@@ -314,5 +316,72 @@ func TestQwen3ParserToolCallIndexResetOnInit(t *testing.T) {
 	}
 	if !toolCallEqual(calls[0], want) {
 		t.Fatalf("got %#v, want %#v", calls[0], want)
+	}
+}
+
+func TestQwen3ParserQuotedToolDelimiter(t *testing.T) {
+	for _, tc := range []struct{ name, text string }{
+		{"plain", "ordinary text"},
+		{"delimiter", "literal </tool_call> text"},
+		{"escaped_quote", `quote " then </tool_call>`},
+		{"backslash", `slash \ then </tool_call>`},
+		{"repeated", "</tool_call> then </tool_call>"},
+		{"unicode", "汉字 </tool_call> λ"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var payload strings.Builder
+			encoder := json.NewEncoder(&payload)
+			encoder.SetEscapeHTML(false)
+			if err := encoder.Encode(map[string]any{
+				"name": "write_file", "arguments": map[string]string{"content": tc.text},
+			}); err != nil {
+				t.Fatal(err)
+			}
+			input := "before<tool_call>" + payload.String() + "</tool_call>" +
+				`<tool_call>{"name":"finish","arguments":{}}</tool_call>after`
+			// Every boundary includes splits inside the quoted tag, escaped
+			// quotes/backslashes, UTF-8 bytes, and the actual closing tag.
+			for split := 0; split <= len(input); split++ {
+				parser := &Qwen3Parser{}
+				parser.Init(nil, nil, nil)
+				var content strings.Builder
+				var calls []api.ToolCall
+				for i, chunk := range []string{input[:split], input[split:]} {
+					text, thinking, got, err := parser.Add(chunk, i == 1)
+					if err != nil {
+						t.Fatalf("split %d: %v", split, err)
+					}
+					if thinking != "" {
+						t.Fatalf("split %d: unexpected thinking %q", split, thinking)
+					}
+					content.WriteString(text)
+					calls = append(calls, got...)
+				}
+				if content.String() != "beforeafter" || len(calls) != 2 {
+					t.Fatalf("split %d: content=%q, calls=%v", split, content.String(), calls)
+				}
+				if calls[0].Function.Name != "write_file" || calls[1].Function.Name != "finish" ||
+					calls[0].Function.Index != 0 || calls[1].Function.Index != 1 {
+					t.Fatalf("split %d: wrong tool calls: %v", split, calls)
+				}
+				if value, ok := calls[0].Function.Arguments.Get("content"); !ok || value != tc.text {
+					t.Fatalf("split %d: argument=%v, want %q", split, value, tc.text)
+				}
+			}
+		})
+	}
+}
+
+func TestQwen3ParserInvalidToolJSONAtEOF(t *testing.T) {
+	for _, input := range []string{
+		`<tool_call>{"name":"write_file","arguments":{"content":"unfinished</tool_call>`,
+		`<tool_call>{"name":"write_file","arguments":invalid}</tool_call>`,
+	} {
+		parser := &Qwen3Parser{}
+		parser.Init(nil, nil, nil)
+		_, _, calls, err := parser.Add(input, true)
+		if err == nil || len(calls) != 0 {
+			t.Fatalf("expected a JSON error and no tool calls for %q, got calls=%v, err=%v", input, calls, err)
+		}
 	}
 }


### PR DESCRIPTION
A valid Qwen3 JSON tool call can contain the literal text `</tool_call>` inside an argument, such as the contents of a file the model is writing. The parser currently splits at that text and returns an unexpected-end-of-JSON error instead of the tool call.

Find the closing delimiter outside JSON string literals, tracking escaped quotes and backslashes. Keep waiting when the only delimiter is inside an unfinished string; at EOF, preserve the existing JSON error for malformed unterminated strings. Other tool formats and trailing-buffer flushing are unchanged.

The regression checks literal/repeated delimiters, escaped quotes, backslashes, Unicode and a plain control at every two-chunk byte boundary. It verifies exact argument values, surrounding content, and the names/indexes of two successive calls. Five quoted-delimiter cases fail on the original code while the plain case passes. Malformed-JSON EOF controls are also covered.

```bash
go test ./model/parsers ./model/renderers -count=1 -race
go vet ./model/parsers ./model/renderers
```

Both packages pass, including the new tests. This uses parser inputs directly; no live model inference or whole-server/GPU build was run. The patch targets the JSON Qwen3 parser; the XML-based Qwen3-Coder parser is outside its scope.
