### PR TITLE
docs: add marbor to Infrastructure & Deployment community list

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,10 @@ console.log(response.message.content);
 - [Koyeb](https://www.koyeb.com/deploy/ollama)
 - [Harbor](https://github.com/av/harbor) - Containerized LLM toolkit with Ollama as default backend
 
+#### Load Balancing
+
+- [marbor](https://github.com/Anirudhx7/marbor) - GPU-aware control plane and warm-state router for self-hosted Ollama/vLLM/TGI/llama.cpp/MLX fleets, with cost-aware cloud overflow
+
 #### Package Managers
 
 - [Pacman](https://archlinux.org/packages/extra/x86_64/ollama/)


### PR DESCRIPTION
Adds marbor (https://github.com/Anirudhx7/marbor) to the Community Integrations section, under a new "Load Balancing" subsection alongside Cloud and Package Managers under Infrastructure & Deployment.

marbor is an Apache-2.0 Go control plane that sits in front of multiple Ollama/vLLM/TGI/llama.cpp/MLX nodes, routing each request to whichever node already has the model warm in VRAM, with optional cost-aware overflow to a cloud provider when local capacity is saturated.

No existing subsection fit cleanly (Cloud and Package Managers are both deployment-target categories, not routing/scheduling), so I added a small "Load Balancing" subsection rather than force it into either.