### PR TITLE
llm: key VRAM accounting on the child's actual log device names

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -154,6 +154,12 @@ type llamaServerRunner struct {
 	// used to map DeviceIDs to device names for VRAMByGPU lookups.
 	gpus []ml.DeviceInfo
 
+	// deviceLogKeys[i] is the name llama-server uses for gpus[i] in its
+	// log output, may differ from gpus[i].Name when the child only sees a
+	// filtered subset of devices (zero indexed). Recorded at
+	// launch; keys match vramByDevice and systemFreeAtLoad.
+	deviceLogKeys []string
+
 	ggml          *ggml.GGML
 	totalLayers   uint64 // maximum offloadable model layers
 	loadStart     time.Time
@@ -920,7 +926,7 @@ func NewLlamaServerRunner(
 	memWriter := &memoryParsingWriter{inner: status}
 
 	mediaMarker := newLlamaServerMediaMarker()
-	extraEnvs := ml.GetDevicesEnv(gpus)
+	extraEnvs, deviceLogKeys := ml.GetDevicesEnvAndLogNames(gpus)
 	serverEnvs := make(map[string]string, len(extraEnvs)+1)
 	for k, v := range extraEnvs {
 		serverEnvs[k] = v
@@ -954,6 +960,7 @@ func NewLlamaServerRunner(
 		vramByDevice:     make(map[string]uint64),
 		systemFreeAtLoad: make(map[string]uint64),
 		gpus:             gpus,
+		deviceLogKeys:    deviceLogKeys,
 		ggml:             f,
 		totalLayers:      f.KV().BlockCount() + 1,
 		rawEmbeddings:    legacyEmbeddingsWereRaw(f.KV()),
@@ -2617,7 +2624,8 @@ func (s *llamaServerRunner) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo 
 	infos := make([]ml.DeviceInfo, len(s.gpus))
 	for i, gpu := range s.gpus {
 		infos[i] = gpu
-		used := s.vramByDevice[gpu.Name]
+		logKey := s.deviceLogKey(i, gpu)
+		used := s.vramByDevice[logKey]
 
 		// Our accounting: total minus what we allocated
 		var accountedFree uint64
@@ -2629,7 +2637,7 @@ func (s *llamaServerRunner) GetDeviceInfos(ctx context.Context) []ml.DeviceInfo 
 		// we've allocated since. This captures external consumers on platforms
 		// where the driver reports accurately.
 		systemFree := accountedFree // default to our accounting
-		if sysFree, ok := s.systemFreeAtLoad[gpu.Name]; ok {
+		if sysFree, ok := s.systemFreeAtLoad[logKey]; ok {
 			if used < sysFree {
 				systemFree = sysFree - used
 			} else {
@@ -2870,11 +2878,22 @@ func (s *llamaServerRunner) VRAMByGPU(id ml.DeviceID) uint64 {
 
 	// Map DeviceID to the log device name used by llama-server.
 	// Discovery stores the device name (e.g., "CUDA0", "ROCm0", "MTL0") from
-	// --list-devices stdout, which matches the buffer log prefix.
-	for _, gpu := range s.gpus {
+	// --list-devices stdout, but that only matches the child's own log prefix
+	// when nothing was filtered. See deviceLogKeys.
+	for i, gpu := range s.gpus {
 		if gpu.DeviceID == id {
-			return s.vramByDevice[gpu.Name]
+			return s.vramByDevice[s.deviceLogKey(i, gpu)]
 		}
 	}
 	return 0
+}
+
+// deviceLogKey returns the name llama-server uses for s.gpus[i] in its own
+// log output. gpu must be s.gpus[i]; falls back to gpu.Name if no log key
+// was recorded at launch.
+func (s *llamaServerRunner) deviceLogKey(i int, gpu ml.DeviceInfo) string {
+	if i < len(s.deviceLogKeys) && s.deviceLogKeys[i] != "" {
+		return s.deviceLogKeys[i]
+	}
+	return gpu.Name
 }

--- a/llm/llama_server_test.go
+++ b/llm/llama_server_test.go
@@ -3768,3 +3768,107 @@ func fakeRunningCmd() *exec.Cmd {
 	// SIGKILL children when the test process exits.
 	return cmd
 }
+
+// A visible-devices filter renumbers the child's devices from zero, so
+// vramByDevice/systemFreeAtLoad are keyed by deviceLogKeys, not discovery names.
+func TestVRAMByGPUUsesChildLogKeys(t *testing.T) {
+	const gib = 1024 * 1024 * 1024
+
+	tests := []struct {
+		name          string
+		gpus          []ml.DeviceInfo
+		deviceLogKeys []string
+		vramByDevice  map[string]uint64
+		query         ml.DeviceID
+		want          uint64
+	}{
+		{
+			// Single-GPU placement: always masked to CUDA0 in the child,
+			// regardless of discovery index.
+			name: "device at discovery index 1 is charged",
+			gpus: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{Library: "CUDA", ID: "1"}, Name: "CUDA1", TotalMemory: 24 * gib},
+			},
+			deviceLogKeys: []string{"CUDA0"},
+			vramByDevice:  map[string]uint64{"CUDA0": 2 * gib},
+			query:         ml.DeviceID{Library: "CUDA", ID: "1"},
+			want:          2 * gib,
+		},
+		{
+			// Keying on the discovery name here does not miss: it hits the
+			// entry belonging to the other device, returning 3 GiB.
+			name: "masked subset does not read the neighbouring device",
+			gpus: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{Library: "CUDA", ID: "1"}, Name: "CUDA1", TotalMemory: 24 * gib},
+				{DeviceID: ml.DeviceID{Library: "CUDA", ID: "2"}, Name: "CUDA2", TotalMemory: 24 * gib},
+			},
+			deviceLogKeys: []string{"CUDA0", "CUDA1"},
+			vramByDevice:  map[string]uint64{"CUDA0": 2 * gib, "CUDA1": 3 * gib},
+			query:         ml.DeviceID{Library: "CUDA", ID: "1"},
+			want:          2 * gib,
+		},
+		{
+			name: "unfiltered runner keys on the discovery name",
+			gpus: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{Library: "CUDA", ID: "1"}, Name: "CUDA1", TotalMemory: 24 * gib},
+				{DeviceID: ml.DeviceID{Library: "Vulkan", ID: "0"}, Name: "Vulkan0", TotalMemory: 24 * gib},
+			},
+			deviceLogKeys: []string{"CUDA1", "Vulkan0"},
+			vramByDevice:  map[string]uint64{"CUDA1": 2 * gib, "Vulkan0": 3 * gib},
+			query:         ml.DeviceID{Library: "Vulkan", ID: "0"},
+			want:          3 * gib,
+		},
+		{
+			// Runners without launch-time keys fall back to the discovery name.
+			name: "no log keys recorded falls back to discovery name",
+			gpus: []ml.DeviceInfo{
+				{DeviceID: ml.DeviceID{Library: "CUDA", ID: "1"}, Name: "CUDA1", TotalMemory: 24 * gib},
+			},
+			deviceLogKeys: nil,
+			vramByDevice:  map[string]uint64{"CUDA1": 2 * gib},
+			query:         ml.DeviceID{Library: "CUDA", ID: "1"},
+			want:          2 * gib,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runner := &llamaServerRunner{
+				gpus:          tt.gpus,
+				deviceLogKeys: tt.deviceLogKeys,
+				vramByDevice:  tt.vramByDevice,
+			}
+			if got := runner.VRAMByGPU(tt.query); got != tt.want {
+				t.Errorf("VRAMByGPU(%v) = %d, want %d", tt.query, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetDeviceInfosUsesChildLogKeys(t *testing.T) {
+	const gib = 1024 * 1024 * 1024
+
+	// Arm B of the reproduction: a 2 GiB model on the device discovery calls
+	// CUDA1. Keyed on the discovery name the lookup misses, free memory comes
+	// back as TotalMemory, and the scheduler keeps treating the card as empty.
+	runner := &llamaServerRunner{
+		gpus: []ml.DeviceInfo{
+			{DeviceID: ml.DeviceID{Library: "CUDA", ID: "1"}, Name: "CUDA1", TotalMemory: 24 * gib},
+		},
+		deviceLogKeys:    []string{"CUDA0"},
+		vramByDevice:     map[string]uint64{"CUDA0": 2 * gib},
+		systemFreeAtLoad: map[string]uint64{"CUDA0": 23 * gib},
+	}
+
+	infos := runner.GetDeviceInfos(context.Background())
+	if len(infos) != 1 {
+		t.Fatalf("got %d device infos, want 1", len(infos))
+	}
+	// min(24 - 2, 23 - 2) = 21
+	if got, want := infos[0].FreeMemory, uint64(21*gib); got != want {
+		t.Errorf("FreeMemory = %d GiB, want %d GiB", got/gib, want/gib)
+	}
+	if infos[0].FreeMemory == infos[0].TotalMemory {
+		t.Error("device reported fully free while holding a model")
+	}
+}

--- a/ml/device.go
+++ b/ml/device.go
@@ -359,15 +359,32 @@ func (f FlashAttentionType) String() string {
 // figure out the device environment variables and any recorded
 // per-device runner environment overrides.
 func GetDevicesEnv(l []DeviceInfo) map[string]string {
+	env, _ := GetDevicesEnvAndLogNames(l)
+	return env
+}
+
+// GetDevicesEnvAndLogNames returns the child environment variables along with,
+// for each device in l, the name the child process will use for that device
+// in its own log output - which is positional, and may not match
+// DeviceInfo.Name, when a visible-devices filter is applied.
+func GetDevicesEnvAndLogNames(l []DeviceInfo) (map[string]string, []string) {
 	if len(l) == 0 {
-		return nil
+		return nil, nil
 	}
 	// CUDA-only groups need filtering so devices removed during discovery do
 	// not reappear in the child process.
 	mustFilter := len(l) == 1 || allDevicesUseLibrary(l, "CUDA")
 	env := map[string]string{}
-	for _, d := range l {
-		d.updateVisibleDevicesEnv(env, mustFilter)
+	logNames := make([]string, len(l))
+	for i, d := range l {
+		childOrdinal, filtered := d.updateVisibleDevicesEnv(env, mustFilter)
+		if filtered {
+			logNames[i] = d.childLogName(childOrdinal)
+		} else {
+			// Unfiltered, the child enumerates every device exactly as
+			// discovery, names agree.
+			logNames[i] = d.Name
+		}
 		for k, v := range d.RunnerEnvOverrides {
 			if existing, ok := env[k]; ok && existing != v {
 				slog.Warn("conflicting device environment override", "key", k, "existing", existing, "new", v, "library", d.Library, "id", d.ID)
@@ -376,7 +393,18 @@ func GetDevicesEnv(l []DeviceInfo) map[string]string {
 		}
 	}
 
-	return env
+	return env, logNames
+}
+
+// childLogName returns the name a child process will print for this device
+// when it is the device at index ordinal in the child's filtered view.
+func (d DeviceInfo) childLogName(ordinal int) string {
+	prefix := strings.TrimRight(d.Name, "0123456789")
+	if prefix == "" {
+		// No usable prefix to renumber.
+		return d.Name
+	}
+	return prefix + strconv.Itoa(ordinal)
 }
 
 func allDevicesUseLibrary(l []DeviceInfo, library string) bool {
@@ -415,7 +443,11 @@ func (d DeviceInfo) PreferredLibrary(other DeviceInfo) bool {
 	return false
 }
 
-func (d DeviceInfo) updateVisibleDevicesEnv(env map[string]string, mustFilter bool) {
+// updateVisibleDevicesEnv appends this device to the appropriate visible-devices
+// variable in env. It reports the ordinal the device will occupy in the child's
+// renumbered view, and whether filtering applies to it at all; when it does not,
+// the child sees the unfiltered device list and the ordinal is meaningless.
+func (d DeviceInfo) updateVisibleDevicesEnv(env map[string]string, mustFilter bool) (int, bool) {
 	var envVar string
 	var rocmOrdinalEnv string
 	switch d.Library {
@@ -431,16 +463,16 @@ func (d DeviceInfo) updateVisibleDevicesEnv(env map[string]string, mustFilter bo
 		if !mustFilter {
 			// By default we try to avoid filtering CUDA devices because ROCm also
 			// looks at the CUDA env var, and gets confused in mixed-vendor environments.
-			return
+			return 0, false
 		}
 		envVar = "CUDA_VISIBLE_DEVICES"
 	case "Vulkan":
 		if !mustFilter {
-			return
+			return 0, false
 		}
 		envVar = "GGML_VK_VISIBLE_DEVICES"
 	default:
-		return
+		return 0, false
 	}
 	v, existing := env[envVar]
 	childOrdinal := visibleDeviceCount(v)
@@ -462,6 +494,8 @@ func (d DeviceInfo) updateVisibleDevicesEnv(env map[string]string, mustFilter bo
 		v = v + strconv.Itoa(childOrdinal)
 		env[rocmOrdinalEnv] = v
 	}
+
+	return childOrdinal, true
 }
 
 func visibleDeviceCount(value string) int {

--- a/ml/device_test.go
+++ b/ml/device_test.go
@@ -3,6 +3,7 @@ package ml
 import (
 	"bytes"
 	"log/slog"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -266,5 +267,109 @@ func TestFlashAttentionSupportedWarnsWhenCUDADriverUnknown(t *testing.T) {
 	}
 	if !strings.Contains(logs.String(), "CUDA driver version unavailable") {
 		t.Fatalf("expected unknown driver warning, got %q", logs.String())
+	}
+}
+
+func TestGetDevicesEnvAndLogNames(t *testing.T) {
+	// The child only sees the devices in its visible-devices variable and
+	// numbers them from zero, so the name it logs is positional, not discovery's.
+	tests := []struct {
+		name    string
+		gpus    []DeviceInfo
+		wantEnv map[string]string
+		want    []string
+	}{
+		{
+			name: "single CUDA at a non-zero index renumbers to zero",
+			gpus: []DeviceInfo{
+				{DeviceID: DeviceID{Library: "CUDA", ID: "1"}, FilterID: "1", Name: "CUDA1"},
+			},
+			wantEnv: map[string]string{"CUDA_VISIBLE_DEVICES": "1"},
+			want:    []string{"CUDA0"},
+		},
+		{
+			name: "masked subset renumbers contiguously from zero",
+			gpus: []DeviceInfo{
+				{DeviceID: DeviceID{Library: "CUDA", ID: "1"}, FilterID: "1", Name: "CUDA1"},
+				{DeviceID: DeviceID{Library: "CUDA", ID: "2"}, FilterID: "2", Name: "CUDA2"},
+			},
+			wantEnv: map[string]string{"CUDA_VISIBLE_DEVICES": "1,2"},
+			want:    []string{"CUDA0", "CUDA1"},
+		},
+		{
+			name: "all devices selected: names unchanged",
+			gpus: []DeviceInfo{
+				{DeviceID: DeviceID{Library: "CUDA", ID: "0"}, FilterID: "0", Name: "CUDA0"},
+				{DeviceID: DeviceID{Library: "CUDA", ID: "1"}, FilterID: "1", Name: "CUDA1"},
+			},
+			wantEnv: map[string]string{"CUDA_VISIBLE_DEVICES": "0,1"},
+			want:    []string{"CUDA0", "CUDA1"},
+		},
+		{
+			name: "selection order, not driver order, decides the child's numbering",
+			gpus: []DeviceInfo{
+				{DeviceID: DeviceID{Library: "CUDA", ID: "1"}, FilterID: "1", Name: "CUDA1"},
+				{DeviceID: DeviceID{Library: "CUDA", ID: "0"}, FilterID: "0", Name: "CUDA0"},
+			},
+			wantEnv: map[string]string{"CUDA_VISIBLE_DEVICES": "1,0"},
+			want:    []string{"CUDA0", "CUDA1"},
+		},
+		{
+			name: "mixed vendor is not filtered, so names are unchanged",
+			gpus: []DeviceInfo{
+				{DeviceID: DeviceID{Library: "CUDA", ID: "1"}, FilterID: "1", Name: "CUDA1"},
+				{DeviceID: DeviceID{Library: "Vulkan", ID: "0"}, FilterID: "0", Name: "Vulkan0"},
+			},
+			wantEnv: map[string]string{},
+			want:    []string{"CUDA1", "Vulkan0"},
+		},
+		{
+			name: "single Vulkan at a non-zero index renumbers to zero",
+			gpus: []DeviceInfo{
+				{DeviceID: DeviceID{Library: "Vulkan", ID: "1"}, FilterID: "1", Name: "Vulkan1"},
+			},
+			wantEnv: map[string]string{"GGML_VK_VISIBLE_DEVICES": "1"},
+			want:    []string{"Vulkan0"},
+		},
+		{
+			name: "Metal is never filtered",
+			gpus: []DeviceInfo{
+				{DeviceID: DeviceID{Library: "Metal", ID: "0"}, Name: "Metal0"},
+			},
+			wantEnv: map[string]string{},
+			want:    []string{"Metal0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env, got := GetDevicesEnvAndLogNames(tt.gpus)
+			if !slices.Equal(got, tt.want) {
+				t.Errorf("log names = %v, want %v", got, tt.want)
+			}
+			for k, want := range tt.wantEnv {
+				if env[k] != want {
+					t.Errorf("%s = %q, want %q", k, env[k], want)
+				}
+			}
+			if len(tt.wantEnv) == 0 && len(env) != 0 {
+				t.Errorf("env = %v, want empty", env)
+			}
+		})
+	}
+}
+
+func TestGetDevicesEnvAndLogNamesROCmMatchesOrdinal(t *testing.T) {
+	// ROCm is always filtered, and the child ordinal it is told to use must be
+	// the same number the log names are built from.
+	gpus := []DeviceInfo{
+		{DeviceID: DeviceID{Library: "ROCm", ID: "1"}, FilterID: "1", Name: "ROCm1"},
+		{DeviceID: DeviceID{Library: "ROCm", ID: "2"}, FilterID: "2", Name: "ROCm2"},
+	}
+
+	_, got := GetDevicesEnvAndLogNames(gpus)
+	want := []string{"ROCm0", "ROCm1"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("log names = %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

`vramByDevice` and `systemFreeAtLoad` are keyed by the name llama-server
prints in its log; all three lookup sites instead read `DeviceInfo.Name`, the
name discovery assigned. The two agree only when placement starts at device
0. A visible-devices filter renumbers the child's devices from zero, so a
single-GPU placement on a non-zero device gets a log name that discovery's
name doesn't match.

The lookup then misses: the scheduler treats an occupied card as empty,
causing load imbalance and eventual OOM on one GPU in multi-GPU setups.

## Fix

Record the name the child will actually use for each device at launch
(`GetDevicesEnvAndLogNames`), and look up by that instead of the discovery
name.

A positional-index fallback isn't sufficient on its own: a masked subset can
make two devices' fallback names collide.

Fixes #18349
