### PR TITLE
server: preserve imported GGUF blobs after validation

### DIFF
--- a/app/ui/app/codegen/gotypes.gen.ts
+++ b/app/ui/app/codegen/gotypes.gen.ts
@@ -418,6 +418,7 @@ export class Settings {
     OnboardingVersion: number;
     AutoUpdateEnabled: boolean;
     ClaudeDesktopUsed: boolean;
+    CodexDesktopUsed: boolean;
 
     constructor(source: any = {}) {
         if ('string' === typeof source) source = JSON.parse(source);
@@ -439,6 +440,7 @@ export class Settings {
         this.OnboardingVersion = source["OnboardingVersion"];
         this.AutoUpdateEnabled = source["AutoUpdateEnabled"];
         this.ClaudeDesktopUsed = source["ClaudeDesktopUsed"];
+        this.CodexDesktopUsed = source["CodexDesktopUsed"];
     }
 }
 export class SettingsResponse {

--- a/server/create.go
+++ b/server/create.go
@@ -1039,6 +1039,20 @@ func rewriteLayerWithLlamaQuantize(layer *layerGGML, typeName string, fn func(re
 		in = splitInput
 	}
 
+	if typeName == "COPY" && len(layer.splitParts) == 0 {
+		// Validate the tensor data without replacing the original blob. COPY
+		// can rewrite metadata even when the tensor values are unchanged.
+		out, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
+		if err != nil {
+			return nil, err
+		}
+		defer out.Close()
+		if err := rewrite(in, out, fnWrap); err != nil {
+			return nil, err
+		}
+		return layer, nil
+	}
+
 	temp, err := os.CreateTemp(filepath.Dir(blob), typeName)
 	if err != nil {
 		return nil, err

--- a/server/create_gguf_integration_test.go
+++ b/server/create_gguf_integration_test.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"bytes"
+	"encoding/binary"
+	"math"
+	"os"
+	"testing"
+
+	"github.com/ollama/ollama/api"
+	"github.com/ollama/ollama/fs/ggml"
+	"github.com/ollama/ollama/manifest"
+	"github.com/ollama/ollama/types/model"
+)
+
+func TestCreateModelGGUFValidationWithLlamaQuantize(t *testing.T) {
+	// Helper binaries are built relative to the repository root.
+	t.Chdir("..")
+	if _, err := findLlamaQuantize(); err != nil {
+		t.Skipf("requires a built llama-quantize: %v", err)
+	}
+	oldRun := runLlamaQuantize
+	runLlamaQuantize = runLlamaQuantizeCommand
+	t.Cleanup(func() { runLlamaQuantize = oldRun })
+
+	for _, tt := range []struct {
+		name    string
+		value   float32
+		wantErr bool
+	}{
+		{name: "valid", value: 1},
+		{name: "nan", value: float32(math.NaN()), wantErr: true},
+		{name: "inf", value: float32(math.Inf(1)), wantErr: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("OLLAMA_MODELS", t.TempDir())
+			data := make([]byte, 16)
+			for i := 0; i < len(data); i += 4 {
+				binary.LittleEndian.PutUint32(data[i:], math.Float32bits(tt.value))
+			}
+			_, digest := createBinFile(t, ggml.KV{
+				"general.architecture":                   "llama",
+				"general.file_type":                      uint32(ggml.FileTypeF32),
+				"llama.context_length":                   uint32(32),
+				"llama.embedding_length":                 uint32(2),
+				"llama.block_count":                      uint32(1),
+				"llama.feed_forward_length":              uint32(2),
+				"llama.attention.head_count":             uint32(1),
+				"llama.attention.layer_norm_rms_epsilon": float32(1e-5),
+			}, []*ggml.Tensor{{
+				Name:     "blk.0.attn_q.weight",
+				Kind:     uint32(ggml.TensorTypeF32),
+				Shape:    []uint64{2, 2},
+				WriterTo: bytes.NewReader(data),
+			}})
+			layers, err := ggufLayers(digest, "test.gguf", func(api.ProgressResponse) {})
+			if err != nil {
+				t.Fatal(err)
+			}
+			blob, err := manifest.BlobsPath(digest)
+			if err != nil {
+				t.Fatal(err)
+			}
+			before, err := os.ReadFile(blob)
+			if err != nil {
+				t.Fatal(err)
+			}
+			name := model.ParseName("test-create-native:latest")
+			err = createModel(api.CreateRequest{Model: name.String()}, name, layers, &model.ConfigV2{}, func(api.ProgressResponse) {})
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected invalid tensor data to be rejected")
+				}
+				if _, err := manifest.ParseNamedManifest(name); !os.IsNotExist(err) {
+					t.Fatalf("expected no manifest for invalid model, got %v", err)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
+				mf, err := manifest.ParseNamedManifest(name)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(mf.Layers) != 1 || mf.Layers[0].Digest != digest {
+					t.Fatalf("model layers = %+v, want original digest %q", mf.Layers, digest)
+				}
+			}
+			after, err := os.ReadFile(blob)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(before, after) {
+				t.Fatal("original GGUF contents changed")
+			}
+		})
+	}
+}

--- a/server/quantization_stub_test.go
+++ b/server/quantization_stub_test.go
@@ -18,8 +18,10 @@ func copyLlamaQuantizeInput(in, out *os.File, _ *fsggml.GGML, _ fsggml.FileType,
 	if _, err := out.Seek(0, io.SeekStart); err != nil {
 		return err
 	}
-	if err := out.Truncate(0); err != nil {
-		return err
+	if out.Name() != os.DevNull {
+		if err := out.Truncate(0); err != nil {
+			return err
+		}
 	}
 	if _, err := io.Copy(out, in); err != nil {
 		return err

--- a/server/routes_create_test.go
+++ b/server/routes_create_test.go
@@ -245,7 +245,14 @@ func TestCreateModelValidatesTextOnlyFileGGUFWithoutQuantization(t *testing.T) {
 	oldRun := runLlamaQuantize
 	runLlamaQuantize = func(in, out *os.File, orig *ggml.GGML, fileType ggml.FileType, typeName string, progressFn func(uint64)) error {
 		gotTypeName = typeName
-		return copyLlamaQuantizeInput(in, out, orig, fileType, typeName, progressFn)
+		// COPY can change metadata even though it does not quantize tensors.
+		kv := maps.Clone(orig.KV())
+		kv["general.quantization_version"] = uint32(2)
+		var tensors []*ggml.Tensor
+		for _, tensor := range orig.Tensors().Items() {
+			tensors = append(tensors, tensorFromFile(in, orig.Tensors().Offset+tensor.Offset, tensor))
+		}
+		return ggml.WriteGGUF(out, kv, tensors)
 	}
 	t.Cleanup(func() {
 		runLlamaQuantize = oldRun
@@ -280,6 +287,18 @@ func TestCreateModelValidatesTextOnlyFileGGUFWithoutQuantization(t *testing.T) {
 	if gotTypeName != "COPY" {
 		t.Fatalf("llama-quantize type = %q, want COPY", gotTypeName)
 	}
+
+	mf, err := manifest.ParseNamedManifest(name)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mf.Layers) != 1 || mf.Layers[0].Digest != digest {
+		t.Fatalf("model layers = %+v, want original digest %q", mf.Layers, digest)
+	}
+	checkFileExists(t, filepath.Join(envconfig.Models(), "blobs", "*"), []string{
+		filepath.Join(envconfig.Models(), "blobs", strings.ReplaceAll(digest, ":", "-")),
+		filepath.Join(envconfig.Models(), "blobs", strings.ReplaceAll(mf.Config.Digest, ":", "-")),
+	})
 }
 
 func TestCreateModelValidatesSplitGGUFWithOriginalShardNames(t *testing.T) {


### PR DESCRIPTION
Importing a single GGUF without quantization currently replaces the uploaded blob with llama-quantize's COPY output. COPY may reorder or add metadata, changing the digest and writing another full model file.

Run the same tensor validation with COPY output directed to the null device, then reference the original blob. Split-model merging, requested quantization, and compatibility transformations retain their existing paths. The regression test verifies the original manifest digest and absence of an additional model blob even when COPY rewrites metadata.

Fixes #17554.

Local validation on macOS arm64:

- The digest regression failed before the change and passed afterward.
- `go test -count=1 -bench=. -benchtime=1x ./...`
- `go test -race -count=1 ./...`
- `go test ./server -run '^TestCreateModelGGUFValidationWithLlamaQuantize$' -count=1 -v` using the locally built, pinned llama.cpp b10864 helper: all three subtests ran and passed. Valid GGUF bytes and digest were preserved; NaN/Inf tensor data was rejected without creating a manifest.
- `go generate ./...`, generated-file consistency check, and `go build .`
- `go test -count=1 -tags updater_live ./app/...`
- `golangci-lint run --timeout=10m` (0 issues).

The shared prerequisite commit synchronizes the generated `Settings.CodexDesktopUsed` field with the existing Go struct, making the repository's generation check reproducible. Its 180 UI tests and UI build passed locally.
