### PR TITLE
model/parsers: avoid gemma4 string placeholder collisions

### DIFF
--- a/model/parsers/gemma4.go
+++ b/model/parsers/gemma4.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"regexp"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -428,18 +429,20 @@ func parseGemma4ToolCall(content string, tools []api.Tool) (api.ToolCall, error)
 
 // gemma4ArgsToJSON converts Gemma 4's custom argument format to valid JSON.
 func gemma4ArgsToJSON(s string) string {
+	// Keep placeholder indices free of JSON syntax: rune(44) is a comma and
+	// collides with the boundary between adjacent placeholders in an array.
 	var quotedStrings []string
 	text := gemma4QuotedStringRe.ReplaceAllStringFunc(s, func(match string) string {
 		submatches := gemma4QuotedStringRe.FindStringSubmatch(match)
 		quotedStrings = append(quotedStrings, submatches[1])
-		return "\x00" + string(rune(len(quotedStrings)-1)) + "\x00"
+		return "\x00STR" + strconv.Itoa(len(quotedStrings)-1) + "\x00"
 	})
 
 	text = quoteGemma4BareKeys(text)
 
 	for i, value := range quotedStrings {
 		escaped, _ := json.Marshal(value)
-		text = strings.ReplaceAll(text, "\x00"+string(rune(i))+"\x00", string(escaped))
+		text = strings.ReplaceAll(text, "\x00STR"+strconv.Itoa(i)+"\x00", string(escaped))
 	}
 
 	return text

--- a/model/parsers/gemma4_test.go
+++ b/model/parsers/gemma4_test.go
@@ -1,6 +1,7 @@
 package parsers
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -1499,5 +1500,44 @@ func TestParseGemma4ToolCall_RawQuotedStructuralString(t *testing.T) {
 
 	if diff := cmp.Diff(want, got, argsComparer); diff != "" {
 		t.Fatalf("tool call mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestGemma4ParserManyStringsBeforeArray(t *testing.T) {
+	for _, count := range []int{43, 44, 45, 50, 130} {
+		t.Run(fmt.Sprintf("strings_%d", count), func(t *testing.T) {
+			var fields []string
+			expected := map[string]any{}
+			for i := 0; i < count; i++ {
+				key, value := fmt.Sprintf("k%d", i), fmt.Sprintf("v%d", i)
+				fields = append(fields, key+":"+gemma4StringDelimiter+value+gemma4StringDelimiter)
+				expected[key] = value
+			}
+			fields = append(fields, `members:[<|"|>a<|"|>,<|"|>b<|"|>]`)
+			expected["members"] = []any{"a", "b"}
+			input := "<|tool_call>call:submit{" + strings.Join(fields, ",") + "}<tool_call|>"
+			for _, chunkSize := range []int{len(input), 1} {
+				t.Run(fmt.Sprintf("chunk_%d", chunkSize), func(t *testing.T) {
+					p := &Gemma4Parser{}
+					p.Init(nil, nil, nil)
+					var calls []api.ToolCall
+					for start := 0; start < len(input); start += chunkSize {
+						end := min(start+chunkSize, len(input))
+						content, thinking, chunkCalls, err := p.Add(input[start:end], end == len(input))
+						if err != nil {
+							t.Fatal(err)
+						}
+						if content != "" || thinking != "" {
+							t.Fatalf("unexpected text: content=%q thinking=%q", content, thinking)
+						}
+						calls = append(calls, chunkCalls...)
+					}
+					want := []api.ToolCall{{Function: api.ToolCallFunction{Name: "submit", Arguments: testArgs(expected)}}}
+					if diff := cmp.Diff(want, calls, argsComparer); diff != "" {
+						t.Fatalf("tool calls mismatch (-want +got):\n%s", diff)
+					}
+				})
+			}
+		})
 	}
 }


### PR DESCRIPTION
Fixes #18354.

Gemma4 can silently drop a valid tool call containing 45 scalar strings followed by a two-string array. The placeholder for string 44 is `NUL + comma + NUL`, which also matches the boundary between later array placeholders and corrupts the JSON during restoration.

Use prefixed decimal placeholder indices so they cannot collide with JSON separators. Add regressions that verify exact arguments around the failure boundary and at higher counts, with both complete input and one-byte streaming chunks.

Validation:
- New regression fails on the unmodified parser.
- `go test ./model/parsers` passes with the fix.
- `go vet ./model/parsers` passes.

The synthetic Cloud reproducer also returns empty results with the failing shape and correct results when only the array position changes.
