### PR TITLE
proxy: let Claude Desktop use a model's full context window

### DIFF
--- a/app/cmd/app/app_darwin.go
+++ b/app/cmd/app/app_darwin.go
@@ -90,12 +90,15 @@ var (
 	claudeProxyFail   claudeProxyFailure
 	claudeDesktop     claudeDesktopController = &launch.ClaudeDesktop{}
 
-	claudeDesktopInstalled        = launch.ClaudeDesktopInstalled
-	claudeDesktopRunning          = launch.ClaudeDesktopRunning
-	claudeProxyListenAddr         = proxy.DefaultClaudeDesktopListenAddr
-	claudeProxyRetryWait          = 750 * time.Millisecond
-	claudeProxyRetryPoll          = 50 * time.Millisecond
-	claudeAccessRetryWait         = 3 * time.Second
+	claudeDesktopInstalled = launch.ClaudeDesktopInstalled
+	claudeDesktopRunning   = launch.ClaudeDesktopRunning
+	claudeProxyListenAddr  = proxy.DefaultClaudeDesktopListenAddr
+	claudeProxyRetryWait   = 750 * time.Millisecond
+	claudeProxyRetryPoll   = 50 * time.Millisecond
+	claudeAccessRetryWait  = 3 * time.Second
+	// claudeContextLengthTimeout bounds one model metadata lookup. A cloud
+	// model's metadata is fetched from Ollama.com, so allow for a round trip.
+	claudeContextLengthTimeout    = 10 * time.Second
 	claudeAccessRetryPoll         = 100 * time.Millisecond
 	claudeCatalogRefreshInterval  = time.Minute
 	claudeCatalogNow              = time.Now
@@ -117,6 +120,8 @@ var (
 
 	claudeAccessStateResolver = currentClaudeDesktopAccessState
 	claudeLocalModelsResolver = currentClaudeDesktopLocalModels
+
+	claudeContextLengthResolver = currentClaudeDesktopContextLength
 )
 
 var errClaudeDesktopAccessUnavailable = errors.New("Ollama couldn't verify the selected models. Try again")
@@ -616,8 +621,9 @@ func startClaudeAppProxy() error {
 			_, selected, _ := refreshClaudeDesktopCatalog(ctx, current, false)
 			return selected, nil
 		},
-		ResolveAccessState: claudeAccessStateResolver,
-		ListLocalModels:    claudeLocalModelsResolver,
+		ResolveAccessState:   claudeAccessStateResolver,
+		ListLocalModels:      claudeLocalModelsResolver,
+		ResolveContextLength: claudeContextLengthResolver,
 	})
 	if err != nil {
 		return recordClaudeProxyFailure(err, claudeProxyFailureNone)
@@ -1027,6 +1033,45 @@ func claudeLocalModels(
 		}
 	}
 	return names, nil
