### PR TITLE
app: gate Codex Settings recommendations on integration use

### DIFF
--- a/app/cmd/app/codex_app_darwin.go
+++ b/app/cmd/app/codex_app_darwin.go
@@ -232,7 +232,12 @@ func getCodexDesktopModelsSettings() (codexDesktopModelsSettings, error) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	inventory, err := loadCodexDesktopModelInventory(ctx)
+	includeRecommendations := false
+	if hasUsedCodexDesktopIntegration() {
+		access, err := codexDesktopAccessState(ctx)
+		includeRecommendations = err == nil && access.Cloud == proxy.ClaudeDesktopCloudOn
+	}
+	inventory, err := loadCodexDesktopModelInventory(ctx, includeRecommendations)
 	if err != nil {
 		return settings, err
 	}
@@ -333,7 +338,7 @@ func applyCodexDesktopModelsLocked(selected []string, restartConfirmed, openWhen
 }
 
 func loadCodexDesktopModels(ctx context.Context, selected []string) (string, []launch.LaunchModel, error) {
-	inventory, err := loadCodexDesktopModelInventory(ctx)
+	inventory, err := loadCodexDesktopModelInventory(ctx, true)
 	if err != nil {
 		return "", nil, err
 	}
@@ -349,7 +354,7 @@ func loadCodexDesktopModels(ctx context.Context, selected []string) (string, []l
 }
 
 func loadCodexDesktopConnectionModels(ctx context.Context, selected []string) (string, []launch.LaunchModel, error) {
-	inventory, err := loadCodexDesktopModelInventory(ctx)
+	inventory, err := loadCodexDesktopModelInventory(ctx, true)
 	if err != nil {
 		return "", nil, err
 	}
@@ -389,19 +394,22 @@ func hydrateCodexDesktopModelCapabilities(ctx context.Context, models []launch.L
 }
 
 func loadCodexDesktopAvailableModels(ctx context.Context) ([]launch.LaunchModel, error) {
-	inventory, err := loadCodexDesktopModelInventory(ctx)
+	inventory, err := loadCodexDesktopModelInventory(ctx, true)
 	return inventory.Available, err
 }
 
-func loadCodexDesktopModelInventory(ctx context.Context) (codexDesktopModelInventory, error) {
+func loadCodexDesktopModelInventory(ctx context.Context, includeRecommendations bool) (codexDesktopModelInventory, error) {
 	client, err := codexDesktopClientFactory()
 	if err != nil {
 		return codexDesktopModelInventory{}, err
 	}
 
-	recommendations, recommendationsErr := codexDesktopRecommendations(ctx)
-	if recommendationsErr != nil {
-		slog.Debug("could not load ChatGPT model recommendations", "error", recommendationsErr)
+	var recommendations []api.ModelRecommendation
+	if includeRecommendations {
+		recommendations, err = codexDesktopRecommendations(ctx)
+		if err != nil {
+			slog.Debug("could not load ChatGPT model recommendations", "error", err)
+		}
 	}
 	var access proxy.ClaudeDesktopAccessState
 	accessKnown := false
@@ -431,8 +439,9 @@ func loadCodexDesktopModelInventory(ctx context.Context) (codexDesktopModelInven
 		}
 
 		last = buildCodexDesktopModelInventory(recommendations, listed, accountCloud, access, accessKnown, listKnown, cloudKnown)
+		// Settings may have no models when recommendation discovery is disabled.
 		// Retry access lookup failures even when recommendations are available.
-		if len(last.Available) > 0 && (accessKnown || attempt+1 == codexDesktopModelLoadAttempts) {
+		if (len(last.Available) > 0 || (!includeRecommendations && listKnown && cloudKnown)) && (accessKnown || attempt+1 == codexDesktopModelLoadAttempts) {
 			return last, nil
 		}
 		if attempt+1 == codexDesktopModelLoadAttempts {

--- a/app/cmd/app/codex_app_darwin.go
+++ b/app/cmd/app/codex_app_darwin.go
@@ -232,18 +232,18 @@ func getCodexDesktopModelsSettings() (codexDesktopModelsSettings, error) {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	includeRecommendations := false
-	if hasUsedCodexDesktopIntegration() {
-		access, err := codexDesktopAccessState(ctx)
-		includeRecommendations = err == nil && access.Cloud == proxy.ClaudeDesktopCloudOn
-	}
-	inventory, err := loadCodexDesktopModelInventory(ctx, includeRecommendations)
+	inventory, err := loadCodexDesktopModelInventory(ctx, false)
 	if err != nil {
 		return settings, err
 	}
 	settings.Available = codexDesktopModelNames(inventory.Available)
 	if len(settings.Selected) == 0 {
 		settings.Selected = codexDesktopModelNames(codexDesktopDefaultModels(inventory))
+		// Start must send a displayed fallback explicitly, since its recommendation
+		// discovery may produce different defaults than this Settings inventory.
+		settings.UsesDefaults = slices.ContainsFunc(inventory.Catalog, func(model codexDesktopCatalogModel) bool {
+			return model.Recommended
+		})
 	}
 	settings.Models = codexDesktopModelStatuses(inventory, settings.Selected)
 	return settings, nil
@@ -398,19 +398,20 @@ func loadCodexDesktopAvailableModels(ctx context.Context) ([]launch.LaunchModel,
 	return inventory.Available, err
 }
 
-func loadCodexDesktopModelInventory(ctx context.Context, includeRecommendations bool) (codexDesktopModelInventory, error) {
+// Explicit connection and apply flows force recommendations; Settings requires
+// prior integration use and a successful Cloud On access lookup.
+func loadCodexDesktopModelInventory(ctx context.Context, forceRecommendations bool) (codexDesktopModelInventory, error) {
 	client, err := codexDesktopClientFactory()
 	if err != nil {
 		return codexDesktopModelInventory{}, err
 	}
 
-	var recommendations []api.ModelRecommendation
-	if includeRecommendations {
-		recommendations, err = codexDesktopRecommendations(ctx)
-		if err != nil {
-			slog.Debug("could not load ChatGPT model recommendations", "error", err)
-		}
+	used := false
+	if !forceRecommendations {
+		used = hasUsedCodexDesktopIntegration()
 	}
+	var recommendations []api.ModelRecommendation
+	recommendationsRequested := false
 	var access proxy.ClaudeDesktopAccessState
 	accessKnown := false
 	var last codexDesktopModelInventory
@@ -422,6 +423,15 @@ func loadCodexDesktopModelInventory(ctx context.Context, includeRecommendations 
 				accessKnown = true
 			} else {
 				slog.Debug("could not determine ChatGPT model access", "error", accessErr)
+			}
+		}
+
+		includeRecommendations := forceRecommendations || (used && accessKnown && access.Cloud == proxy.ClaudeDesktopCloudOn)
+		if includeRecommendations && !recommendationsRequested {
+			recommendationsRequested = true
+			recommendations, err = codexDesktopRecommendations(ctx)
+			if err != nil {
+				slog.Debug("could not load ChatGPT model recommendations", "error", err)
 			}
 		}
 

--- a/app/cmd/app/codex_app_darwin_test.go
+++ b/app/cmd/app/codex_app_darwin_test.go
@@ -1175,6 +1175,133 @@ func TestCodexDesktopSettingsRecommendationEligibility(t *testing.T) {
 	}
 }
 
+func TestCodexDesktopSettingsStartSelectionAndAccessRecovery(t *testing.T) {
+	for _, tt := range []struct {
+		name           string
+		used           bool
+		empty          bool
+		running        bool
+		cloud          proxy.ClaudeDesktopCloudStatus
+		accessFailures int
+		wantSelected   []string
+		wantDefaults   bool
+		wantFetches    int
+	}{
+		{name: "unused local fallback", cloud: proxy.ClaudeDesktopCloudOn, wantSelected: []string{"qwen3:8b"}},
+		{name: "cloud off local fallback", used: true, cloud: proxy.ClaudeDesktopCloudOff, wantSelected: []string{"qwen3:8b"}},
+		{name: "cloud on after access recovery", used: true, empty: true, cloud: proxy.ClaudeDesktopCloudOn, accessFailures: 1, wantSelected: []string{"recommended:cloud"}, wantDefaults: true, wantFetches: 1},
+		{name: "restart after access recovery", used: true, running: true, empty: true, cloud: proxy.ClaudeDesktopCloudOn, accessFailures: 1, wantSelected: []string{"recommended:cloud"}, wantDefaults: true, wantFetches: 1},
+		{name: "cloud off after access recovery", used: true, empty: true, cloud: proxy.ClaudeDesktopCloudOff, accessFailures: 1},
+		{name: "unused after access recovery", empty: true, cloud: proxy.ClaudeDesktopCloudOn, accessFailures: 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			previousStore := appStore
+			previousController := codexDesktop
+			previousClientFactory := codexDesktopClientFactory
+			previousCloudModels := codexDesktopCloudModels
+			previousAttempts := codexDesktopModelLoadAttempts
+			previousWait := codexDesktopModelRetryWait
+			appStore = &store.Store{DBPath: filepath.Join(t.TempDir(), "db.sqlite")}
+			t.Cleanup(func() {
+				appStore.Close()
+				appStore = previousStore
+				codexDesktop = previousController
+				codexDesktopClientFactory = previousClientFactory
+				codexDesktopCloudModels = previousCloudModels
+				codexDesktopModelLoadAttempts = previousAttempts
+				codexDesktopModelRetryWait = previousWait
+			})
+			if tt.used {
+				if err := markCodexDesktopIntegrationUsed(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			controller := &fakeCodexDesktopController{installed: true, configured: tt.running, running: tt.running}
+			codexDesktop = controller
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/tags":
+					if tt.empty {
+						_, _ = w.Write([]byte(`{"models":[]}`))
+					} else {
+						_, _ = w.Write([]byte(`{"models":[{"name":"qwen3:8b"}]}`))
+					}
+				case "/api/show":
+					_, _ = w.Write([]byte(`{"capabilities":["completion"]}`))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+			base, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			client := api.NewClient(base, server.Client())
+			codexDesktopClientFactory = func() (*api.Client, error) { return client, nil }
+			codexDesktopCloudModels = func(context.Context) ([]string, error) { return nil, nil }
+			access := proxy.ClaudeDesktopAccessState{Cloud: tt.cloud, Account: proxy.ClaudeDesktopAccountSignedIn, Plan: "free"}
+			stubCodexDesktopCatalogSources(t, nil, access)
+			accessRequests := 0
+			codexDesktopAccessState = func(context.Context) (proxy.ClaudeDesktopAccessState, error) {
+				accessRequests++
+				if accessRequests <= tt.accessFailures {
+					return proxy.ClaudeDesktopAccessState{}, errors.New("server restarting")
+				}
+				return access, nil
+			}
+			fetches := 0
+			codexDesktopRecommendations = func(context.Context) ([]api.ModelRecommendation, error) {
+				fetches++
+				return []api.ModelRecommendation{{Model: "recommended:cloud", RequiredPlan: "free"}}, nil
+			}
+			codexDesktopModelLoadAttempts = 2
+			codexDesktopModelRetryWait = time.Millisecond
+
+			settings, err := getCodexDesktopModelsSettings()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Equal(settings.Selected, tt.wantSelected) || settings.UsesDefaults != tt.wantDefaults {
+				t.Fatalf("selected = %v, usesDefaults = %v; want %v, %v", settings.Selected, settings.UsesDefaults, tt.wantSelected, tt.wantDefaults)
+			}
+			if fetches != tt.wantFetches {
+				t.Fatalf("Settings recommendation fetches = %d, want %d", fetches, tt.wantFetches)
+			}
+			if len(config.IntegrationModels(codexDesktopIntegrationName)) != 0 || hasUsedCodexDesktopIntegration() != tt.used {
+				t.Fatal("Settings changed saved selection or integration history")
+			}
+			if len(settings.Selected) == 0 {
+				return
+			}
+			// Match Settings' unchanged Start payload: only recommendations stay implicit.
+			selected := settings.Selected
+			if settings.UsesDefaults {
+				selected = nil
+			}
+			wantFetches := tt.wantFetches + 1
+			err = applyCodexDesktopModels(selected, false)
+			if tt.running {
+				if !errors.Is(err, errCodexDesktopRestartConfirmationRequired) {
+					t.Fatalf("Restart error = %v, want confirmation required", err)
+				}
+				err = applyCodexDesktopModels(selected, true)
+				wantFetches++
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !slices.Equal(controller.models, settings.Selected) {
+				t.Fatalf("started models = %v, want displayed selection %v", controller.models, settings.Selected)
+			}
+			if fetches != wantFetches {
+				t.Fatalf("explicit Start did not fetch recommendations: fetches = %d", fetches)
+			}
+		})
+	}
+}
+
 func TestGetCodexDesktopModelsSettingsKeepsSelectionWhenInventoryFails(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	originalController := codexDesktop

--- a/app/cmd/app/codex_app_darwin_test.go
+++ b/app/cmd/app/codex_app_darwin_test.go
@@ -841,6 +841,15 @@ func TestCodexDesktopDefaultsForFreeAccountFollowRecommendationMetadata(t *testi
 
 func TestCodexDesktopAutomaticSelectionFollowsCurrentAccount(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
+	previousStore := appStore
+	appStore = &store.Store{DBPath: filepath.Join(t.TempDir(), "db.sqlite")}
+	t.Cleanup(func() {
+		appStore.Close()
+		appStore = previousStore
+	})
+	if err := markCodexDesktopIntegrationUsed(); err != nil {
+		t.Fatal(err)
+	}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/api/tags" {
 			http.NotFound(w, r)
@@ -1040,6 +1049,132 @@ func TestLoadCodexDesktopRecommendationsUsesCodexQualifier(t *testing.T) {
 	}
 }
 
+func TestCodexDesktopSettingsRecommendationEligibility(t *testing.T) {
+	for _, tt := range []struct {
+		name        string
+		used        bool
+		installed   bool
+		cloud       proxy.ClaudeDesktopCloudStatus
+		account     proxy.ClaudeDesktopAccountStatus
+		empty       bool
+		accessErr   error
+		connect     bool
+		wantFetches int
+	}{
+		{name: "unused and not installed", cloud: proxy.ClaudeDesktopCloudOn},
+		{name: "installed but unused", installed: true, cloud: proxy.ClaudeDesktopCloudOn},
+		{name: "unused with empty inventory", cloud: proxy.ClaudeDesktopCloudOn, empty: true},
+		{name: "used and cloud on", used: true, installed: true, cloud: proxy.ClaudeDesktopCloudOn, account: proxy.ClaudeDesktopAccountSignedIn, wantFetches: 2},
+		{name: "used without current installation", used: true, cloud: proxy.ClaudeDesktopCloudOn, account: proxy.ClaudeDesktopAccountSignedIn, wantFetches: 2},
+		{name: "used and signed out", used: true, cloud: proxy.ClaudeDesktopCloudOn, account: proxy.ClaudeDesktopAccountSignedOut, wantFetches: 2},
+		{name: "used and cloud off", used: true, cloud: proxy.ClaudeDesktopCloudOff},
+		{name: "cloud off with empty inventory", used: true, cloud: proxy.ClaudeDesktopCloudOff, empty: true},
+		{name: "used and cloud unknown", used: true, cloud: proxy.ClaudeDesktopCloudUnknown},
+		{name: "access lookup failed", used: true, cloud: proxy.ClaudeDesktopCloudOn, accessErr: errors.New("access unavailable")},
+		{name: "first explicit connection", installed: true, cloud: proxy.ClaudeDesktopCloudOn, account: proxy.ClaudeDesktopAccountSignedIn, connect: true, wantFetches: 1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("HOME", t.TempDir())
+			previousStore := appStore
+			previousController := codexDesktop
+			previousClientFactory := codexDesktopClientFactory
+			previousCloudModels := codexDesktopCloudModels
+			previousRecommendations := codexDesktopRecommendations
+			previousAccess := codexDesktopAccessState
+			previousAttempts := codexDesktopModelLoadAttempts
+			appStore = &store.Store{DBPath: filepath.Join(t.TempDir(), "db.sqlite")}
+			t.Cleanup(func() {
+				appStore.Close()
+				appStore = previousStore
+				codexDesktop = previousController
+				codexDesktopClientFactory = previousClientFactory
+				codexDesktopCloudModels = previousCloudModels
+				codexDesktopRecommendations = previousRecommendations
+				codexDesktopAccessState = previousAccess
+				codexDesktopModelLoadAttempts = previousAttempts
+			})
+			if tt.used {
+				if err := markCodexDesktopIntegrationUsed(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			codexDesktop = &fakeCodexDesktopController{installed: tt.installed}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/api/tags":
+					if tt.empty {
+						_, _ = w.Write([]byte(`{"models":[]}`))
+						return
+					}
+					_, _ = w.Write([]byte(`{"models":[{"name":"qwen3:8b"}]}`))
+				case "/api/show":
+					_, _ = w.Write([]byte(`{"capabilities":["completion"]}`))
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+			base, err := url.Parse(server.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			client := api.NewClient(base, server.Client())
+			codexDesktopClientFactory = func() (*api.Client, error) { return client, nil }
+			codexDesktopCloudModels = func(context.Context) ([]string, error) { return nil, nil }
+			codexDesktopAccessState = func(context.Context) (proxy.ClaudeDesktopAccessState, error) {
+				return proxy.ClaudeDesktopAccessState{Cloud: tt.cloud, Account: tt.account, Plan: "free"}, tt.accessErr
+			}
+			fetches := 0
+			codexDesktopRecommendations = func(context.Context) ([]api.ModelRecommendation, error) {
+				fetches++
+				return []api.ModelRecommendation{{Model: "recommended:cloud", RequiredPlan: "free"}}, nil
+			}
+			codexDesktopModelLoadAttempts = 1
+
+			if tt.connect {
+				_, models, err := loadCodexDesktopConnectionModels(context.Background(), nil)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if got := codexDesktopModelNames(models); !slices.Equal(got, []string{"recommended:cloud"}) {
+					t.Fatalf("connection models = %v, want first-use recommendations", got)
+				}
+			} else {
+				saved := []string{"qwen3:8b", "saved-missing:cloud"}
+				if err := config.SaveIntegration(codexDesktopIntegrationName, saved); err != nil {
+					t.Fatal(err)
+				}
+				for range 2 {
+					settings, err := getCodexDesktopModelsSettings()
+					if err != nil {
+						t.Fatal(err)
+					}
+					if !slices.Equal(settings.Selected, saved) || settings.UsesDefaults {
+						t.Fatalf("settings = %#v, want preserved explicit selection", settings)
+					}
+					if !tt.empty && !slices.Contains(settings.Available, "qwen3:8b") {
+						t.Fatalf("available = %v, want local model even without recommendations", settings.Available)
+					}
+					if !slices.ContainsFunc(settings.Models, func(model codexDesktopModelStatus) bool {
+						return model.Name == "saved-missing:cloud" && model.Selected
+					}) {
+						t.Fatalf("models = %v, want saved unavailable model retained", settings.Models)
+					}
+				}
+				if got := config.IntegrationModels(codexDesktopIntegrationName); !slices.Equal(got, saved) {
+					t.Fatalf("saved models = %v, want %v", got, saved)
+				}
+			}
+			if fetches != tt.wantFetches {
+				t.Fatalf("recommendation fetches = %d, want %d", fetches, tt.wantFetches)
+			}
+			if hasUsedCodexDesktopIntegration() != tt.used {
+				t.Fatal("model discovery changed the integration use history")
+			}
+		})
+	}
+}
+
 func TestGetCodexDesktopModelsSettingsKeepsSelectionWhenInventoryFails(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	originalController := codexDesktop
@@ -1194,7 +1329,7 @@ func TestLoadCodexDesktopModelInventoryRetriesAccountAccessDuringServerRestart(t
 	codexDesktopModelLoadAttempts = 3
 	codexDesktopModelRetryWait = time.Millisecond
 
-	inventory, err := loadCodexDesktopModelInventory(context.Background())
+	inventory, err := loadCodexDesktopModelInventory(context.Background(), true)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Only fetch Codex recommendations in Settings after the integration has been used and Cloud is confirmed on, matching Claude’s eligibility check. Skip the request for unused integrations, Cloud off or unknown, and failed access lookups.

Preserve local/account models and saved selections, and allow an empty inventory without a refresh warning when recommendations are skipped. Explicit connection and apply flows still fetch recommendations.