### PR TITLE
README: add OpenHuman to Community Integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ console.log(response.message.content);
 - [Kerlig AI](https://www.kerlig.com/) - AI writing assistant for macOS
 - [Hillnote](https://hillnote.com) - Markdown-first AI workspace
 - [Perfect Memory AI](https://www.perfectmemory.ai/) - Productivity AI personalized by screen and meeting history
+- [OpenHuman](https://github.com/tinyhumansai/openhuman) - Local-first AI desktop app with agents, workflows, and MCP for Mac, Windows, and Linux
 
 #### Mobile
 


### PR DESCRIPTION
Adds OpenHuman to Community Integrations > Chat Interfaces > Desktop. OpenHuman is an open-source (GPL-3.0), local-first AI desktop app for Mac, Windows and Linux with agents, workflows and an MCP client. Ollama is a first-class local model backend: users point OpenHuman at their Ollama server and pick any pulled model. I am on the team that builds it.