### PR TITLE
fix: parse Gemma4 tool keys containing spaces

### DIFF
--- a/model/parsers/gemma4.go
+++ b/model/parsers/gemma4.go
@@ -472,9 +472,10 @@ func quoteGemma4BareKeys(s string) string {
 		sb.WriteString(s[spaceStart:i])
 
 		keyEnd := gemma4BareKeyEnd(s, i)
-		if keyEnd > i && keyEnd < len(s) && s[keyEnd] == ':' {
+		key := strings.TrimSpace(s[i:keyEnd])
+		if key != "" && keyEnd < len(s) && s[keyEnd] == ':' {
 			sb.WriteByte('"')
-			sb.WriteString(s[i:keyEnd])
+			sb.WriteString(key)
 			sb.WriteByte('"')
 			sb.WriteByte(':')
 			i = keyEnd + 1
@@ -489,7 +490,7 @@ func gemma4BareKeyEnd(s string, start int) int {
 	i := start
 	for i < len(s) {
 		r, size := utf8.DecodeRuneInString(s[i:])
-		if !(r == '_' || unicode.IsLetter(r) || unicode.IsDigit(r)) {
+		if r == ':' || r == ',' || r == '{' || r == '[' || r == '}' || r == ']' || r == '"' {
 			break
 		}
 		i += size

--- a/model/parsers/gemma4_test.go
+++ b/model/parsers/gemma4_test.go
@@ -942,6 +942,11 @@ func TestGemma4ArgsToJSON(t *testing.T) {
 			input:    `{meta:{title:<|"|>t "1"<|"|>,note:"n \"2\""},items:[<|"|>x "3"<|"|>,"y \"4\""]}`,
 			expected: `{"meta":{"title":"t \"1\"","note":"n \"2\""},"items":["x \"3\"","y \"4\""]}`,
 		},
+		{
+			name:     "bare_key_with_spaces",
+			input:    `{Basic LLM Chain:<|"|>value<|"|>}`,
+			expected: `{"Basic LLM Chain":"value"}`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Parse Gemma 4 bare object keys that contain spaces before the colon.
- Add a regression test for tool-call arguments such as `{"Basic LLM Chain": ...}`.

## Motivation

Gemma 4 tool schemas commonly use display names containing spaces as object keys. The parser previously stopped scanning a bare key at the first space, leaving the key unquoted and causing the entire tool call to be dropped.

Fixes #18390

## Testing

- `gofmt -w model/parsers/gemma4.go model/parsers/gemma4_test.go`
- `go test ./model/parsers -run 'TestGemma4ArgsToJSON|TestGemma4'`
