### PR TITLE
model/parsers: preserve empty FunctionGemma arrays

### DIFF
--- a/model/parsers/functiongemma.go
+++ b/model/parsers/functiongemma.go
@@ -292,7 +292,7 @@ func (p *FunctionGemmaParser) parseValue(value string) any {
 
 // parseArray parses an array value
 func (p *FunctionGemmaParser) parseArray(content string) []any {
-	var result []any
+	result := make([]any, 0)
 	parts := p.splitArguments(content)
 	for _, part := range parts {
 		result = append(result, p.parseValue(part))

--- a/model/parsers/functiongemma_test.go
+++ b/model/parsers/functiongemma_test.go
@@ -1,6 +1,8 @@
 package parsers
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -429,4 +431,51 @@ func TestFunctionGemmaParser_HasSupport(t *testing.T) {
 	parser := &FunctionGemmaParser{}
 	assert.True(t, parser.HasToolSupport())
 	assert.False(t, parser.HasThinkingSupport())
+}
+
+func TestFunctionGemmaArrayJSON(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		arguments string
+		want      string
+	}{
+		{"empty", "items:[]", `{"items":[]}`},
+		{"nested_object", "payload:{items:[]}", `{"payload":{"items":[]}}`},
+		{"nested_array", "items:[[]]", `{"items":[[]]}`},
+		{"nonempty", "items:[1,<escape>x<escape>]", `{"items":[1,"x"]}`},
+	} {
+		for _, streaming := range []bool{false, true} {
+			name := tc.name
+			if streaming {
+				name += "/streaming"
+			}
+			t.Run(name, func(t *testing.T) {
+				p := ParserForName("functiongemma")
+				p.Init(nil, nil, nil)
+				input := "<start_function_call>call:set_items{" + tc.arguments + "}<end_function_call>"
+				chunks := []string{input}
+				if streaming {
+					chunks = strings.Split(input, "")
+				}
+				var calls []api.ToolCall
+				for i, chunk := range chunks {
+					_, _, got, err := p.Add(chunk, i == len(chunks)-1)
+					if err != nil {
+						t.Fatal(err)
+					}
+					calls = append(calls, got...)
+				}
+				if len(calls) != 1 {
+					t.Fatalf("got %d tool calls, want 1", len(calls))
+				}
+				encoded, err := json.Marshal(calls[0].Function.Arguments)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if string(encoded) != tc.want {
+					t.Errorf("arguments = %s, want %s", encoded, tc.want)
+				}
+			})
+		}
+	}
 }


### PR DESCRIPTION
FunctionGemma arguments such as `items:[]` currently become `{"items":null}` in the API response because `parseArray` returns a nil slice. This also affects empty arrays nested inside objects or arrays.

Initialize the result as an empty slice so the JSON type is preserved. The regression checks the actual marshaled tool arguments for whole responses and one-character streaming chunks, including a nonempty control.

`go test ./model/parsers ./model/renderers -count=1` and `go vet ./model/parsers ./model/renderers` pass. The original implementation fails the six empty-array cases.
