### PR TITLE
model/parsers: fix gemma4 string placeholder collision with arrays

### DIFF
--- a/model/parsers/gemma4.go
+++ b/model/parsers/gemma4.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"regexp"
+	"strconv"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -432,17 +433,42 @@ func gemma4ArgsToJSON(s string) string {
 	text := gemma4QuotedStringRe.ReplaceAllStringFunc(s, func(match string) string {
 		submatches := gemma4QuotedStringRe.FindStringSubmatch(match)
 		quotedStrings = append(quotedStrings, submatches[1])
-		return "\x00" + string(rune(len(quotedStrings)-1)) + "\x00"
+		return gemma4StringPlaceholder(len(quotedStrings) - 1)
 	})
 
 	text = quoteGemma4BareKeys(text)
 
 	for i, value := range quotedStrings {
 		escaped, _ := json.Marshal(value)
-		text = strings.ReplaceAll(text, "\x00"+string(rune(i))+"\x00", string(escaped))
+		text = strings.ReplaceAll(text, gemma4StringPlaceholder(i), string(escaped))
 	}
 
 	return text
+}
+
+// gemma4StringPlaceholder returns the NUL-delimited marker gemma4ArgsToJSON
+// substitutes for the string at the given index while it restructures the
+// surrounding Gemma 4 argument syntax into JSON. The index is rendered as
+// decimal digits rather than a single rune. JSON's own structural bytes
+// (',', ':', '{', '}', '[', ']', '"') are never digits, so a two-NUL span can
+// only decode as pure digits when it is one complete, still-unresolved
+// placeholder; it can never straddle the seam between two different
+// placeholders, because that seam always has a non-digit JSON separator
+// sitting between the two NULs.
+//
+// A raw rune index does not have that property: rune(44) is a comma, so the
+// placeholder for string index 44 is byte-identical to the "\x00,\x00" seam
+// that two adjacent, still-unresolved array element placeholders produce
+// around their separating comma. Restoring index 44 first (the restore loop
+// runs in index order) then matches that seam instead of, or in addition to,
+// its own placeholder, splicing string 44's value into the array and
+// corrupting the two placeholders it straddles. That happens whenever 45 or
+// more strings precede an array: the 45th string takes index 44, and the
+// array's own elements have not been restored yet. json.Unmarshal then fails
+// on the stray NUL bytes left behind, and the caller silently drops the tool
+// call. See https://github.com/ollama/ollama/issues/18354.
+func gemma4StringPlaceholder(i int) string {
+	return "\x00" + strconv.Itoa(i) + "\x00"
 }
 
 func quoteGemma4BareKeys(s string) string {

--- a/model/parsers/gemma4_test.go
+++ b/model/parsers/gemma4_test.go
@@ -1,6 +1,8 @@
 package parsers
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -952,6 +954,91 @@ func TestGemma4ArgsToJSON(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestGemma4ArgsToJSON_StringPlaceholderCollision reproduces
+// https://github.com/ollama/ollama/issues/18354.
+//
+// gemma4ArgsToJSON fences each quoted string with the placeholder
+// "\x00" + string(rune(index)) + "\x00" while it converts bare keys, then
+// restores the placeholders in index order. rune(44) is a comma, byte
+// identical to the JSON array separator that sits between two
+// still-unreplaced placeholders. When 45 or more scalar strings are restored
+// before an array gets its turn, index 44 lands on a scalar, and replacing
+// that placeholder also matches the "\x00,\x00" seam between the array's
+// first two elements, splicing the scalar's value into the array and
+// corrupting both element placeholders it straddles. The result is invalid
+// JSON and the caller drops the whole tool call.
+func TestGemma4ArgsToJSON_StringPlaceholderCollision(t *testing.T) {
+	scalarField := func(i int, expected map[string]any) string {
+		key, value := fmt.Sprintf("k%02d", i), fmt.Sprintf("v%02d", i)
+		expected[key] = value
+		return key + ":" + gemma4StringDelimiter + value + gemma4StringDelimiter
+	}
+	arrayField := func(expected map[string]any) string {
+		expected["members"] = []any{"a", "b"}
+		return "members:[" + gemma4StringDelimiter + "a" + gemma4StringDelimiter + "," +
+			gemma4StringDelimiter + "b" + gemma4StringDelimiter + "]"
+	}
+
+	build := func(scalarCount int, array func(map[string]any) string, arrayFirst bool) (string, map[string]any) {
+		expected := map[string]any{}
+		var fields []string
+		if arrayFirst && array != nil {
+			fields = append(fields, array(expected))
+		}
+		for i := 0; i < scalarCount; i++ {
+			fields = append(fields, scalarField(i, expected))
+		}
+		if !arrayFirst && array != nil {
+			fields = append(fields, array(expected))
+		}
+		return "{" + strings.Join(fields, ",") + "}", expected
+	}
+
+	check := func(t *testing.T, input string, expected map[string]any) {
+		t.Helper()
+		jsonStr := gemma4ArgsToJSON(input)
+		var got map[string]any
+		if err := json.Unmarshal([]byte(jsonStr), &got); err != nil {
+			t.Fatalf("gemma4ArgsToJSON produced invalid JSON: %v\noutput: %q", err, jsonStr)
+		}
+		if diff := cmp.Diff(expected, got); diff != "" {
+			t.Errorf("arguments mismatch (-want +got):\n%s", diff)
+		}
+	}
+
+	// 45 scalar strings followed by a two-string array: the reporter's
+	// failing shape. Index 44's placeholder collides with the boundary
+	// between the array's two still-raw element placeholders.
+	t.Run("45_scalars_then_array", func(t *testing.T) {
+		input, expected := build(45, arrayField, false)
+		check(t, input, expected)
+	})
+
+	// 43 scalar strings followed by the same array: index 44 now belongs to
+	// the array's own second element, so restoring it is a correct self
+	// match rather than a false-positive collision.
+	t.Run("43_scalars_then_array", func(t *testing.T) {
+		input, expected := build(43, arrayField, false)
+		check(t, input, expected)
+	})
+
+	// Same 47 values, array moved first: its two elements take indices 0
+	// and 1, so they are long since resolved by the time index 44 comes
+	// around and there is nothing left for it to collide with.
+	t.Run("array_then_45_scalars", func(t *testing.T) {
+		input, expected := build(45, arrayField, true)
+		check(t, input, expected)
+	})
+
+	// Same 45 values, all scalar, no array: index 44 exists but no two raw
+	// placeholders are ever adjacent across a bare comma, so there is
+	// nothing for it to collide with.
+	t.Run("45_scalars_no_array", func(t *testing.T) {
+		input, expected := build(45, nil, false)
+		check(t, input, expected)
+	})
 }
 
 func TestRepairGemma4MissingStringDelimiter(t *testing.T) {


### PR DESCRIPTION
Fixes #18354.

## Silent failure and user impact

A valid Gemma4 tool call can come back with empty `content` and no `tool_calls`, with `done_reason: stop`, even though the model produced a correct call. This happens whenever a tool's arguments contain 45 or more scalar string values followed by an array. The caller gets nothing back and no error surfaces to the user; the failure is logged at `slog.Warn` level only, inside `parseGemma4ToolCall` (`model/parsers/gemma4.go:318-322`).

## Mechanism

`gemma4ArgsToJSON` (`model/parsers/gemma4.go:430-446` before this change) protects each Gemma4 quoted string with a placeholder while it converts the surrounding syntax to JSON, then restores the placeholders in index order:

```go
return "\x00" + string(rune(len(quotedStrings)-1)) + "\x00"
...
text = strings.ReplaceAll(text, "\x00"+string(rune(i))+"\x00", string(escaped))
```

`rune(44)` is a comma. So the placeholder for the string at index 44 is the exact byte sequence `\x00,\x00`. That sequence is also what two adjacent, still-unresolved array element placeholders produce around their separating JSON comma: `\x00` (end of element N) + `,` (array separator) + `\x00` (start of element N+1).

With 45 scalar strings before a two-string array, the array's elements get indices 45 and 46. The restore loop runs 0..46 in order, so index 44 is processed before 45 and 46. `strings.ReplaceAll(text, "\x00,\x00", ...)` matches both the true placeholder for string 44 and the seam between the array's still-raw elements 45 and 46, splicing string 44's escaped value into the middle of the array and leaving orphaned `\x00` bytes on either side. `json.Unmarshal` then fails with `invalid character '\x00' looking for beginning of value`, exactly the error in the issue, and the tool call is dropped.

This explains all four of the reporter's experiments:

- **45 scalars + array, 2/2 empty**: index 44 is a scalar, indices 45/46 (the array) are still raw when 44 is restored. Collision.
- **43 scalars + array, 2/2 correct**: the array's own elements now take indices 43 and 44. Index 44 is the array's own second element, so its restoration is a correct self-match, not a false-positive collision with something else.
- **array renamed to sort first, 1/1 correct**: when the array is emitted before the scalars, its elements take indices 0 and 1 and are fully resolved long before the loop reaches index 44. Nothing unresolved is left for 44 to collide with.
- **all scalar, no array, 1/1 correct**: index 44 still exists, but no two raw placeholders are ever directly adjacent across a bare comma outside an array, so there is no seam for it to match.

I verified this by constructing the parser input directly (no model call) and inspecting the corrupted output. For 45 scalars `k00..k44` followed by `members:[<|"|>a<|"|>,<|"|>b<|"|>]`, `gemma4ArgsToJSON` returns (truncated):

```
..."k44":"v44","members":[\x00-"v44".\x00]}
```

`\x00-` and `.\x00` are the surviving fragments of the array's two element placeholders after `"v44"` was spliced into their seam.

## Fix

`model/parsers/gemma4.go`: render the placeholder index as decimal digits (`strconv.Itoa`) instead of a single raw rune, via a new `gemma4StringPlaceholder` helper used in both the encode and restore passes.

This is structural, not a threshold raise. JSON's own structural bytes (`,` `:` `{` `}` `[` `]` `"`) are never digits, so a `\x00...\x00` span can only decode as pure digits when it is one complete, still-unresolved placeholder. It can never straddle the seam between two different placeholders, because that seam always has a non-digit JSON separator sitting between the two NULs. No index value can produce a collision this way, so the fix does not just move the failure to a higher count.

## Tests

Added `TestGemma4ArgsToJSON_StringPlaceholderCollision` in `model/parsers/gemma4_test.go`, covering the same four shapes as the issue directly against `gemma4ArgsToJSON` (no model call): 45 scalars then array, 43 scalars then array, array then 45 scalars, and 45 scalars with no array.

RED, on unmodified main (159b1c3331a176abf7e8484e44d517db726707db):

```
$ go test ./model/parsers/... -run TestGemma4ArgsToJSON_StringPlaceholderCollision -v
=== RUN   TestGemma4ArgsToJSON_StringPlaceholderCollision
=== RUN   TestGemma4ArgsToJSON_StringPlaceholderCollision/45_scalars_then_array
    gemma4_test.go:1016: gemma4ArgsToJSON produced invalid JSON: invalid character '\x00' looking for beginning of value
        output: "{\"k00\":\"v00\",...,\"k44\":\"v44\",\"members\":[\x00-\"v44\".\x00]}"
=== RUN   TestGemma4ArgsToJSON_StringPlaceholderCollision/43_scalars_then_array
=== RUN   TestGemma4ArgsToJSON_StringPlaceholderCollision/array_then_45_scalars
=== RUN   TestGemma4ArgsToJSON_StringPlaceholderCollision/45_scalars_no_array
--- FAIL: TestGemma4ArgsToJSON_StringPlaceholderCollision (0.00s)
    --- FAIL: TestGemma4ArgsToJSON_StringPlaceholderCollision/45_scalars_then_array (0.00s)
    --- PASS: TestGemma4ArgsToJSON_StringPlaceholderCollision/43_scalars_then_array (0.00s)
    --- PASS: TestGemma4ArgsToJSON_StringPlaceholderCollision/array_then_45_scalars (0.00s)
    --- PASS: TestGemma4ArgsToJSON_StringPlaceholderCollision/45_scalars_no_array (0.00s)
FAIL
```

GREEN, with the fix:

```
$ go test ./model/parsers/... -run TestGemma4ArgsToJSON_StringPlaceholderCollision -v
=== RUN   TestGemma4ArgsToJSON_StringPlaceholderCollision
=== RUN   TestGemma4ArgsToJSON_StringPlaceholderCollision/45_scalars_then_array
=== RUN   TestGemma4ArgsToJSON_StringPlaceholderCollision/43_scalars_then_array
=== RUN   TestGemma4ArgsToJSON_StringPlaceholderCollision/array_then_45_scalars
=== RUN   TestGemma4ArgsToJSON_StringPlaceholderCollision/45_scalars_no_array
--- PASS: TestGemma4ArgsToJSON_StringPlaceholderCollision (0.00s)
    --- PASS: TestGemma4ArgsToJSON_StringPlaceholderCollision/45_scalars_then_array (0.00s)
    --- PASS: TestGemma4ArgsToJSON_StringPlaceholderCollision/43_scalars_then_array (0.00s)
    --- PASS: TestGemma4ArgsToJSON_StringPlaceholderCollision/array_then_45_scalars (0.00s)
    --- PASS: TestGemma4ArgsToJSON_StringPlaceholderCollision/45_scalars_no_array (0.00s)
PASS
```

Full package, with the fix:

```
$ go test ./model/parsers/...
ok  	github.com/ollama/ollama/model/parsers	0.027s

$ go test ./model/...
ok  	github.com/ollama/ollama/model/parsers	0.027s
ok  	github.com/ollama/ollama/model/renderers	0.016s

$ gofmt -l model/parsers/gemma4.go model/parsers/gemma4_test.go
(no output)

$ go vet ./model/parsers/...
(no output)
```
