### PR TITLE
model/renderers: always render the qwen3.5 assistant think block on history replay

### DIFF
--- a/model/renderers/qwen35_test.go
+++ b/model/renderers/qwen35_test.go
@@ -90,6 +90,60 @@ func TestQwen35RendererNoThinkPrefill(t *testing.T) {
 	}
 }
 
+func TestQwen35RendererReplaysAssistantThinkBlock(t *testing.T) {
+	renderer := rendererForName("qwen3.5")
+
+	// Thinking request: the generation turn prefill ends with an explicit
+	// think block, so the replayed assistant turn must reproduce it to keep
+	// the prompt cache common prefix intact.
+	first, err := renderer.Render([]api.Message{{Role: "user", Content: "What is 2+2?"}}, nil, &api.ThinkValue{Value: true})
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+
+	// Multi-turn replay with a thinking assistant turn.
+	multiWithThink, err := renderer.Render([]api.Message{
+		{Role: "user", Content: "What is 2+2?"},
+		{
+			Role:     "assistant",
+			Thinking: "Simple addition.",
+			Content:  "4",
+		},
+		{Role: "user", Content: "And 3+3?"},
+	}, nil, &api.ThinkValue{Value: true})
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+
+	// The multi-turn render must start with the single-turn prefix.
+	// Without alwaysRenderAssistantThinkBlock this breaks at the assistant
+	// turn because history replay omits the think block that was present in
+	// the generation prefill.
+	if !strings.HasPrefix(multiWithThink, first) {
+		t.Fatalf("multi-turn render must replay the generation-turn assistant think block to keep the prompt cache prefix intact\ngeneration:\n%s\nreplay:\n%s", first, multiWithThink)
+	}
+
+	// No-think request: the generation prefill emits an empty think block;
+	// history replay must reproduce it so the KV cache is not invalidated.
+	firstNoThink, err := renderer.Render([]api.Message{{Role: "user", Content: "hi"}}, nil, &api.ThinkValue{Value: false})
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+
+	multiNoThink, err := renderer.Render([]api.Message{
+		{Role: "user", Content: "hi"},
+		{Role: "assistant", Content: "hello"},
+		{Role: "user", Content: "bye"},
+	}, nil, &api.ThinkValue{Value: false})
+	if err != nil {
+		t.Fatalf("render failed: %v", err)
+	}
+
+	if !strings.HasPrefix(multiNoThink, firstNoThink) {
+		t.Fatalf("multi-turn no-think render must replay the empty think block\ngeneration:\n%s\nreplay:\n%s", firstNoThink, multiNoThink)
+	}
+}
+
 func TestQwen35RendererBackToBackToolCallsAndResponses(t *testing.T) {
 	renderer := &Qwen35Renderer{isThinking: true}
 

--- a/model/renderers/renderer.go
+++ b/model/renderers/renderer.go
@@ -67,7 +67,13 @@ func rendererForName(name string) Renderer {
 		renderer := &Qwen3VLRenderer{isThinking: true, useImgTags: RenderImgTags}
 		return renderer
 	case "qwen3.5":
-		renderer := &Qwen35Renderer{isThinking: true, emitEmptyThinkOnNoThink: true, useImgTags: RenderImgTags}
+		// The qwen3.5 assistant prefill always contains a think block: a
+		// thinking request renders the block and a no-think request renders
+		// an empty one (emitEmptyThinkOnNoThink). History assistant turns
+		// must reproduce it, otherwise the prompt cache common prefix breaks
+		// at the first assistant turn and every follow-up request
+		// re-processes the full prompt. Matches the qwen3.8 behavior.
+		renderer := &Qwen35Renderer{isThinking: true, alwaysRenderAssistantThinkBlock: true, emitEmptyThinkOnNoThink: true, useImgTags: RenderImgTags}
 		return renderer
 	case "qwen3.8":
 		return newQwen38Renderer()


### PR DESCRIPTION
## Summary

Multi-turn conversations with qwen3.5 models re-process the full prompt on every follow-up request. The renderer always emits a think block into the assistant prefill of the generation turn (a real block for thinking requests, an empty one via `emitEmptyThinkOnNoThink` for no-think requests), but replayed assistant history omits it, mirroring the upstream qwen3.5 chat template, which strips reasoning from completed assistant turns.

The cached KV prefix therefore contains think tokens the replay never reproduces: the prompt cache common prefix breaks at the first assistant turn, and the runner falls back to full prompt re-processing on every follow-up. Measured on a long-context qwen3.5 MoE model, multi-turn prompt reuse went from 0% to 95-100% once replay matches the cached prefix, and follow-up TTFT on a ~200k-token conversation dropped from ~76s to ~2.5s.

## Changes

- Set `alwaysRenderAssistantThinkBlock` for the qwen3.5 renderer, matching the existing qwen3.8 (`newQwen38Renderer`) and ornith renderers, which already render history think blocks.
- This is a deliberate divergence from the qwen3.5 template's history stripping in exchange for a prefix cache that can actually match: the generation turn is what the KV cache holds, so replay must reproduce it. Qwen's own qwen3.8 template moved to preserved-thinking semantics (a `preserve_thinking` variable defaulting to true), so replaying assistant reasoning follows the direction the upstream templates took.

## Validation

- `go test ./model/renderers/`
- New regression test asserts that a multi-turn render keeps the single-turn prefix for both thinking and no-think requests - the invariant the prompt cache depends on.