### PR TITLE
tools: parse args fields in JSON tool calls

### DIFF
--- a/tools/tools.go
+++ b/tools/tools.go
@@ -297,6 +297,9 @@ func findArguments(tool *api.Tool, buffer []byte) (map[string]any, int) {
 						if args, ok := findMap("arguments", obj); ok {
 							return args, true
 						}
+						if args, ok := findMap("args", obj); ok {
+							return args, true
+						}
 						if args, ok := findMap("parameters", obj); ok {
 							return args, true
 						}

--- a/tools/tools_test.go
+++ b/tools/tools_test.go
@@ -188,6 +188,23 @@ func TestParser(t *testing.T) {
 			},
 		},
 		{
+			name:    "tool call with args alias",
+			inputs:  []string{`<tool_call>{"name": "get_conditions", "args": {"location": "San Francisco"}}</tool_call>`},
+			content: "",
+			tmpl:    qwen,
+			calls: []api.ToolCall{
+				{
+					Function: api.ToolCallFunction{
+						Index: 0,
+						Name:  "get_conditions",
+						Arguments: testArgs(map[string]any{
+							"location": "San Francisco",
+						}),
+					},
+				},
+			},
+		},
+		{
 			name:    "empty args",
 			inputs:  []string{`<tool_call>{"name": "get_conditions", "arguments": {}}</tool_call>`},
 			content: "",


### PR DESCRIPTION
## Summary

Ollama’s generic tool parser already accepts JSON calls whose arguments are under `arguments` or `parameters`, but some tool-capable models emit the equivalent `args` field. When that shape is used, the parser recognizes the tool name but cannot extract its arguments, so the completed call is discarded.

This change treats `args` as another alias and adds a regression test using the existing `<tool_call>` JSON format. It fixes the model behavior reported in #18357 without adding model-specific parsing.

## Validation

- `go test ./tools`
- `go test ./server`
- `git diff --check`

Fixes #18357