### PR TITLE
app/ui/app: surface failed and incomplete chat streams

### DIFF
--- a/app/ui/app/codegen/gotypes.gen.ts
+++ b/app/ui/app/codegen/gotypes.gen.ts
@@ -418,6 +418,7 @@ export class Settings {
     OnboardingVersion: number;
     AutoUpdateEnabled: boolean;
     ClaudeDesktopUsed: boolean;
+    CodexDesktopUsed: boolean;
 
     constructor(source: any = {}) {
         if ('string' === typeof source) source = JSON.parse(source);
@@ -439,6 +440,7 @@ export class Settings {
         this.OnboardingVersion = source["OnboardingVersion"];
         this.AutoUpdateEnabled = source["AutoUpdateEnabled"];
         this.ClaudeDesktopUsed = source["ClaudeDesktopUsed"];
+        this.CodexDesktopUsed = source["CodexDesktopUsed"];
     }
 }
 export class SettingsResponse {

--- a/app/ui/app/src/api.test.ts
+++ b/app/ui/app/src/api.test.ts
@@ -8,7 +8,79 @@ import {
   fetchConnectUrl,
   getClaudeDesktopAvailableModels,
   getIntegrationStatuses,
+  sendMessage,
 } from "./api";
+import { Model } from "@/gotypes";
+
+describe("sendMessage", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  async function readEvents() {
+    const events = [];
+    for await (const event of sendMessage(
+      "test",
+      "hello",
+      new Model({ model: "test" }),
+    )) {
+      events.push(event);
+    }
+    return events;
+  }
+
+  it.each([
+    "",
+    '{"eventName":"chat_created","chatId":"test"}\n',
+    '{"eventName":"chat","content":"partial"}\n',
+    '{"eventName":"download","done":true}\n',
+  ])(
+    "reports a stream that ends without a terminal chat event",
+    async (body) => {
+      vi.stubGlobal("fetch", vi.fn().mockResolvedValue(new Response(body)));
+      await expect(readEvents()).rejects.toThrow("response was complete");
+    },
+  );
+
+  it("accepts a completed response with a final event without a newline", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(
+            '{"eventName":"chat","content":"hello"}\n{"eventName":"done"}',
+          ),
+        ),
+    );
+    await expect(readEvents()).resolves.toMatchObject([
+      { eventName: "chat", content: "hello" },
+      { eventName: "done" },
+    ]);
+  });
+
+  it("preserves a server error and its code as the terminal event", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              eventName: "error",
+              error: "Sign in required",
+              code: "cloud_unauthorized",
+            }),
+          ),
+        ),
+    );
+    await expect(readEvents()).resolves.toMatchObject([
+      {
+        eventName: "error",
+        error: "Sign in required",
+        code: "cloud_unauthorized",
+      },
+    ]);
+  });
+});
 
 describe("fetchConnectUrl", () => {
   afterEach(() => {

--- a/app/ui/app/src/api.ts
+++ b/app/ui/app/src/api.ts
@@ -244,9 +244,7 @@ export async function getClaudeDesktopAvailableModels(
     const seen = new Set<string>();
     return [...localModels, ...cloudModels]
       .filter((model: ModelResponse) => {
-        const base = model.name
-          .replace(/:latest$/, "")
-          .replace(/:cloud$/, "");
+        const base = model.name.replace(/:latest$/, "").replace(/:cloud$/, "");
         if (!base || seen.has(base)) return false;
 
         const families = model.details?.families;
@@ -347,12 +345,19 @@ export async function* sendMessage(
         break;
       case "error":
         yield new ErrorEvent(event);
-        break;
+        return;
+      case "done":
+        yield new ChatEvent(event);
+        return;
       default:
         yield new ChatEvent(event);
         break;
     }
   }
+
+  throw new Error(
+    "The connection closed before the response was complete. Please try again.",
+  );
 }
 
 export async function getSettings(): Promise<{

--- a/app/ui/app/src/components/Chat.test.tsx
+++ b/app/ui/app/src/components/Chat.test.tsx
@@ -1,0 +1,60 @@
+import type { ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { afterEach, expect, it, vi } from "vitest";
+import { ErrorEvent } from "@/gotypes";
+import Chat from "./Chat";
+
+vi.mock("@tanstack/react-router", () => ({ useNavigate: () => vi.fn() }));
+vi.mock("@/hooks/useSelectedModel", () => ({
+  useSelectedModel: () => ({ selectedModel: null }),
+}));
+vi.mock("@/hooks/useUser", () => ({ useUser: () => ({ user: null }) }));
+vi.mock("@/hooks/useHealth", () => ({
+  useHealth: () => ({ isHealthy: true }),
+}));
+vi.mock("@/hooks/useModelCapabilities", () => ({
+  useHasVisionCapability: () => false,
+}));
+vi.mock("@/hooks/useMessageAutoscroll", () => ({
+  useMessageAutoscroll: () => ({
+    containerRef: { current: null },
+    spacerHeight: 0,
+    handleNewUserMessage: vi.fn(),
+  }),
+}));
+vi.mock("./FileUpload", () => ({
+  FileUpload: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+vi.mock("./ChatForm", () => ({ default: () => <form data-chat-form /> }));
+vi.mock("./MessageList", () => ({ default: () => null }));
+
+import { StreamingProvider } from "@/contexts/StreamingContext";
+
+afterEach(() => vi.unstubAllGlobals());
+
+it.each(["Load failed", null])(
+  "renders new-chat request errors beside the form: %s",
+  (message) => {
+    vi.stubGlobal("navigator", { platform: "MacIntel" });
+    const client = new QueryClient();
+    client.setQueryData(
+      ["chatError", ""],
+      message ? new ErrorEvent({ eventName: "error", error: message }) : null,
+    );
+    try {
+      const html = renderToStaticMarkup(
+        <QueryClientProvider client={client}>
+          <StreamingProvider>
+            <Chat chatId="new" />
+          </StreamingProvider>
+        </QueryClientProvider>,
+      );
+      expect(html).toContain("data-chat-form");
+      if (message) expect(html).toContain(message);
+      else expect(html).not.toContain("<h3>Error</h3>");
+    } finally {
+      client.clear();
+    }
+  },
+);

--- a/app/ui/app/src/components/Chat.tsx
+++ b/app/ui/app/src/components/Chat.tsx
@@ -4,6 +4,7 @@ import { FileUpload } from "./FileUpload";
 import { DisplayUpgrade } from "./DisplayUpgrade";
 import { DisplayStale } from "./DisplayStale";
 import { DisplayLogin } from "./DisplayLogin";
+import { ErrorMessage } from "./ErrorMessage";
 import {
   useChat,
   useSendMessage,
@@ -204,6 +205,11 @@ export default function Chat({ chatId }: { chatId: string }) {
       {chatId === "new" ? (
         <div className="flex flex-col h-screen justify-center relative">
           <div className="px-6">
+            {chatError && (
+              <div className="mx-auto max-w-[768px]">
+                <ErrorMessage error={chatError} />
+              </div>
+            )}
             <ChatForm
               hasMessages={false}
               onSubmit={handleChatFormSubmit}

--- a/app/ui/app/src/hooks/useChats.test.tsx
+++ b/app/ui/app/src/hooks/useChats.test.tsx
@@ -1,0 +1,296 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Chat, ErrorEvent, Model } from "@/gotypes";
+import {
+  StreamingProvider,
+  useStreamingContext,
+} from "@/contexts/StreamingContext";
+import { useCancelMessage, useChatError, useSendMessage } from "./useChats";
+
+vi.mock("./useSelectedModel", () => ({
+  useSelectedModel: () => ({ selectedModel: new Model({ model: "test" }) }),
+}));
+
+const cleanups: Array<() => Promise<void>> = [];
+
+beforeEach(() => {
+  vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true);
+  vi.spyOn(console, "error").mockImplementation(() => {});
+});
+
+afterEach(async () => {
+  for (const cleanup of cleanups.splice(0)) await cleanup();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+async function renderChat(chatId: string) {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: Infinity },
+      mutations: { retry: false, gcTime: 0 },
+    },
+  });
+  client.setQueryData(["chat", chatId], {
+    chat: new Chat({ id: chatId, messages: [] }),
+  });
+  let mutation: ReturnType<typeof useSendMessage>;
+  let streaming: ReturnType<typeof useStreamingContext>;
+  let cancel: ReturnType<typeof useCancelMessage>;
+  let renderer: ReactTestRenderer;
+  function Probe() {
+    mutation = useSendMessage(chatId);
+    streaming = useStreamingContext();
+    cancel = useCancelMessage();
+    const { data: error } = useChatError(chatId === "new" ? "" : chatId);
+    return <span>{error?.error}</span>;
+  }
+  await act(async () => {
+    renderer = create(
+      <QueryClientProvider client={client}>
+        <StreamingProvider>
+          <Probe />
+        </StreamingProvider>
+      </QueryClientProvider>,
+    );
+  });
+  cleanups.push(async () => {
+    await act(async () => renderer.unmount());
+    client.clear();
+  });
+  return {
+    client,
+    get streaming() {
+      return streaming!;
+    },
+    cancel: (id: string) => cancel!(id),
+    start: () => mutation!.mutateAsync({ message: "hello" }),
+  };
+}
+
+function controlledResponse() {
+  let controller: ReadableStreamDefaultController<Uint8Array>;
+  const response = new Response(
+    new ReadableStream<Uint8Array>({
+      start(value) {
+        controller = value;
+      },
+    }),
+  );
+  return {
+    response,
+    send: (...events: object[]) =>
+      controller!.enqueue(
+        new TextEncoder().encode(
+          events.map((event) => JSON.stringify(event)).join("\n") + "\n",
+        ),
+      ),
+    fail: (error: Error) => controller!.error(error),
+    close: () => controller!.close(),
+  };
+}
+
+describe("chat stream failures", () => {
+  it("shows an unexpected transport abort when the user did not cancel", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockRejectedValue(
+          new DOMException("The operation was aborted", "AbortError"),
+        ),
+    );
+    const chat = await renderChat("existing");
+    await act(async () => {
+      await expect(chat.start()).rejects.toThrow("The operation was aborted");
+    });
+    expect(
+      chat.client.getQueryData<ErrorEvent>(["chatError", "existing"])?.error,
+    ).toBe("The operation was aborted");
+    expect(chat.streaming.streamingChatIds.size).toBe(0);
+  });
+
+  it.each(["existing", "new"])(
+    "preserves server error codes for a %s chat",
+    async (chatId) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(
+            JSON.stringify({
+              eventName: "error",
+              error: "Sign in required",
+              code: "cloud_unauthorized",
+            }),
+          ),
+        ),
+      );
+      const chat = await renderChat(chatId);
+      await act(async () => {
+        await chat.start();
+      });
+      expect(
+        chat.client.getQueryData(["chatError", chatId === "new" ? "" : chatId]),
+      ).toMatchObject({
+        error: "Sign in required",
+        code: "cloud_unauthorized",
+      });
+      expect(chat.streaming.streamingChatIds.size).toBe(0);
+      expect(chat.streaming.abortControllers.size).toBe(0);
+    },
+  );
+
+  it("finishes a normal response without an error or leftover streaming state", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response(
+            '{"eventName":"chat","content":"complete"}\n{"eventName":"done"}\n',
+          ),
+        ),
+    );
+    const chat = await renderChat("existing");
+    await act(async () => {
+      await chat.start();
+    });
+    expect(chat.client.getQueryData(["chatError", "existing"])).toBeNull();
+    expect(
+      chat.client
+        .getQueryData<{ chat: Chat }>(["chat", "existing"])
+        ?.chat.messages?.at(-1)?.content,
+    ).toBe("complete");
+    expect(chat.streaming.streamingChatIds.size).toBe(0);
+    expect(chat.streaming.abortControllers.size).toBe(0);
+    expect(chat.streaming.loadingChats.size).toBe(0);
+  });
+
+  it.each(["existing", "new"])(
+    "shows a request error for a %s chat and clears streaming state",
+    async (chatId) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockRejectedValue(new TypeError("Load failed")),
+      );
+      const chat = await renderChat(chatId);
+      await act(async () => {
+        await expect(chat.start()).rejects.toThrow("Load failed");
+      });
+      expect(
+        chat.client.getQueryData(["chatError", chatId === "new" ? "" : chatId]),
+      ).toMatchObject({
+        eventName: "error",
+        error: "Load failed",
+      });
+      expect(chat.streaming.streamingChatIds.size).toBe(0);
+      expect(chat.streaming.abortControllers.size).toBe(0);
+    },
+  );
+
+  it("reports a failure after chat creation against the new ID and preserves buffered content", async () => {
+    const stream = controlledResponse();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(stream.response));
+    const chat = await renderChat("new");
+    let request: Promise<unknown>;
+    await act(async () => {
+      request = chat.start();
+      request.catch(() => {});
+    });
+    await act(async () =>
+      stream.send(
+        { eventName: "chat_created", chatId: "created" },
+        { eventName: "download", total: 100, completed: 50 },
+        { eventName: "chat", content: "first" },
+        { eventName: "chat", content: " second" },
+      ),
+    );
+    expect(chat.streaming.streamingChatIds.has("created")).toBe(true);
+    expect(chat.streaming.abortControllers.has("created")).toBe(true);
+    await act(async () => {
+      stream.fail(new TypeError("Connection lost"));
+      await expect(request!).rejects.toThrow("Connection lost");
+    });
+    expect(
+      chat.client.getQueryData<ErrorEvent>(["chatError", "created"])?.error,
+    ).toBe("Connection lost");
+    expect(
+      chat.client
+        .getQueryData<{ chat: Chat }>(["chat", "created"])
+        ?.chat.messages?.at(-1)?.content,
+    ).toBe("first second");
+    expect(chat.streaming.streamingChatIds.size).toBe(0);
+    expect(chat.streaming.abortControllers.size).toBe(0);
+    expect(chat.streaming.downloadProgress.size).toBe(0);
+    expect(chat.streaming.loadingChats.size).toBe(0);
+  });
+
+  it("keeps waiting for inference after chat creation and cleans up a failure before the first token", async () => {
+    const stream = controlledResponse();
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue(stream.response));
+    const chat = await renderChat("new");
+    let request: Promise<unknown>;
+    await act(async () => {
+      request = chat.start();
+      request.catch(() => {});
+    });
+    await act(async () =>
+      stream.send({ eventName: "chat_created", chatId: "created" }),
+    );
+    expect(chat.streaming.streamingChatIds.has("created")).toBe(true);
+    expect(chat.streaming.loadingChats.size).toBe(0);
+    await act(async () => {
+      stream.fail(new TypeError("Connection lost"));
+      await expect(request!).rejects.toThrow("Connection lost");
+    });
+    expect(chat.streaming.streamingChatIds.size).toBe(0);
+    expect(chat.streaming.loadingChats.size).toBe(0);
+    expect(chat.streaming.abortControllers.size).toBe(0);
+  });
+
+  it("shows a premature EOF instead of leaving the chat waiting", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi
+        .fn()
+        .mockResolvedValue(
+          new Response('{"eventName":"chat","content":"partial"}\n'),
+        ),
+    );
+    const chat = await renderChat("existing");
+    await act(async () => {
+      await expect(chat.start()).rejects.toThrow("response was complete");
+    });
+    expect(
+      chat.client.getQueryData<ErrorEvent>(["chatError", "existing"])?.error,
+    ).toContain("response was complete");
+    expect(chat.streaming.streamingChatIds.size).toBe(0);
+  });
+
+  it("keeps an intentional cancellation quiet", async () => {
+    const stream = controlledResponse();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockImplementation((_url, init: RequestInit) => {
+        init.signal!.addEventListener("abort", () =>
+          stream.fail(new DOMException("Aborted", "AbortError")),
+        );
+        return Promise.resolve(stream.response);
+      }),
+    );
+    const chat = await renderChat("existing");
+    let request: Promise<unknown>;
+    await act(async () => {
+      request = chat.start();
+      request.catch(() => {});
+    });
+    await act(async () => {
+      chat.cancel("existing");
+      await expect(request!).rejects.toThrow("Aborted");
+    });
+    expect(chat.client.getQueryData(["chatError", "existing"])).toBeNull();
+    expect(chat.streaming.streamingChatIds.size).toBe(0);
+    expect(chat.streaming.abortControllers.size).toBe(0);
+  });
+});

