### PR TITLE
docs: fix usage heading and login typo in onyx guide

### DIFF
--- a/docs/integrations/onyx.mdx
+++ b/docs/integrations/onyx.mdx
@@ -23,9 +23,9 @@ Deploy Onyx with the [quickstart guide](https://docs.onyx.app/deployment/getting
 Resourcing/scaling docs [here](https://docs.onyx.app/deployment/getting_started/resourcing).
 </Info>
 
-## Usage with Ollama 
+## Usage with Ollama
 
-1. Login to your Onyx deployment (create an account first).
+1. Log in to your Onyx deployment (create an account first).
 <div style={{ display: 'flex', justifyContent: 'center' }}>
   <img 
     src="/images/onyx-login.png" 


### PR DESCRIPTION
docs/integrations/onyx.mdx: strip trailing space in 'Usage with Ollama' heading and use verb form 'Log in to your Onyx deployment'. Keeps alt='Onyx Login Page' as-is since it labels the pictured UI.