### PR TITLE
server: bound cloud proxy connect and TTFB timeouts

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -302,6 +302,40 @@ func Uint64(key string, defaultValue uint64) func() uint64 {
 // Set aside VRAM per GPU
 var GpuOverhead = Uint64("OLLAMA_GPU_OVERHEAD", 0)
 
+// Duration returns a function that reads a duration-valued environment
+// variable, accepting Go duration strings ("30s", "1m") or a bare integer
+// (interpreted as seconds), falling back to defaultValue when unset or
+// invalid.
+func Duration(key string, defaultValue time.Duration) func() time.Duration {
+	return func() time.Duration {
+		if s := Var(key); s != "" {
+			if d, err := time.ParseDuration(s); err == nil {
+				return d
+			} else if n, err := strconv.ParseInt(s, 10, 64); err == nil {
+				return time.Duration(n) * time.Second
+			}
+			slog.Warn("invalid environment variable, using default", "key", key, "value", s, "default", defaultValue)
+		}
+		return defaultValue
+	}
+}
+
+var (
+	// CloudProxyConnectTimeout bounds the time to establish a TCP connection
+	// and complete the TLS handshake to the cloud proxy.
+	CloudProxyConnectTimeout = Duration("OLLAMA_CLOUD_PROXY_CONNECT_TIMEOUT", 10*time.Second)
+	// CloudProxyTTFBTimeout bounds the time to receive the first response byte
+	// (time-to-first-byte) from the cloud proxy. Once a response starts
+	// streaming, no total timeout is enforced so long-lived generations are
+	// not cut short.
+	CloudProxyTTFBTimeout = Duration("OLLAMA_CLOUD_PROXY_TTFB_TIMEOUT", 60*time.Second)
+	// CloudProxyIdleConnTimeout bounds how long an idle keep-alive connection
+	// to the cloud proxy is retained before being closed. A short value
+	// proactively evicts stale connections that a load balancer or NAT may
+	// have silently dropped, preventing reuse of half-open connections.
+	CloudProxyIdleConnTimeout = Duration("OLLAMA_CLOUD_PROXY_IDLE_CONN_TIMEOUT", 30*time.Second)
+)
+
 type EnvVar struct {
 	Name        string
 	Value       any
@@ -310,32 +344,35 @@ type EnvVar struct {
 
 func AsMap() map[string]EnvVar {
 	ret := map[string]EnvVar{
-		"OLLAMA_DEBUG":                {"OLLAMA_DEBUG", LogLevel(), "Show additional debug information (e.g. OLLAMA_DEBUG=1)"},
-		"OLLAMA_DEBUG_LOG_REQUESTS":   {"OLLAMA_DEBUG_LOG_REQUESTS", DebugLogRequests(), "Log inference request bodies and replay curl commands to a temp directory"},
-		"OLLAMA_GO_TEMPLATE":          {"OLLAMA_GO_TEMPLATE", GoTemplate(true), "Enable Modelfile TEMPLATE based rendering when available"},
-		"OLLAMA_FLASH_ATTENTION":      {"OLLAMA_FLASH_ATTENTION", FlashAttention(false), "Enabled flash attention"},
-		"OLLAMA_KV_CACHE_TYPE":        {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
-		"OLLAMA_GPU_OVERHEAD":         {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},
-		"OLLAMA_IGPU_ENABLE":          {"OLLAMA_IGPU_ENABLE", String("OLLAMA_IGPU_ENABLE")(), "Enable integrated GPUs"},
-		"LLAMA_ARG_FIT":               {"LLAMA_ARG_FIT", String("LLAMA_ARG_FIT")(), "Enable llama.cpp automatic fit of unset memory options (default \"on\")"},
-		"LLAMA_ARG_FIT_TARGET":        {"LLAMA_ARG_FIT_TARGET", String("LLAMA_ARG_FIT_TARGET")(), "Target free VRAM margin per device for llama.cpp fit (MiB)"},
-		"OLLAMA_HOST":                 {"OLLAMA_HOST", Host(), "IP Address for the ollama server (default 127.0.0.1:11434)"},
-		"OLLAMA_KEEP_ALIVE":           {"OLLAMA_KEEP_ALIVE", KeepAlive(), "The duration that models stay loaded in memory (default \"5m\")"},
-		"OLLAMA_LLM_LIBRARY":          {"OLLAMA_LLM_LIBRARY", LLMLibrary(), "Set LLM library to bypass autodetection"},
-		"OLLAMA_LOAD_TIMEOUT":         {"OLLAMA_LOAD_TIMEOUT", LoadTimeout(), "How long to allow model loads to stall before giving up (default \"5m\")"},
-		"OLLAMA_MAX_LOADED_MODELS":    {"OLLAMA_MAX_LOADED_MODELS", MaxRunners(), "Maximum number of loaded models per GPU"},
-		"OLLAMA_MAX_TRANSFER_STREAMS": {"OLLAMA_MAX_TRANSFER_STREAMS", MaxTransferStreams(), "Maximum parallel transfer streams for safetensors model pulls/pushes (default 4)"},
-		"OLLAMA_MAX_QUEUE":            {"OLLAMA_MAX_QUEUE", MaxQueue(), "Maximum number of queued requests"},
-		"OLLAMA_MODELS":               {"OLLAMA_MODELS", Models(), "The path to the models directory"},
-		"OLLAMA_NO_CLOUD":             {"OLLAMA_NO_CLOUD", NoCloud(), "Disable Ollama cloud features (remote inference and web search)"},
-		"OLLAMA_NOHISTORY":            {"OLLAMA_NOHISTORY", NoHistory(), "Do not preserve readline history"},
-		"OLLAMA_NOPRUNE":              {"OLLAMA_NOPRUNE", NoPrune(), "Do not prune model blobs on startup"},
-		"OLLAMA_NUM_PARALLEL":         {"OLLAMA_NUM_PARALLEL", NumParallel(), "Maximum number of parallel requests"},
-		"OLLAMA_ORIGINS":              {"OLLAMA_ORIGINS", AllowedOrigins(), "A comma separated list of allowed origins"},
-		"OLLAMA_SCHED_SPREAD":         {"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
-		"OLLAMA_CONTEXT_LENGTH":       {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4k/32k/256k based on VRAM)"},
-		"OLLAMA_EDITOR":               {"OLLAMA_EDITOR", Editor(), "Path to editor for interactive prompt editing (Ctrl+G)"},
-		"OLLAMA_REMOTES":              {"OLLAMA_REMOTES", Remotes(), "Allowed hosts for remote models (default \"ollama.com\")"},
+		"OLLAMA_DEBUG":                         {"OLLAMA_DEBUG", LogLevel(), "Show additional debug information (e.g. OLLAMA_DEBUG=1)"},
+		"OLLAMA_DEBUG_LOG_REQUESTS":            {"OLLAMA_DEBUG_LOG_REQUESTS", DebugLogRequests(), "Log inference request bodies and replay curl commands to a temp directory"},
+		"OLLAMA_GO_TEMPLATE":                   {"OLLAMA_GO_TEMPLATE", GoTemplate(true), "Enable Modelfile TEMPLATE based rendering when available"},
+		"OLLAMA_FLASH_ATTENTION":               {"OLLAMA_FLASH_ATTENTION", FlashAttention(false), "Enabled flash attention"},
+		"OLLAMA_KV_CACHE_TYPE":                 {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
+		"OLLAMA_GPU_OVERHEAD":                  {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},
+		"OLLAMA_IGPU_ENABLE":                   {"OLLAMA_IGPU_ENABLE", String("OLLAMA_IGPU_ENABLE")(), "Enable integrated GPUs"},
+		"LLAMA_ARG_FIT":                        {"LLAMA_ARG_FIT", String("LLAMA_ARG_FIT")(), "Enable llama.cpp automatic fit of unset memory options (default \"on\")"},
+		"LLAMA_ARG_FIT_TARGET":                 {"LLAMA_ARG_FIT_TARGET", String("LLAMA_ARG_FIT_TARGET")(), "Target free VRAM margin per device for llama.cpp fit (MiB)"},
+		"OLLAMA_HOST":                          {"OLLAMA_HOST", Host(), "IP Address for the ollama server (default 127.0.0.1:11434)"},
+		"OLLAMA_KEEP_ALIVE":                    {"OLLAMA_KEEP_ALIVE", KeepAlive(), "The duration that models stay loaded in memory (default \"5m\")"},
+		"OLLAMA_LLM_LIBRARY":                   {"OLLAMA_LLM_LIBRARY", LLMLibrary(), "Set LLM library to bypass autodetection"},
+		"OLLAMA_LOAD_TIMEOUT":                  {"OLLAMA_LOAD_TIMEOUT", LoadTimeout(), "How long to allow model loads to stall before giving up (default \"5m\")"},
+		"OLLAMA_MAX_LOADED_MODELS":             {"OLLAMA_MAX_LOADED_MODELS", MaxRunners(), "Maximum number of loaded models per GPU"},
+		"OLLAMA_MAX_TRANSFER_STREAMS":          {"OLLAMA_MAX_TRANSFER_STREAMS", MaxTransferStreams(), "Maximum parallel transfer streams for safetensors model pulls/pushes (default 4)"},
+		"OLLAMA_MAX_QUEUE":                     {"OLLAMA_MAX_QUEUE", MaxQueue(), "Maximum number of queued requests"},
+		"OLLAMA_MODELS":                        {"OLLAMA_MODELS", Models(), "The path to the models directory"},
+		"OLLAMA_NO_CLOUD":                      {"OLLAMA_NO_CLOUD", NoCloud(), "Disable Ollama cloud features (remote inference and web search)"},
+		"OLLAMA_NOHISTORY":                     {"OLLAMA_NOHISTORY", NoHistory(), "Do not preserve readline history"},
+		"OLLAMA_NOPRUNE":                       {"OLLAMA_NOPRUNE", NoPrune(), "Do not prune model blobs on startup"},
+		"OLLAMA_NUM_PARALLEL":                  {"OLLAMA_NUM_PARALLEL", NumParallel(), "Maximum number of parallel requests"},
+		"OLLAMA_ORIGINS":                       {"OLLAMA_ORIGINS", AllowedOrigins(), "A comma separated list of allowed origins"},
+		"OLLAMA_SCHED_SPREAD":                  {"OLLAMA_SCHED_SPREAD", SchedSpread(), "Always schedule model across all GPUs"},
+		"OLLAMA_CONTEXT_LENGTH":                {"OLLAMA_CONTEXT_LENGTH", ContextLength(), "Context length to use unless otherwise specified (default: 4k/32k/256k based on VRAM)"},
+		"OLLAMA_CLOUD_PROXY_CONNECT_TIMEOUT":   {"OLLAMA_CLOUD_PROXY_CONNECT_TIMEOUT", CloudProxyConnectTimeout(), "Timeout for establishing a connection to the cloud proxy (default \"10s\")"},
+		"OLLAMA_CLOUD_PROXY_TTFB_TIMEOUT":      {"OLLAMA_CLOUD_PROXY_TTFB_TIMEOUT", CloudProxyTTFBTimeout(), "Timeout for the first response byte from the cloud proxy (default \"60s\")"},
+		"OLLAMA_CLOUD_PROXY_IDLE_CONN_TIMEOUT": {"OLLAMA_CLOUD_PROXY_IDLE_CONN_TIMEOUT", CloudProxyIdleConnTimeout(), "How long an idle cloud proxy connection is kept alive (default \"30s\")"},
+		"OLLAMA_EDITOR":                        {"OLLAMA_EDITOR", Editor(), "Path to editor for interactive prompt editing (Ctrl+G)"},
+		"OLLAMA_REMOTES":                       {"OLLAMA_REMOTES", Remotes(), "Allowed hosts for remote models (default \"ollama.com\")"},
 
 		// Informational
 		"HTTP_PROXY":  {"HTTP_PROXY", String("HTTP_PROXY")(), "HTTP proxy"},

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -293,6 +293,57 @@ func TestLoadTimeout(t *testing.T) {
 	}
 }
 
+func TestCloudProxyTimeouts(t *testing.T) {
+	cases := map[string]time.Duration{
+		"":    10 * time.Second,
+		"5s":  5 * time.Second,
+		"1m":  time.Minute,
+		"120": 2 * time.Minute,
+		"???": 10 * time.Second,
+		"1d":  10 * time.Second,
+	}
+	for tt, expect := range cases {
+		t.Run("connect/"+tt, func(t *testing.T) {
+			t.Setenv("OLLAMA_CLOUD_PROXY_CONNECT_TIMEOUT", tt)
+			if actual := CloudProxyConnectTimeout(); actual != expect {
+				t.Errorf("expected %s, got %s", expect, actual)
+			}
+		})
+	}
+
+	ttfbCases := map[string]time.Duration{
+		"":    60 * time.Second,
+		"5s":  5 * time.Second,
+		"1m":  time.Minute,
+		"120": 2 * time.Minute,
+		"???": 60 * time.Second,
+	}
+	for tt, expect := range ttfbCases {
+		t.Run("ttfb/"+tt, func(t *testing.T) {
+			t.Setenv("OLLAMA_CLOUD_PROXY_TTFB_TIMEOUT", tt)
+			if actual := CloudProxyTTFBTimeout(); actual != expect {
+				t.Errorf("expected %s, got %s", expect, actual)
+			}
+		})
+	}
+
+	idleCases := map[string]time.Duration{
+		"":    30 * time.Second,
+		"5s":  5 * time.Second,
+		"1m":  time.Minute,
+		"120": 2 * time.Minute,
+		"???": 30 * time.Second,
+	}
+	for tt, expect := range idleCases {
+		t.Run("idle/"+tt, func(t *testing.T) {
+			t.Setenv("OLLAMA_CLOUD_PROXY_IDLE_CONN_TIMEOUT", tt)
+			if actual := CloudProxyIdleConnTimeout(); actual != expect {
+				t.Errorf("expected %s, got %s", expect, actual)
+			}
+		})
+	}
+}
+
 func TestVar(t *testing.T) {
 	cases := map[string]string{
 		"value":       "value",

--- a/server/cloud_proxy.go
+++ b/server/cloud_proxy.go
@@ -37,16 +37,6 @@ const (
 )
 
 var (
-	// cloudProxyConnectTimeout bounds the time to establish a TCP connection
-	// to the cloud proxy, including TLS handshake.
-	cloudProxyConnectTimeout = 10 * time.Second
-
-	// cloudProxyResponseHeaderTimeout bounds the time to receive the first
-	// response byte (TTFB) from the cloud proxy. Once the response starts
-	// streaming, no total timeout is enforced so long-lived generations are
-	// not cut short.
-	cloudProxyResponseHeaderTimeout = 60 * time.Second
-
 	cloudProxyBaseURL     = defaultCloudProxyBaseURL
 	cloudProxySigningHost = defaultCloudProxySigningHost
 	cloudProxySignRequest = signCloudProxyRequest
@@ -83,18 +73,21 @@ func init() {
 }
 
 // newCloudProxyHTTPClient returns the client used to forward requests to the
-// cloud proxy. Connect and response-header (TTFB) phases are bounded so a
-// stalled upstream fails fast instead of hanging the request indefinitely.
-// No total timeout is set: once a response starts streaming, long-lived
+// cloud proxy. Connect, TLS, and response-header (TTFB) phases are bounded so
+// a stalled upstream fails fast instead of hanging the request indefinitely.
+// Idle keep-alive connections are evicted after a short window so stale
+// connections silently dropped by a load balancer or NAT are not reused. No
+// total timeout is set: once a response starts streaming, long-lived
 // generations must be allowed to run to completion.
 func newCloudProxyHTTPClient() *http.Client {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.DialContext = (&net.Dialer{
-		Timeout:   cloudProxyConnectTimeout,
+		Timeout:   envconfig.CloudProxyConnectTimeout(),
 		KeepAlive: 30 * time.Second,
 	}).DialContext
-	transport.TLSHandshakeTimeout = cloudProxyConnectTimeout
-	transport.ResponseHeaderTimeout = cloudProxyResponseHeaderTimeout
+	transport.TLSHandshakeTimeout = envconfig.CloudProxyConnectTimeout()
+	transport.ResponseHeaderTimeout = envconfig.CloudProxyTTFBTimeout()
+	transport.IdleConnTimeout = envconfig.CloudProxyIdleConnTimeout()
 
 	return &http.Client{Transport: transport}
 }

--- a/server/cloud_proxy.go
+++ b/server/cloud_proxy.go
@@ -37,10 +37,21 @@ const (
 )
 
 var (
+	// cloudProxyConnectTimeout bounds the time to establish a TCP connection
+	// to the cloud proxy, including TLS handshake.
+	cloudProxyConnectTimeout = 10 * time.Second
+
+	// cloudProxyResponseHeaderTimeout bounds the time to receive the first
+	// response byte (TTFB) from the cloud proxy. Once the response starts
+	// streaming, no total timeout is enforced so long-lived generations are
+	// not cut short.
+	cloudProxyResponseHeaderTimeout = 60 * time.Second
+
 	cloudProxyBaseURL     = defaultCloudProxyBaseURL
 	cloudProxySigningHost = defaultCloudProxySigningHost
 	cloudProxySignRequest = signCloudProxyRequest
 	cloudProxySigninURL   = signinURL
+	cloudProxyHTTPClient  = newCloudProxyHTTPClient()
 )
 
 var hopByHopHeaders = map[string]struct{}{
@@ -69,6 +80,23 @@ func init() {
 	if overridden {
 		slog.Info("cloud base URL override enabled", "env", cloudProxyBaseURLEnv, "url", cloudProxyBaseURL, "mode", mode)
 	}
+}
+
+// newCloudProxyHTTPClient returns the client used to forward requests to the
+// cloud proxy. Connect and response-header (TTFB) phases are bounded so a
+// stalled upstream fails fast instead of hanging the request indefinitely.
+// No total timeout is set: once a response starts streaming, long-lived
+// generations must be allowed to run to completion.
+func newCloudProxyHTTPClient() *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = (&net.Dialer{
+		Timeout:   cloudProxyConnectTimeout,
+		KeepAlive: 30 * time.Second,
+	}).DialContext
+	transport.TLSHandshakeTimeout = cloudProxyConnectTimeout
+	transport.ResponseHeaderTimeout = cloudProxyResponseHeaderTimeout
+
+	return &http.Client{Transport: transport}
 }
 
 func cloudPassthroughMiddleware(disabledOperation string) gin.HandlerFunc {
@@ -214,10 +242,10 @@ func proxyCloudRequestWithPath(c *gin.Context, body []byte, path string, disable
 		return
 	}
 
-	// TODO(drifkin): Add phase-specific proxy timeouts.
-	// Connect/TLS/TTFB should have bounded timeouts, but once streaming starts
-	// we should not enforce a short total timeout for long-lived responses.
-	resp, err := http.DefaultClient.Do(outReq)
+	// Connect, TLS, and TTFB are bounded by cloudProxyHTTPClient. Once the
+	// response starts streaming, no total timeout is enforced so long-lived
+	// generations are not cut short.
+	resp, err := cloudProxyHTTPClient.Do(outReq)
 	if err != nil {
 		c.JSON(http.StatusBadGateway, gin.H{"error": err.Error()})
 		return

--- a/server/cloud_proxy_test.go
+++ b/server/cloud_proxy_test.go
@@ -334,14 +334,12 @@ func TestCloudProxyTTFBTimeoutFailsFast(t *testing.T) {
 	defer upstream.Close()
 
 	originalBaseURL := cloudProxyBaseURL
-	originalTimeout := cloudProxyResponseHeaderTimeout
 	originalClient := cloudProxyHTTPClient
 	cloudProxyBaseURL = upstream.URL
-	cloudProxyResponseHeaderTimeout = 200 * time.Millisecond
+	t.Setenv("OLLAMA_CLOUD_PROXY_TTFB_TIMEOUT", "200ms")
 	cloudProxyHTTPClient = newCloudProxyHTTPClient()
 	t.Cleanup(func() {
 		cloudProxyBaseURL = originalBaseURL
-		cloudProxyResponseHeaderTimeout = originalTimeout
 		cloudProxyHTTPClient = originalClient
 	})
 
@@ -375,5 +373,22 @@ func TestCloudProxyTTFBTimeoutFailsFast(t *testing.T) {
 	// The request must fail fast (bounded by the TTFB timeout), not hang.
 	if elapsed > 5*time.Second {
 		t.Fatalf("expected fast failure, took %v", elapsed)
+	}
+}
+
+// TestCloudProxyHTTPClientIdleConnTimeout verifies that the idle-connection
+// timeout is wired into the cloud proxy transport, so stale keep-alive
+// connections are evicted rather than reused.
+func TestCloudProxyHTTPClientIdleConnTimeout(t *testing.T) {
+	t.Setenv("OLLAMA_CLOUD_PROXY_IDLE_CONN_TIMEOUT", "45s")
+
+	client := newCloudProxyHTTPClient()
+	transport, ok := client.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", client.Transport)
+	}
+
+	if got := transport.IdleConnTimeout; got != 45*time.Second {
+		t.Fatalf("expected idle conn timeout 45s, got %v", got)
 	}
 }

--- a/server/cloud_proxy_test.go
+++ b/server/cloud_proxy_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/klauspost/compress/zstd"
@@ -315,4 +316,64 @@ func (r *chunkRecorder) Write(p []byte) (int, error) {
 	cp := append([]byte(nil), p...)
 	r.chunks = append(r.chunks, cp)
 	return len(p), nil
+}
+
+// TestCloudProxyTTFBTimeoutFailsFast verifies that a cloud upstream that
+// accepts the connection but never sends a response header is aborted by the
+// response-header timeout instead of hanging the request indefinitely.
+func TestCloudProxyTTFBTimeoutFailsFast(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	setTestHome(t, t.TempDir())
+
+	// A handler that reads the request but never writes a response, simulating
+	// a stalled cloud upstream.
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.Copy(io.Discard, r.Body)
+		<-r.Context().Done()
+	}))
+	defer upstream.Close()
+
+	originalBaseURL := cloudProxyBaseURL
+	originalTimeout := cloudProxyResponseHeaderTimeout
+	originalClient := cloudProxyHTTPClient
+	cloudProxyBaseURL = upstream.URL
+	cloudProxyResponseHeaderTimeout = 200 * time.Millisecond
+	cloudProxyHTTPClient = newCloudProxyHTTPClient()
+	t.Cleanup(func() {
+		cloudProxyBaseURL = originalBaseURL
+		cloudProxyResponseHeaderTimeout = originalTimeout
+		cloudProxyHTTPClient = originalClient
+	})
+
+	s := &Server{}
+	router, err := s.GenerateRoutes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	local := httptest.NewServer(router)
+	defer local.Close()
+
+	reqBody := `{"model":"kimi-k2.5:cloud","prompt":"hello","stream":false}`
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodPost, local.URL+"/api/generate", bytes.NewBufferString(reqBody))
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	start := time.Now()
+	resp, err := local.Client().Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	elapsed := time.Since(start)
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("expected status 502, got %d", resp.StatusCode)
+	}
+
+	// The request must fail fast (bounded by the TTFB timeout), not hang.
+	if elapsed > 5*time.Second {
+		t.Fatalf("expected fast failure, took %v", elapsed)
+	}
 }


### PR DESCRIPTION
## Problem

Cloud models (`:cloud` suffix) wedge after sustained use. The cloud proxy forwards requests with `http.DefaultClient`, which has no timeout. When the cloud upstream stalls, the request hangs indefinitely with no recovery — `POST /api/generate` receives the request and never sends a status line, and the connection just dies.

Fixes #18381.

## Change

Bound the connect/TLS and response-header (TTFB) phases of the cloud proxy client, while leaving the streaming phase unbounded so long-lived generations are not cut short.

- Connect + TLS handshake: 10s
- TTFB (first response byte): 60s
- Streaming: unbounded

This replaces the `// TODO(drifkin): Add phase-specific proxy timeouts` comment that was already in the code.

## Test

Added `TestCloudProxyTTFBTimeoutFailsFast`, which points the proxy at an upstream that accepts the connection but never writes a response, and asserts the request fails fast with 502 instead of hanging.

Verified red/green: with `http.DefaultClient` the test hangs and times out; with the bounded client it returns 502 in ~200ms.

## Verification

- `go test -race ./server/` — pass
- `golangci-lint run ./server/...` — 0 issues
- `go mod tidy --diff` — clean
- `gofmt` / `go vet` — clean
