### PR TITLE
docs: strip trailing whitespace in marimo integration

### DIFF
--- a/docs/integrations/marimo.mdx
+++ b/docs/integrations/marimo.mdx
@@ -4,7 +4,7 @@ title: marimo
 
 ## Install
 
-Install [marimo](https://marimo.io). You can use `pip` or `uv` for this. You 
+Install [marimo](https://marimo.io). You can use `pip` or `uv` for this. You
 can also use `uv` to create a sandboxed environment for marimo by running:
 
 ```
@@ -25,7 +25,7 @@ would typically point the base url to `http://localhost:11434/v1`.
   />
 </div>
 
-2. Once the AI provider is set up, you can turn on/off specific AI models you'd like to access. 
+2. Once the AI provider is set up, you can turn on/off specific AI models you'd like to access.
 
 <div style={{ display: 'flex', justifyContent: 'center' }}>
   <img 
@@ -35,7 +35,7 @@ would typically point the base url to `http://localhost:11434/v1`.
   />
 </div>
 
-3. You can also add a model to the list of available models by scrolling to the bottom and using the UI there. 
+3. You can also add a model to the list of available models by scrolling to the bottom and using the UI there.
 
 <div style={{ display: 'flex', justifyContent: 'center' }}>
   <img 
@@ -68,6 +68,6 @@ would typically point the base url to `http://localhost:11434/v1`.
 
 ## Connecting to ollama.com
 
-1. Sign in to ollama cloud via `ollama signin` 
+1. Sign in to ollama cloud via `ollama signin`
 2. In the ollama model settings add a model that ollama hosts, like `gpt-oss:120b`.
 3. You can now refer to this model in marimo!


### PR DESCRIPTION
Strips trailing whitespace on 4 lines in `docs/integrations/marimo.mdx` (lines 7, 28, 38, 71). No content changes. Line 58 intentionally untouched (covered by #16786).
