### PR TITLE
Add OLLAMA_CONTEXT_SHIFT so a server can refuse over-long prompts

### DIFF
--- a/envconfig/config.go
+++ b/envconfig/config.go
@@ -228,6 +228,10 @@ var (
 	SchedSpread = Bool("OLLAMA_SCHED_SPREAD")
 	// ContextLength sets the default context length
 	ContextLength = Uint("OLLAMA_CONTEXT_LENGTH", 0)
+	// ContextShift sets the default for shifting a prompt that is longer than the context.
+	// A request that sets \"shift\" itself still wins. When off, such a prompt is refused
+	// instead of being silently truncated to part of what was sent.
+	ContextShift = BoolWithDefault("OLLAMA_CONTEXT_SHIFT")
 	// Auth enables authentication between the Ollama client and server
 	UseAuth = Bool("OLLAMA_AUTH")
 	// EnableVulkan controls Vulkan backend discovery.
@@ -314,6 +318,7 @@ func AsMap() map[string]EnvVar {
 		"OLLAMA_DEBUG_LOG_REQUESTS":   {"OLLAMA_DEBUG_LOG_REQUESTS", DebugLogRequests(), "Log inference request bodies and replay curl commands to a temp directory"},
 		"OLLAMA_GO_TEMPLATE":          {"OLLAMA_GO_TEMPLATE", GoTemplate(true), "Enable Modelfile TEMPLATE based rendering when available"},
 		"OLLAMA_FLASH_ATTENTION":      {"OLLAMA_FLASH_ATTENTION", FlashAttention(false), "Enabled flash attention"},
+		"OLLAMA_CONTEXT_SHIFT":        {"OLLAMA_CONTEXT_SHIFT", ContextShift(true), "Shift a prompt longer than the context instead of refusing it (default true)"},
 		"OLLAMA_KV_CACHE_TYPE":        {"OLLAMA_KV_CACHE_TYPE", KvCacheType(), "Quantization type for the K/V cache (default: f16)"},
 		"OLLAMA_GPU_OVERHEAD":         {"OLLAMA_GPU_OVERHEAD", GpuOverhead(), "Reserve a portion of VRAM per GPU (bytes)"},
 		"OLLAMA_IGPU_ENABLE":          {"OLLAMA_IGPU_ENABLE", String("OLLAMA_IGPU_ENABLE")(), "Enable integrated GPUs"},

--- a/envconfig/config_test.go
+++ b/envconfig/config_test.go
@@ -437,3 +437,25 @@ func TestNoCloud(t *testing.T) {
 		})
 	}
 }
+
+func TestContextShift(t *testing.T) {
+	cases := map[string]struct {
+		value string
+		want  bool
+	}{
+		"empty keeps the default":    {"", true},
+		"false refuses long prompts": {"false", false},
+		"zero refuses long prompts":  {"0", false},
+		"true shifts":                {"true", true},
+		"nonsense keeps the default": {"banana", true},
+	}
+
+	for name, tt := range cases {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("OLLAMA_CONTEXT_SHIFT", tt.value)
+			if got := ContextShift(true); got != tt.want {
+				t.Errorf("ContextShift(true) = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/server/sched.go
+++ b/server/sched.go
@@ -131,6 +131,13 @@ func resolveContextShift(shift *bool, m *Model) bool {
 		return *shift
 	}
 
+	// An operator can turn shifting off for the whole server. Without this, every client
+	// has to remember to send \"shift\": false, and one that forgets gets an answer built
+	// from part of its prompt with nothing to say so.
+	if !envconfig.ContextShift(true) {
+		return false
+	}
+
 	return supportsContextShift(m)
 }
 

--- a/server/sched_test.go
+++ b/server/sched_test.go
@@ -926,6 +926,33 @@ func TestResolveContextShift(t *testing.T) {
 	}
 }
 
+func TestResolveContextShiftEnv(t *testing.T) {
+	trueValue := true
+	falseValue := false
+
+	tests := []struct {
+		name  string
+		env   string
+		shift *bool
+		model *Model
+		want  bool
+	}{
+		{name: "env unset keeps shifting", want: true},
+		{name: "env off refuses instead of shifting", env: "false", want: false},
+		{name: "env on keeps shifting", env: "true", want: true},
+		{name: "request wins over env off", env: "false", shift: &trueValue, want: true},
+		{name: "request wins over env on", env: "true", shift: &falseValue, want: false},
+		{name: "env off and deepseek2 still off", env: "false", model: &Model{Config: model.ConfigV2{ModelFamily: "deepseek2"}}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OLLAMA_CONTEXT_SHIFT", tt.env)
+			require.Equal(t, tt.want, resolveContextShift(tt.shift, tt.model))
+		})
+	}
+}
+
 func TestSchedNeedsReloadIgnoresAutomaticNumCtxClamp(t *testing.T) {
 	ctx, done := context.WithTimeout(t.Context(), 100*time.Millisecond)
 	defer done()


### PR DESCRIPTION
## The problem

A prompt longer than the context is shifted: `llm/llama_server.go` cuts it to roughly half the window (`contextShiftPromptLimit`) and answers anyway. The only sign is a `slog.Warn` in the server log. The caller gets HTTP 200, a `prompt_eval_count` that reports the truncated number, and a confident answer built from part of what it sent.

Measured on 0.34.0 (Linux):

| Request | Result today |
|---|---|
| ~12,000-token prompt, `num_ctx` 4096 | 200, `prompt_eval_count: 2050`, empty answer |
| ~120,000-token prompt, `num_ctx` 65536 | 200, `prompt_eval_count: 32770`, plausible answer from a third of the input |

`shift: false` already turns this off per request (#12888), but every client has to remember it, and the OpenAI-compatible endpoints have no field for it. An operator who wants "never answer from a truncated prompt" cannot express that.

## The change

`OLLAMA_CONTEXT_SHIFT` sets the default for the whole server:

- unset → today's behaviour, unchanged;
- `false` → an over-long prompt returns the existing 400 ("the prompt is longer than the context length currently available to the model…");
- a request that sets `shift` still wins, and deepseek2 still never shifts.

Five lines in `resolveContextShift` and `envconfig`, plus tests for both.

## Verified

Built from this branch and run against a 4096-token window:

```
unset:                     HTTP 200, prompt_tokens=2050, answer=''      (1 "truncating input prompt" warning)
OLLAMA_CONTEXT_SHIFT=false: HTTP 400, "the prompt is longer than the context length…"  (no warning)
```

`go test ./envconfig/ ./server/` passes; `gofmt` clean.

Refs #14259 (silent truncation). On the machine where this came up, a truncated request also returned the *previous* request's answer (#17847), so refusing was worth more than any partial answer.

Prepared with an AI assistant; the measurements are from runs on my own machine.
