### PR TITLE
installer(windows): remove ollama install path from user PATH on uninstall

### DIFF
--- a/app/ollama.iss
+++ b/app/ollama.iss
@@ -181,6 +181,32 @@ begin
   Result := Pos(';' + ExpandConstant(Param) + ';', ';' + OrigPath + ';') = 0;
 end;
 
+procedure RemovePath(Param: string);
+var
+  OrigPath, NewPath, ParamPadded: string;
+  P: Integer;
+begin
+  if not RegQueryStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', OrigPath)
+  then begin
+    exit;
+  end;
+  ParamPadded := ExpandConstant(Param);
+  { Match on a padded copy so we only ever remove a whole path segment, never
+    a substring inside a different, unrelated PATH entry. }
+  NewPath := ';' + OrigPath + ';';
+  P := Pos(';' + ParamPadded + ';', NewPath);
+  if P = 0 then begin
+    { Not present (e.g. user already removed it manually); nothing to do. }
+    exit;
+  end;
+  Delete(NewPath, P, Length(ParamPadded) + 1);
+  if (Length(NewPath) > 0) and (NewPath[1] = ';') then
+    Delete(NewPath, 1, 1);
+  if (Length(NewPath) > 0) and (NewPath[Length(NewPath)] = ';') then
+    Delete(NewPath, Length(NewPath), 1);
+  RegWriteStringValue(HKEY_CURRENT_USER, 'Environment', 'Path', NewPath);
+end;
+
 function GetDirSize(Path: String): Int64;
 var
   FindRec: TFindRec;
@@ -307,6 +333,8 @@ end;
 procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
 begin
   if CurUninstallStep = usDone then begin
+    Log('removing {app} from user PATH');
+    RemovePath('{app}');
     if DeleteModelsChecked then begin
       Log('user requested model cleanup');
       if (VarIsEmpty(ModelsDir)) then begin


### PR DESCRIPTION
## Problem
Uninstalling Ollama on Windows leaves a stale entry in the
current-user PATH environment variable, since the uninstaller
never removes what the installer added.

## Fix
Adds RemovePath logic to the uninstall step in app/ollama.iss,
mirroring the existing NeedsAddPath/install-time logic, so the
PATH entry is cleanly removed on uninstall. The installer uses
whole-segment matching so unrelated PATH entries are preserved.

## Testing
Verified with Inno Setup 6.7.3 and a standalone test harness (not included
in this PR) that:
- The Pascal Script compiles cleanly
- A test segment was added to the user PATH
- The same RemovePath code from this patch removed it
- The resulting PATH matched the original value exactly, byte-for-byte
- No other PATH entries were corrupted

Fixes #10514