### PR TITLE
llm: raise token repeat limit to 100 and return error instead of incomplete result

### DIFF
--- a/llm/llama_server.go
+++ b/llm/llama_server.go
@@ -1700,9 +1700,9 @@ func (s *llamaServerRunner) Completion(ctx context.Context, req CompletionReques
 				lastToken = strings.TrimSpace(lsResp.Content)
 				tokenRepeat = 0
 			}
-			if tokenRepeat > 30 {
+			if tokenRepeat > 100 {
 				slog.Debug("prediction aborted, token repeat limit reached")
-				return ctx.Err()
+				return fmt.Errorf("prediction aborted, token repeat limit reached")
 			}
 
 			if lsResp.Content != "" && !lsResp.Stop {


### PR DESCRIPTION
LLM generation that repeats tokens (eg, OCR with a visual model on a page image in which the index use "....." to separate title from page number) gets terminated early, but the response is incomplete and gives no indication an error has occurred.  Increase the limit to something less likely to be a legitimate run of tokens, but not so long as to take forever to hit.  Return an actual error rather than in incomplete success.

Pre test:
```console
$ curl -s localhost:11434/api/generate -d '{"model":"qwen3.5","prompt":"repeat the following exactly: '"$(printf '😊%.0s' {1..40})"'","stream":false,"think":false}' | jq 'del(.context)'
{
  "model": "qwen3.5",
  "created_at": "2026-09-10T20:31:05.441153004Z",
  "response": "😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊😊",
  "done": false
}
```
Post test:
```console
$ curl -s -D /dev/stderr localhost:11434/api/generate -d '{"model":"qwen3.5","prompt":"repeat the following exactly: '"$(printf '😊%.0s' {1..400})"'","stream":false,"think":false}' | jq 'del(.context)'
HTTP/1.1 500 Internal Server Error
Content-Type: application/json; charset=utf-8
Date: Thu, 10 Sep 2026 20:37:04 GMT
Content-Length: 58

{
  "error": "prediction aborted, token repeat limit reached"
}
```
Fixes: #7547
Fixes: #8967
Fixes: #14117

cc @ParthSareen based on https://github.com/ollama/ollama/issues/7547#issuecomment-2483642131