### PR TITLE
mlxrunner: Evict prefix cache snapshots from the active conversation

### DIFF
--- a/x/mlxrunner/prefix_cache.go
+++ b/x/mlxrunner/prefix_cache.go
@@ -606,15 +606,13 @@ func (c *prefixCache) enforceEvictionPolicy() {
 		return
 	}
 
-	activeSet := make(map[*trieNode]bool, len(c.activePath))
-	for _, n := range c.activePath {
-		activeSet[n] = true
-	}
-
 	for c.pagedOutBytes > maxPagedOutBytes {
+		// Evicting the frontier's parent merges the frontier into it, so
+		// resolve the frontier again after every eviction.
+		frontier := c.activePath[len(c.activePath)-1]
 		var best *trieNode
 		walkNodes(c.root, func(n *trieNode) bool {
-			if n == c.root || activeSet[n] || len(n.children) > 1 {
+			if n == c.root || n == frontier || len(n.children) > 1 {
 				return true
 			}
 			// Evict: oldest, then deepest, then largest.
@@ -644,7 +642,11 @@ func (c *prefixCache) evictNode(node *trieNode) {
 		// Interior node with one child: merge with child.
 		before := c.pagedOutBytes
 		tokens := len(node.tokens)
+		child := node.children[0]
 		mergeWithChild(node, c.caches, &c.pagedOutBytes)
+		if i := slices.Index(c.activePath, child); i >= 0 {
+			c.activePath = slices.Delete(c.activePath, i, i+1)
+		}
 		slog.Debug("evicting interior node", "offset", node.startOffset(), "tokens", tokens, "freed", mlx.PrettyBytes(int(before-c.pagedOutBytes)))
 	} else {
 		panic("evictNode called on multi-child branch point")

--- a/x/mlxrunner/prefix_cache.go
+++ b/x/mlxrunner/prefix_cache.go
@@ -3,14 +3,22 @@
 // optional per-layer snapshots that can be paged in/out of the live MLX cache
 // arrays.
 //
-// Key properties:
+// Invariants:
 //   - Only one path through the trie is "active" (backed by live MLX arrays)
 //     at a time. Switching paths pages in the new path from its snapshots.
-//   - Every node carries its snapshots from creation: prefill captures for
-//     prompt segments, a page-out at close for generated ones. Sliceable
-//     (KV) layers always span exactly the node's edge; whole-state layers
-//     (recurrent, rotating) keep entries only at node ends.
+//   - Sliceable (KV) layers: every node holds a snapshot covering exactly its
+//     edge, so the layer's history is complete along any path from the root.
+//   - Whole-state (recurrent, rotating) layers: what a node holds is the
+//     state at its end offset. A node may hold none.
+//   - Whole-state is captured only while the live caches sit at that offset
+//     (prefill captures, the page-out at close) and is never rebuilt later. A
+//     node split out of an existing edge afterward therefore holds none.
+//   - A request resumes at the deepest node at or below its match that holds
+//     whole-state. begin schedules a capture at the match, so any node a
+//     request resumes at holds whole-state afterward.
 //   - All cache layers must stay at the same token offset.
+//   - Draft caches are settled whenever the trie captures, pages out, or
+//     rewinds: no entry is still waiting on the next token.
 //   - Sibling edges must not share a common token prefix (compressed trie
 //     invariant).
 //   - begin() always re-evaluates at least one token so the pipeline can seed
@@ -281,7 +289,7 @@ pageIn:
 // state that prefix alone determines (offset - draftLookahead), which is where
 // a prompt sharing exactly that prefix restores. The offsets are merged with
 // any snapshots begin already scheduled (e.g. a branch point), with coinciding
-// offsets upgraded to user so eviction preserves them.
+// offsets upgraded to user so compaction keeps them.
 //
 // Offsets at or before the current cache position, or past the end of the
 // prompt, are dropped: callers only request offsets ahead of the prefill base,
@@ -471,20 +479,21 @@ func (c *prefixCache) compactPath() {
 	c.activePath = c.activePath[:n-1]
 }
 
-// pageOut captures a fresh node's state from the live caches, which rest
-// exactly at its end. Nodes reached by traversal already carry snapshots.
+// pageOut captures the snapshots a node is missing from the live caches, which
+// rest exactly at its end.
 func (c *prefixCache) pageOut(node *trieNode) {
-	if node.hasSnapshots() {
+	if hasAllSnapshots(node, c.caches) {
 		return
 	}
 	snaps := make([]cache.Snapshot, len(c.caches))
+	copy(snaps, node.snapshots)
 	for i, kv := range c.caches {
-		if kv == nil {
+		if kv == nil || snaps[i] != nil {
 			continue
 		}
 		snaps[i] = kv.Snapshot(node.startOffset())
 	}
-	node.setSnapshots(snaps, &c.pagedOutBytes)
+	node.swapSnapshots(snaps, &c.pagedOutBytes)
 	logutil.Trace(fmt.Sprintf("page out: [%d, %d)", node.startOffset(), node.endOffset))
 	c.enforceEvictionPolicy()
 }

--- a/x/mlxrunner/prefix_cache.go
+++ b/x/mlxrunner/prefix_cache.go
@@ -283,11 +283,19 @@ pageIn:
 			}
 		}
 	}
+
+	// If the live offset falls inside the last node, split it so the reused
+	// head stays on the active path and only the unused tail can be evicted.
 	for i := len(c.activePath) - 1; i >= 0; i-- {
-		if c.activePath[i].endOffset <= minOff {
-			c.activePath = c.activePath[:i+1]
-			break
+		node := c.activePath[i]
+		if i > 0 && node.startOffset() >= minOff {
+			continue
 		}
+		if node.endOffset > minOff {
+			node = splitNode(node, minOff-node.startOffset(), c.caches, &c.pagedOutBytes)
+		}
+		c.activePath = append(c.activePath[:i], node)
+		break
 	}
 
 	// Update last-used time on only the final used node. For recurrent

--- a/x/mlxrunner/prefix_cache.go
+++ b/x/mlxrunner/prefix_cache.go
@@ -19,6 +19,8 @@
 //   - All cache layers must stay at the same token offset.
 //   - Draft caches are settled whenever the trie captures, pages out, or
 //     rewinds: no entry is still waiting on the next token.
+//   - A non-causal media item's tokens are evaluated in one batch: no node
+//     boundary or resume point lies strictly inside them.
 //   - Sibling edges must not share a common token prefix (compressed trie
 //     invariant).
 //   - begin() always re-evaluates at least one token so the pipeline can seed
@@ -64,6 +66,7 @@ type cacheSession struct {
 	cache     *prefixCache
 	inputs    []int32
 	effInputs []uint32 // inputs' key alphabet, media folds applied
+	items     []mediaItem
 	outputs   []int32
 
 	caches    []cache.Cache
@@ -104,6 +107,10 @@ func (c *prefixCache) begin(inputs []int32, items []mediaItem) *cacheSession {
 	if matched == len(inputs) && matched > 0 {
 		matchPath, matched = findBestMatch(c.root, keys[:matched-1])
 	}
+	// A match ending inside a non-causal media item resumes before it.
+	if item := insideAtomicItem(items, matched); item != nil {
+		matchPath, matched = findBestMatch(c.root, keys[:item.pos])
+	}
 
 	// Switch to the matched path, paging in/out as needed.
 	c.switchToPath(matchPath, matched)
@@ -116,6 +123,7 @@ func (c *prefixCache) begin(inputs []int32, items []mediaItem) *cacheSession {
 		cache:     c,
 		inputs:    inputs,
 		effInputs: effInputs,
+		items:     items,
 		caches:    c.caches,
 		remaining: remaining,
 	}
@@ -133,6 +141,18 @@ func (c *prefixCache) begin(inputs []int32, items []mediaItem) *cacheSession {
 	slog.Info(msg, "total", len(inputs), "matched", originalMatched, "cached", prefix, "left", len(remaining))
 
 	return session
+}
+
+// insideAtomicItem returns the non-causal media item that offset lies strictly
+// inside, or nil.
+func insideAtomicItem(items []mediaItem, offset int) *mediaItem {
+	for i := range items {
+		item := &items[i]
+		if item.atomic() && item.pos < offset && offset < item.pos+item.length {
+			return item
+		}
+	}
+	return nil
 }
 
 // effectiveKeyTokens returns the per-position key alphabet: the token ID
@@ -287,7 +307,8 @@ pageIn:
 // prefill records interior states without the caller breaking the batch. A
 // passed offset names a token prefix; the capture lands at the deepest
 // state that prefix alone determines (offset - draftLookahead), which is where
-// a prompt sharing exactly that prefix restores. The offsets are merged with
+// a prompt sharing exactly that prefix restores. An offset inside a non-causal
+// media item's tokens moves past them. The offsets are merged with
 // any snapshots begin already scheduled (e.g. a branch point), with coinciding
 // offsets upgraded to user so compaction keeps them.
 //
@@ -299,6 +320,9 @@ func (s *cacheSession) schedulePrefillSnapshots(offsets []int) {
 	base := c.minCacheOffset()
 	for _, offset := range offsets {
 		offset -= c.draftLookahead
+		if item := insideAtomicItem(s.items, offset); item != nil {
+			offset = item.pos + item.length
+		}
 		if offset <= base || offset > len(s.inputs) {
 			continue
 		}

--- a/x/mlxrunner/prefix_cache_test.go
+++ b/x/mlxrunner/prefix_cache_test.go
@@ -881,7 +881,7 @@ func TestEvictionPreservesActiveConversations(t *testing.T) {
 			t.Fatalf("pagedOutBytes = %d, want <= %d", pc.pagedOutBytes, maxPagedOutBytes)
 		}
 
-		// Active path should be untouched.
+		// The branch point and the frontier survive.
 		if len(pc.activePath) < 2 {
 			t.Fatalf("activePath should have >= 2 nodes, got %d", len(pc.activePath))
 		}
@@ -954,8 +954,26 @@ func TestUserSnapshotResistsAutoMerge(t *testing.T) {
 			t.Fatalf("user node children = %d, want 2", len(userNode.children))
 		}
 
-		// Inflate snapshot sizes and evict. The non-active branch should be
-		// evicted, leaving the user node with one child.
+		// Inflate snapshot sizes so that evicting the non-active branch alone
+		// brings the trie under budget, leaving the user node with one child.
+		var kept, evicted int
+		walkNodes(pc.root, func(n *trieNode) bool {
+			for _, s := range n.snapshots {
+				if s == nil {
+					continue
+				}
+				if n.parent == userNode && !slices.Contains(pc.activePath, n) {
+					evicted++
+				} else {
+					kept++
+				}
+			}
+			return true
+		})
+		if evicted == 0 {
+			t.Fatal("no snapshots on the non-active branch")
+		}
+		size := int(maxPagedOutBytes) / kept
 		walkNodes(pc.root, func(n *trieNode) bool {
 			if !n.hasSnapshots() {
 				return true
@@ -963,7 +981,7 @@ func TestUserSnapshotResistsAutoMerge(t *testing.T) {
 			snaps := make([]cache.Snapshot, len(n.snapshots))
 			for i, s := range n.snapshots {
 				if s != nil {
-					snaps[i] = &fakeSnapshot{byteSize: 5 * 1024 * 1024 * 1024}
+					snaps[i] = &fakeSnapshot{byteSize: size}
 				}
 			}
 			n.setSnapshots(snaps, &pc.pagedOutBytes)

--- a/x/mlxrunner/prefix_cache_test.go
+++ b/x/mlxrunner/prefix_cache_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ollama/ollama/x/mlxrunner/cache"
 	"github.com/ollama/ollama/x/mlxrunner/mlx"
+	"github.com/ollama/ollama/x/mlxrunner/model/base"
 )
 
 // snapshotTracker records every fakeSnapshot created and every Close() call
@@ -1006,6 +1007,46 @@ func TestSnapshotBeyondPrefillSkipped(t *testing.T) {
 			}
 			return true
 		})
+
+		checkTrieInvariants(t, pc.root)
+	})
+}
+
+// TestAtomicMediaBoundaries verifies that a non-causal media item is never
+// split by the cache: a capture scheduled inside its tokens lands at their
+// end, and a prompt whose match ends inside them resumes before them.
+func TestAtomicMediaBoundaries(t *testing.T) {
+	forEachEnv(t, func(t *testing.T, env *testEnv) {
+		pc := env.pc
+		inputs := []int32{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
+		const itemPos, itemLen = 3, 6
+		items := []mediaItem{{pos: itemPos, length: itemLen, fold: 1 << 31, item: &base.PreparedItem{}}}
+
+		session := pc.begin(inputs, items)
+		session.schedulePrefillSnapshots([]int{itemPos + itemLen/2})
+		feedAll(pc.caches, inputs[pc.minCacheOffset():len(inputs)-1])
+		session.attachPrefillSnapshots()
+		session.close()
+
+		walkNodes(pc.root, func(n *trieNode) bool {
+			if itemPos < n.endOffset && n.endOffset < itemPos+itemLen {
+				t.Errorf("trie node ends at %d, inside the item's tokens [%d,%d)", n.endOffset, itemPos, itemPos+itemLen)
+			}
+			return true
+		})
+		if !nodeExistsAtOffset(pc.root, itemPos+itemLen) {
+			t.Errorf("capture inside the item did not move to its end %d", itemPos+itemLen)
+		}
+
+		// A prompt ending inside the item matches the stored path through its
+		// last token, which would put the resume point inside the item.
+		short := inputs[:itemPos+itemLen-2]
+		shortItems := []mediaItem{{pos: itemPos, length: len(short) - itemPos, fold: 1 << 31, item: &base.PreparedItem{}}}
+		session = pc.begin(short, shortItems)
+		if resumed := len(short) - len(session.remaining); resumed > itemPos {
+			t.Errorf("resumed at %d, inside the item's tokens starting at %d", resumed, itemPos)
+		}
+		session.close()
 
 		checkTrieInvariants(t, pc.root)
 	})


### PR DESCRIPTION
The prefix cache currently protects every node on the active path from eviction, so a conversation's own snapshots are never freed no matter how far over budget the cache is. This doesn't matter much for models that only have KV caches, since those snapshots reference the live buffer. However, models with sliding window or recurrent layers store a complete copy of that state for each snapshot (about 800 MB per turn on gemma4:31b) and memory grows without bound over a long conversation.

This changes eviction to protect only the frontier and branch points and treat everything else as LRU, including the current conversation's older turns. On qwen3.8:27b over 50 turns, the cache holds at the 8 GB budget rather than continuing to grow, with unchanged output. The exemption dates from when the frontier was extended in place without a snapshot, which has not been the case since snapshots started being captured at close.

Also includes three smaller fixes: snapshots are no longer scheduled in the middle of non-causal media, which must be processed in a single batch; a node split off at close now captures its full state rather than being skipped because it already had a KV snapshot; and a request that resumes partway through a cached edge now splits that edge at the resume point so the reused head stays on the active path. Previously the whole edge was left off the path and could be evicted mid-request, after which a later request resuming there either re-prefilled from scratch or, if eviction had merged the node into its parent, restored the wrong tokens.

Fixes #17783
