### PR TITLE
mlxrunner: check system free memory and wait for evicted runners before loading the next MLX model

### DIFF
--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -42,6 +42,7 @@ type Client struct {
 	status            *llm.StatusWriter
 	mu                sync.Mutex
 	cmd               *exec.Cmd
+	closed            bool
 }
 
 // NewClient prepares a new MLX runner client for LLM models.
@@ -141,15 +142,11 @@ func (c *Client) Close() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	c.closed = true
 	if c.cmd != nil && c.cmd.Process != nil {
 		slog.Info("stopping mlx runner subprocess", "pid", c.cmd.Process.Pid)
-		c.cmd.Process.Signal(os.Interrupt)
-
-		select {
-		case <-c.done:
-		case <-time.After(5 * time.Second):
-			c.cmd.Process.Kill()
-		}
+		c.cmd.Process.Kill()
+		<-c.done
 		c.cmd = nil
 	}
 	return nil
@@ -405,19 +402,24 @@ func (c *Client) Load(ctx context.Context, systemInfo ml.SystemInfo, gpus []ml.D
 		}
 	}
 
-	c.cmd = cmd
-
 	status := llm.NewStatusWriter(os.Stderr)
-	c.status = status
 	// os/exec serializes Write calls when shared, which keeps the status writer
 	// from seeing concurrent stdout/stderr fragments.
 	cmd.Stdout = status
 	cmd.Stderr = status
 
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.closed {
+		return nil, errors.New("mlx runner client is closed")
+	}
+
+	c.status = status
 	slog.Info("starting mlx runner subprocess", "model", c.modelName, "port", c.port)
 	if err := cmd.Start(); err != nil {
 		return nil, fmt.Errorf("failed to start mlx runner: %w", err)
 	}
+	c.cmd = cmd
 
 	// Reap subprocess when it exits
 	go func() {

--- a/x/mlxrunner/client.go
+++ b/x/mlxrunner/client.go
@@ -301,11 +301,14 @@ func (c *Client) HasExited() bool {
 }
 
 // Load checks whether the model fits in GPU memory and starts the subprocess.
-func (c *Client) Load(ctx context.Context, _ ml.SystemInfo, gpus []ml.DeviceInfo, requireFull bool) ([]ml.DeviceID, error) {
+func (c *Client) Load(ctx context.Context, systemInfo ml.SystemInfo, gpus []ml.DeviceInfo, requireFull bool) ([]ml.DeviceID, error) {
 	if len(gpus) > 0 {
 		modelSize := c.memory.Load()
 		// We currently only use the first GPU with MLX
 		available := gpus[0].FreeMemory
+		if requireFull && gpus[0].Integrated && systemInfo.FreeMemory > 0 && systemInfo.FreeMemory < available {
+			available = systemInfo.FreeMemory
+		}
 		overhead := gpus[0].MinimumMemory() + envconfig.GpuOverhead()
 		if available > overhead {
 			available -= overhead


### PR DESCRIPTION
When the scheduler decides whether an MLX model fits alongside loaded ones, its free-memory figure is the Metal working set minus what Ollama's own runners report. Memory held by other applications is invisible to it, so the load can start on a machine that is already short of memory and push the system into swap and compression. While other models are loaded, the fit check now also bounds available memory by the system's free memory, the same rule llama-server loads already apply, and a miss evicts an idle model instead.

That eviction is only useful if its memory is back before the next load starts. The scheduler begins loading as soon as Close returns, but the MLX client sent SIGKILL without waiting, so the old runner could still be exiting with its memory held. Close now kills the runner and waits for it to be reaped, as the llama-server client does, and Load records the process under the mutex and refuses to start once Close has run.

First loads are unchanged and still load against the working-set figure alone, as both engines do today. The check does not cover memory that grows after load, such as KV caches and prefix-cache snapshots.