### PR TITLE
template: render tool function and parameters as JSON

### DIFF
--- a/template/template.go
+++ b/template/template.go
@@ -422,12 +422,22 @@ type templateToolFunction struct {
 	Parameters  templateToolFunctionParameters `json:"parameters"`
 }
 
+func (t templateToolFunction) String() string {
+	bts, _ := json.Marshal(t)
+	return string(bts)
+}
+
 type templateToolFunctionParameters struct {
 	Type       string             `json:"type"`
 	Defs       any                `json:"$defs,omitempty"`
 	Items      any                `json:"items,omitempty"`
 	Required   []string           `json:"required,omitempty"`
 	Properties templateProperties `json:"properties"`
+}
+
+func (t templateToolFunctionParameters) String() string {
+	bts, _ := json.Marshal(t)
+	return string(bts)
 }
 
 // templateToolCall is a template-compatible representation of api.ToolCall

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -699,6 +699,80 @@ func TestTemplatePropertiesJSON(t *testing.T) {
 	}
 }
 
+func TestTemplateToolFunctionJSON(t *testing.T) {
+	// Test that {{ .Function }} and {{ .Function.Parameters }} output valid JSON,
+	// not Go struct syntax like "{get_weather ... {object <nil> <nil> [city] ...}}"
+	props := api.NewToolPropertiesMap()
+	props.Set("city", api.ToolProperty{Type: api.PropertyType{"string"}, Description: "City name"})
+
+	values := Values{
+		Messages: []api.Message{{Role: "user", Content: "test"}},
+		Tools: api.Tools{{
+			Type: "function",
+			Function: api.ToolFunction{
+				Name:        "get_weather",
+				Description: "Get current weather for a city",
+				Parameters: api.ToolFunctionParameters{
+					Type:       "object",
+					Required:   []string{"city"},
+					Properties: props,
+				},
+			},
+		}},
+	}
+
+	render := func(t *testing.T, s string) string {
+		t.Helper()
+		// Note: template must reference .Messages to trigger the modern code path that converts Tools
+		tmpl, err := Parse(`{{- range .Messages }}{{- end }}{{- range .Tools }}` + s + `{{- end }}`)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		var buf bytes.Buffer
+		if err := tmpl.Execute(&buf, values); err != nil {
+			t.Fatal(err)
+		}
+		return buf.String()
+	}
+
+	parameters := `{"type":"object","required":["city"],"properties":{"city":{"type":"string","description":"City name"}}}`
+	function := `{"name":"get_weather","description":"Get current weather for a city","parameters":` + parameters + `}`
+
+	cases := []struct {
+		name     string
+		template string
+		expected string
+	}{
+		{"function", `{{ .Function }}`, function},
+		{"function parameters", `{{ .Function.Parameters }}`, parameters},
+		{"json function", `{{ json .Function }}`, function},
+	}
+
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			got := render(t, tt.template)
+
+			var gotJSON, expectedJSON any
+			if err := json.Unmarshal([]byte(got), &gotJSON); err != nil {
+				t.Fatalf("not valid JSON: %s, error: %v", got, err)
+			}
+			if err := json.Unmarshal([]byte(tt.expected), &expectedJSON); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(gotJSON, expectedJSON); diff != "" {
+				t.Errorf("mismatch (-got +want):\n%s", diff)
+			}
+		})
+	}
+
+	t.Run("function name", func(t *testing.T) {
+		if got := render(t, `{{ .Function.Name }}`); got != "get_weather" {
+			t.Errorf("got %q, want %q", got, "get_weather")
+		}
+	})
+}
+
 func TestTemplateArgumentsRange(t *testing.T) {
 	// Test that we can range over Arguments in templates
 	tmpl := `{{- range .Messages }}{{- range .ToolCalls }}{{- range $k, $v := .Function.Arguments }}{{ $k }}={{ $v }};{{- end }}{{- end }}{{- end }}`


### PR DESCRIPTION
### What breaks

Since #13525 (e51dead6, first tagged in v0.14.0-rc0), `Template.Execute` passes `.Tools` to Go chat templates as `templateTools` instead of `api.Tools` (`template/template.go:276`). `templateTools`, `templateTool`, `templateArgs` and `templateProperties` print as JSON through their `String()` methods (`template.go:379-409`). `templateToolFunction` and `templateToolFunctionParameters` (`template.go:419-431`) have no `String()` method. So a template line such as the Qwen3 one

```
{"type": "function", "function": {{ .Function }}}
```

renders Go struct syntax:

```
{"type": "function", "function": {get_weather Get current weather for a city {object <nil> <nil> [city] {"city":{"type":"string","description":"City name"}}}}}
```

instead of JSON:

```
{"type": "function", "function": {"name":"get_weather","description":"Get current weather for a city","parameters":{"type":"object","required":["city"],"properties":{"city":{"type":"string","description":"City name"}}}}}
```

`{{ .Function.Parameters }}` has the same problem. #13636 restored JSON for tool-call arguments and parameter properties, and #16031 later added `templateTool.String()`, so `{{ . }}` works. These two types were never covered. The bisect, the affected versions, and which library templates reach this path on main are in https://github.com/ollama/ollama/issues/14601#issuecomment-5636865937.

### Fix

Add `String()` methods to `templateToolFunction` and `templateToolFunctionParameters` that `json.Marshal` the value, the same as the sibling types. `{{ json .Function }}` output is unchanged. Field access (`{{ .Function.Name }}`) and ranging over `.Function.Parameters.Properties` work as before.

### Test

`TestTemplateToolFunctionJSON` in `template/template_test.go` renders a tools template through `Template.Execute`. The template references `.Messages`, so the non-legacy path that converts tools runs. The test checks that:
- `{{ .Function }}`, `{{ .Function.Parameters }}` and `{{ json .Function }}` are valid JSON matching the expected function and parameters objects
- `{{ .Function.Name }}` still renders the bare name

### Related

Fixes #14601

- This fixes Bug 1 of the issue. Bug 2 is struck through there as a client-side problem. The issue's separate `/think`/`/no_think` finding is a change to the model's Modelfile TEMPLATE, which the reporter notes can be made there; this PR does not touch it.
- #14695 made the same change. Its author closed it as stale, with unresolvable merge conflicts after Ollama was restructured, and noted that the fix "is still valid but needs a fresh PR against current main". Its third method, `templateTool.String()`, has since landed in #16031. This PR adds the two remaining methods against current main, with a new test.
- #18318 changes the `String()` receivers of `api.ToolFunction`, `api.ToolFunctionParameters` and `api.ToolCallFunctionArguments` in `api/types.go`. Templates rendered through `Template.Execute` get `templateToolFunction` values built in `convertToolsForTemplate`, not `api.ToolFunction`, so that change doesn't affect this output. The two PRs touch different files.

### How it was tested

On main at b68b112b, with go1.26.0 linux/amd64 (the version `go.mod` requires):
- With the `template.go` change reverted, the new test fails. The `function` subtest reports `not valid JSON: {get_weather Get current weather for a city {object <nil> <nil> [city] ...}}` and `function_parameters` reports `not valid JSON: {object <nil> <nil> [city] ...}`, while `json_function` and `function_name` pass.
- With the change, all four subtests pass.
- `go test ./template/...` and `go test ./thinking/...` pass.
- `go vet ./template/` reports nothing.
- `gofmt -l` and `gofumpt -l` (v0.9.2) print nothing for the changed files.
- `golangci-lint run ./template/...` (v2.13.2, with the repo's `.golangci.yaml`) reports 0 issues.
- Not run: the full `go test ./...`, or any model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015DUJPW1e74y1meH5UePzvU