### PR TITLE
server: reject invalid embeddings before returning success

### DIFF
--- a/app/ui/app/codegen/gotypes.gen.ts
+++ b/app/ui/app/codegen/gotypes.gen.ts
@@ -418,6 +418,7 @@ export class Settings {
     OnboardingVersion: number;
     AutoUpdateEnabled: boolean;
     ClaudeDesktopUsed: boolean;
+    CodexDesktopUsed: boolean;
 
     constructor(source: any = {}) {
         if ('string' === typeof source) source = JSON.parse(source);
@@ -439,6 +440,7 @@ export class Settings {
         this.OnboardingVersion = source["OnboardingVersion"];
         this.AutoUpdateEnabled = source["AutoUpdateEnabled"];
         this.ClaudeDesktopUsed = source["ClaudeDesktopUsed"];
+        this.CodexDesktopUsed = source["CodexDesktopUsed"];
     }
 }
 export class SettingsResponse {

--- a/server/routes.go
+++ b/server/routes.go
@@ -988,12 +988,13 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 			// TODO: this first normalization should be done by the model
 			embedding, err = normalize(embedding)
 			if err != nil {
-				return err
+				slog.Error("invalid embedding", "model", req.Model, "input_index", i, "error", err)
+				return api.StatusError{StatusCode: http.StatusInternalServerError, ErrorMessage: err.Error()}
 			}
 			if req.Dimensions > 0 && req.Dimensions < len(embedding) {
 				embedding, err = normalize(embedding[:req.Dimensions])
 				if err != nil {
-					return err
+					return api.StatusError{StatusCode: http.StatusBadRequest, ErrorMessage: fmt.Sprintf("cannot normalize embedding with dimensions %d: %s", req.Dimensions, err)}
 				}
 			}
 			embeddings[i] = embedding
@@ -1029,19 +1030,34 @@ func (s *Server) EmbedHandler(c *gin.Context) {
 }
 
 func normalize(vec []float32) ([]float32, error) {
-	var sum float32
-	for _, v := range vec {
-		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
-			return nil, errors.New("embedding contains NaN or Inf values")
-		}
-		sum += v * v
+	norm, err := embeddingNorm(vec)
+	if err != nil {
+		return nil, err
 	}
-
-	norm := float32(1.0 / max(math.Sqrt(float64(sum)), 1e-12))
-	for i := range vec {
-		vec[i] *= norm
+	for i, v := range vec {
+		vec[i] = float32(float64(v) / norm)
 	}
 	return vec, nil
+}
+
+func embeddingNorm(vec []float32) (float64, error) {
+	if len(vec) == 0 {
+		return 0, errors.New("empty embedding")
+	}
+
+	// Accumulate in float64 so finite float32 values cannot overflow or
+	// underflow while computing the norm.
+	var sum float64
+	for _, v := range vec {
+		if math.IsNaN(float64(v)) || math.IsInf(float64(v), 0) {
+			return 0, errors.New("embedding contains NaN or Inf values")
+		}
+		sum += float64(v) * float64(v)
+	}
+	if sum == 0 {
+		return 0, errors.New("embedding has zero norm")
+	}
+	return math.Sqrt(sum), nil
 }
 
 func (s *Server) EmbeddingsHandler(c *gin.Context) {
@@ -1090,6 +1106,11 @@ func (s *Server) EmbeddingsHandler(c *gin.Context) {
 	if err != nil {
 		s.sched.expireRunnersForRuntimeOOM(m, err)
 		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": strings.TrimSpace(err.Error())})
+		return
+	}
+	if _, err := embeddingNorm(embedding); err != nil {
+		slog.Error("invalid embedding", "model", req.Model, "error", err)
+		c.AbortWithStatusJSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 

--- a/server/routes_embed_test.go
+++ b/server/routes_embed_test.go
@@ -1,0 +1,148 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/ollama/ollama/llm"
+)
+
+type embeddingTestRunner struct {
+	llm.LlamaServer
+	embeddings map[string][]float32
+}
+
+func (r *embeddingTestRunner) Embedding(_ context.Context, input string) ([]float32, int, error) {
+	return slices.Clone(r.embeddings[input]), 1, nil
+}
+
+func TestEmbeddingHandlersRejectInvalidVectors(t *testing.T) {
+	for _, endpoint := range []string{"/api/embed", "/v1/embeddings", "/api/embeddings"} {
+		for _, tc := range []struct {
+			name   string
+			vector []float32
+			want   string
+		}{
+			{"zero", []float32{0, 0, 0}, "zero norm"},
+			{"empty", nil, "empty embedding"},
+			{"nan", []float32{1, float32(math.NaN())}, "NaN or Inf"},
+			{"infinity", []float32{1, float32(math.Inf(1))}, "NaN or Inf"},
+		} {
+			t.Run(endpoint+"/"+tc.name, func(t *testing.T) {
+				h := embeddingTestHandler(t, map[string][]float32{"bad": tc.vector, "good": {3, 4, 0}})
+				body := map[string]any{"model": "embed-test", "input": []string{"good", "bad"}}
+				if endpoint == "/api/embeddings" {
+					body = map[string]any{"model": "embed-test", "prompt": "bad"}
+				}
+				w := embeddingTestRequest(t, h, endpoint, body)
+				if w.Code != http.StatusInternalServerError {
+					t.Fatalf("status = %d, want 500; body = %s", w.Code, w.Body.String())
+				}
+				if !strings.Contains(w.Body.String(), tc.want) {
+					t.Fatalf("body = %s, want error containing %q", w.Body.String(), tc.want)
+				}
+			})
+		}
+	}
+}
+
+func TestEmbedValidVectorsAndPreload(t *testing.T) {
+	h := embeddingTestHandler(t, map[string][]float32{"good": {3, 4, 0}})
+	for _, tc := range []struct {
+		name       string
+		input      any
+		dimensions int
+		want       [][]float32
+	}{
+		{"single", "good", 0, [][]float32{{0.6, 0.8, 0}}},
+		{"batch", []string{"good", "good"}, 0, [][]float32{{0.6, 0.8, 0}, {0.6, 0.8, 0}}},
+		{"dimensions", "good", 1, [][]float32{{1}}},
+		{"preload", "", 0, [][]float32{}},
+		{"empty_batch", []string{}, 0, [][]float32{}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := embeddingTestRequest(t, h, "/api/embed", map[string]any{
+				"model": "embed-test", "input": tc.input, "dimensions": tc.dimensions,
+			})
+			if w.Code != http.StatusOK {
+				t.Fatalf("status = %d, want 200; body = %s", w.Code, w.Body.String())
+			}
+			var response struct {
+				Embeddings [][]float32 `json:"embeddings"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+				t.Fatal(err)
+			}
+			if !slices.EqualFunc(response.Embeddings, tc.want, slices.Equal[[]float32]) {
+				t.Fatalf("embeddings = %v, want %v", response.Embeddings, tc.want)
+			}
+		})
+	}
+	for _, prompt := range []string{"", "good"} {
+		w := embeddingTestRequest(t, h, "/api/embeddings", map[string]any{"model": "embed-test", "prompt": prompt})
+		if w.Code != http.StatusOK {
+			t.Fatalf("legacy embedding status = %d; body = %s", w.Code, w.Body.String())
+		}
+		var response struct {
+			Embedding []float64 `json:"embedding"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &response); err != nil {
+			t.Fatal(err)
+		}
+		want := []float64{}
+		if prompt != "" {
+			want = []float64{3, 4, 0}
+		}
+		if !slices.Equal(response.Embedding, want) {
+			t.Fatalf("legacy embedding = %v, want %v", response.Embedding, want)
+		}
+	}
+}
+
+func TestEmbedRejectsZeroNormAfterTruncation(t *testing.T) {
+	h := embeddingTestHandler(t, map[string][]float32{"good": {0, 0, 1}})
+	for _, endpoint := range []string{"/api/embed", "/v1/embeddings"} {
+		w := embeddingTestRequest(t, h, endpoint, map[string]any{
+			"model": "embed-test", "input": "good", "dimensions": 2,
+		})
+		if w.Code != http.StatusBadRequest {
+			t.Fatalf("%s: status = %d, want 400; body = %s", endpoint, w.Code, w.Body.String())
+		}
+		if !strings.Contains(w.Body.String(), "cannot normalize embedding with dimensions 2") {
+			t.Fatalf("%s: unexpected error: %s", endpoint, w.Body.String())
+		}
+	}
+}
+
+func embeddingTestHandler(t *testing.T, embeddings map[string][]float32) http.Handler {
+	t.Helper()
+	t.Setenv("OLLAMA_MODELS", t.TempDir())
+	mock := &mockRunner{LlamaServer: &embeddingTestRunner{embeddings: embeddings}}
+	s := newServerWithMockRunner(t, mock)
+	createMinimalGGUFModel(t, s, "embed-test", nil, "", nil)
+	h, err := s.GenerateRoutes()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return h
+}
+
+func embeddingTestRequest(t *testing.T, h http.Handler, endpoint string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPost, endpoint, bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w
+}

--- a/server/routes_test.go
+++ b/server/routes_test.go
@@ -942,7 +942,10 @@ func TestNormalize(t *testing.T) {
 		{input: []float32{0, 1, 2, 3}, expectError: false},
 		{input: []float32{0.1, 0.2, 0.3}, expectError: false},
 		{input: []float32{-0.1, 0.2, 0.3, -0.4}, expectError: false},
-		{input: []float32{0, 0, 0}, expectError: false},
+		{input: []float32{0, 0, 0}, expectError: true},
+		{input: nil, expectError: true},
+		{input: []float32{math.MaxFloat32, math.MaxFloat32}, expectError: false},
+		{input: []float32{math.SmallestNonzeroFloat32, math.SmallestNonzeroFloat32}, expectError: false},
 		{input: []float32{float32(math.NaN()), 0.2, 0.3}, expectError: true},
 		{input: []float32{0.1, float32(math.NaN()), 0.3}, expectError: true},
 		{input: []float32{float32(math.Inf(1)), 0.2, 0.3}, expectError: true},
@@ -952,13 +955,9 @@ func TestNormalize(t *testing.T) {
 	isNormalized := func(vec []float32) (res bool) {
 		sum := 0.0
 		for _, v := range vec {
-			sum += float64(v * v)
+			sum += float64(v) * float64(v)
 		}
-		if math.Abs(sum-1) > 1e-6 {
-			return sum == 0
-		} else {
-			return true
-		}
+		return !math.IsNaN(sum) && math.Abs(sum-1) <= 1e-6
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
A runner can return an all-zero embedding and the API currently reports HTTP 200. Validate runner output in the native and OpenAI-compatible embedding endpoints, returning HTTP 500 and logging invalid vectors. Empty model-preload requests retain their existing behavior, and the legacy endpoint retains the magnitude of valid vectors.

Compute the norm in float64 to avoid turning finite float32 inputs into invalid results through overflow or underflow. A requested dimension reduction that leaves a zero vector returns HTTP 400.

Related to #17878. This addresses the missing server-side failure signal; the model-specific trigger for persistent zero vectors remains under investigation.

Local validation on macOS arm64:

- Regression tests failed against the original handlers and passed after the change.
- `go test -count=1 -bench=. -benchtime=1x ./...`
- `go test -race -count=1 ./...`
- Focused embedding API and normalization tests, including zero-norm dimension reduction, with `-race -count=1`.
- `go generate ./...`, generated-file consistency check, and `go build .`
- `go test -count=1 -tags updater_live ./app/...`
- `golangci-lint run --timeout=10m` (0 issues).

The shared prerequisite commit synchronizes the generated `Settings.CodexDesktopUsed` field with the existing Go struct, making the repository's generation check reproducible. Its 180 UI tests and UI build passed locally.
