### PR TITLE
template: avoid mutating caller messages when collating

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -364,7 +364,11 @@ func collate(msgs []api.Message) (string, []*api.Message) {
 
 		// merges consecutive messages of the same role into a single message (except for tool messages)
 		if len(collated) > 0 && collated[len(collated)-1].Role == msgs[i].Role && msgs[i].Role != "tool" {
-			collated[len(collated)-1].Content += "\n\n" + msgs[i].Content
+			// Merge into a copy: collated holds pointers into the caller's slice,
+			// so writing through them mutates the caller's messages.
+			merged := *collated[len(collated)-1]
+			merged.Content += "\n\n" + msgs[i].Content
+			collated[len(collated)-1] = &merged
 		} else {
 			collated = append(collated, &msgs[i])
 		}

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -614,6 +614,83 @@ func TestCollate(t *testing.T) {
 	}
 }
 
+func TestCollateDoesNotMutateInput(t *testing.T) {
+	cases := []struct {
+		name string
+		msgs []api.Message
+	}{
+		{
+			name: "consecutive user messages",
+			msgs: []api.Message{
+				{Role: "user", Content: "Hello"},
+				{Role: "user", Content: "How are you?"},
+			},
+		},
+		{
+			name: "consecutive system messages",
+			msgs: []api.Message{
+				{Role: "system", Content: "You are helpful"},
+				{Role: "system", Content: "Answer briefly"},
+				{Role: "user", Content: "Hello"},
+			},
+		},
+		{
+			name: "runs of several roles",
+			msgs: []api.Message{
+				{Role: "system", Content: "A"},
+				{Role: "system", Content: "B"},
+				{Role: "system", Content: "C"},
+				{Role: "user", Content: "D"},
+				{Role: "user", Content: "E"},
+				{Role: "assistant", Content: "F"},
+				{Role: "assistant", Content: "G"},
+			},
+		},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			want := slices.Clone(tt.msgs)
+			collate(tt.msgs)
+			if diff := cmp.Diff(tt.msgs, want); diff != "" {
+				t.Errorf("collate mutated its input (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExecuteDoesNotMutateMessages(t *testing.T) {
+	tmpl, err := Parse(`{{- range .Messages }}{{ .Role }}: {{ .Content }}
+{{ end }}`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msgs := []api.Message{
+		{Role: "system", Content: "You are helpful"},
+		{Role: "system", Content: "Answer briefly"},
+		{Role: "user", Content: "Hello"},
+		{Role: "user", Content: "Are you there?"},
+	}
+	want := slices.Clone(msgs)
+
+	// Rendering the same messages twice must produce the same output; it does
+	// not if Execute writes merged content back into the caller's slice.
+	var first, second bytes.Buffer
+	if err := tmpl.Execute(&first, Values{Messages: msgs}); err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(msgs, want); diff != "" {
+		t.Errorf("Execute mutated its input messages (-got +want):\n%s", diff)
+	}
+	if err := tmpl.Execute(&second, Values{Messages: msgs}); err != nil {
+		t.Fatal(err)
+	}
+	if diff := cmp.Diff(second.String(), first.String()); diff != "" {
+		t.Errorf("rendering the same messages twice differs (-second +first):\n%s", diff)
+	}
+}
+
 func TestTemplateArgumentsJSON(t *testing.T) {
 	// Test that {{ .Function.Arguments }} outputs valid JSON, not map[key:value]
 	tmpl := `{{- range .Messages }}{{- range .ToolCalls }}{{ .Function.Arguments }}{{- end }}{{- end }}`


### PR DESCRIPTION
`Template.Execute` modifies the messages it is given. Rendering the same
messages twice does not produce the same output: the second render merges
content that the first render had already merged.

```go
msgs := []api.Message{
    {Role: "system", Content: "AAA"},
    {Role: "system", Content: "BBB"},
}
tmpl.Execute(&buf, template.Values{Messages: msgs})
// msgs[0].Content is now "AAA\n\nBBB"
```

## Root cause

`collate` stores pointers into the caller's slice and writes through them when
merging consecutive messages of the same role.

- https://github.com/ollama/ollama/blob/159b1c3331a176abf7e8484e44d517db726707db/template/template.go#L369 takes `&msgs[i]`, the address of an element in the caller's backing array
- https://github.com/ollama/ollama/blob/159b1c3331a176abf7e8484e44d517db726707db/template/template.go#L367 appends to `.Content` through that pointer

So the merge writes into the caller's messages.

## Fix

Merge into a copy of the message instead of writing through the pointer. Only
the merge branch copies, so the common case where nothing is merged is
unaffected. The collated output is unchanged; only the side effect is gone.

## Impact

`server/prompt.go:chatPrompt` rebuilds the system block on every truncation
iteration and passes `append(system, msgs[i:]...)` to the template. When
`system` has spare capacity, that append writes in place, so `collate` merges
into `system` itself. The final render then merges the already-merged content
again, and every system message except the first is emitted twice.

Prompt length after truncation, with N system messages interleaved with turns
and `num_ctx=200`:

| system messages | expected | actual | inflation |
|----------------:|---------:|-------:|----------:|
| 2               | 506      | 506    | 1.00x     |
| 3               | 713      | 1127   | 1.58x     |
| 5               | 1127     | 1955   | 1.73x     |
| 9               | 1955     | 3611   | 1.85x     |
| 27              | 5681     | 11063  | 1.95x     |

Whether it triggers depends on the slice capacity, which is why it is
intermittent. `make([]api.Message, 0)` grows 1, 2, 4, 8..., so with 3 system
messages `len=3, cap=4` and the append writes in place. With 2, `len=cap=2` and
it reallocates, leaving the caller untouched.

The measurements in the table come from a test against `chatPrompt` that is not
part of this PR, which is scoped to `template`. Happy to share it if useful.

## Testing

Two tests added. Both fail on main and pass with this change:

```
--- FAIL: TestCollateDoesNotMutateInput/consecutive_system_messages
    template_test.go:656: collate mutated its input (-got +want):
          []api.Message{
          	{
          		Role:     "system",
        - 		Content:  "You are helpful\n\nAnswer briefly",
        + 		Content:  "You are helpful",
          		...
          	},
          	{Role: "system", Content: "Answer briefly"},
          }
--- FAIL: TestExecuteDoesNotMutateMessages
    template_test.go:684: Execute mutated its input messages
    template_test.go:690: rendering the same messages twice differs
```

`go test ./template/ ./api/ ./server/` passes with this change.

## Scope

This change only touches `collate`. The truncation loop in `chatPrompt` also
makes one tokenize round-trip per discarded message; that is a separate issue
and I will raise it on its own.
