### PR TITLE
README: add AI Arena Lite desktop integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ console.log(response.message.content);
 
 #### Desktop
 
+- [AI Arena Lite](https://aiarena.me/ai-arena-lite/) - Windows desktop app for multi-agent conversations with Ollama
 - [Dify.AI](https://github.com/langgenius/dify) - LLM app development platform
 - [AnythingLLM](https://github.com/Mintplex-Labs/anything-llm) - All-in-one AI app for Mac, Windows, and Linux
 - [Maid](https://github.com/Mobile-Artificial-Intelligence/maid) - Cross-platform mobile and desktop client


### PR DESCRIPTION
Adds AI Arena Lite to the Desktop section of Community Integrations. It is a Windows app that connects to Ollama for multi-agent conversations, with configurable agent roles and a shared transcript.

The linked product page provides the public Windows beta download and an [Ollama setup guide](https://aiarena.me/guides/ollama-ai-collaboration/).

Validation: confirmed the public product page, setup guide and installer release are available. This adds one README list entry; no app code changes are included.