--- a/app/ui/app/src/hooks/useChats.ts
+++ b/app/ui/app/src/hooks/useChats.ts
@@ -195,7 +195,6 @@ export const useIsWaitingForLoad = (chatId: string) => {
 };
 
 export const useSendMessage = (chatId: string) => {
-  let updatableChatId = chatId;
   const queryClient = useQueryClient();
   const { selectedModel } = useSelectedModel();
   const {
@@ -208,6 +207,11 @@ export const useSendMessage = (chatId: string) => {
 
   const cleanupStreaming = (id: string) => {
     setStreamingChatIds((prev: Set<string>) => {
+      const newSet = new Set(prev);
+      newSet.delete(id);
+      return newSet;
+    });
+    setLoadingChats((prev) => {
       const newSet = new Set(prev);
       newSet.delete(id);
       return newSet;
@@ -226,13 +230,6 @@ export const useSendMessage = (chatId: string) => {
 
   return useMutation({
     mutationKey: ["sendMessage", chatId],
-    onSuccess: () => {
-      cleanupStreaming(updatableChatId);
-    },
-    onError: (error) => {
-      console.error("error mutating sendMessage", error);
-      cleanupStreaming(updatableChatId);
-    },
     mutationFn: async ({
       message,
       attachments,
@@ -252,290 +249,165 @@ export const useSendMessage = (chatId: string) => {
       think?: boolean | string;
       onChatEvent?: (event: ChatEventUnion) => void;
     }) => {
-      // For existing chats, set streaming state and add optimistic user message
-      if (chatId !== "new") {
-        setStreamingChatIds((prev: Set<string>) => {
-          const newSet = new Set(prev);
-          newSet.add(chatId);
-          return newSet;
-        });
-        queryClient.cancelQueries({ queryKey: ["chat", chatId] });
-
-        // Only add optimistic message for non-empty messages
-        if (message.trim() !== "") {
-          // Optimistically add the user message
-          queryClient.setQueryData(
-            ["chat", chatId],
-            (old: { chat: Chat } | undefined) => {
-              if (!old) return old;
-
-              const newMessage = new Message({
-                role: "user",
-                content: message,
-                attachments: attachments,
-              });
-
-              let messages = old.chat.messages || [];
-
-              // If editing a message (index provided), truncate messages array
-              if (
-                index !== undefined &&
-                index >= 0 &&
-                index < messages.length
-              ) {
-                messages = messages.slice(0, index);
-              }
-
-              return {
-                ...old,
-                chat: new Chat({
-                  ...old.chat,
-                  messages: [...messages, newMessage],
-                }),
-              };
-            },
-          );
-        }
-      }
-
-      if (!selectedModel) {
-        throw new Error("No model selected");
-      }
-
-      const effectiveModel = new Model({
-        model: selectedModel.model,
-        digest: selectedModel.digest,
-        modified_at: selectedModel.modified_at,
-      });
-
-      const abortController = new AbortController();
-      setAbortControllers((prev) => {
-        const newMap = new Map(prev);
-        newMap.set(updatableChatId, abortController);
-        return newMap;
-      });
-
-      const events = sendMessage(
-        chatId,
-        message,
-        effectiveModel,
-        attachments,
-        abortController.signal,
-        index,
-        webSearch,
-        fileTools,
-        forceUpdate,
-        think,
-      );
       let currentChatId = chatId;
-      let isCancelled = false;
+      const abortController = new AbortController();
+      let batcher:
+        | ReturnType<typeof createQueryBatcher<{ chat: Chat }>>
+        | undefined;
 
-      // Listen for abort signal to set cancelled flag
-      abortController.signal.addEventListener("abort", () => {
-        isCancelled = true;
-      });
-
-      // Create batcher for streaming updates with smoother intervals, prevents state update depth being exceeded
-      // and allows for smoother updates at high frame rates
-      let batcher = createQueryBatcher<{ chat: Chat }>(
-        queryClient,
-        ["chat", currentChatId],
-        { batchInterval: 4, immediateFirst: true }, // ~250fps for smoother updates
-      );
-
-      for await (const event of events) {
-        // If cancelled, continue draining the stream but don't update UI
-        if (isCancelled) {
-          continue;
-        }
-
-        // download events don't count as loaded
-        // TODO(jmorganca): loading should potentially be an event instead of
-        // reducing it this way
-        if (
-          event.eventName !== "download" &&
-          !loadingChats.has(currentChatId)
-        ) {
-          // If this is the first time loading this chat, mark it as loaded
-          setLoadingChats((prev: Set<string>) => {
+      try {
+        // For existing chats, set streaming state and add optimistic user message
+        if (chatId !== "new") {
+          setStreamingChatIds((prev: Set<string>) => {
             const newSet = new Set(prev);
-            newSet.add(currentChatId);
+            newSet.add(chatId);
             return newSet;
           });
-        }
+          queryClient.cancelQueries({ queryKey: ["chat", chatId] });
 
-        switch (event.eventName) {
-          case "chat": {
-            // Update the current chat data with streaming content
-            batcher.scheduleBatch((old: { chat: Chat } | undefined) => {
-              if (!old) return old;
-
-              const existingMessages = old.chat.messages || [];
-              const newMessages = [...existingMessages];
-
-              // Find or create the assistant message
-              let lastMessage = newMessages[newMessages.length - 1];
-              if (!lastMessage || lastMessage.role !== "assistant") {
-                newMessages.push(
-                  new Message({
-                    role: "assistant",
-                    content: "",
-                    thinking: "",
-                    model: effectiveModel.model,
-                  }),
-                );
-                lastMessage = newMessages[newMessages.length - 1];
-              }
-
-              // Update the last message with new content
-              if (lastMessage) {
-                const updatedContent =
-                  (lastMessage.content || "") + (event.content || "");
-                const updatedThinking =
-                  (lastMessage.thinking || "") + (event.thinking || "");
-                const updatedMessage = new Message({
-                  ...lastMessage,
-                  content: updatedContent,
-                  thinking: updatedThinking,
-                });
-                if (event.thinkingTimeStart) {
-                  updatedMessage.thinkingTimeStart = event.thinkingTimeStart;
-                }
-                if (event.thinkingTimeEnd) {
-                  updatedMessage.thinkingTimeEnd = event.thinkingTimeEnd;
-                }
-                newMessages[newMessages.length - 1] = updatedMessage;
-              }
-
-              return {
-                ...old,
-                chat: new Chat({
-                  ...old.chat,
-                  messages: newMessages,
-                }),
-              };
-            });
-            break;
-          }
-          case "thinking": {
-            // Handle thinking content
-            batcher.scheduleBatch((old: { chat: Chat } | undefined) => {
-              if (!old) return old;
-
-              const existingMessages = old.chat.messages || [];
-              const newMessages = [...existingMessages];
-
-              // Find or create the assistant message
-              let lastMessage = newMessages[newMessages.length - 1];
-              if (!lastMessage || lastMessage.role !== "assistant") {
-                newMessages.push(
-                  new Message({
-                    role: "assistant",
-                    content: "",
-                    thinking: "",
-                    model: effectiveModel.model,
-                  }),
-                );
-                lastMessage = newMessages[newMessages.length - 1];
-              }
-
-              // Update the last message with new thinking content
-              if (lastMessage) {
-                const updatedThinking =
-                  (lastMessage.thinking || "") + (event.thinking || "");
-                const updatedMessage = new Message({
-                  ...lastMessage,
-                  thinking: updatedThinking,
-                });
-                if (event.thinkingTimeStart) {
-                  updatedMessage.thinkingTimeStart = event.thinkingTimeStart;
-                }
-                newMessages[newMessages.length - 1] = updatedMessage;
-              }
-
-              return {
-                ...old,
-                chat: new Chat({
-                  ...old.chat,
-                  messages: newMessages,
-                }),
-              };
-            });
-            break;
-          }
-          case "tool_call": {
-            // Handle tool call events - these are now mostly handled by assistant_with_tools
-            // but kept for backward compatibility, potentially still good for normal tool calling models
+          // Only add optimistic message for non-empty messages
+          if (message.trim() !== "") {
+            // Optimistically add the user message
             queryClient.setQueryData(
-              ["chat", currentChatId],
+              ["chat", chatId],
               (old: { chat: Chat } | undefined) => {
                 if (!old) return old;
 
-                const existingMessages = old.chat.messages || [];
-                const newMessages = [...existingMessages];
+                const newMessage = new Message({
+                  role: "user",
+                  content: message,
+                  attachments: attachments,
+                });
 
-                // Add tool call message
-                if (event.toolCall) {
-                  newMessages.push(
-                    new Message({
-                      role: "tool",
-                      content: `Tool ${event.toolCall.function.name} called`,
-                      tool_calls: [event.toolCall],
-                      thinkingTimeStart: event.thinkingTimeStart,
-                      thinkingTimeEnd: event.thinkingTimeEnd,
-                    }),
-                  );
+                let messages = old.chat.messages || [];
+
+                // If editing a message (index provided), truncate messages array
+                if (
+                  index !== undefined &&
+                  index >= 0 &&
+                  index < messages.length
+                ) {
+                  messages = messages.slice(0, index);
                 }
 
                 return {
                   ...old,
                   chat: new Chat({
                     ...old.chat,
-                    messages: newMessages,
+                    messages: [...messages, newMessage],
                   }),
                 };
               },
             );
-            break;
           }
-          case "assistant_with_tools": {
-            // Handle assistant messages that include tool calls
-            queryClient.setQueryData(
-              ["chat", currentChatId],
-              (old: { chat: Chat } | undefined) => {
+        }
+
+        if (!selectedModel) {
+          throw new Error("No model selected");
+        }
+
+        const effectiveModel = new Model({
+          model: selectedModel.model,
+          digest: selectedModel.digest,
+          modified_at: selectedModel.modified_at,
+        });
+
+        setAbortControllers((prev) => {
+          const newMap = new Map(prev);
+          newMap.set(chatId, abortController);
+          return newMap;
+        });
+
+        const events = sendMessage(
+          chatId,
+          message,
+          effectiveModel,
+          attachments,
+          abortController.signal,
+          index,
+          webSearch,
+          fileTools,
+          forceUpdate,
+          think,
+        );
+        let isCancelled = false;
+
+        // Listen for abort signal to set cancelled flag
+        abortController.signal.addEventListener("abort", () => {
+          isCancelled = true;
+        });
+
+        // Create batcher for streaming updates with smoother intervals, prevents state update depth being exceeded
+        // and allows for smoother updates at high frame rates
+        batcher = createQueryBatcher<{ chat: Chat }>(
+          queryClient,
+          ["chat", currentChatId],
+          { batchInterval: 4, immediateFirst: true }, // ~250fps for smoother updates
+        );
+
+        for await (const event of events) {
+          // If cancelled, continue draining the stream but don't update UI
+          if (isCancelled) {
+            continue;
+          }
+
+          // Download and chat creation events do not indicate inference has loaded.
+          // TODO(jmorganca): loading should potentially be an event instead of
+          // reducing it this way
+          if (
+            event.eventName !== "download" &&
+            event.eventName !== "chat_created" &&
+            !loadingChats.has(currentChatId)
+          ) {
+            // If this is the first time loading this chat, mark it as loaded
+            setLoadingChats((prev: Set<string>) => {
+              const newSet = new Set(prev);
+              newSet.add(currentChatId);
+              return newSet;
+            });
+          }
+
+          switch (event.eventName) {
+            case "chat": {
+              // Update the current chat data with streaming content
+              batcher.scheduleBatch((old: { chat: Chat } | undefined) => {
                 if (!old) return old;
 
                 const existingMessages = old.chat.messages || [];
                 const newMessages = [...existingMessages];
 
-                // Find the last assistant message and update it with tool calls
-                const lastMessage = newMessages[newMessages.length - 1];
-                if (lastMessage && lastMessage.role === "assistant") {
-                  // Update existing assistant message with tool calls
-                  const updatedMessage = new Message({
-                    ...lastMessage,
-                    content: lastMessage.content + (event.content || ""),
-                    thinking: lastMessage.thinking + (event.thinking || ""),
-                    tool_calls: event.toolCalls,
-                    thinkingTimeStart:
-                      lastMessage.thinkingTimeStart || event.thinkingTimeStart,
-                    thinkingTimeEnd: event.thinkingTimeEnd,
-                    model: selectedModel.model,
-                  });
-                  newMessages[newMessages.length - 1] = updatedMessage;
-                } else {
-                  // No existing assistant message, create new one
+                // Find or create the assistant message
+                let lastMessage = newMessages[newMessages.length - 1];
+                if (!lastMessage || lastMessage.role !== "assistant") {
                   newMessages.push(
                     new Message({
                       role: "assistant",
-                      content: event.content,
-                      thinking: event.thinking,
-                      tool_calls: event.toolCalls,
-                      thinkingTimeStart: event.thinkingTimeStart,
-                      thinkingTimeEnd: event.thinkingTimeEnd,
-                      model: selectedModel.model,
+                      content: "",
+                      thinking: "",
+                      model: effectiveModel.model,
                     }),
                   );
+                  lastMessage = newMessages[newMessages.length - 1];
+                }
+
+                // Update the last message with new content
+                if (lastMessage) {
+                  const updatedContent =
+                    (lastMessage.content || "") + (event.content || "");
+                  const updatedThinking =
+                    (lastMessage.thinking || "") + (event.thinking || "");
+                  const updatedMessage = new Message({
+                    ...lastMessage,
+                    content: updatedContent,
+                    thinking: updatedThinking,
+                  });
+                  if (event.thinkingTimeStart) {
+                    updatedMessage.thinkingTimeStart = event.thinkingTimeStart;
+                  }
+                  if (event.thinkingTimeEnd) {
+                    updatedMessage.thinkingTimeEnd = event.thinkingTimeEnd;
+                  }
+                  newMessages[newMessages.length - 1] = updatedMessage;
                 }
 
                 return {
@@ -545,187 +417,337 @@ export const useSendMessage = (chatId: string) => {
                     messages: newMessages,
                   }),
                 };
-              },
-            );
-            break;
-          }
-          case "tool_result": {
-            // Handle tool result events
-            queryClient.setQueryData(
-              ["chat", currentChatId],
-              (old: { chat: Chat } | undefined) => {
+              });
+              break;
+            }
+            case "thinking": {
+              // Handle thinking content
+              batcher.scheduleBatch((old: { chat: Chat } | undefined) => {
                 if (!old) return old;
 
                 const existingMessages = old.chat.messages || [];
                 const newMessages = [...existingMessages];
 
-                newMessages.push(
-                  Object.assign(
+                // Find or create the assistant message
+                let lastMessage = newMessages[newMessages.length - 1];
+                if (!lastMessage || lastMessage.role !== "assistant") {
+                  newMessages.push(
                     new Message({
-                      role: "tool",
-                      content: event.content,
-                      thinkingTimeStart: event.thinkingTimeStart,
-                      thinkingTimeEnd: event.thinkingTimeEnd,
+                      role: "assistant",
+                      content: "",
+                      thinking: "",
+                      model: effectiveModel.model,
                     }),
-                    {
-                      tool_result: (event as any).toolResultData,
-                      ...((event as any).toolName
-                        ? { tool_name: (event as any).toolName }
-                        : {}),
-                    },
-                  ),
-                );
+                  );
+                  lastMessage = newMessages[newMessages.length - 1];
+                }
+
+                // Update the last message with new thinking content
+                if (lastMessage) {
+                  const updatedThinking =
+                    (lastMessage.thinking || "") + (event.thinking || "");
+                  const updatedMessage = new Message({
+                    ...lastMessage,
+                    thinking: updatedThinking,
+                  });
+                  if (event.thinkingTimeStart) {
+                    updatedMessage.thinkingTimeStart = event.thinkingTimeStart;
+                  }
+                  newMessages[newMessages.length - 1] = updatedMessage;
+                }
 
                 return {
                   ...old,
                   chat: new Chat({
                     ...old.chat,
                     messages: newMessages,
-                    browser_state: event.toolState ?? old.chat.browser_state,
                   }),
                 };
-              },
-            );
-            break;
-          }
-          case "download": {
-            setDownloadProgress((prev) => {
-              const newMap = new Map(prev);
-              newMap.set(currentChatId, event);
-              return newMap;
-            });
+              });
+              break;
+            }
+            case "tool_call": {
+              // Handle tool call events - these are now mostly handled by assistant_with_tools
+              // but kept for backward compatibility, potentially still good for normal tool calling models
+              queryClient.setQueryData(
+                ["chat", currentChatId],
+                (old: { chat: Chat } | undefined) => {
+                  if (!old) return old;
 
-            if (event.done && selectedModel) {
-              const currentStaleModels =
-                queryClient.getQueryData<Map<string, boolean>>([
-                  "staleModels",
-                ]) || new Map();
-              const newStaleMap = new Map(currentStaleModels);
-              newStaleMap.delete(selectedModel.model);
-              queryClient.setQueryData(["staleModels"], newStaleMap);
+                  const existingMessages = old.chat.messages || [];
+                  const newMessages = [...existingMessages];
 
-              queryClient.invalidateQueries({ queryKey: ["models"] });
+                  // Add tool call message
+                  if (event.toolCall) {
+                    newMessages.push(
+                      new Message({
+                        role: "tool",
+                        content: `Tool ${event.toolCall.function.name} called`,
+                        tool_calls: [event.toolCall],
+                        thinkingTimeStart: event.thinkingTimeStart,
+                        thinkingTimeEnd: event.thinkingTimeEnd,
+                      }),
+                    );
+                  }
 
-              // Fetch fresh capabilities for the downloaded model
-              getModelCapabilities(selectedModel.model)
-                .then((capabilities) => {
-                  queryClient.setQueryData(
-                    ["modelCapabilities", selectedModel.model],
-                    capabilities,
+                  return {
+                    ...old,
+                    chat: new Chat({
+                      ...old.chat,
+                      messages: newMessages,
+                    }),
+                  };
+                },
+              );
+              break;
+            }
+            case "assistant_with_tools": {
+              // Handle assistant messages that include tool calls
+              queryClient.setQueryData(
+                ["chat", currentChatId],
+                (old: { chat: Chat } | undefined) => {
+                  if (!old) return old;
+
+                  const existingMessages = old.chat.messages || [];
+                  const newMessages = [...existingMessages];
+
+                  // Find the last assistant message and update it with tool calls
+                  const lastMessage = newMessages[newMessages.length - 1];
+                  if (lastMessage && lastMessage.role === "assistant") {
+                    // Update existing assistant message with tool calls
+                    const updatedMessage = new Message({
+                      ...lastMessage,
+                      content: lastMessage.content + (event.content || ""),
+                      thinking: lastMessage.thinking + (event.thinking || ""),
+                      tool_calls: event.toolCalls,
+                      thinkingTimeStart:
+                        lastMessage.thinkingTimeStart ||
+                        event.thinkingTimeStart,
+                      thinkingTimeEnd: event.thinkingTimeEnd,
+                      model: selectedModel.model,
+                    });
+                    newMessages[newMessages.length - 1] = updatedMessage;
+                  } else {
+                    // No existing assistant message, create new one
+                    newMessages.push(
+                      new Message({
+                        role: "assistant",
+                        content: event.content,
+                        thinking: event.thinking,
+                        tool_calls: event.toolCalls,
+                        thinkingTimeStart: event.thinkingTimeStart,
+                        thinkingTimeEnd: event.thinkingTimeEnd,
+                        model: selectedModel.model,
+                      }),
+                    );
+                  }
+
+                  return {
+                    ...old,
+                    chat: new Chat({
+                      ...old.chat,
+                      messages: newMessages,
+                    }),
+                  };
+                },
+              );
+              break;
+            }
+            case "tool_result": {
+              // Handle tool result events
+              queryClient.setQueryData(
+                ["chat", currentChatId],
+                (old: { chat: Chat } | undefined) => {
+                  if (!old) return old;
+
+                  const existingMessages = old.chat.messages || [];
+                  const newMessages = [...existingMessages];
+
+                  newMessages.push(
+                    Object.assign(
+                      new Message({
+                        role: "tool",
+                        content: event.content,
+                        thinkingTimeStart: event.thinkingTimeStart,
+                        thinkingTimeEnd: event.thinkingTimeEnd,
+                      }),
+                      {
+                        tool_result: event.toolResultData,
+                        ...(event.toolName
+                          ? { tool_name: event.toolName }
+                          : {}),
+                      },
+                    ),
                   );
-                })
-                .catch((error) => {
-                  console.error(
-                    "Failed to fetch capabilities after download:",
-                    error,
-                  );
-                  queryClient.invalidateQueries({
-                    queryKey: ["modelCapabilities", selectedModel.model],
+
+                  return {
+                    ...old,
+                    chat: new Chat({
+                      ...old.chat,
+                      messages: newMessages,
+                      browser_state: event.toolState ?? old.chat.browser_state,
+                    }),
+                  };
+                },
+              );
+              break;
+            }
+            case "download": {
+              setDownloadProgress((prev) => {
+                const newMap = new Map(prev);
+                newMap.set(currentChatId, event);
+                return newMap;
+              });
+
+              if (event.done && selectedModel) {
+                const currentStaleModels =
+                  queryClient.getQueryData<Map<string, boolean>>([
+                    "staleModels",
+                  ]) || new Map();
+                const newStaleMap = new Map(currentStaleModels);
+                newStaleMap.delete(selectedModel.model);
+                queryClient.setQueryData(["staleModels"], newStaleMap);
+
+                queryClient.invalidateQueries({ queryKey: ["models"] });
+
+                // Fetch fresh capabilities for the downloaded model
+                getModelCapabilities(selectedModel.model)
+                  .then((capabilities) => {
+                    queryClient.setQueryData(
+                      ["modelCapabilities", selectedModel.model],
+                      capabilities,
+                    );
+                  })
+                  .catch((error) => {
+                    console.error(
+                      "Failed to fetch capabilities after download:",
+                      error,
+                    );
+                    queryClient.invalidateQueries({
+                      queryKey: ["modelCapabilities", selectedModel.model],
+                    });
                   });
-                });
-            }
-            break;
-          }
-          case "error": {
-            // Clean up streaming state
-            setStreamingChatIds((prev: Set<string>) => {
-              const newSet = new Set(prev);
-              newSet.delete(currentChatId);
-              return newSet;
-            });
-            setDownloadProgress((prev) => {
-              const newMap = new Map(prev);
-              newMap.delete(currentChatId);
-              return newMap;
-            });
-
-            // Set error using separate React Query cache
-            queryClient.setQueryData(
-              ["chatError", currentChatId],
-              event as ErrorEvent,
-            );
-            break;
-          }
-          case "done":
-            // TODO(drifkin): update the chat with the thinking time for cases
-            // where there is thinking content, but no other content (which
-            // should be very rare)
-            setStreamingChatIds((prev: Set<string>) => {
-              const newSet = new Set(prev);
-              newSet.delete(currentChatId);
-              return newSet;
-            });
-            // Clear download progress when streaming is done
-            setDownloadProgress((prev) => {
-              const newMap = new Map(prev);
-              newMap.delete(currentChatId);
-              return newMap;
-            });
-            // Ensure chat is fresh for next fetch
-            queryClient.invalidateQueries({
-              queryKey: ["chat", currentChatId],
-            });
-            break;
-          case "chat_created": {
-            if (!event.chatId) break;
-            const newId = event.chatId;
-            updatableChatId = newId;
-            setStreamingChatIds((prev: Set<string>) => {
-              const newSet = new Set(prev);
-              newSet.add(newId);
-              return newSet;
-            });
-            setAbortControllers((prev) => {
-              const newMap = new Map(prev);
-              const controller = newMap.get(chatId);
-              if (controller) {
-                newMap.delete(chatId);
-                newMap.set(newId, controller);
               }
-              return newMap;
-            });
-
-            // Flush current batcher and create new one for the new chat ID
-            batcher.flushBatch();
-            batcher.cleanup();
-            currentChatId = newId;
-            batcher = createQueryBatcher<{ chat: Chat }>(
-              queryClient,
-              ["chat", currentChatId],
-              { batchInterval: 4, immediateFirst: true },
-            );
-
-            // Create initial chat data for the new chat
-            queryClient.setQueryData(["chat", newId], {
-              chat: new Chat({
-                id: newId,
-                model: effectiveModel.model,
-                messages: [
-                  new Message({
-                    role: "user",
-                    content: message,
-                    attachments: attachments,
-                  }),
-                ],
-              }),
-            });
-
-            // Cancel the old "new" chat query if it exists
-            if (chatId === "new") {
-              queryClient.cancelQueries({ queryKey: ["chat", "new"] });
+              break;
             }
+            case "error": {
+              // Clean up streaming state
+              setStreamingChatIds((prev: Set<string>) => {
+                const newSet = new Set(prev);
+                newSet.delete(currentChatId);
+                return newSet;
+              });
+              setDownloadProgress((prev) => {
+                const newMap = new Map(prev);
+                newMap.delete(currentChatId);
+                return newMap;
+              });
 
-            // Invalidate chats list to include the new chat
-            queryClient.invalidateQueries({ queryKey: ["chats"] });
-            break;
+              // Set error using separate React Query cache
+              queryClient.setQueryData(
+                ["chatError", currentChatId === "new" ? "" : currentChatId],
+                event as ErrorEvent,
+              );
+              break;
+            }
+            case "done":
+              // TODO(drifkin): update the chat with the thinking time for cases
+              // where there is thinking content, but no other content (which
+              // should be very rare)
+              setStreamingChatIds((prev: Set<string>) => {
+                const newSet = new Set(prev);
+                newSet.delete(currentChatId);
+                return newSet;
+              });
+              // Clear download progress when streaming is done
+              setDownloadProgress((prev) => {
+                const newMap = new Map(prev);
+                newMap.delete(currentChatId);
+                return newMap;
+              });
+              // Ensure chat is fresh for next fetch
+              queryClient.invalidateQueries({
+                queryKey: ["chat", currentChatId],
+              });
+              break;
+            case "chat_created": {
+              if (!event.chatId) break;
+              const newId = event.chatId;
+              setStreamingChatIds((prev: Set<string>) => {
+                const newSet = new Set(prev);
+                newSet.add(newId);
+                return newSet;
+              });
+              setAbortControllers((prev) => {
+                const newMap = new Map(prev);
+                const controller = newMap.get(chatId);
+                if (controller) {
+                  newMap.delete(chatId);
+                  newMap.set(newId, controller);
+                }
+                return newMap;
+              });
+
+              // Flush current batcher and create new one for the new chat ID
+              batcher.flushBatch();
+              batcher.cleanup();
+              currentChatId = newId;
+              batcher = createQueryBatcher<{ chat: Chat }>(
+                queryClient,
+                ["chat", currentChatId],
+                { batchInterval: 4, immediateFirst: true },
+              );
+
+              // Create initial chat data for the new chat
+              queryClient.setQueryData(["chat", newId], {
+                chat: new Chat({
+                  id: newId,
+                  model: effectiveModel.model,
+                  messages: [
+                    new Message({
+                      role: "user",
+                      content: message,
+                      attachments: attachments,
+                    }),
+                  ],
+                }),
+              });
+
+              // Cancel the old "new" chat query if it exists
+              if (chatId === "new") {
+                queryClient.cancelQueries({ queryKey: ["chat", "new"] });
+              }
+
+              // Invalidate chats list to include the new chat
+              queryClient.invalidateQueries({ queryKey: ["chats"] });
+              break;
+            }
           }
+          onChatEvent?.(event);
         }
-        onChatEvent?.(event);
+      } catch (error) {
+        // An aborted transport can also be a failure; only suppress it when
+        // the user cancelled this request through our controller.
+        if (!abortController.signal.aborted) {
+          console.error("error mutating sendMessage", error);
+          queryClient.setQueryData(
+            ["chatError", currentChatId === "new" ? "" : currentChatId],
+            new ErrorEvent({
+              eventName: "error",
+              error:
+                error instanceof Error
+                  ? error.message
+                  : "Failed to send message. Please try again.",
+            }),
+          );
+        }
+        throw error;
+      } finally {
+        // Preserve received content and release state even if the stream fails.
+        batcher?.flushBatch();
+        batcher?.cleanup();
+        cleanupStreaming(currentChatId);
       }
-
-      // Flush any remaining batched updates and cleanup
-      batcher.flushBatch();
-      batcher.cleanup();
     },
   });
 };

--- a/app/ui/app/src/util/jsonl-parsing.test.ts
+++ b/app/ui/app/src/util/jsonl-parsing.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { parseJsonlFromResponse, parseJsonlFromStream } from "./jsonl-parsing";
+
+async function collect<T>(events: AsyncIterable<T>) {
+  const result: T[] = [];
+  for await (const event of events) result.push(event);
+  return result;
+}
+
+describe("JSONL streams", () => {
+  it("cancels unread data after a malformed event", async () => {
+    const cancel = vi.fn();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode("invalid\n"));
+      },
+      cancel,
+    });
+    await expect(collect(parseJsonlFromStream(stream))).rejects.toThrow();
+    expect(cancel).toHaveBeenCalledOnce();
+    expect(stream.locked).toBe(false);
+  });
+
+  it("handles split UTF-8 characters, blank lines, and a final line without a newline", async () => {
+    const bytes = new TextEncoder().encode(
+      '\n{"content":"你好"}\r\n{"done":true}',
+    );
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        for (const byte of bytes) controller.enqueue(Uint8Array.of(byte));
+        controller.close();
+      },
+    });
+
+    await expect(collect(parseJsonlFromStream(stream))).resolves.toEqual([
+      { content: "你好" },
+      { done: true },
+    ]);
+    expect(stream.locked).toBe(false);
+  });
+
+  it.each(['{"content":\n', '{"content":'])(
+    "rejects malformed or truncated JSON: %s",
+    async (body) => {
+      const response = new Response(body);
+      await expect(collect(parseJsonlFromResponse(response))).rejects.toThrow();
+      expect(response.body!.locked).toBe(false);
+    },
+  );
+
+  it("reports an HTTP error instead of yielding it as stream data", async () => {
+    const response = new Response('{"error":"model failed to load"}', {
+      status: 500,
+    });
+    await expect(collect(parseJsonlFromResponse(response))).rejects.toThrow(
+      "model failed to load",
+    );
+  });
+
+  it("includes the HTTP status when the error response is not JSON", async () => {
+    const response = new Response("Bad Gateway", { status: 502 });
+    await expect(collect(parseJsonlFromResponse(response))).rejects.toThrow(
+      "502",
+    );
+  });
+});

--- a/app/ui/app/src/util/jsonl-parsing.ts
+++ b/app/ui/app/src/util/jsonl-parsing.ts
@@ -11,12 +11,9 @@ export async function* parseJsonlFromStream<T>(
 
       if (done) {
         // Process any remaining data in buffer
+        buffer += decoder.decode();
         if (buffer.trim()) {
-          try {
-            yield JSON.parse(buffer.trim());
-          } catch (error) {
-            console.error(`Failed to parse final buffer: ${buffer}`, error);
-          }
+          yield JSON.parse(buffer.trim());
         }
         break;
       }
@@ -31,15 +28,13 @@ export async function* parseJsonlFromStream<T>(
       for (const line of lines) {
         const trimmed = line.trim();
         if (trimmed) {
-          try {
-            yield JSON.parse(trimmed);
-          } catch (error) {
-            console.error(`Failed to parse line: ${trimmed}`, error);
-          }
+          yield JSON.parse(trimmed);
         }
       }
     }
   } finally {
+    // Release unread data if parsing fails or the consumer stops early.
+    await reader.cancel().catch(() => {});
     reader.releaseLock();
   }
 }
@@ -50,6 +45,18 @@ export async function* parseJsonlFromStream<T>(
 export async function* parseJsonlFromResponse<T>(
   response: Response,
 ): AsyncGenerator<T, void, unknown> {
+  if (!response.ok) {
+    let message = `Request failed (${response.status})`;
+    try {
+      const body = await response.json();
+      if (typeof body?.error === "string" && body.error) {
+        message = body.error;
+      }
+    } catch {
+      // Non-JSON error responses still need to report the HTTP status.
+    }
+    throw new Error(message);
+  }
   if (!response.body) {
     throw new Error("Response body is null");
   }


### PR DESCRIPTION
Chat transport failures currently only reach the console, and a stream ending without a terminal event is treated as success. Surface HTTP errors, failed reads, malformed JSONL, and premature EOF through the existing inline chat error state. A server error or done event terminates the stream normally.

Keep request cleanup tied to the actual chat ID, including after chat creation. Flush received content and release streaming, loading, download, and abort-controller state on every exit. Only an explicit cancellation through the request's own controller suppresses the error display; an unexpected transport AbortError remains visible. Display initial request failures on the new-chat screen as well.

Related to #18368. This covers the missing failure notification and stuck UI state. The original large-document inference cancellation has not been reproduced with the reporter's models on this machine.

Local validation on macOS arm64:

- Added regressions failed before the change; all 204 UI tests passed with `npm test -- --run` afterward, including rendering an initial request error on the new-chat screen.
- Hook tests cover request failure, premature EOF, cancellation, unexpected aborts, normal completion, server error codes, new chat IDs, buffered content, and a disconnect while waiting for the first token.
- `go generate ./...` (including TypeScript compilation and Vite build), generated-file consistency check, and `go build .`
- `go test -count=1 -bench=. -benchtime=1x ./...`
- `go test -race -count=1 ./...`
- `go test -count=1 -tags updater_live ./app/...`
- ESLint for all changed TypeScript files (0 errors) and `golangci-lint run --timeout=10m` (0 issues).

The shared prerequisite commit synchronizes the generated `Settings.CodexDesktopUsed` field with the existing Go struct, making the repository's generation check reproducible. Its 180 UI tests and UI build passed locally.
