### PR TITLE
server: propagate cloud stream failures

### DIFF
--- a/server/cloud_proxy.go
+++ b/server/cloud_proxy.go
@@ -264,7 +264,9 @@ func proxyCloudRequestWithPath(c *gin.Context, body []byte, path string, disable
 			"request_context_err", ctxErr,
 			"error", err,
 		)
-		return
+		// Do not finish an incomplete upstream response as a successful stream.
+		// Propagate the abort through recovery middleware to net/http.
+		panic(http.ErrAbortHandler)
 	}
 }
 

--- a/server/cloud_proxy_test.go
+++ b/server/cloud_proxy_test.go
@@ -63,6 +63,34 @@ func TestCopyProxyResponseHeaders_StripsConnectionTokenHeaders(t *testing.T) {
 	}
 }
 
+func TestProxyCloudRequestWithPath_PropagatesUpstreamStreamFailure(t *testing.T) {
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"message":"partial"}`)
+		w.(http.Flusher).Flush()
+		panic(http.ErrAbortHandler)
+	}))
+	defer upstream.Close()
+
+	previousBaseURL := cloudProxyBaseURL
+	cloudProxyBaseURL = upstream.URL
+	defer func() { cloudProxyBaseURL = previousBaseURL }()
+
+	recorder := httptest.NewRecorder()
+	ctx, _ := gin.CreateTestContext(recorder)
+	ctx.Request = httptest.NewRequest(http.MethodPost, "/api/chat", nil)
+
+	var recovered any
+	func() {
+		defer func() { recovered = recover() }()
+		proxyCloudRequestWithPath(ctx, nil, "/api/chat", "test")
+	}()
+
+	if recovered != http.ErrAbortHandler {
+		t.Fatalf("panic = %v, want %v", recovered, http.ErrAbortHandler)
+	}
+}
+
 func TestResolveCloudProxyBaseURL_Default(t *testing.T) {
 	baseURL, signingHost, overridden, err := resolveCloudProxyBaseURL("", gin.ReleaseMode)
 	if err != nil {


### PR DESCRIPTION
## Summary

An upstream cloud response can terminate after partial output, but the proxy currently treats the failed copy as normal completion. Propagate non-client stream-copy failures through `http.ErrAbortHandler` so clients observe the aborted response.

Fixes #18193

## Reviewers

@ParthSareen
@jessegross