### PR TITLE
scripts: store the ollama system user under /var/lib

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -197,7 +197,7 @@ trap install_success EXIT
 configure_systemd() {
     if ! id ollama >/dev/null 2>&1; then
         status "Creating ollama user..."
-        $SUDO useradd -r -s /bin/false -U -m -d /usr/share/ollama ollama
+        $SUDO useradd -r -s /bin/false -U -m -d /var/lib/ollama ollama
     fi
     if getent group render >/dev/null 2>&1; then
         status "Adding ollama user to render group..."


### PR DESCRIPTION
## Summary

New Linux installations currently create the `ollama` system user with `/usr/share/ollama` as its home directory. That places the service user’s default mutable model state under `/usr`, which is read-only on immutable-root distributions such as Fedora Silverblue and can also consume a transient overlay.

Create new users with the FHS state directory `/var/lib/ollama` instead. The installer already skips `useradd` when an `ollama` user exists, so upgrades retain the existing home and model location.

## Validation

- `sh -n scripts/install.sh`
- `git diff --check`

Fixes #18361