### PR TITLE
docs: fix subject-verb agreement in streaming guide

### DIFF
--- a/docs/api/streaming.mdx
+++ b/docs/api/streaming.mdx
@@ -16,7 +16,7 @@ Certain API endpoints stream responses by default, such as `/api/generate`. Thes
 
 ## Disabling streaming
 
-Streaming can be disabled by providing `{"stream": false}` in the request body for any endpoint that support streaming. This will cause responses to be returned in the `application/json` format instead:
+Streaming can be disabled by providing `{"stream": false}` in the request body for any endpoint that supports streaming. This will cause responses to be returned in the `application/json` format instead:
 
 ```json
 {"model":"gemma4","created_at":"2025-10-26T17:15:24.166576Z","response":"That's a fantastic question!","done":true}


### PR DESCRIPTION
## Summary
Change "any endpoint that support streaming" to
"any endpoint that supports streaming" in the API streaming guide.

## Validation
- git diff --check passed.
- Confirmed that only this wording changed after normalizing Git line endings.
- No code, examples, or API behavior changed; runtime tests were not run.

AI assistance was used to prepare and check this documentation edit.