### PR TITLE
openai: support standalone named function outputs

### DIFF
--- a/api/types.go
+++ b/api/types.go
@@ -204,8 +204,6 @@ type Message struct {
 	ToolCalls  []ToolCall  `json:"tool_calls,omitempty"`
 	ToolName   string      `json:"tool_name,omitempty"`
 	ToolCallID string      `json:"tool_call_id,omitempty"`
-	// ToolNamespace qualifies ToolName for standalone tool outputs without a call ID.
-	ToolNamespace string `json:"tool_namespace,omitempty"`
 }
 
 func (m *Message) UnmarshalJSON(b []byte) error {

--- a/api/types.go
+++ b/api/types.go
@@ -204,6 +204,8 @@ type Message struct {
 	ToolCalls  []ToolCall  `json:"tool_calls,omitempty"`
 	ToolName   string      `json:"tool_name,omitempty"`
 	ToolCallID string      `json:"tool_call_id,omitempty"`
+	// ToolNamespace qualifies ToolName for standalone tool outputs without a call ID.
+	ToolNamespace string `json:"tool_namespace,omitempty"`
 }
 
 func (m *Message) UnmarshalJSON(b []byte) error {

--- a/openai/responses.go
+++ b/openai/responses.go
@@ -181,11 +181,15 @@ type ResponsesFunctionCall struct {
 
 func (ResponsesFunctionCall) responsesInputItem() {}
 
-// ResponsesFunctionCallOutput represents a function call result from the client.
+// ResponsesFunctionCallOutput represents a paired result or standalone named
+// output from the client.
 type ResponsesFunctionCallOutput struct {
-	Type   string `json:"type"`    // always "function_call_output"
-	CallID string `json:"call_id"` // links to the original function call
-	Output string `json:"output"`  // the function result
+	ID        string `json:"id,omitempty"`
+	Type      string `json:"type"`              // always "function_call_output"
+	CallID    string `json:"call_id,omitempty"` // links to the original function call, if any
+	Name      string `json:"name,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Output    string `json:"output"`
 
 	// OutputItems is populated when output is provided as Responses content
 	// items instead of the string shorthand.
@@ -194,18 +198,27 @@ type ResponsesFunctionCallOutput struct {
 
 func (o *ResponsesFunctionCallOutput) UnmarshalJSON(data []byte) error {
 	var aux struct {
-		Type   string          `json:"type"`
-		CallID string          `json:"call_id"`
-		Output json.RawMessage `json:"output"`
+		ID        string          `json:"id"`
+		Type      string          `json:"type"`
+		CallID    *string         `json:"call_id"`
+		Name      string          `json:"name"`
+		Namespace string          `json:"namespace"`
+		Output    json.RawMessage `json:"output"`
 	}
 	if err := json.Unmarshal(data, &aux); err != nil {
 		return err
 	}
 
-	o.Type = aux.Type
-	o.CallID = aux.CallID
-	o.Output = ""
-	o.OutputItems = nil
+	if aux.CallID != nil && strings.TrimSpace(*aux.CallID) == "" {
+		return errors.New("function output call_id must not be empty")
+	}
+	if aux.CallID == nil && strings.TrimSpace(aux.Name) == "" {
+		return errors.New("standalone function output is missing name")
+	}
+	*o = ResponsesFunctionCallOutput{ID: aux.ID, Type: aux.Type, Name: aux.Name, Namespace: aux.Namespace}
+	if aux.CallID != nil {
+		o.CallID = *aux.CallID
+	}
 
 	if len(aux.Output) == 0 {
 		return nil
@@ -654,12 +667,16 @@ func FromResponsesRequest(r ResponsesRequest) (*api.ChatRequest, error) {
 					return nil, err
 				}
 			}
-			messages = append(messages, api.Message{
+			message := api.Message{
 				Role:       "tool",
 				Content:    content,
 				Images:     images,
 				ToolCallID: v.CallID,
-			})
+			}
+			if v.CallID == "" {
+				message.ToolName = qualifyNamespaceToolName(v.Namespace, v.Name)
+			}
+			messages = append(messages, message)
 		case ResponsesToolSearchCall:
 			messages = appendResponseToolCall(messages, api.ToolCall{
 				ID: v.CallID,

--- a/openai/responses_compact.go
+++ b/openai/responses_compact.go
@@ -49,14 +49,23 @@ type OllamaCompactionPayload struct {
 	Version  int           `json:"version"`
 	Summary  string        `json:"summary"`
 	Retained []api.Message `json:"retained"`
+	// StandaloneNames preserves Responses identities by retained-message index.
+	// Qualified native names alone cannot distinguish every namespace/member pair.
+	StandaloneNames map[int]compactionFunctionName `json:"standalone_names,omitempty"`
+}
+
+type compactionFunctionName struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
 }
 
 // CompactionTranscriptItem is one ordered input item shown to the compaction
 // model. Ref is request-local and is the only value the model may select.
 type CompactionTranscriptItem struct {
-	Ref     string      `json:"ref"`
-	Type    string      `json:"type"`
-	Message api.Message `json:"message"`
+	Ref            string                  `json:"ref"`
+	Type           string                  `json:"type"`
+	Message        api.Message             `json:"message"`
+	StandaloneName *compactionFunctionName `json:"standalone_name,omitempty"`
 }
 
 type compactionToolMetadata struct {
@@ -65,10 +74,11 @@ type compactionToolMetadata struct {
 }
 
 type compactionTranscriptItemWire struct {
-	Ref        string      `json:"ref"`
-	Type       string      `json:"type"`
-	Message    api.Message `json:"message"`
-	ImageCount int         `json:"image_count,omitempty"`
+	Ref            string                  `json:"ref"`
+	Type           string                  `json:"type"`
+	Message        api.Message             `json:"message"`
+	StandaloneName *compactionFunctionName `json:"standalone_name,omitempty"`
+	ImageCount     int                     `json:"image_count,omitempty"`
 }
 
 type compactionToolGroup struct {
@@ -300,6 +310,15 @@ func decodeOllamaCompactionItem(item json.RawMessage) (OllamaCompactionPayload, 
 }
 
 func payloadToResponsesItems(payload OllamaCompactionPayload) ([]json.RawMessage, error) {
+	for index, name := range payload.StandaloneNames {
+		if index < 0 || index >= len(payload.Retained) {
+			return nil, fmt.Errorf("standalone name refers to invalid retained-message index %d", index)
+		}
+		message := payload.Retained[index]
+		if message.Role != "tool" || message.ToolCallID != "" || strings.TrimSpace(name.Name) == "" || qualifyNamespaceToolName(name.Namespace, name.Name) != message.ToolName {
+			return nil, fmt.Errorf("standalone name does not match retained message %d", index)
+		}
+	}
 	b, err := json.Marshal(payload)
 	if err != nil {
 		return nil, err
@@ -322,8 +341,8 @@ func payloadToResponsesItems(payload OllamaCompactionPayload) ([]json.RawMessage
 		return nil, err
 	}
 	items = append(items, call, result)
-	for _, message := range payload.Retained {
-		converted, err := messageToResponsesItems(message)
+	for i, message := range payload.Retained {
+		converted, err := messageToResponsesItems(message, payload.StandaloneNames[i])
 		if err != nil {
 			return nil, fmt.Errorf("invalid retained message: %w", err)
 		}
@@ -332,7 +351,7 @@ func payloadToResponsesItems(payload OllamaCompactionPayload) ([]json.RawMessage
 	return items, nil
 }
 
-func messageToResponsesItems(message api.Message) ([]json.RawMessage, error) {
+func messageToResponsesItems(message api.Message, standaloneName compactionFunctionName) ([]json.RawMessage, error) {
 	var values []any
 	if message.Thinking != "" {
 		values = append(values, map[string]any{
@@ -342,16 +361,16 @@ func messageToResponsesItems(message api.Message) ([]json.RawMessage, error) {
 	}
 	if message.Role == "tool" {
 		if message.ToolCallID == "" {
-			if strings.TrimSpace(message.ToolName) == "" {
-				return nil, errors.New("retained tool message is missing tool_call_id or name")
+			if strings.TrimSpace(standaloneName.Name) == "" {
+				return nil, errors.New("retained tool message is missing tool_call_id or standalone name")
 			}
 			output, err := responsesContentValue(message.Content, message.Images)
 			if err != nil {
 				return nil, err
 			}
-			value := map[string]any{"type": "function_call_output", "name": message.ToolName, "output": output}
-			if message.ToolNamespace != "" {
-				value["namespace"] = message.ToolNamespace
+			value := map[string]any{"type": "function_call_output", "name": standaloneName.Name, "output": output}
+			if standaloneName.Namespace != "" {
+				value["namespace"] = standaloneName.Namespace
 			}
 			values = append(values, value)
 		} else if message.ToolName == "tool_search" {
@@ -465,9 +484,13 @@ func newResponsesCompactionPlan(req rawResponsesRequest, rawItems []json.RawMess
 		if err != nil {
 			return nil, fmt.Errorf("input[%d]: %w", i, err)
 		}
-		items = append(items, CompactionTranscriptItem{
+		entry := CompactionTranscriptItem{
 			Ref: fmt.Sprintf("item_%06d", i+1), Type: kind, Message: message,
-		})
+		}
+		if output, ok := item.(ResponsesFunctionCallOutput); ok && output.CallID == "" {
+			entry.StandaloneName = &compactionFunctionName{Name: output.Name, Namespace: output.Namespace}
+		}
+		items = append(items, entry)
 	}
 
 	groups, forced, err := analyzeCompactionToolState(items)
@@ -514,8 +537,7 @@ func compactionMessage(item ResponsesInputItem) (api.Message, string, error) {
 		}
 		message := api.Message{Role: "tool", Content: content, Images: images, ToolCallID: value.CallID}
 		if value.CallID == "" {
-			message.ToolName = value.Name
-			message.ToolNamespace = value.Namespace
+			message.ToolName = qualifyNamespaceToolName(value.Namespace, value.Name)
 		}
 		return message, "function_call_output", nil
 	case ResponsesToolSearchCall:
@@ -523,9 +545,6 @@ func compactionMessage(item ResponsesInputItem) (api.Message, string, error) {
 			ID: value.CallID, Function: api.ToolCallFunction{Name: "tool_search", Arguments: value.Arguments},
 		}}}, "function_call", nil
 	case ResponsesToolSearchOutput:
-		if value.CallID == "" {
-			return api.Message{}, "", errors.New("tool search output is missing call_id")
-		}
 		tools, err := json.Marshal(value.Tools)
 		if err != nil {
 			return api.Message{}, "", fmt.Errorf("invalid tool search output: %w", err)
@@ -611,7 +630,7 @@ func analyzeCompactionToolState(items []CompactionTranscriptItem) ([]compactionT
 			ordered = append(ordered, group)
 		case "function_call_output":
 			callID := item.Message.ToolCallID
-			if callID == "" && strings.TrimSpace(item.Message.ToolName) != "" {
+			if callID == "" && item.StandaloneName != nil {
 				// Standalone outputs can carry the task instructions. Retain them
 				// without inventing a call or relying on the summary to repeat them.
 				forced[item.Ref] = struct{}{}
@@ -699,7 +718,7 @@ func (p *ResponsesCompactionPlan) TrimForContextLimit() int {
 		message := item.Message
 		message.Images = nil
 		metadata, err := json.Marshal(compactionTranscriptItemWire{
-			Ref: item.Ref, Type: item.Type, Message: message, ImageCount: len(item.Message.Images),
+			Ref: item.Ref, Type: item.Type, Message: message, StandaloneName: item.StandaloneName, ImageCount: len(item.Message.Images),
 		})
 		if err != nil {
 			return 0
@@ -816,7 +835,7 @@ func (p *ResponsesCompactionPlan) summaryTranscriptMessages() ([]any, error) {
 		images := message.Images
 		message.Images = nil
 		metadata, err := json.Marshal(compactionTranscriptItemWire{
-			Ref: item.Ref, Type: item.Type, Message: message, ImageCount: len(images),
+			Ref: item.Ref, Type: item.Type, Message: message, StandaloneName: item.StandaloneName, ImageCount: len(images),
 		})
 		if err != nil {
 			return nil, err
@@ -893,13 +912,21 @@ func (p *ResponsesCompactionPlan) Complete(body []byte) (ResponsesCompactionResu
 	}
 
 	retained := make([]api.Message, 0, len(selected))
+	var standaloneNames map[int]compactionFunctionName
 	for _, item := range p.items {
 		if _, ok := selected[item.Ref]; ok {
+			if item.StandaloneName != nil {
+				if standaloneNames == nil {
+					standaloneNames = make(map[int]compactionFunctionName)
+				}
+				standaloneNames[len(retained)] = *item.StandaloneName
+			}
 			retained = append(retained, item.Message)
 		}
 	}
 	payload := OllamaCompactionPayload{
 		Type: OllamaCompactionPayloadType, Version: OllamaCompactionPayloadVersion, Summary: selection.Summary, Retained: retained,
+		StandaloneNames: standaloneNames,
 	}
 	if p.omittedItems > 0 {
 		payload.Summary = fmt.Sprintf(compactionOmissionNotice, p.omittedItems) + "\n\n" + payload.Summary

--- a/openai/responses_compact.go
+++ b/openai/responses_compact.go
@@ -342,9 +342,19 @@ func messageToResponsesItems(message api.Message) ([]json.RawMessage, error) {
 	}
 	if message.Role == "tool" {
 		if message.ToolCallID == "" {
-			return nil, errors.New("retained tool message is missing tool_call_id")
-		}
-		if message.ToolName == "tool_search" {
+			if strings.TrimSpace(message.ToolName) == "" {
+				return nil, errors.New("retained tool message is missing tool_call_id or name")
+			}
+			output, err := responsesContentValue(message.Content, message.Images)
+			if err != nil {
+				return nil, err
+			}
+			value := map[string]any{"type": "function_call_output", "name": message.ToolName, "output": output}
+			if message.ToolNamespace != "" {
+				value["namespace"] = message.ToolNamespace
+			}
+			values = append(values, value)
+		} else if message.ToolName == "tool_search" {
 			if len(message.Images) > 0 {
 				return nil, errors.New("retained tool search output cannot contain images")
 			}
@@ -502,12 +512,20 @@ func compactionMessage(item ResponsesInputItem) (api.Message, string, error) {
 				return api.Message{}, "", err
 			}
 		}
-		return api.Message{Role: "tool", Content: content, Images: images, ToolCallID: value.CallID}, "function_call_output", nil
+		message := api.Message{Role: "tool", Content: content, Images: images, ToolCallID: value.CallID}
+		if value.CallID == "" {
+			message.ToolName = value.Name
+			message.ToolNamespace = value.Namespace
+		}
+		return message, "function_call_output", nil
 	case ResponsesToolSearchCall:
 		return api.Message{Role: "assistant", ToolCalls: []api.ToolCall{{
 			ID: value.CallID, Function: api.ToolCallFunction{Name: "tool_search", Arguments: value.Arguments},
 		}}}, "function_call", nil
 	case ResponsesToolSearchOutput:
+		if value.CallID == "" {
+			return api.Message{}, "", errors.New("tool search output is missing call_id")
+		}
 		tools, err := json.Marshal(value.Tools)
 		if err != nil {
 			return api.Message{}, "", fmt.Errorf("invalid tool search output: %w", err)
@@ -571,6 +589,7 @@ func analyzeCompactionToolState(items []CompactionTranscriptItem) ([]compactionT
 	}
 	byCallID := make(map[string]*pendingGroup)
 	ignoredCallIDs := make(map[string]struct{})
+	forced := make(map[string]struct{})
 	var ordered []*pendingGroup
 
 	for i, item := range items {
@@ -592,6 +611,12 @@ func analyzeCompactionToolState(items []CompactionTranscriptItem) ([]compactionT
 			ordered = append(ordered, group)
 		case "function_call_output":
 			callID := item.Message.ToolCallID
+			if callID == "" && strings.TrimSpace(item.Message.ToolName) != "" {
+				// Standalone outputs can carry the task instructions. Retain them
+				// without inventing a call or relying on the summary to repeat them.
+				forced[item.Ref] = struct{}{}
+				continue
+			}
 			if _, ignored := ignoredCallIDs[callID]; ignored {
 				continue
 			}
@@ -607,7 +632,6 @@ func analyzeCompactionToolState(items []CompactionTranscriptItem) ([]compactionT
 		}
 	}
 
-	forced := make(map[string]struct{})
 	groups := make([]compactionToolGroup, 0, len(ordered))
 	for _, candidate := range ordered {
 		groups = append(groups, candidate.group)

--- a/openai/responses_compact_names_test.go
+++ b/openai/responses_compact_names_test.go
@@ -1,0 +1,193 @@
+package openai
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/ollama/ollama/api"
+)
+
+func TestCompactionPreservesAmbiguousStandaloneNames(t *testing.T) {
+	body := []byte(`{"model":"test","input":[
+		{"type":"message","role":"user","content":"Continue."},
+		{"type":"function_call_output","namespace":"a.b","name":"c","output":"first"},
+		{"type":"message","role":"assistant","content":"Acknowledged."},
+		{"type":"function_call_output","namespace":"a","name":"b.c","output":"second"},
+		{"type":"function_call_output","name":"a.b.c","output":"third"},
+		{"type":"message","role":"user","content":"Keep working."}
+	]}`)
+	wantNames := []compactionFunctionName{
+		{Name: "c", Namespace: "a.b"},
+		{Name: "b.c", Namespace: "a"},
+		{Name: "a.b.c"},
+	}
+	wantContent := []string{"first", "second", "third"}
+	standaloneIndices := []int{1, 3, 4}
+	wantOrdinary := map[int]api.Message{
+		0: {Role: "user", Content: "Continue."},
+		2: {Role: "assistant", Content: "Acknowledged."},
+	}
+	wantRetainedCount := len(wantNames) + len(wantOrdinary)
+	for cycle := range 2 {
+		plan, err := PrepareStandaloneCompaction(body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var retainRefs []string
+		for _, item := range plan.items {
+			for _, want := range wantOrdinary {
+				if item.Message.Role == want.Role && item.Message.Content == want.Content {
+					retainRefs = append(retainRefs, item.Ref)
+				}
+			}
+		}
+		if len(retainRefs) != len(wantOrdinary) {
+			t.Fatalf("cycle %d: ordinary messages missing from the transcript", cycle)
+		}
+		result, err := plan.Complete(compactionResponseBody(t, map[string]any{
+			"summary": "Continue the task.", "retain_item_ids": retainRefs,
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		payload := decodeResultPayload(t, result)
+		if len(payload.Retained) != wantRetainedCount || len(payload.StandaloneNames) != len(wantNames) {
+			t.Fatalf("cycle %d: retained messages or names changed: %+v", cycle, payload)
+		}
+		for i, want := range wantNames {
+			index := standaloneIndices[i]
+			if got := payload.StandaloneNames[index]; got != want {
+				t.Errorf("cycle %d: retained name %d = %+v, want %+v", cycle, index, got, want)
+			}
+			if got := payload.Retained[index]; got.ToolName != "a.b.c" || got.ToolCallID != "" || got.Content != wantContent[i] {
+				t.Errorf("cycle %d: retained message %d changed: %+v", cycle, index, got)
+			}
+		}
+		for index, want := range wantOrdinary {
+			if got := payload.Retained[index]; got.Role != want.Role || got.Content != want.Content {
+				t.Errorf("cycle %d: ordinary retained message %d changed: %+v", cycle, index, got)
+			}
+		}
+		replay, err := json.Marshal(map[string]any{"model": "test", "input": []any{result.Item}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		expanded, changed, err := ExpandResponsesCompactionInput(replay)
+		if err != nil || !changed {
+			t.Fatalf("cycle %d: changed=%v err=%v", cycle, changed, err)
+		}
+		var request ResponsesRequest
+		if err := json.Unmarshal(expanded, &request); err != nil {
+			t.Fatal(err)
+		}
+		if len(request.Input.Items) != 2+wantRetainedCount {
+			t.Fatalf("cycle %d: got %d items, want summary pair and five retained messages", cycle, len(request.Input.Items))
+		}
+		for i, want := range wantNames {
+			index := standaloneIndices[i] + 2
+			output, ok := request.Input.Items[index].(ResponsesFunctionCallOutput)
+			if !ok || output.CallID != "" || output.Name != want.Name || output.Namespace != want.Namespace || output.Output != wantContent[i] {
+				t.Errorf("cycle %d: output %d lost its original identity or order: %+v", cycle, index, request.Input.Items[index])
+			}
+		}
+		chat, err := FromResponsesRequest(request)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(chat.Messages) != 2+wantRetainedCount {
+			t.Fatalf("cycle %d: got %d native messages", cycle, len(chat.Messages))
+		}
+		for i := range wantNames {
+			index := standaloneIndices[i] + 2
+			if got := chat.Messages[index]; got.ToolName != "a.b.c" || got.ToolCallID != "" || got.Content != wantContent[i] {
+				t.Errorf("cycle %d: native output %d changed: %+v", cycle, index, got)
+			}
+		}
+		for index, want := range wantOrdinary {
+			if got := chat.Messages[index+2]; got.Role != want.Role || got.Content != want.Content {
+				t.Errorf("cycle %d: ordinary native message %d changed: %+v", cycle, index+2, got)
+			}
+		}
+		body = expanded
+	}
+}
+
+func TestCompactionRejectsInvalidStandaloneNames(t *testing.T) {
+	standalone := []api.Message{{Role: "tool", ToolName: "workspace.handoff", Content: "Continue the task."}}
+	name := compactionFunctionName{Name: "handoff", Namespace: "workspace"}
+	for _, test := range []struct {
+		name     string
+		retained []api.Message
+		names    map[int]compactionFunctionName
+	}{
+		{name: "negative index", retained: standalone, names: map[int]compactionFunctionName{-1: name}},
+		{name: "index past retained", retained: standalone, names: map[int]compactionFunctionName{1: name}},
+		{name: "missing identity", retained: standalone},
+		{name: "different native name", retained: standalone, names: map[int]compactionFunctionName{0: {Name: "other", Namespace: "workspace"}}},
+		{name: "blank name", retained: standalone, names: map[int]compactionFunctionName{0: {Name: " ", Namespace: "workspace"}}},
+		{name: "user message", retained: []api.Message{{Role: "user", ToolName: "workspace.handoff", Content: "Continue."}}, names: map[int]compactionFunctionName{0: name}},
+		{
+			name: "paired output",
+			retained: []api.Message{
+				{Role: "assistant", ToolCalls: []api.ToolCall{{ID: "paired", Function: api.ToolCallFunction{Name: "workspace.handoff", Arguments: api.NewToolCallFunctionArguments()}}}},
+				{Role: "tool", ToolCallID: "paired", ToolName: "workspace.handoff", Content: "Finished."},
+			},
+			names: map[int]compactionFunctionName{1: name},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			payload, err := json.Marshal(OllamaCompactionPayload{
+				Type: OllamaCompactionPayloadType, Version: OllamaCompactionPayloadVersion,
+				Summary: "Continue the task.", Retained: test.retained, StandaloneNames: test.names,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			body, err := json.Marshal(map[string]any{
+				"model": "test", "input": []any{ResponsesCompactionItem{Type: "compaction", EncryptedContent: string(payload)}},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, _, err := ExpandResponsesCompactionInput(body); err == nil {
+				t.Fatal("accepted invalid standalone name metadata")
+			}
+		})
+	}
+}
+
+func TestCompactionReplaysLegacyPairedPayload(t *testing.T) {
+	// Version 1 payloads written before standalone outputs have no name metadata.
+	payload := `{"type":"ollama_compaction","version":1,"summary":"The file was read.","retained":[
+		{"role":"assistant","tool_calls":[{"id":"paired","function":{"name":"workspace.read","arguments":{}}}]},
+		{"role":"tool","tool_call_id":"paired","tool_name":"workspace.read","content":"File contents."}
+	]}`
+	body, err := json.Marshal(map[string]any{
+		"model": "test", "input": []any{ResponsesCompactionItem{Type: "compaction", EncryptedContent: payload}},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expanded, changed, err := ExpandResponsesCompactionInput(body)
+	if err != nil || !changed {
+		t.Fatalf("changed=%v err=%v", changed, err)
+	}
+	var request ResponsesRequest
+	if err := json.Unmarshal(expanded, &request); err != nil {
+		t.Fatal(err)
+	}
+	if len(request.Input.Items) != 4 {
+		t.Fatalf("got %d items, want summary and retained pairs", len(request.Input.Items))
+	}
+	call, ok := request.Input.Items[2].(ResponsesFunctionCall)
+	if !ok || call.CallID != "paired" || call.Name != "workspace.read" {
+		t.Fatalf("legacy call changed: %+v", request.Input.Items[2])
+	}
+	output, ok := request.Input.Items[3].(ResponsesFunctionCallOutput)
+	if !ok || output.CallID != "paired" || output.Output != "File contents." {
+		t.Fatalf("legacy output changed: %+v", request.Input.Items[3])
+	}
+	if _, err := PrepareStandaloneCompaction(expanded); err != nil {
+		t.Fatalf("cannot compact legacy replay: %v", err)
+	}
+}

--- a/openai/responses_compact_test.go
+++ b/openai/responses_compact_test.go
@@ -132,6 +132,120 @@ func TestCompactionTrimKeepsToolPairsAcrossInterleavedResults(t *testing.T) {
 	}
 }
 
+func TestCompactionPreservesStandaloneOutputs(t *testing.T) {
+	body := []byte(`{"model":"test","input":[
+		{"type":"message","role":"user","content":"Continue the task."},
+		{"type":"function_call_output","name":"handoff","namespace":"workspace.tools","output":[
+			{"type":"input_text","text":"Keep the original task instructions."},
+			{"type":"input_image","image_url":"` + compactionTestPNG + `"}
+		]},
+		{"type":"function_call_output","call_id":null,"name":"tool_search","output":"A standalone function can have this name."},
+		{"type":"message","role":"assistant","content":"` + strings.Repeat("old reasoning ", 1000) + `"},
+		{"type":"message","role":"user","content":"Latest request."}
+	]}`)
+	plan, err := PrepareStandaloneCompaction(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if removed := plan.TrimForContextLimit(); removed != 1 {
+		t.Fatalf("removed %d items, want only the old assistant message", removed)
+	}
+	request, err := plan.SummaryRequest("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, marker := range []string{"Keep the original task instructions.", "workspace.tools", "handoff", compactionTestPNG} {
+		if !bytes.Contains(request, []byte(marker)) {
+			t.Errorf("summary request lost %q", marker)
+		}
+	}
+	for cycle := range 2 {
+		result, err := plan.Complete(compactionResponseBody(t, map[string]any{
+			"summary": "Continue the work.", "retain_item_ids": []string{},
+		}))
+		if err != nil {
+			t.Fatal(err)
+		}
+		payload := decodeResultPayload(t, result)
+		if len(payload.Retained) != 2 {
+			t.Fatalf("cycle %d: retained %d messages, want both standalone outputs", cycle, len(payload.Retained))
+		}
+		handoff, search := payload.Retained[0], payload.Retained[1]
+		if handoff.ToolName != "handoff" || handoff.ToolNamespace != "workspace.tools" || handoff.Content != "Keep the original task instructions." || len(handoff.Images) != 1 {
+			t.Fatalf("cycle %d: handoff changed: %+v", cycle, handoff)
+		}
+		if search.ToolName != "tool_search" || search.Content != "A standalone function can have this name." {
+			t.Fatalf("cycle %d: standalone tool_search changed: %+v", cycle, search)
+		}
+		replay, err := json.Marshal(map[string]any{"model": "test", "input": []any{result.Item}})
+		if err != nil {
+			t.Fatal(err)
+		}
+		expanded, changed, err := ExpandResponsesCompactionInput(replay)
+		if err != nil || !changed {
+			t.Fatalf("cycle %d: changed=%v err=%v", cycle, changed, err)
+		}
+		var decoded ResponsesRequest
+		if err := json.Unmarshal(expanded, &decoded); err != nil {
+			t.Fatal(err)
+		}
+		if len(decoded.Input.Items) != 4 {
+			t.Fatalf("cycle %d: want summary pair and two standalone outputs, got %d items", cycle, len(decoded.Input.Items))
+		}
+		for i, want := range []api.Message{handoff, search} {
+			output, ok := decoded.Input.Items[i+2].(ResponsesFunctionCallOutput)
+			if !ok || output.CallID != "" || output.Name != want.ToolName || output.Namespace != want.ToolNamespace || output.Output != want.Content {
+				t.Fatalf("cycle %d: standalone output %d lost identity or gained a call: %+v", cycle, i, decoded.Input.Items[i+2])
+			}
+		}
+		chat, err := FromResponsesRequest(decoded)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(chat.Messages) != 4 || chat.Messages[2].ToolName != "workspace.tools.handoff" || !bytes.Equal(chat.Messages[2].Images[0], handoff.Images[0]) {
+			t.Fatalf("cycle %d: replay changed standalone content or images: %+v", cycle, chat.Messages)
+		}
+		plan, err = PrepareStandaloneCompaction(expanded)
+		if err != nil {
+			t.Fatalf("cycle %d: cannot compact replay: %v", cycle, err)
+		}
+	}
+}
+
+func TestCompactionStandaloneOutputsDoNotRelaxPairing(t *testing.T) {
+	for _, item := range []string{
+		`{"type":"function_call_output","name":"handoff","call_id":"missing","output":"unmatched"}`,
+		`{"type":"tool_search_output","tools":[]}`,
+		`{"type":"tool_search_output","call_id":null,"tools":[]}`,
+		`{"type":"function_call_output","name":"handoff","call_id":"","output":"empty ID"}`,
+		`{"type":"function_call_output","output":"anonymous"}`,
+	} {
+		t.Run(item, func(t *testing.T) {
+			if _, err := PrepareStandaloneCompaction([]byte(`{"model":"test","input":[` + item + `]}`)); err == nil {
+				t.Fatal("accepted invalid or unmatched output")
+			}
+		})
+	}
+	// A name on a result with a call ID does not turn it into a standalone output.
+	plan, err := PrepareStandaloneCompaction([]byte(`{"model":"test","input":[
+		{"type":"function_call","call_id":"paired","name":"read","arguments":"{}"},
+		{"type":"function_call_output","call_id":"paired","name":"read","output":"ok"},
+		{"type":"message","role":"assistant","content":"Read completed."}
+	]}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := plan.Complete(compactionResponseBody(t, map[string]any{
+		"summary": "Finished reading.", "retain_item_ids": []string{},
+	}))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if retained := decodeResultPayload(t, result).Retained; len(retained) != 0 {
+		t.Fatalf("completed pair was forced as standalone state: %+v", retained)
+	}
+}
+
 func compactionResponseBody(t *testing.T, selection map[string]any) []byte {
 	t.Helper()
 	arguments, err := json.Marshal(selection)

--- a/openai/responses_compact_test.go
+++ b/openai/responses_compact_test.go
@@ -171,7 +171,7 @@ func TestCompactionPreservesStandaloneOutputs(t *testing.T) {
 			t.Fatalf("cycle %d: retained %d messages, want both standalone outputs", cycle, len(payload.Retained))
 		}
 		handoff, search := payload.Retained[0], payload.Retained[1]
-		if handoff.ToolName != "handoff" || handoff.ToolNamespace != "workspace.tools" || handoff.Content != "Keep the original task instructions." || len(handoff.Images) != 1 {
+		if handoff.ToolName != "workspace.tools.handoff" || handoff.Content != "Keep the original task instructions." || len(handoff.Images) != 1 {
 			t.Fatalf("cycle %d: handoff changed: %+v", cycle, handoff)
 		}
 		if search.ToolName != "tool_search" || search.Content != "A standalone function can have this name." {
@@ -194,7 +194,8 @@ func TestCompactionPreservesStandaloneOutputs(t *testing.T) {
 		}
 		for i, want := range []api.Message{handoff, search} {
 			output, ok := decoded.Input.Items[i+2].(ResponsesFunctionCallOutput)
-			if !ok || output.CallID != "" || output.Name != want.ToolName || output.Namespace != want.ToolNamespace || output.Output != want.Content {
+			name := payload.StandaloneNames[i]
+			if !ok || output.CallID != "" || output.Name != name.Name || output.Namespace != name.Namespace || output.Output != want.Content {
 				t.Fatalf("cycle %d: standalone output %d lost identity or gained a call: %+v", cycle, i, decoded.Input.Items[i+2])
 			}
 		}

--- a/openai/responses_test.go
+++ b/openai/responses_test.go
@@ -331,6 +331,57 @@ func TestUnmarshalResponsesInputItem(t *testing.T) {
 	})
 }
 
+func TestResponsesStandaloneFunctionOutput(t *testing.T) {
+	for _, tt := range []struct {
+		name      string
+		fields    string
+		wantName  string
+		wantError bool
+	}{
+		{"omitted call ID", `"name":"handoff","namespace":"workspace",`, "workspace.handoff", false},
+		{"null call ID", `"call_id":null,"name":"handoff","namespace":"workspace",`, "workspace.handoff", false},
+		{"no namespace", `"name":"handoff",`, "handoff", false},
+		{"null namespace", `"name":"handoff","namespace":null,`, "handoff", false},
+		{"empty call ID", `"call_id":"","name":"handoff",`, "", true},
+		{"blank call ID", `"call_id":"  ","name":"handoff",`, "", true},
+		{"missing name", ``, "", true},
+		{"null name", `"name":null,`, "", true},
+		{"empty name", `"name":"",`, "", true},
+		{"blank name", `"name":"  ",`, "", true},
+		{"namespace only", `"namespace":"workspace",`, "", true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			body := []byte(`{"model":"test","input":[{"type":"function_call_output","id":"fco_handoff",` + tt.fields + `"output":[{"type":"input_text","text":"Continue the task."}]}]}`)
+			var request ResponsesRequest
+			err := json.Unmarshal(body, &request)
+			if tt.wantError {
+				if err == nil {
+					t.Fatal("accepted invalid standalone output")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			output := request.Input.Items[0].(ResponsesFunctionCallOutput)
+			if output.ID != "fco_handoff" || output.Name != "handoff" || output.CallID != "" || len(output.OutputItems) != 1 {
+				t.Fatalf("standalone identity or content changed: %+v", output)
+			}
+			chat, err := FromResponsesRequest(request)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(chat.Messages) != 1 {
+				t.Fatalf("got %d messages, want the standalone output only", len(chat.Messages))
+			}
+			message := chat.Messages[0]
+			if message.Role != "tool" || message.ToolName != tt.wantName || message.ToolCallID != "" || len(message.ToolCalls) != 0 || message.Content != "Continue the task." {
+				t.Fatalf("standalone output lost its name/content or gained a call: %+v", message)
+			}
+		})
+	}
+}
+
 func TestFromResponsesRequestIgnoresReplayedWebSearchCall(t *testing.T) {
 	req := ResponsesRequest{
 		Model: "test",
@@ -1307,7 +1358,7 @@ func TestFromResponsesRequest_FunctionCallOutput(t *testing.T) {
 		"input": [
 			{"type": "message", "role": "user", "content": [{"type": "input_text", "text": "what is the weather?"}]},
 			{"type": "function_call", "call_id": "call_abc123", "name": "get_weather", "arguments": "{\"city\":\"Paris\"}"},
-			{"type": "function_call_output", "call_id": "call_abc123", "output": "sunny, 72F"}
+			{"type": "function_call_output", "call_id": "call_abc123", "name": "stale_name", "namespace": "stale_namespace", "output": "sunny, 72F"}
 		]
 	}`
 
@@ -1380,6 +1431,9 @@ func TestFromResponsesRequest_FunctionCallOutput(t *testing.T) {
 	}
 	if toolMsg.ToolCallID != "call_abc123" {
 		t.Errorf("expected ToolCallID 'call_abc123', got %q", toolMsg.ToolCallID)
+	}
+	if toolMsg.ToolName != "" {
+		t.Errorf("paired output name %q would override the original call's name", toolMsg.ToolName)
 	}
 }
 

--- a/server/responses_compact_test.go
+++ b/server/responses_compact_test.go
@@ -7,12 +7,16 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"reflect"
 	"strings"
 	"sync"
 	"testing"
 
 	"github.com/gin-gonic/gin"
 
+	"github.com/ollama/ollama/internal/proxy"
 	"github.com/ollama/ollama/openai"
 )
 
@@ -392,6 +396,169 @@ func TestResponsesCompactionTriggerReturnsCodexStream(t *testing.T) {
 	paths, requests := capture.snapshot()
 	if len(paths) != 1 || paths[0] != "/v1/responses" {
 		t.Fatalf("paths=%v requests=%s", paths, requests)
+	}
+}
+
+func TestResponsesCompactionPreservesStandaloneOutputIntoNextTurn(t *testing.T) {
+	const imageURL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+	for _, tt := range []struct {
+		name      string
+		stream    bool
+		namespace string
+		nullID    bool
+	}{
+		{name: "Codex trigger with namespaced handoff", stream: true, namespace: "workspace"},
+		{name: "compact endpoint with null call ID", nullID: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			local, capture := newCompactionTestServer(t, func(attempt int, w http.ResponseWriter, _ *http.Request, _ []byte) {
+				w.Header().Set("Content-Type", "application/json")
+				if attempt%2 == 1 {
+					// The compactor does not select the handoff for retention.
+					_, _ = w.Write(summaryResponse(t, "Continue the task.", nil))
+					return
+				}
+				_, _ = io.WriteString(w, `{"id":"resp_next","object":"response","status":"completed","model":"fixture","output":[],"usage":null}`)
+			})
+			endpoint, path := local, "/v1/responses/compact"
+			if tt.stream {
+				catalogPath := filepath.Join(t.TempDir(), proxy.CodexDesktopRoutingCatalogFilename)
+				if err := os.WriteFile(catalogPath, []byte(`{"models":[{"slug":"fixture:cloud"}]}`), 0o600); err != nil {
+					t.Fatal(err)
+				}
+				handler, err := proxy.NewCodexDesktop(proxy.CodexDesktopConfig{
+					OllamaURL: local.URL, ChatGPTURL: local.URL, OpenAIURL: local.URL,
+					RoutingCatalogPath: catalogPath,
+				})
+				if err != nil {
+					t.Fatal(err)
+				}
+				endpoint = httptest.NewServer(handler)
+				t.Cleanup(endpoint.Close)
+				path = proxy.CodexDesktopPathPrefix + "/v1/responses"
+			}
+
+			output := []any{
+				map[string]any{"type": "input_text", "text": "Use the supplied architecture diagram."},
+				map[string]any{"type": "input_image", "detail": "auto", "image_url": imageURL},
+			}
+			standalone := map[string]any{"type": "function_call_output", "name": "handoff", "output": output}
+			if tt.namespace != "" {
+				standalone["namespace"] = tt.namespace
+			}
+			if tt.nullID {
+				standalone["call_id"] = nil
+			}
+			input := []any{
+				map[string]any{"type": "message", "role": "user", "content": "Implement the feature."},
+				standalone,
+				map[string]any{"type": "message", "role": "assistant", "content": "I have read the handoff."},
+				map[string]any{"type": "message", "role": "user", "content": "Continue."},
+			}
+			for cycle := range 2 {
+				compactInput := append([]any(nil), input...)
+				if tt.stream {
+					compactInput = append(compactInput, map[string]any{"type": "compaction_trigger"})
+				}
+				request, err := json.Marshal(map[string]any{"model": "fixture:cloud", "stream": tt.stream, "input": compactInput})
+				if err != nil {
+					t.Fatal(err)
+				}
+				status, header, body := postCompactionRequest(t, endpoint, path, string(request))
+				if status != http.StatusOK {
+					t.Fatalf("cycle %d compact status=%d body=%s", cycle, status, body)
+				}
+				var compacted openai.ResponsesCompactionItem
+				if tt.stream {
+					if !strings.HasPrefix(header.Get("Content-Type"), "text/event-stream") {
+						t.Fatalf("unexpected stream content-type %q", header.Get("Content-Type"))
+					}
+					done := 0
+					for _, line := range strings.Split(string(body), "\n") {
+						data, ok := strings.CutPrefix(line, "data: ")
+						if !ok || data == "[DONE]" {
+							continue
+						}
+						var event struct {
+							Type string                         `json:"type"`
+							Item openai.ResponsesCompactionItem `json:"item"`
+						}
+						if err := json.Unmarshal([]byte(data), &event); err != nil {
+							t.Fatal(err)
+						}
+						if event.Type == "response.output_item.done" {
+							compacted = event.Item
+							done++
+						}
+					}
+					if done != 1 {
+						t.Fatalf("expected one completed compaction item, got %d: %s", done, body)
+					}
+				} else {
+					var response openai.ResponsesCompactedResponse
+					if err := json.Unmarshal(body, &response); err != nil {
+						t.Fatal(err)
+					}
+					if len(response.Output) != 1 {
+						t.Fatalf("expected one compaction item: %s", body)
+					}
+					compacted = response.Output[0]
+				}
+				if compacted.Type != "compaction" {
+					t.Fatalf("unexpected output item: %+v", compacted)
+				}
+
+				input = []any{compacted, map[string]any{"type": "message", "role": "user", "content": "Continue."}}
+				request, err = json.Marshal(map[string]any{"model": "fixture:cloud", "stream": false, "input": input})
+				if err != nil {
+					t.Fatal(err)
+				}
+				status, _, body = postCompactionRequest(t, endpoint, strings.TrimSuffix(path, "/compact"), string(request))
+				if status != http.StatusOK {
+					t.Fatalf("cycle %d replay status=%d body=%s", cycle, status, body)
+				}
+				paths, bodies := capture.snapshot()
+				if len(paths) != 2*(cycle+1) || paths[len(paths)-1] != "/v1/responses" {
+					t.Fatalf("unexpected upstream requests: %v", paths)
+				}
+				var forwarded struct {
+					Input []map[string]any `json:"input"`
+				}
+				if err := json.Unmarshal(bodies[len(bodies)-1], &forwarded); err != nil {
+					t.Fatal(err)
+				}
+				outputs := 0
+				var summaryCallID string
+				for _, item := range forwarded.Input {
+					if item["type"] == "compaction" {
+						t.Fatalf("opaque compaction item reached upstream: %+v", item)
+					}
+					if item["type"] == "function_call" {
+						if item["name"] != "ollama_compaction_summary" {
+							t.Fatalf("unexpected synthetic function call: %+v", item)
+						}
+						summaryCallID, _ = item["call_id"].(string)
+						continue
+					}
+					if item["type"] != "function_call_output" {
+						continue
+					}
+					if summaryCallID != "" && item["call_id"] == summaryCallID {
+						continue
+					}
+					outputs++
+					if item["call_id"] != nil || item["name"] != "handoff" || !reflect.DeepEqual(item["output"], output) {
+						t.Fatalf("standalone output changed during replay: %+v", item)
+					}
+					if namespace, _ := item["namespace"].(string); namespace != tt.namespace {
+						t.Fatalf("namespace=%q, want %q", namespace, tt.namespace)
+					}
+				}
+				if outputs != 1 {
+					t.Fatalf("expected one replayed standalone output, got %d: %s", outputs, bodies[len(bodies)-1])
+				}
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Accept Codex standalone handoffs across compaction

Codex sends handoff tool results as standalone `function_call_output` items: they have a `name` and optional `namespace`, but no `call_id`. Compaction rejected these inputs, so GLM sessions failed when Codex triggered compaction after a handoff.

This change lets the compaction path accept standalone outputs and round-trip them safely:

- Accept `function_call_output` items with a tool `name`, no `call_id`, and an optional `namespace`.
- Persist standalone outputs in the compaction payload via a new `standalone_names` map, keyed to retained message indexes.
- Internally preserve the namespace by qualifying the tool name (for example, `example.handoff`) so colliding names from different namespaces can't merge.
- On replay, expand the payload back to the original standalone item shape — same `name`, `namespace`, `output`, and no invented `call_id`.
- Keep the existing rule that a stream request may include exactly one final `compaction_trigger`; a trigger on the non-stream compact endpoint stays invalid.
