### PR TITLE
envconfig: ignore userinfo in OLLAMA_HOST when resolving host and port

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -37,6 +37,14 @@ func Host() *url.URL {
 	}
 
 	hostport, path, _ := strings.Cut(hostport, "/")
+
+	// An authority may carry userinfo, which RFC 3986 places before the last
+	// "@". Leaving it in place makes net.SplitHostPort read the credentials as
+	// the host and port.
+	if i := strings.LastIndex(hostport, "@"); i >= 0 {
+		hostport = hostport[i+1:]
+	}
+
 	host, port, err := net.SplitHostPort(hostport)
 	if err != nil {
 		host, port = "127.0.0.1", defaultPort

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -40,6 +40,12 @@ func TestHost(t *testing.T) {
 		"https port":          {"https://1.2.3.4:4321", "https://1.2.3.4:4321"},
 		"proxy path":          {"https://example.com/ollama", "https://example.com:443/ollama"},
 		"ollama.com":          {"ollama.com", "https://ollama.com:443"},
+		"userinfo":            {"http://user:pass@example.com", "http://example.com:80"},
+		"userinfo and port":   {"http://user:pass@example.com:4321", "http://example.com:4321"},
+		"user only":           {"http://user@example.com", "http://example.com:80"},
+		"userinfo no scheme":  {"user:pass@example.com:4321", "http://example.com:4321"},
+		"userinfo ipv6":       {"http://user:pass@[::1]:4321", "http://[::1]:4321"},
+		"userinfo empty host": {"http://user:pass@", "http://127.0.0.1:80"},
 	}
 
 	for name, tt := range cases {


### PR DESCRIPTION
## Problem

`OLLAMA_HOST` accepts a URL, and a URL authority may carry userinfo. `Host()` hands the whole authority to `net.SplitHostPort`, which has no notion of userinfo, so the credentials are read as the host and port.

Every one of these resolves to a host the user did not ask for:

| `OLLAMA_HOST` | resolves to | intended host |
| --- | --- | --- |
| `http://user:pass@example.com` | `user:80` | `example.com:80` |
| `http://user:pass@example.com:4321` | `[user:pass@example.com:4321]:80` | `example.com:4321` |
| `http://user@example.com` | `user@example.com:80` | `example.com:80` |
| `user:pass@example.com:4321` | `[user:pass@example.com:4321]:11434` | `example.com:4321` |
| `http://user:pass@[::1]:4321` | `[user:pass@[::1]:4321]:80` | `[::1]:4321` |

Two separate failures show up depending on the input. When the authority holds a single colon, `SplitHostPort("user:pass@example.com")` returns without error and reports the host as `user`, so the client dials a host named `user`. When it holds more, the split fails and the fallback keeps the entire authority as the host, which also discards an explicit port: `:4321` above becomes `:80`.

## Why it matters

The parsed host is used to dial the server and also to bind it. `cmd/cmd.go` listens on `envconfig.Host().Host`, so a value carrying userinfo makes `ollama serve` bind to a bogus address rather than the requested one. The same value feeds the base URLs written into editor integrations under `cmd/launch`, so those are pointed at the wrong host too.

Nothing about the failure is visible to the user. There is no warning for the single-colon case, and the connection error names a host they never typed.

## The change

Userinfo is dropped from the authority before the host and port are split. RFC 3986 places it before the last `@`, and a host cannot contain `@`, so `strings.LastIndex` is the same rule `net/url` applies when it parses an authority.

This intentionally does not add authentication. The credentials are discarded, exactly as they are today, so the only behavior change is that the request now goes to the host the user wrote. Making Ollama actually authenticate with them is a separate feature, requested in #11468 and #3203.

## Testing

Six cases were added to the existing `TestHost` table, covering user and password, user alone, an explicit port, no scheme, IPv6, and an empty host after the userinfo. All six fail on main with the values in the table above, for example `expected http://example.com:80, got http://user:80`.

`go build ./...`, `go vet`, and the tests for `envconfig`, `api`, `cmd/...`, and `types/...` all pass.