+}
+
+// currentClaudeDesktopContextLength reports a model's trained context length.
+// The recommendation catalog covers recommended models only, so this answers
+// for every model an account can select, at the exact tag it selected.
+func currentClaudeDesktopContextLength(ctx context.Context, model string) int {
+	ctx, cancel := context.WithTimeout(ctx, claudeContextLengthTimeout)
+	defer cancel()
+	client := api.NewClient(envconfig.ConnectableHost(), http.DefaultClient)
+	resp, err := client.Show(ctx, &api.ShowRequest{Model: model})
+	if err != nil || resp == nil {
+		slog.Debug("could not resolve model context length for Claude", "model", model, "error", err)
+		return 0
+	}
+	if resp.Details.ContextLength > 0 {
+		return resp.Details.ContextLength
+	}
+	return modelInfoContextLength(resp.ModelInfo)
+}
+
+// modelInfoContextLength reads the architecture-prefixed context length that
+// model_info reports, such as "deepseek4.context_length".
+func modelInfoContextLength(modelInfo map[string]any) int {
+	for key, value := range modelInfo {
+		if !strings.HasSuffix(key, ".context_length") {
+			continue
+		}
+		switch contextLength := value.(type) {
+		case float64:
+			return int(contextLength)
+		case int:
+			return contextLength
+		case json.Number:
+			if parsed, err := contextLength.Int64(); err == nil {
+				return int(parsed)
+			}
+		}
+	}
+	return 0
 }
 
 func currentClaudeDesktopLocalModels(ctx context.Context) ([]string, error) {

--- a/internal/proxy/claude_desktop.go
+++ b/internal/proxy/claude_desktop.go
@@ -32,14 +32,20 @@ const (
 	healthPath                     = "/_ollama/health"
 	healthHeader                   = "X-Ollama-Claude-Gateway"
 	unsupportedImageNotice         = "[Image omitted by Ollama because the selected model does not support image recognition.]"
+	// claudeDesktopLongContextSuffix marks the million-token variant Claude
+	// Desktop appends to a model ID when the catalog advertises that capacity.
+	claudeDesktopLongContextSuffix = "[1m]"
 )
 
 type gatewayModel struct {
-	ID                  string `json:"id"`
-	Type                string `json:"type"`
-	DisplayName         string `json:"display_name"`
-	CreatedAt           string `json:"created_at"`
-	MaxTokens           int    `json:"max_tokens"`
+	ID          string `json:"id"`
+	Type        string `json:"type"`
+	DisplayName string `json:"display_name"`
+	CreatedAt   string `json:"created_at"`
+	MaxTokens   int    `json:"max_tokens"`
+	// MaxInputTokens carries the trained context limit. It is the
+	// Anthropic-native counterpart to max_tokens, which is an output cap.
+	MaxInputTokens      int    `json:"max_input_tokens,omitempty"`
 	AnthropicFamilyTier string `json:"anthropic_family_tier"`
 	IsFamilyDefault     bool   `json:"is_family_default"`
 	OllamaModel         string `json:"-"`
@@ -57,6 +63,10 @@ type ClaudeDesktopConfig struct {
 	RefreshModels      func(context.Context, []ClaudeDesktopModel) ([]ClaudeDesktopModel, error)
 	ResolveAccessState func(context.Context) (ClaudeDesktopAccessState, error)
 	ListLocalModels    func(context.Context) ([]string, error)
+	// ResolveContextLength reports a model's trained context length. Catalog
+	// metadata covers only recommended models, so account-selected models
+	// reach Claude Desktop without a context size unless this fills it in.
+	ResolveContextLength func(context.Context, string) int
 }
 
 // ClaudeDesktopCounts reports requests routed through the proxy.
@@ -86,9 +96,12 @@ type ClaudeDesktop struct {
 	refreshModels      func(context.Context, []ClaudeDesktopModel) ([]ClaudeDesktopModel, error)
 	resolveAccessState func(context.Context) (ClaudeDesktopAccessState, error)
 	listLocalModels    func(context.Context) ([]string, error)
-	routed             atomic.Uint64
-	shutdown           chan struct{}
-	shutdownOnce       sync.Once
+
+	resolveContextLength func(context.Context, string) int
+	contextLengths       sync.Map
+	routed               atomic.Uint64
+	shutdown             chan struct{}
+	shutdownOnce         sync.Once
 
 	readyMu    sync.Mutex
 	readyUntil time.Time
@@ -139,9 +152,11 @@ func NewClaudeDesktop(config ClaudeDesktopConfig) (*ClaudeDesktop, error) {
 		refreshModels:      config.RefreshModels,
 		resolveAccessState: config.ResolveAccessState,
 		listLocalModels:    config.ListLocalModels,
-		shutdown:           make(chan struct{}),
-		readyWait:          upstreamReadyTimeout,
-		readyPoll:          upstreamReadyPoll,
+
+		resolveContextLength: config.ResolveContextLength,
+		shutdown:             make(chan struct{}),
+		readyWait:            upstreamReadyTimeout,
+		readyPoll:            upstreamReadyPoll,
 	}
 	if len(p.models) == 0 {
 		p.models = SelectClaudeDesktopModels(DefaultClaudeDesktopModels(), nil)
@@ -530,7 +545,13 @@ func (p *ClaudeDesktop) serveModels(w http.ResponseWriter, ctx context.Context, 
 	for _, configuredModel := range configured {
 		access := evaluateClaudeDesktopAccess(configuredModel, state, localModels, inventoryKnown)
 		if access.Availability == ClaudeDesktopAvailabilityAvailable {
-			models = append(models, configuredModel.gateway)
+			gateway := configuredModel.gateway
+			if gateway.MaxInputTokens <= 0 {
+				if contextLength := p.contextLength(ctx, gateway.OllamaModel); contextLength > 0 {
+					gateway.MaxInputTokens = contextLength
+				}
+			}
+			models = append(models, gateway)
 		}
 	}
 
@@ -552,6 +573,27 @@ func (p *ClaudeDesktop) serveModels(w http.ResponseWriter, ctx context.Context, 
 	}); err != nil {
 		p.logger.Debug("write Claude model catalog", "error", err)
 	}
+}
+
+// contextLength reports a model's trained context length, asking the resolver
+// once per model. A model's trained context does not change while the gateway
+// runs, and the lookup reaches the Ollama server, so every catalog request
+// must not repeat it.
+func (p *ClaudeDesktop) contextLength(ctx context.Context, model string) int {
+	if p.resolveContextLength == nil || strings.TrimSpace(model) == "" {
+		return 0
+	}
+	if cached, ok := p.contextLengths.Load(model); ok {
+		return cached.(int)
+	}
+	contextLength := p.resolveContextLength(ctx, model)
+	if contextLength <= 0 {
+		// A failed lookup is not an answer. Retry it on the next request
+		// rather than caching a model as having no context forever.
+		return 0
+	}
+	p.contextLengths.Store(model, contextLength)
+	return contextLength
 }
 
 func (p *ClaudeDesktop) serveTokenCount(w http.ResponseWriter, r *http.Request, models []ClaudeDesktopModel) {
@@ -739,6 +781,10 @@ func (p *ClaudeDesktop) modelForClaudeID(id string) (ClaudeDesktopModel, error) 
 }
 
 func claudeDesktopModelForID(models []ClaudeDesktopModel, id string) (ClaudeDesktopModel, error) {
+	// Claude Desktop offers a second picker entry per model that advertises a
+	// million-token context, and sends it back as the model ID with a "[1m]"
+	// suffix. The suffix selects a context size, not a different route.
+	id = strings.TrimSuffix(id, claudeDesktopLongContextSuffix)
 	for _, model := range models {
 		if model.gateway.ID == id || model.OllamaModel == id {
 			return model, nil

--- a/internal/proxy/claude_desktop_models.go
+++ b/internal/proxy/claude_desktop_models.go
@@ -175,6 +175,7 @@ func ClaudeDesktopModelsFromRecommendations(recommendations []api.ModelRecommend
 		)
 		model.Recommended = true
 		model.entitlementKnown = true
+		model.gateway.MaxInputTokens = recommendation.ContextLength
 		models = append(models, model)
 	}
 	return models
@@ -184,11 +185,11 @@ func ClaudeDesktopModelsFromRecommendations(recommendations []api.ModelRecommend
 // deliberately small; the Ollama.com app-aware endpoint is the primary source.
 func DefaultClaudeDesktopModels() []ClaudeDesktopModel {
 	models := ClaudeDesktopModelsFromRecommendations([]api.ModelRecommendation{
-		{Model: "glm-5.2:cloud", Description: "Long-horizon coding and agentic engineering", MaxOutputTokens: 128_000, RequiredPlan: "pro"},
-		{Model: "kimi-k3:cloud", Description: "Long-horizon agentic reasoning with multimodal tool use", MaxOutputTokens: 262_144, RequiredPlan: "pro"},
-		{Model: "deepseek-v4-pro", Description: "High-performance coding and tool use", MaxOutputTokens: 128_000, RequiredPlan: "pro"},
-		{Model: "deepseek-v4-flash", Description: "Fast coding and agentic tool use", MaxOutputTokens: 64_000, RequiredPlan: "pro"},
-		{Model: "gemma4:31b-cloud", Description: "Agentic workflows and multimodal reasoning", MaxOutputTokens: 262_144, RequiredPlan: "free"},
+		{Model: "glm-5.2:cloud", Description: "Long-horizon coding and agentic engineering", MaxOutputTokens: 128_000, ContextLength: 202_752, RequiredPlan: "pro"},
+		{Model: "kimi-k3:cloud", Description: "Long-horizon agentic reasoning with multimodal tool use", MaxOutputTokens: 262_144, ContextLength: 262_144, RequiredPlan: "pro"},
+		{Model: "deepseek-v4-pro", Description: "High-performance coding and tool use", MaxOutputTokens: 128_000, ContextLength: 163_840, RequiredPlan: "pro"},
+		{Model: "deepseek-v4-flash", Description: "Fast coding and agentic tool use", MaxOutputTokens: 64_000, ContextLength: 163_840, RequiredPlan: "pro"},
+		{Model: "gemma4:31b-cloud", Description: "Agentic workflows and multimodal reasoning", MaxOutputTokens: 262_144, ContextLength: 262_144, RequiredPlan: "free"},
 	})
 	// Preserve the proven fallback route while the endpoint remains free to
 	// move the canonical DeepSeek alias independently.

--- a/internal/proxy/claude_desktop_models_test.go
+++ b/internal/proxy/claude_desktop_models_test.go
@@ -22,8 +22,8 @@ func TestFetchClaudeDesktopModelsUsesAppAwareContract(t *testing.T) {
 		}
 		_ = json.NewEncoder(w).Encode(api.ModelRecommendationsResponse{
 			Recommendations: []api.ModelRecommendation{
-				{Model: "glm-5.2:cloud", Description: "GLM", MaxOutputTokens: 131_072, RequiredPlan: "pro"},
-				{Model: "glm-5.3-flash:cloud", Description: "GLM Flash", MaxOutputTokens: 1_048_576, RequiredPlan: "pro"},
+				{Model: "glm-5.2:cloud", Description: "GLM", MaxOutputTokens: 131_072, ContextLength: 202_752, RequiredPlan: "pro"},
+				{Model: "glm-5.3-flash:cloud", Description: "GLM Flash", MaxOutputTokens: 1_048_576, ContextLength: 1_048_576, RequiredPlan: "pro"},
 				{Model: "gemma4:31b-cloud", Description: "Gemma", MaxOutputTokens: 262_144, RequiredPlan: "free"},
 				{Model: "deepseek-v4-pro", Description: "DeepSeek", MaxOutputTokens: 65_536, RequiredPlan: "pro"},
 				{Model: "qwen3.8:27b", Description: "Qwen", MaxOutputTokens: 131_072},
@@ -54,6 +54,15 @@ func TestFetchClaudeDesktopModelsUsesAppAwareContract(t *testing.T) {
 	}
 	if models[3].DisplayName != "deepseek-v4-pro:cloud" {
 		t.Fatalf("display name = %q, want exact model identifier", models[3].DisplayName)
+	}
+	if got, want := models[0].gateway.MaxInputTokens, 202_752; got != want {
+		t.Fatalf("glm-5.2:cloud max_input_tokens = %d, want %d", got, want)
+	}
+	if got, want := models[1].gateway.MaxInputTokens, 1_048_576; got != want {
+		t.Fatalf("glm-5.3-flash:cloud max_input_tokens = %d, want %d", got, want)
+	}
+	if models[3].gateway.MaxInputTokens != 0 {
+		t.Fatalf("deepseek-v4-pro should omit context size when unset")
 	}
 	for _, model := range models {
 		if !model.Recommended {

--- a/internal/proxy/claude_desktop_test.go
+++ b/internal/proxy/claude_desktop_test.go
@@ -77,15 +77,9 @@ func TestGatewayRoutesClaudeProtocolToOllama(t *testing.T) {
 			if err := json.Unmarshal(body, &catalog); err != nil {
 				t.Fatal(err)
 			}
-			var rawCatalog struct {
-				Data []map[string]json.RawMessage `json:"data"`
-			}
-			if err := json.Unmarshal(body, &rawCatalog); err != nil {
-				t.Fatal(err)
-			}
-			for _, model := range rawCatalog.Data {
-				if _, ok := model["max_input_tokens"]; ok {
-					t.Fatalf("gateway model should not advertise context size: %s", body)
+			for _, model := range catalog.Data {
+				if model.MaxInputTokens <= 0 {
+					t.Fatalf("gateway model %q should advertise context size: %s", model.ID, body)
 				}
 			}
 			gotIDs := make([]string, len(catalog.Data))
@@ -1884,4 +1878,107 @@ func requestModel(t *testing.T, r *http.Request) string {
 		t.Fatal(err)
 	}
 	return payload.Model
+}
+
+func TestGatewayRoutesLongContextModelVariant(t *testing.T) {
+	models := ClaudeDesktopModelsFromRecommendations([]api.ModelRecommendation{
+		{Model: "glm-5.3-flash:cloud", MaxOutputTokens: 1_048_576, ContextLength: 1_048_576, RequiredPlan: "free"},
+	})
+	p, err := NewClaudeDesktop(ClaudeDesktopConfig{
+		ListenAddr: "127.0.0.1:0",
+		OllamaURL:  "http://127.0.0.1:11434",
+		Model:      models[0].OllamaModel,
+		Models:     models,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, admitted := p.modelSnapshot()
+	request := httptest.NewRequest(
+		http.MethodPost,
+		"http://127.0.0.1/v1/messages",
+		strings.NewReader(`{"model":"claude-fable-5[1m]","messages":[]}`),
+	)
+	if err := p.routeModel(request, admitted); err != nil {
+		t.Fatalf("1M model variant was rejected: %v", err)
+	}
+	var payload struct {
+		Model string `json:"model"`
+	}
+	if err := json.NewDecoder(request.Body).Decode(&payload); err != nil {
+		t.Fatal(err)
+	}
+	if payload.Model != models[0].OllamaModel {
+		t.Fatalf("routed model = %q, want %q", payload.Model, models[0].OllamaModel)
+	}
+}
+
+func TestGatewayCatalogResolvesMissingContextLength(t *testing.T) {
+	var lookups atomic.Int32
+	models := SelectClaudeDesktopModels(nil, []string{"local-a"})
+	models[0].gateway.MaxInputTokens = 0
+	p, err := NewClaudeDesktop(ClaudeDesktopConfig{
+		ListenAddr:      "127.0.0.1:0",
+		OllamaURL:       "http://127.0.0.1:11434",
+		Model:           models[0].OllamaModel,
+		Models:          models,
+		ListLocalModels: func(context.Context) ([]string, error) { return []string{"local-a"}, nil },
+		ResolveContextLength: func(_ context.Context, model string) int {
+			lookups.Add(1)
+			if model != "local-a" {
+				t.Errorf("resolved context length for %q, want the routed model", model)
+			}
+			return 1_048_576
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, configured := p.modelSnapshot()
+	for range 2 {
+		recorder := httptest.NewRecorder()
+		p.serveModels(recorder, context.Background(), configured)
+		var catalog struct {
+			Data []gatewayModel `json:"data"`
+		}
+		if err := json.Unmarshal(recorder.Body.Bytes(), &catalog); err != nil {
+			t.Fatal(err)
+		}
+		if len(catalog.Data) != 1 {
+			t.Fatalf("catalog = %d models, want 1", len(catalog.Data))
+		}
+		if catalog.Data[0].MaxInputTokens != 1_048_576 {
+			t.Fatalf("resolved context size = %+v, want 1048576", catalog.Data[0])
+		}
+	}
+	if got := lookups.Load(); got != 1 {
+		t.Fatalf("resolver was called %d times, want one lookup per model", got)
+	}
+}
+
+func TestGatewayCatalogRetriesFailedContextLength(t *testing.T) {
+	var lookups atomic.Int32
+	models := SelectClaudeDesktopModels(nil, []string{"local-a"})
+	p, err := NewClaudeDesktop(ClaudeDesktopConfig{
+		ListenAddr:      "127.0.0.1:0",
+		OllamaURL:       "http://127.0.0.1:11434",
+		Model:           models[0].OllamaModel,
+		Models:          models,
+		ListLocalModels: func(context.Context) ([]string, error) { return []string{"local-a"}, nil },
+		ResolveContextLength: func(context.Context, string) int {
+			lookups.Add(1)
+			return 0
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, configured := p.modelSnapshot()
+	for range 2 {
+		p.serveModels(httptest.NewRecorder(), context.Background(), configured)
+	}
+	if got := lookups.Load(); got != 2 {
+		t.Fatalf("resolver was called %d times, want a retry after a failed lookup", got)
+	}
 }


### PR DESCRIPTION
## Summary

A 1M-capable model reaches Claude Desktop pinned to Desktop's 200k default. Two gaps cause it, and this fixes both.

Claude Desktop does not display an arbitrary context size. It reads `supports_1m`, or `max_input_tokens` at or above one million, and on that basis offers a **second** entry in its model picker whose ID carries a `[1m]` suffix. The gateway advertised neither field, so no 1M entry appeared. When one is made to appear, choosing it fails: the gateway does not recognise the suffixed ID.

- Advertise `max_input_tokens`.
- Accept the `[1m]` suffix when resolving a model. It selects a context size, not a different route.
- Resolve a missing context size from the Ollama server (`/api/show`), cached per model.

## Why not read the size from the recommendation catalog

That was the first attempt, and it does not hold:

- The Claude-specific contract covers recommended models only. An account may also select any model from its cloud inventory, and `/api/tags` reports names and nothing else — those models arrive with no context size at all.
- It is not always current. It lists `deepseek-v4-pro` at `524288`, where `/api/show` on the selected tag reports `1048576`, matching the model's own page.

`/api/show` answers at the exact tag selected, for recommended and account-selected models alike. A trained context does not change while the gateway runs, so the lookup is cached per model; a failed lookup is not cached, so it retries.

## Relationship to other work

- Fixes #18180.
- Overlaps #17981, which advertises `max_input_tokens` from the recommendation catalog. That half is included here, sourced differently for the reasons above. Happy to rebase onto #17981 instead if you would rather land that one first.

## Validation

- `go build ./...`, `go vet`, `gofmt` clean.
- `go test ./internal/proxy/ ./app/cmd/app/` passing, including three added tests: the suffixed ID routes to the mapped model, a resolved context size reaches the catalog with one lookup per model, and a failed lookup retries.
- Verified end to end on macOS against a live gateway. Before, `deepseek-v4-pro:0813:cloud` and `deepseek-v4-flash:0731:cloud` advertised no context size and had no 1M entry; after, both report `max_input_tokens: 1048576` and the 1M entry appears and routes. `nemotron-3-super:cloud`, which no recommendation catalog covers, now reports its real `262144`.
