### PR TITLE
app: allow 1M context in settings

### DIFF
--- a/app/ui/app/src/components/Settings.tsx
+++ b/app/ui/app/src/components/Settings.tsx
@@ -770,6 +770,8 @@ export default function Settings() {
                           { value: 65536, label: "64k" },
                           { value: 131072, label: "128k" },
                           { value: 262144, label: "256k" },
+                          { value: 524288, label: "512k" },
+                          { value: 1048576, label: "1m" },
                         ]}
                       />
                     </div>


### PR DESCRIPTION
## Summary

- Add 512k and 1m options to the context-length slider in Settings.
- Addresses #18352 by allowing the UI to select larger context lengths.

## Validation

- `npm run build` ✅
- `git diff --check` ✅
- `npm test` — 175 passed, 5 unrelated Onboarding test failures