### PR TITLE
docs: fix copy-pasted zed alt text in jetbrains guide

### DIFF
--- a/docs/integrations/jetbrains.mdx
+++ b/docs/integrations/jetbrains.mdx
@@ -41,7 +41,7 @@ Install [IntelliJ](https://www.jetbrains.com/idea/).
 <div style={{ display: 'flex', justifyContent: 'center' }}>
   <img 
     src="/images/intellij-local-models.png" 
-    alt="Zed star icon in bottom right corner"
+    alt="Intellij local models by Ollama"
     width="50%"
   />
 </div>


### PR DESCRIPTION
docs/integrations/jetbrains.mdx: the intellij-local-models.png image carried alt='Zed star icon in bottom right corner', copy-pasted from zed.mdx (which uses it twice). Replace with alt='Intellij local models by Ollama', matching step 5 ('Local models by Ollama') and the file's Intellij casing.