### PR TITLE
model/parsers: preserve gemma4 object keys containing spaces

### DIFF
--- a/model/parsers/gemma4.go
+++ b/model/parsers/gemma4.go
@@ -473,9 +473,9 @@ func quoteGemma4BareKeys(s string) string {
 
 		keyEnd := gemma4BareKeyEnd(s, i)
 		if keyEnd > i && keyEnd < len(s) && s[keyEnd] == ':' {
-			sb.WriteByte('"')
-			sb.WriteString(s[i:keyEnd])
-			sb.WriteByte('"')
+			key := strings.TrimRightFunc(s[i:keyEnd], unicode.IsSpace)
+			quoted, _ := json.Marshal(key)
+			sb.Write(quoted)
 			sb.WriteByte(':')
 			i = keyEnd + 1
 			continue
@@ -489,7 +489,7 @@ func gemma4BareKeyEnd(s string, start int) int {
 	i := start
 	for i < len(s) {
 		r, size := utf8.DecodeRuneInString(s[i:])
-		if !(r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)) {
+		if !(r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsSpace(r)) {
 			break
 		}
 		i += size

--- a/model/parsers/gemma4_test.go
+++ b/model/parsers/gemma4_test.go
@@ -589,6 +589,43 @@ func TestGemma4Parser_StreamingToolCall(t *testing.T) {
 	}
 }
 
+func TestGemma4Parser_SpacedObjectKeys(t *testing.T) {
+	input := `<|tool_call>call:create_workflow{connections:{Basic LLM Chain:{main:[{node:<|"|>Ollama Chat Model<|"|>}]}, Ollama Chat Model:{main:[]}}}<tool_call|>`
+	expected := []api.ToolCall{{
+		Function: api.ToolCallFunction{
+			Name: "create_workflow",
+			Arguments: testArgs(map[string]any{
+				"connections": map[string]any{
+					"Basic LLM Chain": map[string]any{
+						"main": []any{map[string]any{"node": "Ollama Chat Model"}},
+					},
+					"Ollama Chat Model": map[string]any{"main": []any{}},
+				},
+			}),
+		},
+	}}
+
+	// Include complete input and every possible two-chunk streaming boundary.
+	for split := 0; split <= len(input); split++ {
+		parser := &Gemma4Parser{}
+		parser.Init(nil, nil, nil)
+		var calls []api.ToolCall
+		for i, chunk := range []string{input[:split], input[split:]} {
+			content, _, got, err := parser.Add(chunk, i == 1)
+			if err != nil {
+				t.Fatalf("split %d: Add() error = %v", split, err)
+			}
+			if content != "" {
+				t.Fatalf("split %d: unexpected content %q", split, content)
+			}
+			calls = append(calls, got...)
+		}
+		if diff := cmp.Diff(expected, calls, argsComparer); diff != "" {
+			t.Fatalf("split %d: tool calls mismatch (-want +got):\n%s", split, diff)
+		}
+	}
+}
+
 func TestGemma4Parser_IgnoresExtraToolCallCloseTags(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -814,6 +851,36 @@ func TestGemma4ArgsToJSON(t *testing.T) {
 			name:     "nested_object",
 			input:    `{config:{enabled:true,name:<|"|>test<|"|>}}`,
 			expected: `{"config":{"enabled":true,"name":"test"}}`,
+		},
+		{
+			name:     "bare_keys_with_spaces",
+			input:    `{connections:{Basic LLM Chain:{main:[]}, Ollama Chat Model:{main:[]}}}`,
+			expected: `{"connections":{"Basic LLM Chain":{"main":[]}, "Ollama Chat Model":{"main":[]}}}`,
+		},
+		{
+			name:     "bare_key_with_space_before_colon",
+			input:    "{ display name \t :<|\"|>Demo<|\"|>}",
+			expected: `{ "display name":"Demo"}`,
+		},
+		{
+			name:     "bare_key_with_unicode_words",
+			input:    `{节点 名称:<|"|>Demo<|"|>}`,
+			expected: `{"节点 名称":"Demo"}`,
+		},
+		{
+			name:     "bare_key_with_internal_tab",
+			input:    "{display\tname:1}",
+			expected: `{"display\tname":1}`,
+		},
+		{
+			name:     "quoted_keys_with_spaces",
+			input:    `{<|"|>Basic LLM Chain<|"|>:1,"Ollama Chat Model":2}`,
+			expected: `{"Basic LLM Chain":1,"Ollama Chat Model":2}`,
+		},
+		{
+			name:     "whitespace_is_not_an_empty_bare_key",
+			input:    "{ \t :1}",
+			expected: "{ \t :1}",
 		},
 		{
 			name:     "nested_object_with_space_after_object_open_and_before_bare_key",


### PR DESCRIPTION
Gemma 4 can emit bare object keys containing spaces, such as `Basic LLM Chain` in a workflow's connections map. The key scanner stops at the first space, so the key stays unquoted, JSON decoding fails, and the parser drops the tool call.

Allow whitespace within bare keys, trim whitespace before the separator, and quote the key with `json.Marshal` so embedded tabs remain valid JSON. The scanner still stops at punctuation and structural delimiters.

Fixes #18390.

Tests cover nested spaced keys, Unicode words, whitespace before the colon, embedded tabs, already-quoted keys, and whitespace-only input. A parser regression verifies the complete nested tool call across every possible two-chunk boundary.

Validation on Go 1.26.0, Windows/amd64, against `53fed26112817f7c55f664efb9e3f65f06cab7db`:

- Before the production change, the new parser regression returns no tool calls and four new conversion cases fail.
- `go test ./model/parsers -count=1` passes with the change.
- `go vet ./model/parsers` passes.
- `gofmt -l model/parsers/gemma4.go model/parsers/gemma4_test.go` produces no output.
- `git diff --check` passes.

AI-assisted with OpenAI GPT-6 (Codex). The parser tests above were executed locally; no model or GPU was used.
